### PR TITLE
fix: incorrect inclusion of `tool_call` in `OpenAITool.tool_schema`

### DIFF
--- a/mirascope/chat/tools.py
+++ b/mirascope/chat/tools.py
@@ -43,14 +43,13 @@ class OpenAITool(BaseModel):
             fn["parameters"] = {
                 "type": "object",
                 "properties": {
-                    prop: {
-                        key: value
-                        for key, value in prop_schema.items()
-                        if key != "default" and key != "title"
-                    }
+                    prop: {key: value for key, value in prop_schema.items()}
                     for prop, prop_schema in model_schema["properties"].items()
+                    if prop != "tool_call"
                 },
-                "required": model_schema["required"]
+                "required": [
+                    prop for prop in model_schema["required"] if prop != "tool_call"
+                ]
                 if "required" in model_schema
                 else [],
             }

--- a/tests/chat/test_tools.py
+++ b/tests/chat/test_tools.py
@@ -25,13 +25,15 @@ from mirascope.chat.tools import OpenAITool, openai_tool_fn
                             "param": {
                                 "type": "string",
                                 "description": "A test parameter.",
+                                "title": "Param",
                             },
-                            "optional": {"type": "integer"},
-                            "tool_call": {
-                                "$ref": "#/$defs/ChatCompletionMessageToolCall"
+                            "optional": {
+                                "type": "integer",
+                                "title": "Optional",
+                                "default": 0,
                             },
                         },
-                        "required": ["tool_call", "param"],
+                        "required": ["param"],
                     },
                 },
             },
@@ -45,12 +47,8 @@ from mirascope.chat.tools import OpenAITool, openai_tool_fn
                     "description": "A test tool with no parameters.",
                     "parameters": {
                         "type": "object",
-                        "properties": {
-                            "tool_call": {
-                                "$ref": "#/$defs/ChatCompletionMessageToolCall"
-                            }
-                        },
-                        "required": ["tool_call"],
+                        "properties": {},
+                        "required": [],
                     },
                 },
             },


### PR DESCRIPTION
Closes #60 
This inclusion was breaking the usage of tool calls for other models such as Anyscale and Together AI. Removing the erroneous `tool_call` attribute from the schema appears to have solved the issue.