### PR TITLE
added coverage for tests using async generators

### DIFF
--- a/tests/chat/models/test_openai_chat.py
+++ b/tests/chat/models/test_openai_chat.py
@@ -131,23 +131,21 @@ def test_openai_chat_error(mock_create, fixture_foobar_prompt):
 )
 def test_openai_chat_stream(
     mock_create,
-    fixture_chat_completion_chunk,
+    fixture_chat_completion_chunks,
     prompt,
     request,
 ):
     """Tests that `OpenAIChat` returns the expected response when streaming."""
     prompt = request.getfixturevalue(prompt)
-    mock_create.return_value = [fixture_chat_completion_chunk] * 3
+    mock_create.return_value = fixture_chat_completion_chunks
 
     model = "gpt-3.5-turbo-16k"
     chat = OpenAIChat(model, api_key="test")
     stream = chat.stream(prompt, temperature=0.3)
 
-    for chunk in stream:
+    for i, chunk in enumerate(stream):
         assert isinstance(chunk, OpenAIChatCompletionChunk)
-        assert chunk.chunk == fixture_chat_completion_chunk
-        for i, choice in enumerate(chunk.choices):
-            assert choice == fixture_chat_completion_chunk.choices[i]
+        assert chunk.chunk == fixture_chat_completion_chunks[i]
 
     mock_create.assert_called_once_with(
         model=model,

--- a/tests/chat/models/test_openai_chat_async.py
+++ b/tests/chat/models/test_openai_chat_async.py
@@ -122,7 +122,9 @@ async def test_async_openai_chat_stream(
 ):
     """Tests that `AsyncOpenAIChat` returns the expected response when streaming."""
     prompt = request.getfixturevalue(prompt)
-    mock_create.__aiter__.return_value = [fixture_chat_completion_chunk] * 3
+    mock_create.return_value.__aiter__.return_value = [
+        fixture_chat_completion_chunk
+    ] * 3
 
     model = "gpt-3.5-turbo-16k"
     chat = AsyncOpenAIChat(model, api_key="test")
@@ -149,7 +151,9 @@ async def test_async_openai_chat_stream_messages_kwarg(
     mock_create, fixture_chat_completion_chunk
 ):
     """Tests that `AsyncOpenAIChat.stream` works with a messages kwarg."""
-    mock_create.__aiter__.return_value = [fixture_chat_completion_chunk] * 3
+    mock_create.return_value.__aiter__.return_value = [
+        fixture_chat_completion_chunk
+    ] * 3
 
     model = "gpt-3.5-turbo-16k"
     chat = AsyncOpenAIChat(model, api_key="test")
@@ -184,15 +188,14 @@ async def test_async_openai_chat_stream_tools(
     prompt = request.getfixturevalue(prompt)
     tools = [request.getfixturevalue(tool) for tool in tools]
     chunks = [fixture_chat_completion_chunk_with_tools] * 3
-    mock_create.__aiter__.return_value = chunks
+
+    mock_create.return_value.__aiter__.return_value = chunks
 
     chat = AsyncOpenAIChat(api_key="test")
     stream = chat.stream(prompt, tools=tools)
 
-    i = 0
     async for chunk in stream:
-        assert chunk.tool_calls == chunks[i].choices[0].delta.tool_calls
-        i += 1
+        assert chunk.tool_calls == chunks[0].choices[0].delta.tool_calls
 
     mock_create.assert_called_once_with(
         model="gpt-3.5-turbo",

--- a/tests/chat/models/test_openai_chat_async.py
+++ b/tests/chat/models/test_openai_chat_async.py
@@ -116,24 +116,24 @@ async def test_async_openai_chat_error(mock_create, fixture_foobar_prompt):
 @pytest.mark.parametrize("prompt", ["fixture_foobar_prompt", "fixture_messages_prompt"])
 async def test_async_openai_chat_stream(
     mock_create,
-    fixture_chat_completion_chunk,
+    fixture_chat_completion_chunks,
     prompt,
     request,
 ):
     """Tests that `AsyncOpenAIChat` returns the expected response when streaming."""
     prompt = request.getfixturevalue(prompt)
-    mock_create.return_value.__aiter__.return_value = [
-        fixture_chat_completion_chunk
-    ] * 3
+    mock_create.return_value.__aiter__.return_value = fixture_chat_completion_chunks
 
     model = "gpt-3.5-turbo-16k"
     chat = AsyncOpenAIChat(model, api_key="test")
     astream = chat.stream(prompt, temperature=0.3)
+    i = 0
     async for chunk in astream:
         assert isinstance(chunk, OpenAIChatCompletionChunk)
-        assert chunk.chunk == fixture_chat_completion_chunk
-        for i, choice in enumerate(chunk.choices):
-            assert choice == fixture_chat_completion_chunk.choices[i]
+        assert chunk.chunk == fixture_chat_completion_chunks[i]
+        for j, choice in enumerate(chunk.choices):
+            assert choice == fixture_chat_completion_chunks[i].choices[j]
+        i += 1
 
     mock_create.assert_called_once_with(
         model=model,
@@ -148,12 +148,10 @@ async def test_async_openai_chat_stream(
     new_callable=AsyncMock,
 )
 async def test_async_openai_chat_stream_messages_kwarg(
-    mock_create, fixture_chat_completion_chunk
+    mock_create, fixture_chat_completion_chunks
 ):
     """Tests that `AsyncOpenAIChat.stream` works with a messages kwarg."""
-    mock_create.return_value.__aiter__.return_value = [
-        fixture_chat_completion_chunk
-    ] * 3
+    mock_create.return_value.__aiter__.return_value = fixture_chat_completion_chunks
 
     model = "gpt-3.5-turbo-16k"
     chat = AsyncOpenAIChat(model, api_key="test")

--- a/tests/chat/parsers/test_openai_parser_async.py
+++ b/tests/chat/parsers/test_openai_parser_async.py
@@ -33,7 +33,9 @@ async def test_from_stream(
     prompt = request.getfixturevalue(prompt)
 
     tools = [request.getfixturevalue(fixture_tool) for fixture_tool in fixture_tools]
-    mock_create.__aiter__.return_value = fixture_chat_completion_chunks_with_tools
+    mock_create.return_value.__aiter__.return_value = (
+        fixture_chat_completion_chunks_with_tools
+    )
     chat = AsyncOpenAIChat(api_key="test")
     stream = chat.stream(prompt, tools=tools)
     parser = AsyncOpenAIToolStreamParser(tools=tools)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """Fixtures for repeated use in testing."""
-from typing import Optional, Type
+from typing import Type
 
 import pytest
 from openai.types.chat import (
@@ -205,39 +205,58 @@ def fixture_chat_completion_with_bad_tools() -> ChatCompletion:
 
 
 @pytest.fixture()
-def fixture_chat_completion_chunk() -> ChatCompletionChunk:
+def fixture_chat_completion_chunks() -> list[ChatCompletionChunk]:
+    """Returns chat completion chunks."""
+    return [
+        ChatCompletionChunk(
+            id="test_id",
+            choices=[
+                ChunkChoice(
+                    **{"logprobs": None},
+                    delta=ChoiceDelta(content="I'm"),
+                    finish_reason="stop",
+                    index=0,
+                ),
+            ],
+            created=0,
+            model="test_model",
+            object="chat.completion.chunk",
+        ),
+        ChatCompletionChunk(
+            id="test_id",
+            choices=[
+                ChunkChoice(
+                    **{"logprobs": None},
+                    delta=ChoiceDelta(content="testing"),
+                    finish_reason="stop",
+                    index=0,
+                ),
+            ],
+            created=0,
+            model="test_model",
+            object="chat.completion.chunk",
+        ),
+    ]
+
+
+@pytest.fixture()
+def fixture_chat_completion_chunk(
+    fixture_chat_completion_chunks,
+) -> ChatCompletionChunk:
     """Returns a chat completion chunk."""
-    return ChatCompletionChunk(
-        id="test_id",
-        choices=[
-            ChunkChoice(
-                **{"logprobs": None},
-                delta=ChoiceDelta(content="I'm"),
-                finish_reason="stop",
-                index=0,
-            ),
-            ChunkChoice(
-                **{"logprobs": None},
-                delta=ChoiceDelta(content="testing"),
-                finish_reason="stop",
-                index=0,
-            ),
-        ],
-        created=0,
-        model="test_model",
-        object="chat.completion.chunk",
-    )
+    return fixture_chat_completion_chunks[0]
 
 
 @pytest.fixture()
 def fixture_chat_completion_chunks_with_tools(
-    request: Optional[pytest.FixtureRequest] = None,
+    request: pytest.FixtureRequest,
 ) -> list[ChatCompletionChunk]:
     """Returns a list of chat completion chunks with tool calls."""
-    if request:
+    try:
         name = request.param
-    else:
+    except AttributeError:
         name = None
+
     return [
         ChatCompletionChunk(
             id="test_id",
@@ -304,6 +323,19 @@ def fixture_chat_completion_chunks_with_tools(
                             )
                         ]
                     ),
+                    index=0,
+                ),
+            ],
+            created=0,
+            model="test_model",
+            object="chat.completion.chunk",
+        ),
+        ChatCompletionChunk(
+            id="test_id",
+            choices=[
+                ChunkChoice(
+                    logprobs=None,
+                    delta=ChoiceDelta(tool_calls=None),
                     finish_reason="stop",
                     index=0,
                 ),


### PR DESCRIPTION
* Fixed tests with async generators which fixes code coverage
* Fixed mock of openai create to set the return value in the correct spot
* Added fixtures
* Updated fixtures to handle more cases