### PR TITLE
Include `_call_params: CallParams` attribute in `Prompt`

### DIFF
--- a/cookbook/squad_extraction/.mirascope/versions/question/0001_question.py
+++ b/cookbook/squad_extraction/.mirascope/versions/question/0001_question.py
@@ -12,7 +12,7 @@
 
 from pydantic import BaseModel
 
-from mirascope import CallParams, Prompt, tags
+from mirascope import OpenAICallParams, Prompt, tags
 
 prev_revision_id = "None"
 revision_id = "0001"
@@ -35,4 +35,4 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")
+    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")

--- a/cookbook/squad_extraction/.mirascope/versions/question/0001_question.py
+++ b/cookbook/squad_extraction/.mirascope/versions/question/0001_question.py
@@ -12,7 +12,7 @@
 
 from pydantic import BaseModel
 
-from mirascope import Prompt, tags
+from mirascope import CallParams, Prompt, tags
 
 prev_revision_id = "None"
 revision_id = "0001"
@@ -34,3 +34,5 @@ class QuestionPrompt(Prompt):
 
     paragraph: str
     question: str
+
+    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")

--- a/cookbook/squad_extraction/.mirascope/versions/question/0002_question.py
+++ b/cookbook/squad_extraction/.mirascope/versions/question/0002_question.py
@@ -12,7 +12,7 @@
 
 from pydantic import BaseModel, Field
 
-from mirascope import Prompt, messages, tags
+from mirascope import CallParams, Prompt, messages, tags
 
 prev_revision_id = "0001"
 revision_id = "0002"
@@ -46,3 +46,5 @@ class QuestionPrompt(Prompt):
 
     paragraph: str
     question: str
+
+    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")

--- a/cookbook/squad_extraction/.mirascope/versions/question/0002_question.py
+++ b/cookbook/squad_extraction/.mirascope/versions/question/0002_question.py
@@ -12,7 +12,7 @@
 
 from pydantic import BaseModel, Field
 
-from mirascope import CallParams, Prompt, messages, tags
+from mirascope import OpenAICallParams, Prompt, messages, tags
 
 prev_revision_id = "0001"
 revision_id = "0002"
@@ -47,4 +47,4 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")
+    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")

--- a/cookbook/squad_extraction/extract_answers.py
+++ b/cookbook/squad_extraction/extract_answers.py
@@ -13,7 +13,7 @@ settings = Settings()
 
 def main(prompt_version: str):
     """Extracts answers for SQuAD 2.0 questions using GPT 3.5 Turbo."""
-    chat = OpenAIChat(model="gpt-3.5-turbo-1106", api_key=settings.openai_api_key)
+    chat = OpenAIChat(api_key=settings.openai_api_key)
     questions = load_geology_squad()
     extracted_answers = {
         question.id: chat.extract(

--- a/cookbook/squad_extraction/squad_prompts/question.py
+++ b/cookbook/squad_extraction/squad_prompts/question.py
@@ -12,7 +12,7 @@
 
 from pydantic import BaseModel, Field
 
-from mirascope import Prompt, messages, tags
+from mirascope import CallParams, Prompt, messages, tags
 
 
 class ExtractedAnswer(BaseModel):
@@ -47,3 +47,5 @@ class QuestionPrompt(Prompt):
 
     paragraph: str
     question: str
+
+    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")

--- a/cookbook/squad_extraction/squad_prompts/question.py
+++ b/cookbook/squad_extraction/squad_prompts/question.py
@@ -12,7 +12,7 @@
 
 from pydantic import BaseModel, Field
 
-from mirascope import CallParams, Prompt, messages, tags
+from mirascope import OpenAICallParams, Prompt, messages, tags
 
 
 class ExtractedAnswer(BaseModel):
@@ -48,4 +48,4 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")
+    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")

--- a/docs/concepts/llm_convenience_wrappers.md
+++ b/docs/concepts/llm_convenience_wrappers.md
@@ -171,7 +171,7 @@ Tools are extremely useful when you want the model to intelligently choose to ou
 ```python
 from typing import Literal
 
-from mirascope import CallParams, OpenAIChat, Prompt
+from mirascope import OpenAICallParams, OpenAIChat, Prompt
 
 def get_current_weather(
     location: str, unit: Literal["celsius", "fahrenheit"] = "fahrenheit"
@@ -191,7 +191,7 @@ def get_current_weather(
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106",
         tools=[get_current_weather]  # pass in the function itself
     )
@@ -211,7 +211,7 @@ You can also define your own `OpenAITool` class. This is necessary when the func
 ```python
 from typing import Literal
 
-from mirascope import CallParams, OpenAIChat, OpenAITool, Prompt, openai_tool_fn
+from mirascope import OpenAICallParams, OpenAIChat, OpenAITool, Prompt, openai_tool_fn
 from pydantic import Field
 
 
@@ -233,7 +233,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 
@@ -253,7 +253,7 @@ However, attaching the function is not necessary. In fact, often there are times
 ```python
 from typing import Literal
 
-from mirascope import CallParams, OpenAIChat, OpenAITool, Prompt
+from mirascope import OpenAICallParams, OpenAIChat, OpenAITool, Prompt
 from pydantic import Field
 
 
@@ -267,7 +267,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 
@@ -286,7 +286,13 @@ We also support streaming of tools using our `OpenAIToolStreamParser` class. Sim
 ```python
 from typing import Literal
 
-from mirascope import CallParams, OpenAIChat, OpenAITool, OpenAIToolStreamParser, Prompt
+from mirascope import (
+    OpenAICallParams,
+    OpenAIChat,
+    OpenAITool,
+    OpenAIToolStreamParser,
+    Prompt,
+)
 from pydantic import Field
 
 
@@ -300,7 +306,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 

--- a/docs/concepts/pydantic_prompts.md
+++ b/docs/concepts/pydantic_prompts.md
@@ -145,10 +145,11 @@ You can add tags to help organize prompts when you want to use them outside your
 
 !!! note 
 	
-	`@tags` decorator adds `_tags` private attribute to the class
+	`@tags` updates the `_tags` private attribute of the class with the provided list of tags, which you can access using the `tags` classmethod.
 
 ```python
-from mirascope import Prompt, tags
+from mirascope import OpenAIChat, Prompt, tags
+
 
 @tags(["recommendation_project", "version:0001"])
 class BookRecommendationPrompt(Prompt):
@@ -162,7 +163,7 @@ class BookRecommendationPrompt(Prompt):
 prompt = BookRecommendationPrompt(topic="how to bake a cake")
 model = OpenAIChat()
 print(prompt.dump())
-# {'template': 'Can you recommend some books on {topic}?', 'inputs': {'topic': 'how to bake a cake'}, 'tags': ['recommendation_project', 'version:0001']}
+# {'template': 'Can you recommend some books on {topic}?', 'inputs': {'topic': 'how to bake a cake'}, 'tags': ['recommendation_project', 'version:0001'], 'call_params': {'model': 'gpt-3.5-turbo-16k'}}
 ```
 
 ## Future updates

--- a/docs/cookbook/squad_extraction.md
+++ b/docs/cookbook/squad_extraction.md
@@ -49,6 +49,8 @@ class QuestionPrompt(Prompt):
 
     paragraph: str
     question: str
+
+    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")
 ```
 
 Next we'll define the schema we want to extract from the paragraph and a function to extract the schema from a given question:
@@ -60,7 +62,7 @@ from config import Settings
 from prompts.question import ExtractedAnswer, QuestionPrompt
 
 settings = Settings()
-chat = OpenAIChat(model="gpt-3.5-turbo-1106", api_key=settings.openai_api_key)
+chat = OpenAIChat(api_key=settings.openai_api_key)
 
 
 def extract_answer(question: QuestionWithContext) -> str:

--- a/docs/cookbook/squad_extraction.md
+++ b/docs/cookbook/squad_extraction.md
@@ -30,7 +30,7 @@ $ mirascope init --prompts_location squad_prompts; touch prompts/question.py
 
 ```python
 # squad_prompts/question.py
-from mirascope import Prompt
+from mirascope import OpenAICallParams, Prompt
 from pydantic import BaseModel, Field
 
 
@@ -50,7 +50,7 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")
+    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
 ```
 
 Next we'll define the schema we want to extract from the paragraph and a function to extract the schema from a given question:

--- a/examples/function_as_tool.py
+++ b/examples/function_as_tool.py
@@ -2,13 +2,9 @@
 import os
 from typing import Literal
 
-from mirascope import OpenAIChat, Prompt
+from mirascope import CallParams, OpenAIChat, Prompt
 
 os.environ["OPENAI_API_KEY"] = "YOUR_API_KEY"
-
-
-class CurrentWeatherPrompt(Prompt):
-    """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
 
 def get_current_weather(
@@ -26,11 +22,16 @@ def get_current_weather(
     return f"{location} is 65 degrees {unit}."
 
 
-chat = OpenAIChat(model="gpt-3.5-turbo-1106")
-completion = chat.create(
-    CurrentWeatherPrompt(),
-    tools=[get_current_weather],  # pass in the function itself for automatic conversion
-)
+class CurrentWeatherPrompt(Prompt):
+    """What's the weather like in San Francisco, Tokyo, and Paris?"""
+
+    _call_params: CallParams = CallParams(
+        model="gpt-3.5-turbo-1106", tools=[get_current_weather]
+    )
+
+
+chat = OpenAIChat()
+completion = chat.create(CurrentWeatherPrompt())
 
 if tools := completion.tools:
     for tool in tools:

--- a/examples/function_as_tool.py
+++ b/examples/function_as_tool.py
@@ -2,7 +2,7 @@
 import os
 from typing import Literal
 
-from mirascope import CallParams, OpenAIChat, Prompt
+from mirascope import OpenAICallParams, OpenAIChat, Prompt
 
 os.environ["OPENAI_API_KEY"] = "YOUR_API_KEY"
 
@@ -25,7 +25,7 @@ def get_current_weather(
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[get_current_weather]
     )
 

--- a/examples/log.py
+++ b/examples/log.py
@@ -28,6 +28,7 @@ class OpenAIChatCompletionTable(Base):
     template: Mapped[str] = mapped_column(String(), nullable=False)
     inputs: Mapped[Optional[dict]] = mapped_column(JSONB)
     tags: Mapped[Optional[list[str]]] = mapped_column(JSON)
+    call_params: Mapped[Optional[dict]] = mapped_column(JSONB)
     start_time: Mapped[Optional[float]] = mapped_column(Float(), nullable=False)
     end_time: Mapped[Optional[float]] = mapped_column(Float(), nullable=False)
     output: Mapped[Optional[dict]] = mapped_column(JSONB)

--- a/examples/openai_tool.py
+++ b/examples/openai_tool.py
@@ -4,7 +4,7 @@ from typing import Literal
 
 from pydantic import Field
 
-from mirascope import CallParams, OpenAIChat, OpenAITool, Prompt, openai_tool_fn
+from mirascope import OpenAICallParams, OpenAIChat, OpenAITool, Prompt, openai_tool_fn
 
 os.environ["OPENAI_API_KEY"] = "YOUR_API_KEY"
 
@@ -27,7 +27,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 

--- a/examples/openai_tool.py
+++ b/examples/openai_tool.py
@@ -4,13 +4,9 @@ from typing import Literal
 
 from pydantic import Field
 
-from mirascope import OpenAIChat, OpenAITool, Prompt, openai_tool_fn
+from mirascope import CallParams, OpenAIChat, OpenAITool, Prompt, openai_tool_fn
 
 os.environ["OPENAI_API_KEY"] = "YOUR_API_KEY"
-
-
-class CurrentWeatherPrompt(Prompt):
-    """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
 
 def get_current_weather(
@@ -28,11 +24,16 @@ class GetCurrentWeather(OpenAITool):
     unit: Literal["celsius", "fahrenheit"] = "fahrenheit"
 
 
-chat = OpenAIChat(model="gpt-3.5-turbo-1106")
-completion = chat.create(
-    CurrentWeatherPrompt(),
-    tools=[GetCurrentWeather],  # pass in the function itself for automatic conversion
-)
+class CurrentWeatherPrompt(Prompt):
+    """What's the weather like in San Francisco, Tokyo, and Paris?"""
+
+    _call_params: CallParams = CallParams(
+        model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
+    )
+
+
+chat = OpenAIChat()
+completion = chat.create(CurrentWeatherPrompt())
 
 if tools := completion.tools:
     for tool in tools:

--- a/examples/stream_openai_tool.py
+++ b/examples/stream_openai_tool.py
@@ -4,7 +4,13 @@ from typing import Callable, Literal, Type, Union
 
 from pydantic import Field
 
-from mirascope import CallParams, OpenAIChat, OpenAITool, OpenAIToolStreamParser, Prompt
+from mirascope import (
+    OpenAICallParams,
+    OpenAIChat,
+    OpenAITool,
+    OpenAIToolStreamParser,
+    Prompt,
+)
 
 os.environ["OPENAI_API_KEY"] = "YOUR_API_KEY"
 
@@ -29,7 +35,7 @@ tools: list[Union[Callable, Type[OpenAITool]]] = [GetCurrentWeather]
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106",
         tools=tools,  # pass in function itself for automatic conversion
     )

--- a/examples/stream_openai_tool_async.py
+++ b/examples/stream_openai_tool_async.py
@@ -8,7 +8,7 @@ from pydantic import Field
 from mirascope import (
     AsyncOpenAIChat,
     AsyncOpenAIToolStreamParser,
-    CallParams,
+    OpenAICallParams,
     OpenAITool,
     Prompt,
     openai_tool_fn,
@@ -35,7 +35,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106",
         tools=[GetCurrentWeather],  # pass in function itself for automatic conversion
     )

--- a/mirascope/__init__.py
+++ b/mirascope/__init__.py
@@ -5,6 +5,6 @@ from .chat.models import AsyncOpenAIChat, OpenAIChat
 from .chat.parsers import AsyncOpenAIToolStreamParser, OpenAIToolStreamParser
 from .chat.tools import OpenAITool, openai_tool_fn
 from .partial import Partial
-from .prompts import CallParams, Prompt, messages, tags
+from .prompts import OpenAICallParams, Prompt, messages, tags
 
 __version__ = importlib.metadata.version("mirascope")

--- a/mirascope/__init__.py
+++ b/mirascope/__init__.py
@@ -5,6 +5,6 @@ from .chat.models import AsyncOpenAIChat, OpenAIChat
 from .chat.parsers import AsyncOpenAIToolStreamParser, OpenAIToolStreamParser
 from .chat.tools import OpenAITool, openai_tool_fn
 from .partial import Partial
-from .prompts import Prompt, messages, tags
+from .prompts import CallParams, Prompt, messages, tags
 
 __version__ = importlib.metadata.version("mirascope")

--- a/mirascope/chat/models/async_openai_chat.py
+++ b/mirascope/chat/models/async_openai_chat.py
@@ -66,6 +66,7 @@ class AsyncOpenAIChat:
         self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
+        client_wrapper: Optional[Callable] = None,
         **kwargs,
     ):
         """Initializes an instance of `AsyncOpenAIChat."""
@@ -76,6 +77,8 @@ class AsyncOpenAIChat:
             self.model = "gpt-3.5-turbo"
             self.model_is_set = False
         self.client = AsyncOpenAI(api_key=api_key, base_url=base_url, **kwargs)
+        if client_wrapper is not None:
+            self.client = client_wrapper(self.client)
 
     async def create(
         self,

--- a/mirascope/chat/models/async_openai_chat.py
+++ b/mirascope/chat/models/async_openai_chat.py
@@ -111,8 +111,9 @@ class AsyncOpenAIChat:
             if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
-                    "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
-                    "version>=0.3.0. Use `CallParams` inside of your `Prompt` instead.",
+                    "`Prompt` in favor of `OpenAICallParams.model` field inside of "
+                    "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
+                    "`Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -121,7 +122,7 @@ class AsyncOpenAIChat:
             if tools is not None:
                 warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
-                    "Use `CallParams` inside of your `Prompt` instead.",
+                    "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -173,8 +174,9 @@ class AsyncOpenAIChat:
             if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
-                    "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
-                    "version>=0.3.0. Use `CallParams` inside of your `Prompt` instead.",
+                    "`Prompt` in favor of `OpenAICallParams.model` field inside of "
+                    "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
+                    "`Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -183,7 +185,7 @@ class AsyncOpenAIChat:
             if tools is not None:
                 warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
-                    "Use `CallParams` inside of your `Prompt` instead.",
+                    "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/mirascope/chat/models/async_openai_chat.py
+++ b/mirascope/chat/models/async_openai_chat.py
@@ -113,7 +113,7 @@ class AsyncOpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt._call_params.model
+            self.model = prompt.call_params().model
 
             if tools is not None:
                 warn(
@@ -122,8 +122,8 @@ class AsyncOpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt._call_params.tools is not None:
-                tools = prompt._call_params.tools
+            if prompt.call_params().tools is not None:
+                tools = prompt.call_params().tools
 
         start_time = datetime.datetime.now().timestamp() * 1000
         openai_tools = convert_tools_list_to_openai_tools(tools)
@@ -175,7 +175,7 @@ class AsyncOpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt._call_params.model
+            self.model = prompt.call_params().model
 
             if tools is not None:
                 warn(
@@ -184,8 +184,8 @@ class AsyncOpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt._call_params.tools is not None:
-                tools = prompt._call_params.tools
+            if prompt.call_params().tools is not None:
+                tools = prompt.call_params().tools
 
         openai_tools = convert_tools_list_to_openai_tools(tools)
         patch_openai_kwargs(kwargs, prompt, openai_tools)

--- a/mirascope/chat/models/async_openai_chat.py
+++ b/mirascope/chat/models/async_openai_chat.py
@@ -100,13 +100,6 @@ class AsyncOpenAIChat:
             OpenAIError: raises any OpenAI errors, see:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
-        if tools is not None:
-            warn(
-                "The `tools` parameter is deprecated; version>=0.3.0. "
-                "Use `CallParams` inside of your `Prompt` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if isinstance(prompt, Prompt):
             if self.model != "gpt-3.5-turbo":
                 warn(
@@ -117,6 +110,14 @@ class AsyncOpenAIChat:
                     stacklevel=2,
                 )
             self.model = prompt._call_params.model
+
+            if tools is not None:
+                warn(
+                    "The `tools` parameter is deprecated; version>=0.3.0. "
+                    "Use `CallParams` inside of your `Prompt` instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if prompt._call_params.tools is not None:
                 tools = prompt._call_params.tools
 
@@ -161,13 +162,6 @@ class AsyncOpenAIChat:
             OpenAIError: raises any OpenAI errors, see:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
-        if tools is not None:
-            warn(
-                "The `tools` parameter is deprecated; version>=0.3.0. "
-                "Use `CallParams` inside of your `Prompt` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if isinstance(prompt, Prompt):
             if self.model != "gpt-3.5-turbo":
                 warn(
@@ -178,6 +172,14 @@ class AsyncOpenAIChat:
                     stacklevel=2,
                 )
             self.model = prompt._call_params.model
+
+            if tools is not None:
+                warn(
+                    "The `tools` parameter is deprecated; version>=0.3.0. "
+                    "Use `CallParams` inside of your `Prompt` instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if prompt._call_params.tools is not None:
                 tools = prompt._call_params.tools
 

--- a/mirascope/chat/models/async_openai_chat.py
+++ b/mirascope/chat/models/async_openai_chat.py
@@ -64,14 +64,18 @@ class AsyncOpenAIChat:
 
     def __init__(
         self,
-        model: str = "gpt-3.5-turbo",
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         **kwargs,
     ):
         """Initializes an instance of `AsyncOpenAIChat."""
+        if "model" in kwargs:
+            self.model = kwargs.pop("model")
+            self.model_is_set = True
+        else:
+            self.model = "gpt-3.5-turbo"
+            self.model_is_set = False
         self.client = AsyncOpenAI(api_key=api_key, base_url=base_url, **kwargs)
-        self.model = model
 
     async def create(
         self,
@@ -101,7 +105,7 @@ class AsyncOpenAIChat:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
         if isinstance(prompt, Prompt):
-            if self.model != "gpt-3.5-turbo":
+            if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
@@ -163,7 +167,7 @@ class AsyncOpenAIChat:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
         if isinstance(prompt, Prompt):
-            if self.model != "gpt-3.5-turbo":
+            if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "

--- a/mirascope/chat/models/async_openai_chat.py
+++ b/mirascope/chat/models/async_openai_chat.py
@@ -2,6 +2,7 @@
 import datetime
 import logging
 from typing import AsyncGenerator, Callable, Optional, Type, TypeVar, Union
+from warnings import warn
 
 from openai import AsyncOpenAI
 from pydantic import BaseModel, ValidationError
@@ -99,6 +100,26 @@ class AsyncOpenAIChat:
             OpenAIError: raises any OpenAI errors, see:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
+        if tools is not None:
+            warn(
+                "The `tools` parameter is deprecated; version>=0.3.0. "
+                "Use `CallParams` inside of your `Prompt` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if isinstance(prompt, Prompt):
+            if self.model != "gpt-3.5-turbo":
+                warn(
+                    "The `model` parameter will be ignored when `prompt` is of type "
+                    "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
+                    "version>=0.3.0. Use `CallParams` inside of your `Prompt` instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            self.model = prompt._call_params.model
+            if prompt._call_params.tools is not None:
+                tools = prompt._call_params.tools
+
         start_time = datetime.datetime.now().timestamp() * 1000
         openai_tools = convert_tools_list_to_openai_tools(tools)
         patch_openai_kwargs(kwargs, prompt, openai_tools)
@@ -140,6 +161,26 @@ class AsyncOpenAIChat:
             OpenAIError: raises any OpenAI errors, see:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
+        if tools is not None:
+            warn(
+                "The `tools` parameter is deprecated; version>=0.3.0. "
+                "Use `CallParams` inside of your `Prompt` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if isinstance(prompt, Prompt):
+            if self.model != "gpt-3.5-turbo":
+                warn(
+                    "The `model` parameter will be ignored when `prompt` is of type "
+                    "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
+                    "version>=0.3.0. Use `CallParams` inside of your `Prompt` instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+            self.model = prompt._call_params.model
+            if prompt._call_params.tools is not None:
+                tools = prompt._call_params.tools
+
         openai_tools = convert_tools_list_to_openai_tools(tools)
         patch_openai_kwargs(kwargs, prompt, openai_tools)
 

--- a/mirascope/chat/models/openai_chat.py
+++ b/mirascope/chat/models/openai_chat.py
@@ -59,14 +59,18 @@ class OpenAIChat:
 
     def __init__(
         self,
-        model: str = "gpt-3.5-turbo",
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
         **kwargs,
     ):
         """Initializes an instance of `OpenAIChat."""
+        if "model" in kwargs:
+            self.model = kwargs.pop("model")
+            self.model_is_set = True
+        else:
+            self.model = "gpt-3.5-turbo"
+            self.model_is_set = False
         self.client = OpenAI(api_key=api_key, base_url=base_url, **kwargs)
-        self.model = model
 
     def create(
         self,
@@ -98,7 +102,7 @@ class OpenAIChat:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
         if isinstance(prompt, Prompt):
-            if self.model != "gpt-3.5-turbo":
+            if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
@@ -159,7 +163,7 @@ class OpenAIChat:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
         if isinstance(prompt, Prompt):
-            if self.model != "gpt-3.5-turbo":
+            if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "

--- a/mirascope/chat/models/openai_chat.py
+++ b/mirascope/chat/models/openai_chat.py
@@ -97,13 +97,6 @@ class OpenAIChat:
             OpenAIError: raises any OpenAI errors, see:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
-        if tools is not None:
-            warn(
-                "The `tools` parameter is deprecated; version>=0.3.0. "
-                "Use `CallParams` inside of your `Prompt` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if isinstance(prompt, Prompt):
             if self.model != "gpt-3.5-turbo":
                 warn(
@@ -114,6 +107,14 @@ class OpenAIChat:
                     stacklevel=2,
                 )
             self.model = prompt._call_params.model
+
+            if tools is not None:
+                warn(
+                    "The `tools` parameter is deprecated; version>=0.3.0. "
+                    "Use `CallParams` inside of your `Prompt` instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if prompt._call_params.tools is not None:
                 tools = prompt._call_params.tools
 
@@ -157,13 +158,6 @@ class OpenAIChat:
             OpenAIError: raises any OpenAI errors, see:
                 https://platform.openai.com/docs/guides/error-codes/api-errors
         """
-        if tools is not None:
-            warn(
-                "The `tools` parameter is deprecated; version>=0.3.0. "
-                "Use `CallParams` inside of your `Prompt` instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         if isinstance(prompt, Prompt):
             if self.model != "gpt-3.5-turbo":
                 warn(
@@ -174,6 +168,14 @@ class OpenAIChat:
                     stacklevel=2,
                 )
             self.model = prompt._call_params.model
+
+            if tools is not None:
+                warn(
+                    "The `tools` parameter is deprecated; version>=0.3.0. "
+                    "Use `CallParams` inside of your `Prompt` instead.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             if prompt._call_params.tools is not None:
                 tools = prompt._call_params.tools
 

--- a/mirascope/chat/models/openai_chat.py
+++ b/mirascope/chat/models/openai_chat.py
@@ -110,7 +110,7 @@ class OpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt._call_params.model
+            self.model = prompt.call_params().model
 
             if tools is not None:
                 warn(
@@ -119,8 +119,8 @@ class OpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt._call_params.tools is not None:
-                tools = prompt._call_params.tools
+            if prompt.call_params().tools is not None:
+                tools = prompt.call_params().tools
 
         start_time = datetime.datetime.now().timestamp() * 1000
         openai_tools = convert_tools_list_to_openai_tools(tools)
@@ -171,7 +171,7 @@ class OpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt._call_params.model
+            self.model = prompt.call_params().model
 
             if tools is not None:
                 warn(
@@ -180,8 +180,8 @@ class OpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt._call_params.tools is not None:
-                tools = prompt._call_params.tools
+            if prompt.call_params().tools is not None:
+                tools = prompt.call_params().tools
 
         openai_tools = convert_tools_list_to_openai_tools(tools)
         patch_openai_kwargs(kwargs, prompt, openai_tools)

--- a/mirascope/chat/models/openai_chat.py
+++ b/mirascope/chat/models/openai_chat.py
@@ -61,6 +61,7 @@ class OpenAIChat:
         self,
         api_key: Optional[str] = None,
         base_url: Optional[str] = None,
+        client_wrapper: Optional[Callable] = None,
         **kwargs,
     ):
         """Initializes an instance of `OpenAIChat."""
@@ -71,6 +72,8 @@ class OpenAIChat:
             self.model = "gpt-3.5-turbo"
             self.model_is_set = False
         self.client = OpenAI(api_key=api_key, base_url=base_url, **kwargs)
+        if client_wrapper is not None:
+            self.client = client_wrapper(self.client)
 
     def create(
         self,

--- a/mirascope/chat/models/openai_chat.py
+++ b/mirascope/chat/models/openai_chat.py
@@ -86,9 +86,9 @@ class OpenAIChat:
         Args:
             prompt: The prompt to use for the call. This can either be a `Prompt`
                 instance, a raw string, or `None`. If `prompt` is a `Prompt` instance,
-                then the call will use the `CallParams` in the prompt before anything
-                else. If `prompt` is `None`, then the call will attempt to use the
-                `messages` keyword argument.
+                then the call will use the `OpenAICallParams` in the prompt before
+                anything else. If `prompt` is `None`, then the call will attempt to use
+                the `messages` keyword argument.
             tools: (Deprecated) A list of `OpenAITool` types or `Callable` functions
                 that the creation call can decide to use. If `tools` is provided,
                 `tool_choice` will be set to `auto` unless manually specified.
@@ -108,8 +108,9 @@ class OpenAIChat:
             if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
-                    "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
-                    "version>=0.3.0. Use `CallParams` inside of your `Prompt` instead.",
+                    "`Prompt` in favor of `OpenAICallParams.model` field inside of "
+                    "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
+                    "`Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -118,7 +119,7 @@ class OpenAIChat:
             if tools is not None:
                 warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
-                    "Use `CallParams` inside of your `Prompt` instead.",
+                    "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -169,8 +170,9 @@ class OpenAIChat:
             if self.model_is_set:
                 warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
-                    "`Prompt` in favor of `CallParams.model` field inside of `prompt`; "
-                    "version>=0.3.0. Use `CallParams` inside of your `Prompt` instead.",
+                    "`Prompt` in favor of `OpenAICallParams.model` field inside of "
+                    "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
+                    "`Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -179,7 +181,7 @@ class OpenAIChat:
             if tools is not None:
                 warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
-                    "Use `CallParams` inside of your `Prompt` instead.",
+                    "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
@@ -218,8 +220,8 @@ class OpenAIChat:
         Args:
             schema: The `BaseModel` schema to extract from the completion.
             prompt: The prompt from which the schema will be extracted. If `prompt` is
-                a `Prompt` instance, then the call will use the `CallParams` in the
-                prompt.
+                a `Prompt` instance, then the call will use the `OpenAICallParams` in
+                the prompt.
             retries: The maximum number of times to retry the query on validation error.
             **kwargs: Additional keyword arguments to pass to the API call. You can
                 find available keyword arguments here:

--- a/mirascope/chat/tools.py
+++ b/mirascope/chat/tools.py
@@ -19,16 +19,8 @@ class OpenAITool(BaseModel):
     Example:
 
     ```python
-    from mirascope import Prompt, OpenAIChat, OpenAIToolStreamParser
+    from mirascope import CallParams, Prompt, OpenAIChat, OpenAIToolStreamParser
 
-    class AnimalPrompt(Prompt):
-        """
-        Tell me my favorite animal if my favorite food is {food} and my
-        favorite color is {color}.
-        """
-
-        food: str
-        color: str
 
     def animal_matcher(fav_food: str, fav_color: str) -> str:
         """Tells you your most likely favorite animal from personality traits.
@@ -40,23 +32,35 @@ class OpenAITool(BaseModel):
         Returns:
             The animal most likely to be your favorite based on traits.
         """
-    return "Your favorite animal is the best one, a frog."
+        return "Your favorite animal is the best one, a frog."
+
+
+    class AnimalPrompt(Prompt):
+        """
+        Tell me my favorite animal if my favorite food is {food} and my
+        favorite color is {color}.
+        """
+
+        food: str
+        color: str
+
+        _call_params: CallParams = CallParams(tools=[animal_matcher])
 
 
     prompt = AnimalPrompt(food="pizza", color="red")
     chat = OpenAIChat()
 
-    response = chat.create(prompt, tools=[animal_matcher])
+    response = chat.create(prompt)
     tool = response.tool
 
-    print(tool.fn(**tool.model_dump(exclude=["tool_call"])))
+    print(tool.fn(**tool.model_dump(exclude={"tool_call"})))
     #> Your favorite animal is the best one, a frog.
 
-    stream = chat.stream(prompt, tools=[animal_matcher])
-    parser = OpenAIToolStreamParser(tools=[animal_matcher])
+    stream = chat.stream(prompt)
+    parser = OpenAIToolStreamParser(tools=prompt.call_params().tools)
 
     for tool in parser.from_stream(stream):
-        print(tool.fn(**tool.model_dump(exclude=["tool_call"])))
+        print(tool.fn(**tool.model_dump(exclude={"tool_call"})))
     #> Your favorite animal is the best one, a frog.
     ```
     '''

--- a/mirascope/chat/tools.py
+++ b/mirascope/chat/tools.py
@@ -19,7 +19,7 @@ class OpenAITool(BaseModel):
     Example:
 
     ```python
-    from mirascope import CallParams, Prompt, OpenAIChat, OpenAIToolStreamParser
+    from mirascope import OpenAICallParams, Prompt, OpenAIChat, OpenAIToolStreamParser
 
 
     def animal_matcher(fav_food: str, fav_color: str) -> str:
@@ -44,7 +44,7 @@ class OpenAITool(BaseModel):
         food: str
         color: str
 
-        _call_params: CallParams = CallParams(tools=[animal_matcher])
+        _call_params: OpenAICallParams = OpenAICallParams(tools=[animal_matcher])
 
 
     prompt = AnimalPrompt(food="pizza", color="red")

--- a/mirascope/chat/utils.py
+++ b/mirascope/chat/utils.py
@@ -62,9 +62,9 @@ def patch_openai_kwargs(
         kwargs.update(
             {
                 key: value
-                for key, value in prompt._call_params.model_dump(
-                    exclude={"tools", "model"}
-                ).items()
+                for key, value in prompt.call_params()
+                .model_dump(exclude={"tools", "model"})
+                .items()
                 if value is not None
             }
         )

--- a/mirascope/chat/utils.py
+++ b/mirascope/chat/utils.py
@@ -59,6 +59,15 @@ def patch_openai_kwargs(
         ]
     else:
         kwargs["messages"] = prompt.messages
+        kwargs.update(
+            {
+                key: value
+                for key, value in prompt._call_params.model_dump(
+                    exclude={"tools", "model"}
+                ).items()
+                if value is not None
+            }
+        )
 
     if tools:
         kwargs["tools"] = [tool.tool_schema() for tool in tools]

--- a/mirascope/prompts.py
+++ b/mirascope/prompts.py
@@ -110,6 +110,27 @@ class Prompt(BaseModel):
     _tags: list[str] = []
 
     @classmethod
+    def call_params(cls) -> CallParams:
+        """Returns the default value set for `call_params`."""
+        return cls._call_params.default  # type: ignore
+
+    @classmethod
+    def tags(cls) -> list[str]:
+        """Returns the default value set for `_tags`."""
+        if isinstance(cls._tags, list):
+            return cls._tags
+        else:
+            return cls._tags.default
+
+    # prompt_config: PromptConfig = PromptConfig(tags=[], call_params=CallParams())
+    # model_config = ...
+
+    # @classmethod
+    # def call_params(cls) -> CallParams:
+    #     """Returns the default call parameters."""
+    #     return CallParams(model="gpt-3.5-turbo-16k")
+
+    @classmethod
     def template(cls) -> str:
         """Custom parsing functionality for docstring prompt.
 
@@ -146,6 +167,11 @@ class Prompt(BaseModel):
             "template": self.template(),
             "inputs": self.model_dump(),
             "tags": self._tags,
+            "call_params": {
+                key: value
+                for key, value in self.call_params().model_dump().items()
+                if value is not None
+            },
         }
         if completion is not None:
             return prompt_dict | completion

--- a/mirascope/prompts.py
+++ b/mirascope/prompts.py
@@ -32,7 +32,7 @@ def _format_template(prompt: Prompt, template: str) -> str:
     return template.format(**{var: getattr(prompt, var) for var in template_vars})
 
 
-class CallParams(BaseModel):
+class OpenAICallParams(BaseModel):
     """The parameters to use when calling the OpenAI Chat API with a prompt."""
 
     model: str
@@ -106,11 +106,11 @@ class Prompt(BaseModel):
     ```
     '''
 
-    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-16k")
+    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-16k")
     _tags: list[str] = []
 
     @classmethod
-    def call_params(cls) -> CallParams:
+    def call_params(cls) -> OpenAICallParams:
         """Returns the default value set for `call_params`."""
         return cls._call_params.default  # type: ignore
 
@@ -121,14 +121,6 @@ class Prompt(BaseModel):
             return cls._tags
         else:
             return cls._tags.default
-
-    # prompt_config: PromptConfig = PromptConfig(tags=[], call_params=CallParams())
-    # model_config = ...
-
-    # @classmethod
-    # def call_params(cls) -> CallParams:
-    #     """Returns the default call parameters."""
-    #     return CallParams(model="gpt-3.5-turbo-16k")
 
     @classmethod
     def template(cls) -> str:

--- a/tests/chat/models/test_openai_chat.py
+++ b/tests/chat/models/test_openai_chat.py
@@ -1,4 +1,5 @@
 """Tests for mirascope openai chat API model classes."""
+from typing import Type
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -48,6 +49,18 @@ def test_openai_chat(
         stream=False,
         temperature=0.3,
     )
+
+
+def test_openai_chat_with_wrapper():
+    """Tests that `OpenAIChat` can be created with a wrapper."""
+
+    def wrapper(cls: Type[OpenAIChat]) -> Type[OpenAIChat]:
+        setattr(cls, "test_attr", "test_value")
+        return cls
+
+    chat = OpenAIChat(api_key="test", client_wrapper=wrapper)
+    assert hasattr(chat.client, "test_attr")
+    assert chat.client.test_attr == "test_value"
 
 
 @patch(

--- a/tests/chat/models/test_openai_chat.py
+++ b/tests/chat/models/test_openai_chat.py
@@ -33,7 +33,7 @@ def test_openai_chat(
     mock_create.return_value = fixture_chat_completion
 
     model = "gpt-3.5-turbo-16k"
-    chat = OpenAIChat(model, api_key="test")
+    chat = OpenAIChat(model=model, api_key="test")
     assert chat.model == model
 
     completion = chat.create(prompt, temperature=0.3)
@@ -59,7 +59,7 @@ def test_openai_chat_messages_kwarg(mock_create, fixture_chat_completion):
     mock_create.return_value = fixture_chat_completion
 
     model = "gpt-3.5-turbo-16k"
-    chat = OpenAIChat(model, api_key="test")
+    chat = OpenAIChat(model=model, api_key="test")
     assert chat.model == model
 
     messages = [{"role": "user", "content": "content"}]
@@ -141,7 +141,7 @@ def test_openai_chat_stream(
     mock_create.return_value = fixture_chat_completion_chunks
 
     model = "gpt-3.5-turbo-16k"
-    chat = OpenAIChat(model, api_key="test")
+    chat = OpenAIChat(model=model, api_key="test")
     stream = chat.stream(prompt, temperature=0.3)
 
     for i, chunk in enumerate(stream):
@@ -167,7 +167,7 @@ def test_openai_chat_stream_messages_kwarg(mock_create, fixture_chat_completion_
     mock_create.return_value = [fixture_chat_completion_chunk] * 3
 
     model = "gpt-3.5-turbo-16k"
-    chat = OpenAIChat(model, api_key="test")
+    chat = OpenAIChat(model=model, api_key="test")
     messages = [{"role": "user", "content": "content"}]
     stream = chat.stream(messages=messages)
 
@@ -289,7 +289,7 @@ def test_openai_chat_extract_messages_prompt(
     mock_create.return_value = OpenAIChatCompletion(
         completion=fixture_chat_completion_with_tools, tool_types=tools
     )
-    chat = OpenAIChat("gpt-3.5-turbo", api_key="test")
+    chat = OpenAIChat(model="gpt-3.5-turbo", api_key="test")
     messages = [{"role": "user", "content": "content"}]
     model = chat.extract(MySchema, messages=messages)
 

--- a/tests/chat/models/test_openai_chat_async.py
+++ b/tests/chat/models/test_openai_chat_async.py
@@ -1,4 +1,5 @@
 """Tests for mirascope async openai chat API model classes."""
+from typing import Type
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -40,6 +41,18 @@ async def test_async_openai_chat(
         stream=False,
         temperature=0.3,
     )
+
+
+def test_async_openai_chat_with_wrapper():
+    """Tests that `OpenAIChat` can be created with a wrapper."""
+
+    def wrapper(cls: Type[AsyncOpenAIChat]) -> Type[AsyncOpenAIChat]:
+        setattr(cls, "test_attr", "test_value")
+        return cls
+
+    chat = AsyncOpenAIChat(api_key="test", client_wrapper=wrapper)
+    assert hasattr(chat.client, "test_attr")
+    assert chat.client.test_attr == "test_value"
 
 
 @patch(

--- a/tests/chat/models/test_openai_chat_async.py
+++ b/tests/chat/models/test_openai_chat_async.py
@@ -51,7 +51,7 @@ async def test_async_openai_chat_messages_kwarg(mock_create, fixture_chat_comple
     mock_create.return_value = fixture_chat_completion
 
     model = "gpt-3.5-turbo-16k"
-    chat = AsyncOpenAIChat(model, api_key="test")
+    chat = AsyncOpenAIChat(model=model, api_key="test")
     assert chat.model == model
 
     messages = [{"role": "user", "content": "content"}]
@@ -154,7 +154,7 @@ async def test_async_openai_chat_stream_messages_kwarg(
     mock_create.return_value.__aiter__.return_value = fixture_chat_completion_chunks
 
     model = "gpt-3.5-turbo-16k"
-    chat = AsyncOpenAIChat(model, api_key="test")
+    chat = AsyncOpenAIChat(model=model, api_key="test")
     messages = [{"role": "user", "content": "content"}]
     stream = chat.stream(messages=messages)
 
@@ -284,7 +284,7 @@ async def test_async_openai_chat_extract_messages_prompt(
     mock_create.return_value = OpenAIChatCompletion(
         completion=fixture_chat_completion_with_tools, tool_types=tools
     )
-    chat = AsyncOpenAIChat("gpt-3.5-turbo-16k", api_key="test")
+    chat = AsyncOpenAIChat(model="gpt-3.5-turbo-16k", api_key="test")
     messages = [{"role": "user", "content": "content"}]
     model = await chat.extract(MySchema, messages=messages)
 

--- a/tests/chat/models/test_openai_chat_async.py
+++ b/tests/chat/models/test_openai_chat_async.py
@@ -35,7 +35,7 @@ async def test_async_openai_chat(
     assert completion._start_time is not None
     assert completion._end_time is not None
     mock_create.assert_called_once_with(
-        model=prompt._call_params.model,
+        model=prompt.call_params().model,
         messages=prompt.messages,
         stream=False,
         temperature=0.3,
@@ -72,8 +72,11 @@ async def test_async_openai_chat_messages_kwarg(mock_create, fixture_chat_comple
 @pytest.mark.parametrize(
     "prompt,tools",
     [
-        ("fixture_foobar_prompt", ["fixture_my_tool"]),
-        ("fixture_foobar_prompt", ["fixture_my_tool", "fixture_empty_tool"]),
+        ("fixture_foobar_prompt_with_my_tool", ["fixture_my_tool"]),
+        (
+            "fixture_foobar_prompt_with_my_tool_and_empty_tool",
+            ["fixture_my_tool", "fixture_empty_tool"],
+        ),
     ],
 )
 async def test_async_openai_chat_tools(
@@ -82,7 +85,6 @@ async def test_async_openai_chat_tools(
     """Tests that `AsyncOpenAIChat` returns the expected response when called with tools."""
     prompt = request.getfixturevalue(prompt)
     tools = [request.getfixturevalue(tool) for tool in tools]
-    prompt._call_params.tools = tools
     mock_create.return_value = fixture_chat_completion_with_tools
 
     chat = AsyncOpenAIChat(api_key="test")
@@ -90,7 +92,7 @@ async def test_async_openai_chat_tools(
     assert isinstance(completion, OpenAIChatCompletion)
 
     mock_create.assert_called_once_with(
-        model=prompt._call_params.model,
+        model=prompt.call_params().model,
         messages=prompt.messages,
         stream=False,
         tools=[tool.tool_schema() for tool in tools],
@@ -136,7 +138,7 @@ async def test_async_openai_chat_stream(
         i += 1
 
     mock_create.assert_called_once_with(
-        model=prompt._call_params.model,
+        model=prompt.call_params().model,
         messages=prompt.messages,
         stream=True,
         temperature=0.3,
@@ -175,8 +177,11 @@ async def test_async_openai_chat_stream_messages_kwarg(
 @pytest.mark.parametrize(
     "prompt,tools",
     [
-        ("fixture_foobar_prompt", ["fixture_my_tool"]),
-        ("fixture_foobar_prompt", ["fixture_my_tool", "fixture_empty_tool"]),
+        ("fixture_foobar_prompt_with_my_tool", ["fixture_my_tool"]),
+        (
+            "fixture_foobar_prompt_with_my_tool_and_empty_tool",
+            ["fixture_my_tool", "fixture_empty_tool"],
+        ),
     ],
 )
 async def test_async_openai_chat_stream_tools(
@@ -185,7 +190,6 @@ async def test_async_openai_chat_stream_tools(
     """Tests `AsyncOpenAIChat` returns the expected response when called with tools."""
     prompt = request.getfixturevalue(prompt)
     tools = [request.getfixturevalue(tool) for tool in tools]
-    prompt._call_params.tools = tools
     chunks = [fixture_chat_completion_chunk_with_tools] * 3
 
     mock_create.return_value.__aiter__.return_value = chunks
@@ -197,7 +201,7 @@ async def test_async_openai_chat_stream_tools(
         assert chunk.tool_calls == chunks[0].choices[0].delta.tool_calls
 
     mock_create.assert_called_once_with(
-        model=prompt._call_params.model,
+        model=prompt.call_params().model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],

--- a/tests/chat/parsers/test_openai_parser.py
+++ b/tests/chat/parsers/test_openai_parser.py
@@ -13,8 +13,11 @@ from mirascope import OpenAIChat, OpenAITool, OpenAIToolStreamParser
 @pytest.mark.parametrize(
     "prompt,fixture_tools",
     [
-        ("fixture_foobar_prompt", ["fixture_my_tool"]),
-        ("fixture_foobar_prompt", ["fixture_my_tool", "fixture_empty_tool"]),
+        ("fixture_foobar_prompt_with_my_tool", ["fixture_my_tool"]),
+        (
+            "fixture_foobar_prompt_with_my_tool_and_empty_tool",
+            ["fixture_my_tool", "fixture_empty_tool"],
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -39,7 +42,7 @@ def test_from_stream(
         assert isinstance(tool, OpenAITool)
 
     mock_create.assert_called_once_with(
-        model=prompt._call_params.model,
+        model=prompt.call_params().model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],
@@ -52,31 +55,26 @@ def test_from_stream(
     new_callable=MagicMock,
 )
 @pytest.mark.parametrize(
-    "prompt",
-    [
-        ("fixture_foobar_prompt"),
-    ],
-)
-@pytest.mark.parametrize(
     "fixture_chat_completion_chunks_with_tools", ["MyTool"], indirect=True
 )
 def test_from_stream_no_tool(
     mock_create: MagicMock,
     fixture_chat_completion_chunks_with_tools,
-    prompt,
+    fixture_foobar_prompt,
     request: pytest.FixtureRequest,
 ):
     """Tests `OpenAIToolStreamParser.from_stream` with no tools."""
-    prompt = request.getfixturevalue(prompt)
 
     mock_create.return_value = fixture_chat_completion_chunks_with_tools
     chat = OpenAIChat(api_key="test")
-    stream = chat.stream(prompt)
+    stream = chat.stream(fixture_foobar_prompt)
     parser = OpenAIToolStreamParser(tools=[])
     assert sum(1 for _ in parser.from_stream(stream)) == 0
 
+    print(fixture_foobar_prompt.call_params())
+
     mock_create.assert_called_once_with(
-        model=prompt._call_params.model,
-        messages=prompt.messages,
+        model=fixture_foobar_prompt.call_params().model,
+        messages=fixture_foobar_prompt.messages,
         stream=True,
     )

--- a/tests/chat/parsers/test_openai_parser.py
+++ b/tests/chat/parsers/test_openai_parser.py
@@ -39,7 +39,7 @@ def test_from_stream(
         assert isinstance(tool, OpenAITool)
 
     mock_create.assert_called_once_with(
-        model="gpt-3.5-turbo",
+        model=prompt._call_params.model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],
@@ -76,7 +76,7 @@ def test_from_stream_no_tool(
     assert sum(1 for _ in parser.from_stream(stream)) == 0
 
     mock_create.assert_called_once_with(
-        model="gpt-3.5-turbo",
+        model=prompt._call_params.model,
         messages=prompt.messages,
         stream=True,
     )

--- a/tests/chat/parsers/test_openai_parser_async.py
+++ b/tests/chat/parsers/test_openai_parser_async.py
@@ -15,8 +15,11 @@ pytestmark = pytest.mark.asyncio
 @pytest.mark.parametrize(
     "prompt,fixture_tools",
     [
-        ("fixture_foobar_prompt", ["fixture_my_tool"]),
-        ("fixture_foobar_prompt", ["fixture_my_tool", "fixture_empty_tool"]),
+        ("fixture_foobar_prompt_with_my_tool", ["fixture_my_tool"]),
+        (
+            "fixture_foobar_prompt_with_my_tool_and_empty_tool",
+            ["fixture_my_tool", "fixture_empty_tool"],
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -31,8 +34,8 @@ async def test_from_stream(
 ):
     """Tests that `OpenAIToolStreamParser.from_stream` returns the expected tools."""
     prompt = request.getfixturevalue(prompt)
-
     tools = [request.getfixturevalue(fixture_tool) for fixture_tool in fixture_tools]
+
     mock_create.return_value.__aiter__.return_value = (
         fixture_chat_completion_chunks_with_tools
     )
@@ -43,7 +46,7 @@ async def test_from_stream(
         assert isinstance(tool, OpenAITool)
 
     mock_create.assert_called_once_with(
-        model=prompt._call_params.model,
+        model=prompt.call_params().model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],

--- a/tests/chat/parsers/test_openai_parser_async.py
+++ b/tests/chat/parsers/test_openai_parser_async.py
@@ -43,7 +43,7 @@ async def test_from_stream(
         assert isinstance(tool, OpenAITool)
 
     mock_create.assert_called_once_with(
-        model="gpt-3.5-turbo",
+        model=prompt._call_params.model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],

--- a/tests/cli/commands/test_add.py
+++ b/tests/cli/commands/test_add.py
@@ -131,8 +131,7 @@ def test_add_unknown_file(mock_get_mirascope_settings_add: MagicMock):
         versions_location=".mirascope/versions",
     )
     with pytest.raises(FileNotFoundError):
-        result = runner.invoke(app, ["add", "unknown_prompt"], catch_exceptions=False)
-        assert result.exit_code == 1
+        runner.invoke(app, ["add", "unknown_prompt"], catch_exceptions=False)
 
 
 @patch("mirascope.cli.commands.add.check_status")

--- a/tests/cli/commands/test_remove.py
+++ b/tests/cli/commands/test_remove.py
@@ -129,5 +129,4 @@ def test_remove_file_not_found(
     mock_prompt_versions.return_value = fixture_prompt_versions
 
     with pytest.raises(FileNotFoundError):
-        result = runner.invoke(app, ["remove", "test", "0001"], catch_exceptions=False)
-        assert result.exit_code == 1
+        runner.invoke(app, ["remove", "test", "0001"], catch_exceptions=False)

--- a/tests/cli/commands/test_use.py
+++ b/tests/cli/commands/test_use.py
@@ -121,5 +121,4 @@ def test_use_no_version_file(
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         _initialize_tmp_mirascope(Path(td), prompt, [f"0001_{prompt}"])
         with pytest.raises(FileNotFoundError):
-            result = runner.invoke(app, ["use", prompt, "0002"], catch_exceptions=False)
-            assert result.exit_code == 1
+            runner.invoke(app, ["use", prompt, "0002"], catch_exceptions=False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ from pydantic import Field
 
 from mirascope.chat.tools import OpenAITool
 from mirascope.cli.schemas import MirascopeSettings, VersionTextFile
+from mirascope.prompts import CallParams
 
 from .test_prompts import FooBarPrompt, MessagesPrompt, TagPrompt, TagsPrompt
 
@@ -362,6 +363,44 @@ class MyTool(OpenAITool):
     optional: int = 0
 
 
+class EmptyTool(OpenAITool):
+    """A test tool with no parameters."""
+
+
+@pytest.fixture()
+def fixture_empty_tool() -> Type[OpenAITool]:
+    """Returns an `EmptyTool` class."""
+    return EmptyTool
+
+
+class FooBarPromptWithMyTool(FooBarPrompt):
+    __doc__ = FooBarPrompt.__doc__
+
+    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106", tools=[MyTool])
+
+
+@pytest.fixture()
+def fixture_foobar_prompt_with_my_tool() -> FooBarPromptWithMyTool:
+    """Returns a `FooBarPromptWithTools` instance."""
+    return FooBarPromptWithMyTool(foo="foo", bar="bar")
+
+
+class FooBarPromptWithMyToolAndEmptyTool(FooBarPrompt):
+    __doc__ = FooBarPrompt.__doc__
+
+    _call_params: CallParams = CallParams(
+        model="gpt-3.5-turbo-1106", tools=[MyTool, EmptyTool]
+    )
+
+
+@pytest.fixture()
+def fixture_foobar_prompt_with_my_tool_and_empty_tool() -> (
+    FooBarPromptWithMyToolAndEmptyTool
+):
+    """Returns a `FooBarPromptWithTools` instance."""
+    return FooBarPromptWithMyToolAndEmptyTool(foo="foo", bar="bar")
+
+
 @pytest.fixture()
 def fixture_my_tool() -> Type[MyTool]:
     """Returns a `MyTool` class."""
@@ -383,16 +422,6 @@ def fixture_my_tool_instance(fixture_my_tool) -> MyTool:
             type="function",
         ),
     )
-
-
-@pytest.fixture()
-def fixture_empty_tool() -> Type[OpenAITool]:
-    """Returns an `EmptyTool` class."""
-
-    class EmptyTool(OpenAITool):
-        """A test tool with no parameters."""
-
-    return EmptyTool
 
 
 @pytest.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ from pydantic import Field
 
 from mirascope.chat.tools import OpenAITool
 from mirascope.cli.schemas import MirascopeSettings, VersionTextFile
-from mirascope.prompts import CallParams
+from mirascope.prompts import OpenAICallParams
 
 from .test_prompts import FooBarPrompt, MessagesPrompt, TagPrompt, TagsPrompt
 
@@ -376,7 +376,9 @@ def fixture_empty_tool() -> Type[OpenAITool]:
 class FooBarPromptWithMyTool(FooBarPrompt):
     __doc__ = FooBarPrompt.__doc__
 
-    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106", tools=[MyTool])
+    _call_params: OpenAICallParams = OpenAICallParams(
+        model="gpt-3.5-turbo-1106", tools=[MyTool]
+    )
 
 
 @pytest.fixture()
@@ -388,7 +390,7 @@ def fixture_foobar_prompt_with_my_tool() -> FooBarPromptWithMyTool:
 class FooBarPromptWithMyToolAndEmptyTool(FooBarPrompt):
     __doc__ = FooBarPrompt.__doc__
 
-    _call_params: CallParams = CallParams(
+    _call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[MyTool, EmptyTool]
     )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from mirascope.prompts import CallParams, Prompt, messages, tags
+from mirascope.prompts import OpenAICallParams, Prompt, messages, tags
 
 
 class FooBarPrompt(Prompt):
@@ -17,7 +17,7 @@ class FooBarPrompt(Prompt):
 
     foo: str
     bar: str
-    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")
+    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
 
     @property
     def foobar(self) -> str:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -108,6 +108,7 @@ def test_messages(prompt, expected_messages, request):
 @pytest.mark.parametrize(
     "prompt, expected_tags",
     [
+        ("fixture_foobar_prompt", []),
         ("fixture_tag_prompt", ["test_tag"]),
         ("fixture_tags_prompt", ["multiple", "tags"]),
     ],
@@ -116,7 +117,7 @@ def test_tags(prompt, expected_tags, request):
     """Tests that the tags decorator adds a `tags` attribute."""
     prompt = request.getfixturevalue(prompt)
     assert hasattr(prompt, "_tags")
-    assert prompt._tags == expected_tags
+    assert prompt.tags() == expected_tags
 
 
 @pytest.mark.parametrize(

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from mirascope.prompts import Prompt, messages, tags
+from mirascope.prompts import CallParams, Prompt, messages, tags
 
 
 class FooBarPrompt(Prompt):
@@ -17,6 +17,7 @@ class FooBarPrompt(Prompt):
 
     foo: str
     bar: str
+    _call_params: CallParams = CallParams(model="gpt-3.5-turbo-1106")
 
     @property
     def foobar(self) -> str:


### PR DESCRIPTION
- This inclusion enables co-locating all aspects of the call to the LLM that may impact the quality of the `Prompt`.