### PR TITLE
fix: include completion in returned BaseModel from call to extract

### DIFF
--- a/mirascope/chat/models/openai_chat.py
+++ b/mirascope/chat/models/openai_chat.py
@@ -5,7 +5,7 @@ from typing import Callable, Generator, Optional, Type, TypeVar, Union
 from warnings import filterwarnings, warn
 
 from openai import OpenAI
-from pydantic import BaseModel, ValidationError, create_model
+from pydantic import BaseModel, ValidationError
 
 from ...prompts import Prompt
 from ..tools import OpenAITool

--- a/mirascope/chat/utils.py
+++ b/mirascope/chat/utils.py
@@ -1,16 +1,6 @@
 """Utility functions for mirascope chat."""
 from inspect import Parameter, isclass, signature
-from typing import (
-    Any,
-    Callable,
-    Generic,
-    Optional,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-    get_type_hints,
-)
+from typing import Any, Callable, Optional, Type, Union, cast, get_type_hints
 
 from docstring_parser import parse
 from openai.types.chat import ChatCompletionUserMessageParam
@@ -19,7 +9,6 @@ from pydantic.fields import FieldInfo
 
 from ..prompts import Prompt
 from .tools import OpenAITool, openai_tool_fn
-from .types import OpenAIChatCompletion
 
 
 def convert_tools_list_to_openai_tools(

--- a/mirascope/chat/utils.py
+++ b/mirascope/chat/utils.py
@@ -1,6 +1,16 @@
 """Utility functions for mirascope chat."""
 from inspect import Parameter, isclass, signature
-from typing import Any, Callable, Optional, Type, Union, cast, get_type_hints
+from typing import (
+    Any,
+    Callable,
+    Generic,
+    Optional,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    get_type_hints,
+)
 
 from docstring_parser import parse
 from openai.types.chat import ChatCompletionUserMessageParam
@@ -9,6 +19,7 @@ from pydantic.fields import FieldInfo
 
 from ..prompts import Prompt
 from .tools import OpenAITool, openai_tool_fn
+from .types import OpenAIChatCompletion
 
 
 def convert_tools_list_to_openai_tools(

--- a/tests/chat/models/test_openai_chat.py
+++ b/tests/chat/models/test_openai_chat.py
@@ -314,6 +314,7 @@ def test_openai_chat_extract_messages_prompt(
 
     mock_create.assert_called_once()
     assert isinstance(model, MySchema)
+    assert model._completion == mock_create.return_value
 
 
 @patch("mirascope.chat.models.OpenAIChat.create", new_callable=MagicMock)

--- a/tests/chat/models/test_openai_chat_async.py
+++ b/tests/chat/models/test_openai_chat_async.py
@@ -308,6 +308,7 @@ async def test_async_openai_chat_extract_messages_prompt(
 
     mock_create.assert_called_once()
     assert isinstance(model, MySchema)
+    assert model._completion == mock_create.return_value
 
 
 @patch(


### PR DESCRIPTION
- sometimes you'll want access to the completion used to extract a base model, which you can now access through the `._completion` private attribute of the returned BaseModel. It will be of type `OpenAIChatCompletion`