### PR TITLE
Enable setting `call_params` like you would for `model_config` without it appearing in the construction of the prompt.

### DIFF
--- a/cookbook/squad_extraction/.mirascope/versions/question/0001_question.py
+++ b/cookbook/squad_extraction/.mirascope/versions/question/0001_question.py
@@ -35,4 +35,4 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
+    call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")

--- a/cookbook/squad_extraction/.mirascope/versions/question/0002_question.py
+++ b/cookbook/squad_extraction/.mirascope/versions/question/0002_question.py
@@ -47,4 +47,4 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
+    call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")

--- a/cookbook/squad_extraction/squad_prompts/question.py
+++ b/cookbook/squad_extraction/squad_prompts/question.py
@@ -48,4 +48,4 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
+    call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")

--- a/docs/concepts/llm_convenience_wrappers.md
+++ b/docs/concepts/llm_convenience_wrappers.md
@@ -315,7 +315,7 @@ prompt = CurrentWeatherPrompt()
 chat = OpenAIChat()
 completion = chat.stream(prompt)
 
-parser = OpenAIToolStreamParser(tools=prompt.call_params().tools)  # pass in the same tools
+parser = OpenAIToolStreamParser(tools=prompt.call_params.tools)  # pass in the same tools
 for tool in parser.from_stream(completion):
     print(tool)
 ```

--- a/docs/concepts/llm_convenience_wrappers.md
+++ b/docs/concepts/llm_convenience_wrappers.md
@@ -191,7 +191,7 @@ def get_current_weather(
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106",
         tools=[get_current_weather]  # pass in the function itself
     )
@@ -233,7 +233,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 
@@ -267,7 +267,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 
@@ -306,7 +306,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in Los Angeles?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 

--- a/docs/cookbook/squad_extraction.md
+++ b/docs/cookbook/squad_extraction.md
@@ -50,7 +50,7 @@ class QuestionPrompt(Prompt):
     paragraph: str
     question: str
 
-    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
+    call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
 ```
 
 Next we'll define the schema we want to extract from the paragraph and a function to extract the schema from a given question:

--- a/examples/function_as_tool.py
+++ b/examples/function_as_tool.py
@@ -25,7 +25,7 @@ def get_current_weather(
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[get_current_weather]
     )
 

--- a/examples/openai_tool.py
+++ b/examples/openai_tool.py
@@ -27,7 +27,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[GetCurrentWeather]
     )
 

--- a/examples/stream_openai_tool.py
+++ b/examples/stream_openai_tool.py
@@ -35,7 +35,7 @@ tools: list[Union[Callable, Type[OpenAITool]]] = [GetCurrentWeather]
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106",
         tools=tools,  # pass in function itself for automatic conversion
     )

--- a/examples/stream_openai_tool_async.py
+++ b/examples/stream_openai_tool_async.py
@@ -35,7 +35,7 @@ class GetCurrentWeather(OpenAITool):
 class CurrentWeatherPrompt(Prompt):
     """What's the weather like in San Francisco, Tokyo, and Paris?"""
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106",
         tools=[GetCurrentWeather],  # pass in function itself for automatic conversion
     )

--- a/examples/stream_openai_tool_async.py
+++ b/examples/stream_openai_tool_async.py
@@ -48,7 +48,7 @@ async def stream_openai_tool():
     chat = AsyncOpenAIChat()
     prompt = CurrentWeatherPrompt()
     stream_completion = chat.stream(prompt)
-    parser = AsyncOpenAIToolStreamParser(tools=prompt.call_params().tools)
+    parser = AsyncOpenAIToolStreamParser(tools=prompt.call_params.tools)
     async for partial_tool in parser.from_stream(stream_completion):
         print("data: ", partial_tool.__dict__, "\n\n")
 

--- a/mirascope/chat/models/async_openai_chat.py
+++ b/mirascope/chat/models/async_openai_chat.py
@@ -1,8 +1,8 @@
 """Class for interacting with AsyncOpenAI through Chat APIs."""
 import datetime
 import logging
+import warnings
 from typing import AsyncGenerator, Callable, Optional, Type, TypeVar, Union
-from warnings import filterwarnings, warn
 
 from openai import AsyncOpenAI
 from pydantic import BaseModel, ValidationError
@@ -16,7 +16,7 @@ from ..utils import (
     patch_openai_kwargs,
 )
 
-filterwarnings("always", category=DeprecationWarning, module="mirascope")
+warnings.filterwarnings("always", category=DeprecationWarning, module="mirascope")
 logger = logging.getLogger("mirascope")
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
 
@@ -111,7 +111,7 @@ class AsyncOpenAIChat:
         extract = kwargs.pop("extract") if "extract" in kwargs else False
         if isinstance(prompt, Prompt):
             if self.model_is_set:
-                warn(
+                warnings.warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `OpenAICallParams.model` field inside of "
                     "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
@@ -119,17 +119,17 @@ class AsyncOpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt.call_params().model
+            self.model = prompt.call_params.model
 
             if tools is not None and not extract:
-                warn(
+                warnings.warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
                     "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt.call_params().tools is not None:
-                tools = prompt.call_params().tools
+            if prompt.call_params.tools is not None:
+                tools = prompt.call_params.tools
 
         start_time = datetime.datetime.now().timestamp() * 1000
         openai_tools = convert_tools_list_to_openai_tools(tools)
@@ -174,7 +174,7 @@ class AsyncOpenAIChat:
         """
         if isinstance(prompt, Prompt):
             if self.model_is_set:
-                warn(
+                warnings.warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `OpenAICallParams.model` field inside of "
                     "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
@@ -182,17 +182,17 @@ class AsyncOpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt.call_params().model
+            self.model = prompt.call_params.model
 
             if tools is not None:
-                warn(
+                warnings.warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
                     "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt.call_params().tools is not None:
-                tools = prompt.call_params().tools
+            if prompt.call_params.tools is not None:
+                tools = prompt.call_params.tools
 
         openai_tools = convert_tools_list_to_openai_tools(tools)
         patch_openai_kwargs(kwargs, prompt, openai_tools)

--- a/mirascope/chat/models/openai_chat.py
+++ b/mirascope/chat/models/openai_chat.py
@@ -1,8 +1,8 @@
 """Class for interacting with OpenAI through Chat APIs."""
 import datetime
 import logging
+import warnings
 from typing import Callable, Generator, Optional, Type, TypeVar, Union
-from warnings import filterwarnings, warn
 
 from openai import OpenAI
 from pydantic import BaseModel, ValidationError
@@ -16,7 +16,7 @@ from ..utils import (
     patch_openai_kwargs,
 )
 
-filterwarnings("always", category=DeprecationWarning, module="mirascope")
+warnings.filterwarnings("always", category=DeprecationWarning, module="mirascope")
 logger = logging.getLogger("mirascope")
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
 
@@ -108,7 +108,7 @@ class OpenAIChat:
         extract = kwargs.pop("extract") if "extract" in kwargs else False
         if isinstance(prompt, Prompt):
             if self.model_is_set:
-                warn(
+                warnings.warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `OpenAICallParams.model` field inside of "
                     "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
@@ -116,17 +116,17 @@ class OpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt.call_params().model
+            self.model = prompt.call_params.model
 
             if tools is not None and not extract:
-                warn(
+                warnings.warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
                     "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt.call_params().tools is not None:
-                tools = prompt.call_params().tools
+            if prompt.call_params.tools is not None:
+                tools = prompt.call_params.tools
 
         start_time = datetime.datetime.now().timestamp() * 1000
         openai_tools = convert_tools_list_to_openai_tools(tools)
@@ -170,7 +170,7 @@ class OpenAIChat:
         """
         if isinstance(prompt, Prompt):
             if self.model_is_set:
-                warn(
+                warnings.warn(
                     "The `model` parameter will be ignored when `prompt` is of type "
                     "`Prompt` in favor of `OpenAICallParams.model` field inside of "
                     "`prompt`; version>=0.3.0. Use `OpenAICallParams` inside of your "
@@ -178,17 +178,17 @@ class OpenAIChat:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            self.model = prompt.call_params().model
+            self.model = prompt.call_params.model
 
             if tools is not None:
-                warn(
+                warnings.warn(
                     "The `tools` parameter is deprecated; version>=0.3.0. "
                     "Use `OpenAICallParams` inside of your `Prompt` instead.",
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            if prompt.call_params().tools is not None:
-                tools = prompt.call_params().tools
+            if prompt.call_params.tools is not None:
+                tools = prompt.call_params.tools
 
         openai_tools = convert_tools_list_to_openai_tools(tools)
         patch_openai_kwargs(kwargs, prompt, openai_tools)

--- a/mirascope/chat/tools.py
+++ b/mirascope/chat/tools.py
@@ -44,7 +44,7 @@ class OpenAITool(BaseModel):
         food: str
         color: str
 
-        _call_params: OpenAICallParams = OpenAICallParams(tools=[animal_matcher])
+        call_params: OpenAICallParams = OpenAICallParams(tools=[animal_matcher])
 
 
     prompt = AnimalPrompt(food="pizza", color="red")

--- a/mirascope/chat/tools.py
+++ b/mirascope/chat/tools.py
@@ -57,7 +57,7 @@ class OpenAITool(BaseModel):
     #> Your favorite animal is the best one, a frog.
 
     stream = chat.stream(prompt)
-    parser = OpenAIToolStreamParser(tools=prompt.call_params().tools)
+    parser = OpenAIToolStreamParser(tools=prompt.call_params.tools)
 
     for tool in parser.from_stream(stream):
         print(tool.fn(**tool.model_dump(exclude={"tool_call"})))

--- a/mirascope/chat/utils.py
+++ b/mirascope/chat/utils.py
@@ -62,9 +62,9 @@ def patch_openai_kwargs(
         kwargs.update(
             {
                 key: value
-                for key, value in prompt.call_params()
-                .model_dump(exclude={"tools", "model"})
-                .items()
+                for key, value in prompt.call_params.model_dump(
+                    exclude={"tools", "model"}
+                ).items()
                 if value is not None
             }
         )

--- a/tests/chat/models/test_openai_chat.py
+++ b/tests/chat/models/test_openai_chat.py
@@ -42,7 +42,7 @@ def test_openai_chat(
     assert completion._start_time is not None
     assert completion._end_time is not None
     mock_create.assert_called_once_with(
-        model=model if isinstance(prompt, str) else prompt.call_params().model,
+        model=model if isinstance(prompt, str) else prompt.call_params.model,
         messages=prompt.messages
         if isinstance(prompt, Prompt)
         else [{"role": "user", "content": prompt}],
@@ -106,7 +106,7 @@ def test_openai_chat_tools(
     """Tests that `OpenAIChat` returns the expected response when called with tools."""
     prompt = request.getfixturevalue(prompt)
     tools = [request.getfixturevalue(tool) for tool in tools]
-    prompt.call_params().tools = tools
+    prompt.call_params.tools = tools
     mock_create.return_value = fixture_chat_completion_with_tools
 
     chat = OpenAIChat(api_key="test")
@@ -114,7 +114,7 @@ def test_openai_chat_tools(
     assert isinstance(completion, OpenAIChatCompletion)
 
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=False,
         tools=[tool.tool_schema() for tool in tools],
@@ -165,7 +165,7 @@ def test_openai_chat_stream(
         assert chunk.chunk == fixture_chat_completion_chunks[i]
 
     mock_create.assert_called_once_with(
-        model=model if isinstance(prompt, str) else prompt.call_params().model,
+        model=model if isinstance(prompt, str) else prompt.call_params.model,
         messages=prompt.messages
         if isinstance(prompt, Prompt)
         else [{"role": "user", "content": prompt}],
@@ -227,7 +227,7 @@ def test_openai_chat_stream_tools(
         assert chunk.tool_calls == chunks[i].choices[0].delta.tool_calls
 
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],

--- a/tests/chat/models/test_openai_chat_async.py
+++ b/tests/chat/models/test_openai_chat_async.py
@@ -36,7 +36,7 @@ async def test_async_openai_chat(
     assert completion._start_time is not None
     assert completion._end_time is not None
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=False,
         temperature=0.3,
@@ -105,7 +105,7 @@ async def test_async_openai_chat_tools(
     assert isinstance(completion, OpenAIChatCompletion)
 
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=False,
         tools=[tool.tool_schema() for tool in tools],
@@ -151,7 +151,7 @@ async def test_async_openai_chat_stream(
         i += 1
 
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=True,
         temperature=0.3,
@@ -214,7 +214,7 @@ async def test_async_openai_chat_stream_tools(
         assert chunk.tool_calls == chunks[0].choices[0].delta.tool_calls
 
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],

--- a/tests/chat/parsers/test_openai_parser.py
+++ b/tests/chat/parsers/test_openai_parser.py
@@ -42,7 +42,7 @@ def test_from_stream(
         assert isinstance(tool, OpenAITool)
 
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],
@@ -71,10 +71,10 @@ def test_from_stream_no_tool(
     parser = OpenAIToolStreamParser(tools=[])
     assert sum(1 for _ in parser.from_stream(stream)) == 0
 
-    print(fixture_foobar_prompt.call_params())
+    print(fixture_foobar_prompt.call_params)
 
     mock_create.assert_called_once_with(
-        model=fixture_foobar_prompt.call_params().model,
+        model=fixture_foobar_prompt.call_params.model,
         messages=fixture_foobar_prompt.messages,
         stream=True,
     )

--- a/tests/chat/parsers/test_openai_parser_async.py
+++ b/tests/chat/parsers/test_openai_parser_async.py
@@ -46,7 +46,7 @@ async def test_from_stream(
         assert isinstance(tool, OpenAITool)
 
     mock_create.assert_called_once_with(
-        model=prompt.call_params().model,
+        model=prompt.call_params.model,
         messages=prompt.messages,
         stream=True,
         tools=[tool.tool_schema() for tool in tools],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -407,7 +407,7 @@ def fixture_empty_tool() -> Type[OpenAITool]:
 class FooBarPromptWithMyTool(FooBarPrompt):
     __doc__ = FooBarPrompt.__doc__
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[MyTool]
     )
 
@@ -421,7 +421,7 @@ def fixture_foobar_prompt_with_my_tool() -> FooBarPromptWithMyTool:
 class FooBarPromptWithMyToolAndEmptyTool(FooBarPrompt):
     __doc__ = FooBarPrompt.__doc__
 
-    _call_params: OpenAICallParams = OpenAICallParams(
+    call_params: OpenAICallParams = OpenAICallParams(
         model="gpt-3.5-turbo-1106", tools=[MyTool, EmptyTool]
     )
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -17,7 +17,7 @@ class FooBarPrompt(Prompt):
 
     foo: str
     bar: str
-    _call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
+    call_params: OpenAICallParams = OpenAICallParams(model="gpt-3.5-turbo-1106")
 
     @property
     def foobar(self) -> str:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -117,7 +117,7 @@ def test_tags(prompt, expected_tags, request):
     """Tests that the tags decorator adds a `tags` attribute."""
     prompt = request.getfixturevalue(prompt)
     assert hasattr(prompt, "_tags")
-    assert prompt.tags() == expected_tags
+    assert prompt._tags == expected_tags
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Now `call_params` can be set and it won't show up as part of the construction of the prompt.
- Also imported `warnings` instead of `from warnings` as that seems to be common practice.