### PR TITLE
Fix bug with manually setting call params

### DIFF
--- a/mirascope/openai/prompt.py
+++ b/mirascope/openai/prompt.py
@@ -86,8 +86,11 @@ class OpenAIPrompt(BasePrompt):
         messages = super().messages
         return [cast(ChatCompletionMessageParam, message) for message in messages]
 
-    def create(self) -> OpenAIChatCompletion:
+    def create(self, **kwargs: Any) -> OpenAIChatCompletion:
         """Makes a call to the model using this `OpenAIPrompt` instance.
+
+        Args:
+            **kwargs: Additional keyword arguments to pass to the `create` call.
 
         Returns:
             A `OpenAIChatCompletion` instance.
@@ -100,8 +103,10 @@ class OpenAIPrompt(BasePrompt):
         client = OpenAI(base_url=self.call_params.base_url)
         if self.call_params.wrapper is not None:
             client = self.call_params.wrapper(client)
-        kwargs: dict[str, Any] = {}
-        tools = convert_tools_list_to_openai_tools(self.call_params.tools)
+        # kwargs: dict[str, Any] = {}
+        tools = convert_tools_list_to_openai_tools(
+            kwargs.pop("tools") if "tools" in kwargs else None
+        )
         patch_openai_kwargs(kwargs, self, tools)
         completion = client.chat.completions.create(
             model=self.call_params.model,
@@ -231,8 +236,8 @@ class OpenAIPrompt(BasePrompt):
             openai_tool = OpenAITool.from_model(schema)
             return_tool = False
 
-        self.call_params.tools = [openai_tool]
-        completion = self.create()
+        # self.call_params.tools = [openai_tool]
+        completion = self.create(tools=[openai_tool])
         try:
             tool = completion.tool
             if tool is None:

--- a/tests/openai/test_tools.py
+++ b/tests/openai/test_tools.py
@@ -87,6 +87,7 @@ def test_openai_tool_from_tool_call(fixture_my_tool):
     assert isinstance(tool, fixture_my_tool)
     assert tool.param == "param"
     assert tool.optional == 0
+    assert tool.args == {"param": "param", "optional": 0}
 
 
 def test_openai_tool_from_tool_call_validation_error(fixture_my_tool):


### PR DESCRIPTION
- We were manually setting `self.call_params.tools` in extract to pass tools to create, but this set it on the class, so subsequent calls to create would be called with the tools from the previous call to extract.
- Fix is to pass tools in as kwargs and check if we have tools for extract in create.