### PR TITLE
docs: include missing API reference docs

### DIFF
--- a/docs/api/anthropic/extractors.md
+++ b/docs/api/anthropic/extractors.md
@@ -1,0 +1,3 @@
+# anthropic.extractors
+
+::: mirascope.anthropic.extractors

--- a/docs/api/mistral/calls.md
+++ b/docs/api/mistral/calls.md
@@ -1,0 +1,3 @@
+# mistral.calls
+
+::: mirascope.mistral.calls

--- a/docs/api/mistral/extractors.md
+++ b/docs/api/mistral/extractors.md
@@ -1,0 +1,3 @@
+# mistral.extractors
+
+::: mirascope.mistral.extractors

--- a/docs/api/mistral/index.md
+++ b/docs/api/mistral/index.md
@@ -1,0 +1,3 @@
+# mistral
+
+::: mirascope.mistral

--- a/docs/api/mistral/tools.md
+++ b/docs/api/mistral/tools.md
@@ -1,0 +1,3 @@
+# mistral.tools
+
+::: mirascope.mistral.tools

--- a/docs/api/mistral/types.md
+++ b/docs/api/mistral/types.md
@@ -1,0 +1,3 @@
+# mistral.types
+
+::: mirascope.mistral.types

--- a/docs/api/openai/wandb.md
+++ b/docs/api/openai/wandb.md
@@ -1,3 +1,0 @@
-# openai.wandb
-
-::: mirascope.openai.wandb

--- a/docs/api/wandb.md
+++ b/docs/api/wandb.md
@@ -1,0 +1,3 @@
+# wandb
+
+::: mirascope.wandb

--- a/docs/concepts/generating_content.md
+++ b/docs/concepts/generating_content.md
@@ -8,7 +8,7 @@ Now that you have your prompt, you can combine it with a model call to generate 
 
 ## OpenAICall
 
-[`OpenAICall`](../api/openai/calls.md#mirascope.openai.calls.OpenAICall) extends [`BasePrompt`](../api/base/prompt.md#mirascope.base.prompts.BasePrompt) and [`BaseCall`](../api/base/calls.md#mirascope.base.calls.BaseCall) to support interacting with the OpenAI API.
+[`OpenAICall`](../api/openai/calls.md#mirascope.openai.calls.OpenAICall) extends [`BasePrompt`](../api/base/prompts.md#mirascope.base.prompts.BasePrompt) and [`BaseCall`](../api/base/calls.md#mirascope.base.calls.BaseCall) to support interacting with the OpenAI API.
 
 ### Call
 

--- a/docs/concepts/integrations.md
+++ b/docs/concepts/integrations.md
@@ -24,7 +24,7 @@ Now, every call to `call`, `call_async`, `stream`, and `stream_async` will be ex
 
 ## Weights & Biases
 
-If you want to seamlessly use Weights & Biases’ logging functionality, we’ve got you covered -  [`WandbCallMixin`](../api/openai/wandb.md#mirascope.wandb.WandbCallMixin) is a mixin with creation methods that internally call W&B’s `Trace()` function so you can easily log your runs. For standard responses, you can use `call_with_trace()`, and for extractions, you can use [`WandbExtractorMixin`](../api/openai/wandb.md#mirascope.wandb.WandbExtractorMixin)'s `extract_with_trace` method. These mixins are agnostic to the LLM provider, so you can use it with any `BaseCall` or `BaseExtractor` extension such as `OpenAICall` or `AnthropicCall`.
+If you want to seamlessly use Weights & Biases’ logging functionality, we’ve got you covered -  [`WandbCallMixin`](../api/wandb.md#mirascope.wandb.WandbCallMixin) is a mixin with creation methods that internally call W&B’s `Trace()` function so you can easily log your runs. For standard responses, you can use `call_with_trace()`, and for extractions, you can use [`WandbExtractorMixin`](../api/wandb.md#mirascope.wandb.WandbExtractorMixin)'s `extract_with_trace` method. These mixins are agnostic to the LLM provider, so you can use it with any `BaseCall` or `BaseExtractor` extension such as `OpenAICall` or `AnthropicCall`.
 
 ### Generating Content with a W&B Trace
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,6 +111,8 @@ nav:
       - anthropic:
           - "api/anthropic/index.md"
           - calls: "api/anthropic/calls.md"
+          - extractors: "api/anthropic/extractors.md"
+          - tools: "api/anthropic/tools.md"
           - types: "api/anthropic/types.md"
       - base:
           - "api/base/index.md"
@@ -134,10 +136,17 @@ nav:
           - extractors: "api/gemini/extractors.md"
           - tools: "api/gemini/tools.md"
           - types: "api/gemini/types.md"
+      - mistral:
+          - "api/mistral/index.md"
+          - calls: "api/mistral/calls.md"
+          - extractors: "api/mistral/extractors.md"
+          - tools: "api/mistral/tools.md"
+          - types: "api/mistral/types.md"
       - openai:
           - "api/openai/index.md"
           - calls: "api/openai/calls.md"
           - extractors: "api/openai/extractors.md"
           - tools: "api/openai/tools.md"
           - types: "api/openai/types.md"
-          - wandb: "api/openai/wandb.md"
+      - wandb:
+          - "api/wandb.md"


### PR DESCRIPTION
- Fix issues with nav linking to old reference for wandb
- Add missing API reference for Anthropic tools and extractors
- Add missing API reference for Mistral