### PR TITLE
Fix errors and openai dict

### DIFF
--- a/mirascope/anthropic/calls.py
+++ b/mirascope/anthropic/calls.py
@@ -163,7 +163,7 @@ class AnthropicCall(
         kwargs, tool_types = self._setup(kwargs, AnthropicTool)
         messages = self.messages()
         system_message = ""
-        if kwargs["system"] is not None:
+        if "system" in kwargs and kwargs["system"] is not None:
             system_message += kwargs.pop("system")
         if messages[0]["role"] == "system":
             system_message += messages.pop(0)["content"]

--- a/mirascope/anthropic/calls.py
+++ b/mirascope/anthropic/calls.py
@@ -163,6 +163,8 @@ class AnthropicCall(
         kwargs, tool_types = self._setup(kwargs, AnthropicTool)
         messages = self.messages()
         system_message = ""
+        if kwargs["system"] is not None:
+            system_message += kwargs.pop("system")
         if messages[0]["role"] == "system":
             system_message += messages.pop(0)["content"]
         if tool_types:

--- a/mirascope/anthropic/extractors.py
+++ b/mirascope/anthropic/extractors.py
@@ -14,6 +14,13 @@ logger = logging.getLogger("mirascope")
 T = TypeVar("T", bound=ExtractedType)
 
 
+EXTRACT_SYSTEM_MESSAGE = """
+OUTPUT ONLY FUNCTION CALLS WITHOUT ANY ADDITIONAL TEXT.
+You must wrap all invoke calls in the <function_calls> tag.
+ONLY EXTRACT ANSWERS THAT YOU ARE ABSOLUTELY 100% CERTAIN ARE CORRECT.
+""".strip()
+
+
 class AnthropicExtractor(BaseExtractor[AnthropicCall, AnthropicTool, T], Generic[T]):
     '''A class for extracting structured information using Anthropic Claude models.
 
@@ -74,6 +81,7 @@ class AnthropicExtractor(BaseExtractor[AnthropicCall, AnthropicTool, T], Generic
             AttributeError: if there is no tool in the call creation.
             ValidationError: if the schema cannot be instantiated from the completion.
         """
+        kwargs["system"] = EXTRACT_SYSTEM_MESSAGE
         return self._extract(AnthropicCall, AnthropicTool, retries, **kwargs)
 
     async def extract_async(self, retries: int = 0, **kwargs: Any) -> T:
@@ -97,6 +105,7 @@ class AnthropicExtractor(BaseExtractor[AnthropicCall, AnthropicTool, T], Generic
             AttributeError: if there is no tool in the call creation.
             ValidationError: if the schema cannot be instantiated from the completion.
         """
+        kwargs["system"] = EXTRACT_SYSTEM_MESSAGE
         return await self._extract_async(
             AnthropicCall, AnthropicTool, retries, **kwargs
         )

--- a/mirascope/anthropic/types.py
+++ b/mirascope/anthropic/types.py
@@ -102,7 +102,9 @@ class AnthropicCallResponse(BaseCallResponse[Message, AnthropicTool]):
                 "Generation stopped before `</function_calls>` stop sequence. "
                 "This is likely due to a limit on output tokens that is too low. "
                 "Note that this could also indicate no tool is beind called, so we "
-                "recommend that you check the output of the call to confirm."
+                "recommend that you check the output of the call to confirm. "
+                f"Stop Reason: {self.response.stop_reason} "
+                f"Stop Sequence: {self.response.stop_sequence}"
             )
 
         try:

--- a/mirascope/anthropic/types.py
+++ b/mirascope/anthropic/types.py
@@ -1,4 +1,5 @@
 """Type classes for interacting with Anthropics's Claude API."""
+
 import xml.etree.ElementTree as ET
 from typing import Any, Callable, Literal, Optional, Type, Union, cast
 
@@ -90,12 +91,19 @@ class AnthropicCallResponse(BaseCallResponse[Message, AnthropicTool]):
     @property
     def tools(self) -> Optional[list[AnthropicTool]]:
         """Returns the tools for the 0th choice message."""
+        if not self.tool_types:
+            return None
+
         if (
-            not self.tool_types
-            or self.response.stop_reason != "stop_sequence"
+            self.response.stop_reason != "stop_sequence"
             or self.response.stop_sequence != "</function_calls>"
         ):
-            return None
+            raise RuntimeError(
+                "Generation stopped before `</function_calls>` stop sequence. "
+                "This is likely due to a limit on output tokens that is too low. "
+                "Note that this could also indicate no tool is beind called, so we "
+                "recommend that you check the output of the call to confirm."
+            )
 
         try:
             root_node = ET.fromstring(

--- a/mirascope/base/extractors.py
+++ b/mirascope/base/extractors.py
@@ -1,4 +1,5 @@
 """A base abstract interface for extracting structured information using LLMs."""
+
 import logging
 from abc import ABC, abstractmethod
 from enum import Enum

--- a/mirascope/gemini/types.py
+++ b/mirascope/gemini/types.py
@@ -86,6 +86,7 @@ class GeminiCallResponse(
                 "This is likely due to a limit on output tokens that is too low. "
                 "Note that this could also indicate no tool is beind called, so we "
                 "recommend that you check the output of the call to confirm."
+                f"Finish Reason: {self.response.candidates[0].finish_reason}"
             )
 
         tool_calls = [
@@ -108,22 +109,9 @@ class GeminiCallResponse(
         Raises:
             ValidationError: if the tool call doesn't match the tool's schema.
         """
-        if self.tool_types is None:
-            return None
-
-        if self.response.candidates[0].finish_reason != 1:  # STOP = 1
-            raise RuntimeError(
-                "Generation stopped before the stop sequence. "
-                "This is likely due to a limit on output tokens that is too low. "
-                "Note that this could also indicate no tool is beind called, so we "
-                "recommend that you check the output of the call to confirm."
-            )
-
-        tool_call = self.response.candidates[0].content.parts[0].function_call
-        for tool_type in self.tool_types:
-            if tool_call.name == tool_type.__name__:
-                return tool_type.from_tool_call(tool_call)
-
+        tools = self.tools
+        if tools:
+            return tools[0]
         return None
 
     @property

--- a/mirascope/gemini/types.py
+++ b/mirascope/gemini/types.py
@@ -80,6 +80,14 @@ class GeminiCallResponse(
         if self.tool_types is None:
             return None
 
+        if self.response.candidates[0].finish_reason != 1:  # STOP = 1
+            raise RuntimeError(
+                "Generation stopped before the stop sequence. "
+                "This is likely due to a limit on output tokens that is too low. "
+                "Note that this could also indicate no tool is beind called, so we "
+                "recommend that you check the output of the call to confirm."
+            )
+
         tool_calls = [
             part.function_call for part in self.response.candidates[0].content.parts
         ]
@@ -102,6 +110,14 @@ class GeminiCallResponse(
         """
         if self.tool_types is None:
             return None
+
+        if self.response.candidates[0].finish_reason != 1:  # STOP = 1
+            raise RuntimeError(
+                "Generation stopped before the stop sequence. "
+                "This is likely due to a limit on output tokens that is too low. "
+                "Note that this could also indicate no tool is beind called, so we "
+                "recommend that you check the output of the call to confirm."
+            )
 
         tool_call = self.response.candidates[0].content.parts[0].function_call
         for tool_type in self.tool_types:

--- a/mirascope/mistral/types.py
+++ b/mirascope/mistral/types.py
@@ -104,12 +104,13 @@ class MistralCallResponse(BaseCallResponse[ChatCompletionResponse, MistralTool])
         if not self.tool_types or not self.tool_calls or len(self.tool_calls) == 0:
             return None
 
-        if self.choices[0].finish_reason != "tool_call":
+        if self.choices[0].finish_reason != "tool_calls":
             raise RuntimeError(
                 "Finish reason was not `tool_call`, indicating no or failed tool use."
                 "This is likely due to a limit on output tokens that is too low. "
                 "Note that this could also indicate no tool is beind called, so we "
-                "recommend that you check the output of the call to confirm."
+                "recommend that you check the output of the call to confirm. "
+                f"Finish Reason: {self.choices[0].finish_reason}"
             )
 
         extracted_tools = []
@@ -128,22 +129,9 @@ class MistralCallResponse(BaseCallResponse[ChatCompletionResponse, MistralTool])
         Raises:
             ValidationError: if the tool call doesn't match the tool's schema.
         """
-        if not self.tool_types or not self.tool_calls or len(self.tool_calls) == 0:
-            return None
-
-        if self.choices[0].finish_reason != "tool_call":
-            raise RuntimeError(
-                "Finish reason was not `tool_call`, indicating no or failed tool use."
-                "This is likely due to a limit on output tokens that is too low. "
-                "Note that this could also indicate no tool is beind called, so we "
-                "recommend that you check the output of the call to confirm."
-            )
-
-        tool_call = self.tool_calls[0]
-        for tool_type in self.tool_types:
-            if self.tool_calls[0].function.name == tool_type.__name__:
-                return tool_type.from_tool_call(tool_call)
-
+        tools = self.tools
+        if tools:
+            return tools[0]
         return None
 
     def dump(self) -> dict[str, Any]:

--- a/mirascope/mistral/types.py
+++ b/mirascope/mistral/types.py
@@ -104,6 +104,14 @@ class MistralCallResponse(BaseCallResponse[ChatCompletionResponse, MistralTool])
         if not self.tool_types or not self.tool_calls or len(self.tool_calls) == 0:
             return None
 
+        if self.choices[0].finish_reason != "tool_call":
+            raise RuntimeError(
+                "Finish reason was not `tool_call`, indicating no or failed tool use."
+                "This is likely due to a limit on output tokens that is too low. "
+                "Note that this could also indicate no tool is beind called, so we "
+                "recommend that you check the output of the call to confirm."
+            )
+
         extracted_tools = []
         for tool_call in self.tool_calls:
             for tool_type in self.tool_types:
@@ -122,6 +130,14 @@ class MistralCallResponse(BaseCallResponse[ChatCompletionResponse, MistralTool])
         """
         if not self.tool_types or not self.tool_calls or len(self.tool_calls) == 0:
             return None
+
+        if self.choices[0].finish_reason != "tool_call":
+            raise RuntimeError(
+                "Finish reason was not `tool_call`, indicating no or failed tool use."
+                "This is likely due to a limit on output tokens that is too low. "
+                "Note that this could also indicate no tool is beind called, so we "
+                "recommend that you check the output of the call to confirm."
+            )
 
         tool_call = self.tool_calls[0]
         for tool_type in self.tool_types:

--- a/mirascope/openai/calls.py
+++ b/mirascope/openai/calls.py
@@ -87,7 +87,7 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
         client = OpenAI(api_key=self.api_key, base_url=self.base_url)
         if self.call_params.wrapper is not None:
             client = self.call_params.wrapper(client)
-        messages = self._maybe_update_messages(self.messages(), tool_types)
+        messages = self._update_messages_if_json(self.messages(), tool_types)
         start_time = datetime.datetime.now().timestamp() * 1000
         completion = client.chat.completions.create(
             messages=messages,
@@ -121,7 +121,7 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
         client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
         if self.call_params.wrapper_async is not None:
             client = self.call_params.wrapper_async(client)
-        messages = self._maybe_update_messages(self.messages(), tool_types)
+        messages = self._update_messages_if_json(self.messages(), tool_types)
         start_time = datetime.datetime.now().timestamp() * 1000
         completion = await client.chat.completions.create(
             messages=messages,
@@ -155,7 +155,7 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
         client = OpenAI(api_key=self.api_key, base_url=self.base_url)
         if self.call_params.wrapper is not None:
             client = self.call_params.wrapper(client)
-        messages = self._maybe_update_messages(self.messages(), tool_types)
+        messages = self._update_messages_if_json(self.messages(), tool_types)
         stream = client.chat.completions.create(
             messages=messages,
             stream=True,
@@ -190,7 +190,7 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
         client = AsyncOpenAI(api_key=self.api_key, base_url=self.base_url)
         if self.call_params.wrapper_async is not None:
             client = self.call_params.wrapper_async(client)
-        messages = self._maybe_update_messages(self.messages(), tool_types)
+        messages = self._update_messages_if_json(self.messages(), tool_types)
         stream = await client.chat.completions.create(
             messages=messages,
             stream=True,
@@ -223,7 +223,7 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
             kwargs.pop("tools")
         return kwargs, tool_types
 
-    def _maybe_update_messages(
+    def _update_messages_if_json(
         self,
         messages: list[ChatCompletionMessageParam],
         tool_types: Optional[list[type[OpenAITool]]],

--- a/mirascope/openai/calls.py
+++ b/mirascope/openai/calls.py
@@ -11,6 +11,7 @@ from openai.types.chat import (
     ChatCompletionToolMessageParam,
     ChatCompletionUserMessageParam,
 )
+from openai.types.chat.completion_create_params import ResponseFormat
 
 from ..base import BaseCall
 from ..enums import MessageRole
@@ -215,7 +216,10 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
     ]:
         """Overrides the `BaseCall._setup` for Anthropic specific setup."""
         kwargs, tool_types = self._setup(kwargs, OpenAITool)
-        if self.call_params.response_format == {"type": "json_object"} and tool_types:
+        if (
+            self.call_params.response_format == ResponseFormat(type="json_object")
+            and tool_types
+        ):
             kwargs.pop("tools")
         return kwargs, tool_types
 
@@ -224,7 +228,10 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
         messages: list[ChatCompletionMessageParam],
         tool_types: Optional[list[type[OpenAITool]]],
     ) -> list[ChatCompletionMessageParam]:
-        if self.call_params.response_format == {"type": "json_object"} and tool_types:
+        if (
+            self.call_params.response_format == ResponseFormat(type="json_object")
+            and tool_types
+        ):
             messages.append(
                 ChatCompletionUserMessageParam(
                     role="user", content=_json_mode_content(tool_type=tool_types[0])

--- a/mirascope/openai/calls.py
+++ b/mirascope/openai/calls.py
@@ -78,12 +78,14 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
             stream=False,
             **kwargs,
         )
-        return OpenAICallResponse(
+        openai_call_response = OpenAICallResponse(
             response=completion,
             tool_types=tool_types,
             start_time=start_time,
             end_time=datetime.datetime.now().timestamp() * 1000,
         )
+        openai_call_response.response_format = self.call_params.response_format
+        return openai_call_response
 
     async def call_async(self, **kwargs: Any) -> OpenAICallResponse:
         """Makes an asynchronous call to the model using this `OpenAICall`.
@@ -109,12 +111,14 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
             stream=False,
             **kwargs,
         )
-        return OpenAICallResponse(
+        openai_call_response = OpenAICallResponse(
             response=completion,
             tool_types=tool_types,
             start_time=start_time,
             end_time=datetime.datetime.now().timestamp() * 1000,
         )
+        openai_call_response.response_format = self.call_params.response_format
+        return openai_call_response
 
     def stream(self, **kwargs: Any) -> Generator[OpenAICallResponseChunk, None, None]:
         """Streams the response for a call using this `OpenAICall`.
@@ -140,7 +144,13 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
             **kwargs,
         )
         for chunk in stream:
-            yield OpenAICallResponseChunk(chunk=chunk, tool_types=tool_types)
+            openai_call_response_chunk = OpenAICallResponseChunk(
+                chunk=chunk, tool_types=tool_types
+            )
+            openai_call_response_chunk.response_format = (
+                self.call_params.response_format
+            )
+            yield openai_call_response_chunk
 
     async def stream_async(
         self, **kwargs: Any
@@ -168,4 +178,10 @@ class OpenAICall(BaseCall[OpenAICallResponse, OpenAICallResponseChunk, OpenAIToo
             **kwargs,
         )
         async for chunk in stream:
-            yield OpenAICallResponseChunk(chunk=chunk, tool_types=tool_types)
+            openai_call_response_chunk = OpenAICallResponseChunk(
+                chunk=chunk, tool_types=tool_types
+            )
+            openai_call_response_chunk.response_format = (
+                self.call_params.response_format
+            )
+            yield openai_call_response_chunk

--- a/mirascope/openai/types.py
+++ b/mirascope/openai/types.py
@@ -134,6 +134,15 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         if not self.tool_types or not self.tool_calls:
             return None
 
+        if self.choices[0].finish_reason not in ["tool_calls", "function_call"]:
+            raise RuntimeError(
+                "Finish reason was not `tool_calls` or `function_call`, indicating no "
+                "or failed tool use. This is likely due to a limit on output tokens "
+                "that is too low. Note that this could also indicate no tool is beind "
+                "called, so we recommend that you check the output of the call to "
+                "confirm."
+            )
+
         extracted_tools = []
         for tool_call in self.tool_calls:
             for tool_type in self.tool_types:
@@ -152,6 +161,15 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         """
         if not self.tool_types or not self.tool_calls or len(self.tool_calls) == 0:
             return None
+
+        if self.choices[0].finish_reason not in ["tool_calls", "function_call"]:
+            raise RuntimeError(
+                "Finish reason was not `tool_calls` or `function_call`, indicating no "
+                "or failed tool use. This is likely due to a limit on output tokens "
+                "that is too low. Note that this could also indicate no tool is beind "
+                "called, so we recommend that you check the output of the call to "
+                "confirm."
+            )
 
         tool_call = self.tool_calls[0]
         for tool_type in self.tool_types:

--- a/mirascope/openai/types.py
+++ b/mirascope/openai/types.py
@@ -99,6 +99,8 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
     ```
     """
 
+    response_format: Optional[ResponseFormat] = None
+
     @property
     def choices(self) -> list[Choice]:
         """Returns the array of chat completion choices."""
@@ -131,17 +133,22 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         Raises:
             ValidationError: if a tool call doesn't match the tool's schema.
         """
-        if not self.tool_types or not self.tool_calls:
+        if not self.tool_types:
             return None
 
-        if self.choices[0].finish_reason not in ["tool_calls", "function_call"]:
-            raise RuntimeError(
-                "Finish reason was not `tool_calls` or `function_call`, indicating no "
-                "or failed tool use. This is likely due to a limit on output tokens "
-                "that is too low. Note that this could also indicate no tool is beind "
-                "called, so we recommend that you check the output of the call to "
-                "confirm."
-            )
+        if self.response_format != {"type": "json_object"}:
+            if not self.tool_calls:
+                return None
+
+            if self.choices[0].finish_reason not in ["tool_calls", "function_call"]:
+                raise RuntimeError(
+                    "Finish reason was not `tool_calls` or `function_call`, indicating "
+                    "no or failed tool use. This is likely due to a limit on output "
+                    "tokens that is too low. Note that this could also indicate no "
+                    "tool is beind called, so we recommend that you check the output "
+                    "of the call to confirm. "
+                    f"Finish Reason: {self.choices[0].finish_reason}"
+                )
 
         extracted_tools = []
         for tool_call in self.tool_calls:
@@ -159,23 +166,9 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         Raises:
             ValidationError: if the tool call doesn't match the tool's schema.
         """
-        if not self.tool_types or not self.tool_calls or len(self.tool_calls) == 0:
-            return None
-
-        if self.choices[0].finish_reason not in ["tool_calls", "function_call"]:
-            raise RuntimeError(
-                "Finish reason was not `tool_calls` or `function_call`, indicating no "
-                "or failed tool use. This is likely due to a limit on output tokens "
-                "that is too low. Note that this could also indicate no tool is beind "
-                "called, so we recommend that you check the output of the call to "
-                "confirm."
-            )
-
-        tool_call = self.tool_calls[0]
-        for tool_type in self.tool_types:
-            if self.tool_calls[0].function.name == tool_type.__name__:
-                return tool_type.from_tool_call(tool_call)
-
+        tools = self.tools
+        if tools:
+            return tools[0]
         return None
 
     def dump(self) -> dict[str, Any]:
@@ -216,6 +209,8 @@ class OpenAICallResponseChunk(BaseCallResponseChunk[ChatCompletionChunk, OpenAIT
     #  3
     #  .
     """
+
+    response_format: Optional[ResponseFormat] = None
 
     @property
     def choices(self) -> list[ChunkChoice]:

--- a/mirascope/openai/types.py
+++ b/mirascope/openai/types.py
@@ -137,7 +137,7 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         if not self.tool_types:
             return None
 
-        if self.response_format != {"type": "json_object"}:
+        if self.response_format != ResponseFormat(type="json_object"):
             if not self.tool_calls:
                 return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mirascope"
-version = "0.8.2"
+version = "0.8.3"
 description = "LLM toolkit for lightning-fast, high-quality development"
 license = "MIT"
 authors = [

--- a/tests/anthropic/conftest.py
+++ b/tests/anthropic/conftest.py
@@ -85,6 +85,15 @@ def fixture_anthropic_message_with_tools() -> Message:
 
 
 @pytest.fixture()
+def fixture_anthropic_message_with_tools_bad_stop_reason(
+    fixture_anthropic_message_with_tools: Message,
+) -> Message:
+    """Returns an Anthropic message with tools XML in the response"""
+    fixture_anthropic_message_with_tools.stop_reason = "max_tokens"
+    return fixture_anthropic_message_with_tools
+
+
+@pytest.fixture()
 def fixture_anthropic_message_chunk():
     """Returns an Anthropic message."""
     return ContentBlockDeltaEvent(

--- a/tests/anthropic/test_types.py
+++ b/tests/anthropic/test_types.py
@@ -30,6 +30,21 @@ def test_anthropic_call_response(fixture_anthropic_message: Message):
     }
 
 
+def test_anthropic_call_response_with_tools_bad_stop_reason(
+    fixture_anthropic_message_with_tools_bad_stop_reason: Message,
+    fixture_anthropic_book_tool: Type[AnthropicTool],
+):
+    """Tests the `AnthropicCallResponse` class with a tool and bad stop reason."""
+    response = AnthropicCallResponse(
+        response=fixture_anthropic_message_with_tools_bad_stop_reason,
+        tool_types=[fixture_anthropic_book_tool],
+        start_time=0,
+        end_time=1,
+    )
+    with pytest.raises(RuntimeError):
+        response.tool
+
+
 def test_anthropic_call_response_no_tools_node(
     fixture_anthropic_book_tool: Type[AnthropicTool],
 ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ def fixture_chat_completion_with_tools() -> ChatCompletion:
         id="test_id",
         choices=[
             Choice(
-                finish_reason="stop",
+                finish_reason="tool_calls",
                 index=0,
                 message=ChatCompletionMessage(
                     role="assistant",

--- a/tests/gemini/conftest.py
+++ b/tests/gemini/conftest.py
@@ -39,6 +39,7 @@ def fixture_generate_content_response_with_tools():
         GenerateContentResponse(
             candidates=[
                 Candidate(
+                    finish_reason=1,
                     content=Content(
                         parts=[
                             Part(
@@ -61,11 +62,20 @@ def fixture_generate_content_response_with_tools():
                             ),
                         ],
                         role="model",
-                    )
+                    ),
                 )
             ]
         )
     )
+
+
+@pytest.fixture()
+def fixture_generate_content_response_with_tools_bad_stop_sequence(
+    fixture_generate_content_response_with_tools: GenerateContentResponse,
+) -> GenerateContentResponse:
+    """Returns a `GenerateContentResponse` with tools."""
+    fixture_generate_content_response_with_tools.candidates[0].finish_reason = 0
+    return fixture_generate_content_response_with_tools
 
 
 class BookTool(GeminiTool):

--- a/tests/gemini/conftest.py
+++ b/tests/gemini/conftest.py
@@ -74,7 +74,7 @@ def fixture_generate_content_response_with_tools_bad_stop_sequence(
     fixture_generate_content_response_with_tools: GenerateContentResponse,
 ) -> GenerateContentResponse:
     """Returns a `GenerateContentResponse` with tools."""
-    fixture_generate_content_response_with_tools.candidates[0].finish_reason = 0
+    fixture_generate_content_response_with_tools.candidates[0].finish_reason = 0  # type: ignore
     return fixture_generate_content_response_with_tools
 
 

--- a/tests/gemini/test_types.py
+++ b/tests/gemini/test_types.py
@@ -1,6 +1,7 @@
 """Tests for the `mirascope.gemini.types` module."""
 from typing import Type
 
+import pytest
 from google.generativeai.types import GenerateContentResponse  # type: ignore
 
 from mirascope.gemini.tools import GeminiTool
@@ -48,6 +49,22 @@ def test_gemini_call_response_with_tools(
     assert len(tools) == 2
     assert tools[0] == expected_tool
     assert tools[1] == expected_tool
+
+
+def test_gemini_call_response_with_tools_bad_stop_sequence(
+    fixture_generate_content_response_with_tools_bad_stop_sequence: GenerateContentResponse,
+    fixture_book_tool: Type[GeminiTool],
+) -> None:
+    """Tests the `GeminiCallResponse` class with a tool."""
+    response = GeminiCallResponse(
+        response=fixture_generate_content_response_with_tools_bad_stop_sequence,
+        tool_types=[fixture_book_tool],
+        start_time=0,
+        end_time=0,
+    )
+
+    with pytest.raises(RuntimeError):
+        response.tool
 
 
 def test_gemini_call_response_with_no_matching_tools(

--- a/tests/mistral/conftest.py
+++ b/tests/mistral/conftest.py
@@ -113,7 +113,7 @@ def fixture_chat_completion_response_with_tools_bad_stop_sequence(
     fixture_chat_completion_response_with_tools: ChatCompletionResponse,
 ) -> ChatCompletionResponse:
     """Returns a `ChatCompletionResponse` with tools."""
-    fixture_chat_completion_response_with_tools.choices[0].finish_reason = "stop"
+    fixture_chat_completion_response_with_tools.choices[0].finish_reason = "stop"  # type: ignore
     return fixture_chat_completion_response_with_tools
 
 

--- a/tests/mistral/conftest.py
+++ b/tests/mistral/conftest.py
@@ -109,6 +109,15 @@ def fixture_chat_completion_response_with_tools() -> ChatCompletionResponse:
 
 
 @pytest.fixture()
+def fixture_chat_completion_response_with_tools_bad_stop_sequence(
+    fixture_chat_completion_response_with_tools: ChatCompletionResponse,
+) -> ChatCompletionResponse:
+    """Returns a `ChatCompletionResponse` with tools."""
+    fixture_chat_completion_response_with_tools.choices[0].finish_reason = "stop"
+    return fixture_chat_completion_response_with_tools
+
+
+@pytest.fixture()
 def fixture_chat_completion_stream_response() -> list[ChatCompletionStreamResponse]:
     """Returns a list of `ChatCompletionStreamResponse` chunks."""
     return [

--- a/tests/mistral/test_types.py
+++ b/tests/mistral/test_types.py
@@ -1,6 +1,7 @@
 """Tests for the `mirascope.mistral.types` module."""
 from typing import Type
 
+import pytest
 from mistralai.models.chat_completion import (
     ChatCompletionResponse,
     ChatCompletionStreamResponse,
@@ -62,6 +63,23 @@ def test_mistral_call_response_with_tools(
     assert response.tool == expected_tool
     assert len(tools) == 1
     assert tools[0] == expected_tool
+
+
+def test_mistral_call_response_with_tools_bad_stop_sequence(
+    fixture_chat_completion_response_with_tools_bad_stop_sequence: ChatCompletionResponse,
+    fixture_book_tool: Type[MistralTool],
+    fixture_expected_book_tool_instance: MistralTool,
+) -> None:
+    """Tests the `MistralCallResponse` class with a tool."""
+    response = MistralCallResponse(
+        response=fixture_chat_completion_response_with_tools_bad_stop_sequence,
+        tool_types=[fixture_book_tool],
+        start_time=0,
+        end_time=0,
+    )
+
+    with pytest.raises(RuntimeError):
+        response.tool
 
 
 def test_mistral_call_response_with_no_matching_tools(

--- a/tests/openai/conftest.py
+++ b/tests/openai/conftest.py
@@ -59,13 +59,22 @@ def fixture_my_openai_tool_function() -> Callable:
 
 
 @pytest.fixture()
+def fixture_chat_compmletion_with_tools_bad_stop_sequence(
+    fixture_chat_completion_with_tools: ChatCompletion,
+) -> ChatCompletion:
+    """Returns a chat completion with tool calls but a bad stop sequence."""
+    fixture_chat_completion_with_tools.choices[0].finish_reason = "stop"
+    return fixture_chat_completion_with_tools
+
+
+@pytest.fixture()
 def fixture_chat_completion_with_bad_tools() -> ChatCompletion:
     """Returns a chat completion with tool calls that don't match the tool's schema."""
     return ChatCompletion(
         id="test_id",
         choices=[
             Choice(
-                finish_reason="stop",
+                finish_reason="tool_calls",
                 index=0,
                 message=ChatCompletionMessage(
                     role="assistant",
@@ -275,7 +284,7 @@ def fixture_chat_completion_with_str_tool() -> ChatCompletion:
         id="test_id",
         choices=[
             Choice(
-                finish_reason="stop",
+                finish_reason="tool_calls",
                 index=0,
                 message=ChatCompletionMessage(
                     role="assistant",

--- a/tests/openai/conftest.py
+++ b/tests/openai/conftest.py
@@ -26,6 +26,17 @@ from mirascope.openai.types import OpenAICallParams
 
 
 @pytest.fixture()
+def fixture_chat_completion_with_tools_json_mode(
+    fixture_chat_completion: ChatCompletion,
+) -> ChatCompletion:
+    """Returns a chat completion with a JSON mode tool call."""
+    fixture_chat_completion.choices[
+        0
+    ].message.content = '{\n  "param": "param",\n  "optional": 0}'
+    return fixture_chat_completion
+
+
+@pytest.fixture()
 def fixture_my_schema() -> Type[BaseModel]:
     """Returns a `MySchema` class type."""
 

--- a/tests/openai/test_calls.py
+++ b/tests/openai/test_calls.py
@@ -102,7 +102,9 @@ def test_openai_call_call_with_tools_json_mode(
         stream=False,
     )
     assert response.tool_types == [fixture_my_openai_tool]
-    assert response.tool.model_dump() == fixture_my_openai_tool_instance.model_dump()
+    tool = response.tool
+    assert tool is not None
+    assert tool.model_dump() == fixture_my_openai_tool_instance.model_dump()
 
 
 @patch(

--- a/tests/openai/test_calls.py
+++ b/tests/openai/test_calls.py
@@ -9,6 +9,7 @@ from openai.types.chat import (
     ChatCompletionChunk,
     ChatCompletionUserMessageParam,
 )
+from openai.types.chat.completion_create_params import ResponseFormat
 
 from mirascope.openai.calls import OpenAICall, _json_mode_content
 from mirascope.openai.tools import OpenAITool
@@ -84,7 +85,7 @@ def test_openai_call_call_with_tools_json_mode(
         call_params = OpenAICallParams(
             model="gpt-4",
             tools=[fixture_my_openai_tool],
-            response_format={"type": "json_object"},
+            response_format=ResponseFormat(type="json_object"),
         )
 
     call_with_tools = CallWithTools()
@@ -98,7 +99,7 @@ def test_openai_call_call_with_tools_json_mode(
                 content=_json_mode_content(tool_type=fixture_my_openai_tool),
             )
         ],
-        response_format={"type": "json_object"},
+        response_format=ResponseFormat(type="json_object"),
         stream=False,
     )
     assert response.tool_types == [fixture_my_openai_tool]

--- a/tests/openai/test_calls.py
+++ b/tests/openai/test_calls.py
@@ -4,9 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from openai import AsyncOpenAI, OpenAI
-from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat import (
+    ChatCompletion,
+    ChatCompletionChunk,
+    ChatCompletionUserMessageParam,
+)
 
-from mirascope.openai.calls import OpenAICall
+from mirascope.openai.calls import OpenAICall, _json_mode_content
 from mirascope.openai.tools import OpenAITool
 from mirascope.openai.types import (
     OpenAICallParams,
@@ -61,6 +65,44 @@ def test_openai_call_call_with_tools(
         stream=False,
     )
     assert response.tool_types == [fixture_my_openai_tool]
+
+
+@patch("openai.resources.chat.completions.Completions.create", new_callable=MagicMock)
+def test_openai_call_call_with_tools_json_mode(
+    mock_create: MagicMock,
+    fixture_my_openai_tool: Type[OpenAITool],
+    fixture_my_openai_tool_instance: OpenAITool,
+    fixture_chat_completion_with_tools_json_mode: ChatCompletion,
+) -> None:
+    """Tests that tools are properly passed to the create call."""
+    mock_create.return_value = fixture_chat_completion_with_tools_json_mode
+
+    class CallWithTools(OpenAICall):
+        prompt_template = "test"
+
+        api_key = "test"
+        call_params = OpenAICallParams(
+            model="gpt-4",
+            tools=[fixture_my_openai_tool],
+            response_format={"type": "json_object"},
+        )
+
+    call_with_tools = CallWithTools()
+    response = call_with_tools.call()
+    mock_create.assert_called_once_with(
+        model="gpt-4",
+        messages=call_with_tools.messages()
+        + [
+            ChatCompletionUserMessageParam(
+                role="user",
+                content=_json_mode_content(tool_type=fixture_my_openai_tool),
+            )
+        ],
+        response_format={"type": "json_object"},
+        stream=False,
+    )
+    assert response.tool_types == [fixture_my_openai_tool]
+    assert response.tool.model_dump() == fixture_my_openai_tool_instance.model_dump()
 
 
 @patch(

--- a/tests/openai/test_types.py
+++ b/tests/openai/test_types.py
@@ -131,3 +131,18 @@ def test_openai_chat_completion_chunk_with_tools(
     assert openai_chat_completion_chunk.delta == choices[0].delta
     assert openai_chat_completion_chunk.content == ""
     assert openai_chat_completion_chunk.tool_calls == choices[0].delta.tool_calls
+
+
+def test_openai_chat_completion_tools_wrong_stop_sequence(
+    fixture_chat_compmletion_with_tools_bad_stop_sequence: ChatCompletion,
+    fixture_my_openai_tool: Type[OpenAITool],
+):
+    """Tests that `OpenAICallResponse` raises a ValidationError with a wrong stop sequence."""
+    response = OpenAICallResponse(
+        response=fixture_chat_compmletion_with_tools_bad_stop_sequence,
+        tool_types=[fixture_my_openai_tool],
+        start_time=0,
+        end_time=0,
+    )
+    with pytest.raises(RuntimeError):
+        response.tool


### PR DESCRIPTION
Closes #168 

- Raise RuntimeError when stop reason isn't function calls when using `tools` and `tool` convenience functions.
- Enable using `response_format={"type": "json_object"}` when using tools and extraction.
- Update Anthropic system prompt when using extract to force it to use a tool correctly. 