### PR TITLE
feat: enable easier injection of list attributes and properties

### DIFF
--- a/mirascope/base/prompts.py
+++ b/mirascope/base/prompts.py
@@ -93,7 +93,17 @@ class BasePrompt(BaseModel):
             if var is not None
         ]
         return dedented_template.format(
-            **{var: getattr(self, var) for var in template_vars}
+            **{
+                var: "\n".join(
+                    [
+                        value if isinstance(value, str) else str(value)
+                        for value in getattr(self, var)
+                    ]
+                )
+                if isinstance(getattr(self, var), list)
+                else getattr(self, var)
+                for var in template_vars
+            }
         )
 
     def _parse_messages(self, roles: list[str]) -> list[Message]:

--- a/mirascope/base/prompts.py
+++ b/mirascope/base/prompts.py
@@ -92,19 +92,21 @@ class BasePrompt(BaseModel):
             for _, var, _, _ in Formatter().parse(dedented_template)
             if var is not None
         ]
-        return dedented_template.format(
-            **{
-                var: "\n".join(
-                    [
-                        value if isinstance(value, str) else str(value)
-                        for value in getattr(self, var)
-                    ]
-                )
-                if isinstance(getattr(self, var), list)
-                else getattr(self, var)
-                for var in template_vars
-            }
-        )
+
+        values = {}
+        for var in template_vars:
+            attr = getattr(self, var)
+            if attr and isinstance(attr, list):
+                if isinstance(attr[0], list):
+                    values[var] = "\n\n".join(
+                        ["\n".join([str(subitem) for subitem in item]) for item in attr]
+                    )
+                else:
+                    values[var] = "\n".join([str(item) for item in attr])
+            else:
+                values[var] = str(attr)
+
+        return dedented_template.format(**values)
 
     def _parse_messages(self, roles: list[str]) -> list[Message]:
         """Returns messages parsed from the `template` ClassVar.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3279,27 +3279,20 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.9.4"
+version = "0.12.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 files = [
-    {file = "typer-0.9.4-py3-none-any.whl", hash = "sha256:aa6c4a4e2329d868b80ecbaf16f807f2b54e192209d7ac9dd42691d63f7a54eb"},
-    {file = "typer-0.9.4.tar.gz", hash = "sha256:f714c2d90afae3a7929fcd72a3abb08df305e1ff61719381384211c4070af57f"},
+    {file = "typer-0.12.2-py3-none-any.whl", hash = "sha256:e1accbaa7e2b2350753acec896ac30493ac573211a8d4603e88f8356217e01f7"},
+    {file = "typer-0.12.2.tar.gz", hash = "sha256:977929604fde12aeada011852ad9c64370501be6ac2eac248f3161cdc9eeb7c9"},
 ]
 
 [package.dependencies]
-click = ">=7.1.1,<9.0.0"
-colorama = {version = ">=0.4.3,<0.5.0", optional = true, markers = "extra == \"all\""}
-rich = {version = ">=10.11.0,<14.0.0", optional = true, markers = "extra == \"all\""}
-shellingham = {version = ">=1.3.0,<2.0.0", optional = true, markers = "extra == \"all\""}
+click = ">=8.0.0"
+rich = ">=10.11.0"
+shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
-
-[package.extras]
-all = ["colorama (>=0.4.3,<0.5.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
-dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)", "pre-commit (>=2.17.0,<3.0.0)"]
-doc = ["cairosvg (>=2.5.2,<3.0.0)", "mdx-include (>=1.4.1,<2.0.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=8.1.4,<9.0.0)", "pillow (>=9.3.0,<10.0.0)"]
-test = ["black (>=22.3.0,<23.0.0)", "coverage (>=6.2,<7.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.971)", "pytest (>=4.4.0,<8.0.0)", "pytest-cov (>=2.10.0,<5.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<4.0.0)", "rich (>=10.11.0,<14.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "types-pytz"
@@ -3314,13 +3307,13 @@ files = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.10.0"
+version = "4.11.0"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
-    {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
+    {file = "typing_extensions-4.11.0-py3-none-any.whl", hash = "sha256:c1f94d72897edaf4ce775bb7558d5b79d8126906a14ea5ed1635921406c0387a"},
+    {file = "typing_extensions-4.11.0.tar.gz", hash = "sha256:83f085bd5ca59c80295fc2a82ab5dac679cbe02b9f33f7d83af68e241bea51b0"},
 ]
 
 [[package]]
@@ -3871,4 +3864,4 @@ weave = ["weave"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.13"
-content-hash = "155c533bf884601d2f4f38418246a34a093e9ef64a4102d78804d4a9092b9595"
+content-hash = "14e73308f7f61e419cfa3c2fe0e3a515585ecdc9bc6bd21abe696acea42afced"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mirascope"
-version = "0.9.1"
+version = "0.10.0"
 description = "LLM toolkit for lightning-fast, high-quality development"
 license = "MIT"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,18 +17,18 @@ mirascope = 'mirascope.cli.main:app'
 [tool.poetry.dependencies]
 python = ">=3.9,<3.13"
 pydantic = "^2.0.2"
-typer = { version = "^0.9.0", extras = ["all"] }
+typer = { version = ">=0.9.0,<1.0.0", extras = ["all"] }
 Jinja2 = "^3.1.3"
 openai = "^1.6.0"
 docstring-parser = "^0.15"
 
 # A list of optional dependencies that are required for certain features
-wandb = { version = "^0.16.4", optional = true }
-weave = { version = "^0.50.0", optional = true }
+wandb = { version = ">=0.16.4,<1.0.0", optional = true }
+weave = { version = ">=0.50.0,<1.0.0", optional = true }
 google-generativeai = { version = "^0.4.0", optional = true }
-anthropic = { version = "^0.23.1", optional = true }
-mistralai = { version = "^0.1.6", optional = true }
-groq = { version = "^0.4.2", optional = true }
+anthropic = { version = ">=0.23.1,<1.0.0", optional = true }
+mistralai = { version = ">=0.1.6,<1.0.0", optional = true }
+groq = { version = ">=0.4.2,<1.0.0", optional = true }
 
 [tool.poetry.extras]
 wandb = ["wandb"]

--- a/tests/base/test_prompts.py
+++ b/tests/base/test_prompts.py
@@ -147,6 +147,6 @@ def test_base_prompt_list_attribute() -> None:
         my_list_of_lists: list[list[str]]
 
     my_list = ["my", "list"]
-    my_list_of_lists = [my_list]
+    my_list_of_lists = [my_list, my_list]
     prompt = MyPrompt(my_list=my_list, my_list_of_lists=my_list_of_lists)
-    assert str(prompt) == "my\nlist\n['my', 'list']"
+    assert str(prompt) == "my\nlist\nmy\nlist\n\nmy\nlist"

--- a/tests/base/test_prompts.py
+++ b/tests/base/test_prompts.py
@@ -132,3 +132,21 @@ def test_base_prompt_messages_injection_wrong_type() -> None:
 
     with pytest.raises(ValueError):
         MyPrompt(bad=1).messages()
+
+
+def test_base_prompt_list_attribute() -> None:
+    """Tests that attributes of type list are properly injected."""
+
+    class MyPrompt(BasePrompt):
+        prompt_template = """
+        {my_list}
+        {my_list_of_lists}
+        """
+
+        my_list: list[str]
+        my_list_of_lists: list[list[str]]
+
+    my_list = ["my", "list"]
+    my_list_of_lists = [my_list]
+    prompt = MyPrompt(my_list=my_list, my_list_of_lists=my_list_of_lists)
+    assert str(prompt) == "my\nlist\n['my', 'list']"


### PR DESCRIPTION
- Instead of having to write your own custom property, we will automatically handle `list` attributes by injecting each string in the list into the prompt separated by "\n"
- If the attribute is a list of non-string elements (e.g. list of list), we will inject the string output of each item when calling `str(item)` on it.