### PR TITLE
Expose `with_logfire` from mirascope.logfire

### DIFF
--- a/mirascope/logfire/__init__.py
+++ b/mirascope/logfire/__init__.py
@@ -1,2 +1,4 @@
 """Module for integrations with Pydantic Logfire"""
 from .logfire import with_logfire
+
+__all__ = ["with_logfire"]


### PR DESCRIPTION
Add `with_logfire` to the `__all__` array in order to expose `with_logfire` from mirascope.logfire.

The static type checker pyright does not recognize the following import statement:

```
from mirascrope.logfire import with_logfire
```

And provides the following error:
```
error: "with_logfire" is not exported from module "mirascope.logfire"
    Import from "mirascope.logfire.logfire" instead (reportPrivateImportUsage)
```

In order to match the mirascope + logfire docs, adding the method to the __all__ field should make it importable. This may be something that you would want to take on across this repo.