### PR TITLE
fix: issue with not properly setting messages from extractor in temp call

### DIFF
--- a/mirascope/base/extractors.py
+++ b/mirascope/base/extractors.py
@@ -462,7 +462,9 @@ class BaseExtractor(
 
         properties = getmembers(self)
         for name, value in properties:
-            if not hasattr(TempCall, name):
+            if not hasattr(TempCall, name) or (
+                name == "messages" and "messages" in self.__class__.__dict__
+            ):
                 setattr(TempCall, name, value)
 
         return TempCall

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mirascope"
-version = "0.12.0"
+version = "0.12.1"
 description = "LLM toolkit for lightning-fast, high-quality development"
 license = "MIT"
 authors = [


### PR DESCRIPTION
- `messages` already existed, so method wouldn't get copied if set in extractor
- also needed to ensure not to overwrite the method with `BasePrompt.messages` by ensuring it's defined in the extractor