### PR TITLE
fix: unnecessary prevention of tool calls for finish reason

### DIFF
--- a/mirascope/cohere/types.py
+++ b/mirascope/cohere/types.py
@@ -163,7 +163,7 @@ class CohereCallResponse(BaseCallResponse[NonStreamedChatResponse, CohereTool]):
         if self.response.finish_reason == "MAX_TOKENS":
             raise RuntimeError(
                 "Generation stopped with MAX_TOKENS finish reason. This means that the "
-                "response hit the token limit before completion, "
+                "response hit the token limit before completion."
             )
 
         extracted_tools = []

--- a/mirascope/groq/types.py
+++ b/mirascope/groq/types.py
@@ -139,22 +139,15 @@ class GroqCallResponse(BaseCallResponse[ChatCompletion, GroqTool]):
         if not self.tool_types:
             return None
 
-        if self.response_format != ResponseFormat(type="json_object"):
-            if not self.tool_calls:
-                return None
+        if self.choice.finish_reason == "length":
+            raise RuntimeError(
+                "Finish reason was `length`, indicating the model ran out of tokens "
+                "(and likely could not complete the tool call if trying to)"
+            )
 
-            if self.choices[0].finish_reason not in ["tool_calls", "function_call"]:
-                raise RuntimeError(
-                    "Finish reason was not `tool_calls` or `function_call`, indicating "
-                    "no or failed tool use. This is likely due to a limit on output "
-                    "tokens that is too low. Note that this could also indicate no "
-                    "tool is beind called, so we recommend that you check the output "
-                    "of the call to confirm. "
-                    f"Finish Reason: {self.choices[0].finish_reason}"
-                )
-        else:
-            # Note: we only handle single tool calls in JSON mode.
-            tool_type = self.tool_types[0]
+        def reconstruct_tools_from_content() -> list[GroqTool]:
+            # Note: we only handle single tool calls in this case
+            tool_type = self.tool_types[0]  # type: ignore
             return [
                 tool_type.from_tool_call(
                     ChoiceMessageToolCall(
@@ -166,6 +159,18 @@ class GroqCallResponse(BaseCallResponse[ChatCompletion, GroqTool]):
                     )
                 )
             ]
+
+        if self.response_format == ResponseFormat(type="json_object"):
+            return reconstruct_tools_from_content()
+
+        if not self.tool_calls:
+            # Let's see if we got an assistant message back instead and try to
+            # reconstruct a tool call in this case. We'll assume if it starts with
+            # an open curly bracket that we got a tool call assistant message.
+            if "{" == self.content[0]:
+                # Note: we only handle single tool calls in JSON mode.
+                return reconstruct_tools_from_content()
+            return None
 
         extracted_tools = []
         for tool_call in self.tool_calls:

--- a/mirascope/mistral/types.py
+++ b/mirascope/mistral/types.py
@@ -105,13 +105,11 @@ class MistralCallResponse(BaseCallResponse[ChatCompletionResponse, MistralTool])
         if not self.tool_types or not self.tool_calls or len(self.tool_calls) == 0:
             return None
 
-        if self.choices[0].finish_reason != "tool_calls":
+        if self.choice.finish_reason in ["length", "error"]:
             raise RuntimeError(
-                "Finish reason was not `tool_call`, indicating no or failed tool use."
-                "This is likely due to a limit on output tokens that is too low. "
-                "Note that this could also indicate no tool is beind called, so we "
-                "recommend that you check the output of the call to confirm. "
-                f"Finish Reason: {self.choices[0].finish_reason}"
+                f"Finish reason was {self.choice.finish_reason}, indicating the model "
+                "ran out of token or failed (and could not complete the tool call if "
+                "trying to)."
             )
 
         extracted_tools = []

--- a/mirascope/openai/types.py
+++ b/mirascope/openai/types.py
@@ -148,7 +148,7 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         if self.choice.finish_reason == "length":
             raise RuntimeError(
                 "Finish reason was `length`, indicating the model ran out of tokens "
-                "(and likely could not complete the tool call if trying to)"
+                "(and could not complete the tool call if trying to)"
             )
 
         def reconstruct_tools_from_content() -> list[OpenAITool]:

--- a/tests/groq/conftest.py
+++ b/tests/groq/conftest.py
@@ -111,11 +111,12 @@ def fixture_expected_book_tool_instance() -> BookTool:
         title="The Name of the Wind",
         author="Patrick Rothfuss",
         tool_call=ChoiceMessageToolCall(
-            id="null",
+            id="id",
             function=ChoiceMessageToolCallFunction(
                 name="BookTool",
                 arguments='{"title": "The Name of the Wind","author": "Patrick Rothfuss"}',
             ),
+            type="function",
         ),
     )
 
@@ -136,11 +137,12 @@ def fixture_chat_completion_response_with_tools() -> ChatCompletion:
                     content="",
                     tool_calls=[
                         ChoiceMessageToolCall(
-                            id="null",
+                            id="id",
                             function=ChoiceMessageToolCallFunction(
                                 name="BookTool",
                                 arguments='{"title": "The Name of the Wind","author": "Patrick Rothfuss"}',
                             ),
+                            type="function",
                         )
                     ],
                 ),
@@ -153,11 +155,23 @@ def fixture_chat_completion_response_with_tools() -> ChatCompletion:
 
 
 @pytest.fixture()
+def fixture_chat_completion_response_with_assistant_message_tool(
+    fixture_chat_completion_response: ChatCompletion,
+) -> ChatCompletion:
+    """Returns a `ChatCompletion` with an assistant message tool call (just in case)."""
+    fixture_chat_completion_copy = fixture_chat_completion_response.model_copy()
+    fixture_chat_completion_copy.choices[
+        0
+    ].message.content = '{"title": "The Name of the Wind","author": "Patrick Rothfuss"}'
+    return fixture_chat_completion_copy
+
+
+@pytest.fixture()
 def fixture_chat_completion_response_with_tools_bad_stop_sequence(
     fixture_chat_completion_response_with_tools: ChatCompletion,
 ) -> ChatCompletion:
     """Returns a `ChatCompletion` with tools."""
-    fixture_chat_completion_response_with_tools.choices[0].finish_reason = "stop"  # type: ignore
+    fixture_chat_completion_response_with_tools.choices[0].finish_reason = "length"  # type: ignore
     return fixture_chat_completion_response_with_tools
 
 

--- a/tests/groq/test_types.py
+++ b/tests/groq/test_types.py
@@ -29,7 +29,7 @@ def test_groq_call_response(
     assert response.output_tokens is not None
 
 
-def test_groq_call_response_no_usageq(
+def test_groq_call_response_no_usage(
     fixture_chat_completion_response_no_usage: ChatCompletion,
 ) -> None:
     """Tests the `GroqCallResponse` class."""
@@ -78,6 +78,22 @@ def test_groq_call_response_with_tools(
     assert response.tool == expected_tool
     assert len(tools) == 1
     assert tools[0] == expected_tool
+
+
+def test_groq_call_response_with_assistant_message_tool(
+    fixture_chat_completion_response_with_assistant_message_tool: ChatCompletion,
+    fixture_book_tool: Type[GroqTool],
+    fixture_expected_book_tool_instance: GroqTool,
+):
+    """Tests that `OpenAICallResponse` returns a tool when it's an assistant message."""
+    response = GroqCallResponse(
+        response=fixture_chat_completion_response_with_assistant_message_tool,
+        tool_types=[fixture_book_tool],
+        start_time=0,
+        end_time=0,
+    )
+    assert response.tools is not None
+    assert response.tools[0].tool_call == fixture_expected_book_tool_instance.tool_call
 
 
 def test_groq_call_response_with_tools_bad_stop_sequence(

--- a/tests/mistral/conftest.py
+++ b/tests/mistral/conftest.py
@@ -113,7 +113,7 @@ def fixture_chat_completion_response_with_tools_bad_stop_sequence(
     fixture_chat_completion_response_with_tools: ChatCompletionResponse,
 ) -> ChatCompletionResponse:
     """Returns a `ChatCompletionResponse` with tools."""
-    fixture_chat_completion_response_with_tools.choices[0].finish_reason = "stop"  # type: ignore
+    fixture_chat_completion_response_with_tools.choices[0].finish_reason = "length"  # type: ignore
     return fixture_chat_completion_response_with_tools
 
 

--- a/tests/openai/conftest.py
+++ b/tests/openai/conftest.py
@@ -107,7 +107,7 @@ def fixture_chat_completion_with_tools_bad_stop_sequence(
     fixture_chat_completion_with_tools: ChatCompletion,
 ) -> ChatCompletion:
     """Returns a chat completion with tool calls but a bad stop sequence."""
-    fixture_chat_completion_with_tools.choices[0].finish_reason = "stop"
+    fixture_chat_completion_with_tools.choices[0].finish_reason = "length"
     return fixture_chat_completion_with_tools
 
 


### PR DESCRIPTION
Closes #256 

- Noticed that we were unnecessarily preventing correct behavior if `finish_reason not in ["tool_calls", "function_call"]` even if tools were present.
- This prevented proper use of `tool_choice="required"` since it results (sometimes? always?) in `finish_reason == "stop"`
- Now instead we simply check if `finish_reason == "length"` so let the user know it failed to call the tool (if it was trying to) because it ran out of tokens.
- Made other similar changes for other providers