### PR TITLE
fix: issue where you couldn't pass in the tool call without a follow-up user message

### DIFF
--- a/docs/concepts/tools_(function_calling).md
+++ b/docs/concepts/tools_(function_calling).md
@@ -165,11 +165,12 @@ if tool:
             "name": tool.__class__.__name__,
         },
     ]
+    # Set no question so there isn't a user message
+    forecast.question = ""
 else:
     print(response.content)  # if no tool, print the content of the response
 
 # Call the LLM again with the history including the tool call
-forecast.question = "Is that cold or hot?"
 response = forecast.call()
 print("After Tools Response:", response.content)
 ```

--- a/examples/tool_calls.py
+++ b/examples/tool_calls.py
@@ -35,7 +35,7 @@ forecast = Forecast(question="What's the weather in Tokyo Japan?")
 response = forecast.call()
 forecast.history += [
     {"role": "user", "content": forecast.question},
-    response.message.model_dump(),
+    response.message.model_dump(),  # type: ignore
 ]
 
 tool = response.tool
@@ -54,7 +54,7 @@ if tool:
             "content": output,
             "tool_call_id": tool.tool_call.id,
             "name": tool.__class__.__name__,
-        },
+        },  # type: ignore
     ]
     # Set no question so there isn't a user message
     forecast.question = ""

--- a/mirascope/base/prompts.py
+++ b/mirascope/base/prompts.py
@@ -135,7 +135,8 @@ class BasePrompt(BaseModel):
                 messages += attribute
             else:
                 content = self._format_template(match.group(2))
-                messages.append({"role": role, "content": content})
+                if content:
+                    messages.append({"role": role, "content": content})
         if len(messages) == 0:
             messages.append(
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mirascope"
-version = "0.13.4"
+version = "0.13.5"
 description = "An intuitive approach to building with LLMs"
 license = "MIT"
 authors = [


### PR DESCRIPTION
Closes #265 

- Sometimes you'll want the AI to call a tool before responding.
- This means inserting the tool back into the chat history without an additional user message.
- Previously, if the `USER:` key existed there would be a message.
- Now, if the content is `""` or `None` then it won't be included in the messages array.