### PR TITLE
Update README.md with details on pip install for zsh

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,7 +32,7 @@ pip install mirascope[logfire]    # with_logfire decorator, ...
 pip install mirascope[all]        # all optional dependencies
 ```
 
-> Note: if you're using zsh, the formatting needs to include backslash, e.g. `pip install mirascope\[anthropic\]`
+> Note: escape brackets (e.g. `pip install mirascope\[anthropic\]`) if using zsh
 
 ## Getting Started
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,8 @@ pip install mirascope[logfire]    # with_logfire decorator, ...
 pip install mirascope[all]        # all optional dependencies
 ```
 
+> Note: if you're using zsh, the formatting needs to include backslash, e.g. `pip install mirascope\[anthropic\]`
+
 ## Getting Started
 
 <div align="center">


### PR DESCRIPTION
The default shell in terminal for mac is zsh. We should make formatting difference pip install in zsh explicit