### PR TITLE
Support for AnthropicBedrock and AzureOpenAI

### DIFF
--- a/docs/concepts/supported_llm_providers.md
+++ b/docs/concepts/supported_llm_providers.md
@@ -367,6 +367,40 @@ class RecipeRecommender(OpenAICall):
     call_params = OpenAICallParams(model="mistral")
 ```
 
+## Using Anthropic models on AWS Bedrock
+
+You can use Anthropic models through AWS Bedrock, which is supported in Mirascope through a client wrapper. Simply import the wrapper, provide the correct configuration, and add the wrapper to your call:
+
+```python
+from mirascope.anthropic import (
+    AnthropicCall,
+    AnthropicCallParams,
+    bedrock_client_wrapper,
+)
+from mirascope.base import BaseConfig
+
+
+class BookRecommender(AnthropicCall):
+    prompt_template = "Please recommend a fantasy book."
+
+    call_params = AnthropicCallParams(model="anthropic.claude-3-haiku-20240307-v1:0")
+    configuration = BaseConfig(
+        client_wrappers=[
+            bedrock_client_wrapper(
+                # both of these keys can be configured in your environment
+                aws_secret_key="YOUR_SECRET_KEY",
+                aws_access_key="YOUR_ACCESS_KEY",
+                aws_region="us-west-2",
+            )
+        ]
+    )
+
+
+recommender = BookRecommender()
+response = recommender.call()
+print(response.content)
+```
+
 ## More detailed walkthrough of swapping providers (OpenAI -> Gemini)
 
 The [generative-ai library](https://github.com/GoogleCloudPlatform/generative-ai?tab=readme-ov-file) and [openai-python library](https://github.com/openai/openai-python) are vastly different from each other, so swapping between them to attempt to gain better prompt responses is not worth the engineering effort and maintenance. 

--- a/docs/concepts/supported_llm_providers.md
+++ b/docs/concepts/supported_llm_providers.md
@@ -367,39 +367,75 @@ class RecipeRecommender(OpenAICall):
     call_params = OpenAICallParams(model="mistral")
 ```
 
-## Using Anthropic models on AWS Bedrock
+## Using models hosted on major cloud providers
 
-You can use Anthropic models through AWS Bedrock, which is supported in Mirascope through a client wrapper. Simply import the wrapper, provide the correct configuration, and add the wrapper to your call:
+Some model providers have their models hosted on major cloud providers such as AWS Bedricj and Microsoft Azure. You can use provided client wrappers to access these models by providing the proper configuration:
 
-```python
-from mirascope.anthropic import (
-    AnthropicCall,
-    AnthropicCallParams,
-    bedrock_client_wrapper,
-)
-from mirascope.base import BaseConfig
+=== "Anthropic (AWS Bedrock)"
+
+    ```python
+    import os
+
+    from mirascope.anthropic import (
+        AnthropicCall,
+        AnthropicCallParams,
+        bedrock_client_wrapper,
+    )
+    from mirascope.base import BaseConfig
 
 
-class BookRecommender(AnthropicCall):
-    prompt_template = "Please recommend a fantasy book."
+    class BookRecommender(AnthropicCall):
+        prompt_template = "Please recommend a fantasy book."
 
-    call_params = AnthropicCallParams(model="anthropic.claude-3-haiku-20240307-v1:0")
-    configuration = BaseConfig(
-        client_wrappers=[
-            bedrock_client_wrapper(
-                # both of these keys can be configured in your environment
-                aws_secret_key="YOUR_SECRET_KEY",
-                aws_access_key="YOUR_ACCESS_KEY",
-                aws_region="us-west-2",
-            )
-        ]
+        call_params = AnthropicCallParams(model="anthropic.claude-3-haiku-20240307-v1:0")
+        configuration = BaseConfig(
+            client_wrappers=[
+                bedrock_client_wrapper(
+                    aws_secret_key=os.getenv("AWS_SECRET_ACCESS_KEY"),
+                    aws_access_key=os.getenv("AWS_ACCESS_KEY_ID"),
+                    aws_region="us-west-2",
+                )
+            ]
+        )
+
+
+    recommender = BookRecommender()
+    response = recommender.call()
+    print(response.content)
+    ```
+
+=== "OpenAI (Microsoft Azure)"
+
+    ```python
+    import os
+
+    from mirascope.base import BaseConfig
+    from mirascope.openai import (
+        OpenAICall,
+        OpenAICallParams,
+        azure_client_wrapper,
     )
 
 
-recommender = BookRecommender()
-response = recommender.call()
-print(response.content)
-```
+    class BookRecommender(OpenAICall):
+        prompt_template = "Please recommend a fantasy book."
+
+        call_params = OpenAICallParams(model="NEEDS MODEL NAME ONCE FIGURED OUT")
+        configuration = BaseConfig(
+            client_wrappers=[
+                azure_client_wrapper(
+                    api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+                    api_version="2024-02-01",
+                    azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+                )
+            ]
+        )
+
+
+    recommender = BookRecommender()
+    response = recommender.call()
+    print(response.content)
+    ```
 
 ## More detailed walkthrough of swapping providers (OpenAI -> Gemini)
 

--- a/docs/concepts/supported_llm_providers.md
+++ b/docs/concepts/supported_llm_providers.md
@@ -369,7 +369,7 @@ class RecipeRecommender(OpenAICall):
 
 ## Using models hosted on major cloud providers
 
-Some model providers have their models hosted on major cloud providers such as AWS Bedricj and Microsoft Azure. You can use provided client wrappers to access these models by providing the proper configuration:
+Some model providers have their models hosted on major cloud providers such as AWS Bedrock and Microsoft Azure. You can use provided client wrappers to access these models by providing the proper configuration:
 
 === "Anthropic (AWS Bedrock)"
 

--- a/mirascope/anthropic/__init__.py
+++ b/mirascope/anthropic/__init__.py
@@ -9,7 +9,7 @@ from .types import (
     AnthropicCallResponse,
     AnthropicCallResponseChunk,
 )
-from .utils import anthropic_api_calculate_cost
+from .utils import anthropic_api_calculate_cost, bedrock_client_wrapper
 
 __all__ = [
     "AnthropicCall",

--- a/mirascope/anthropic/__init__.py
+++ b/mirascope/anthropic/__init__.py
@@ -20,4 +20,5 @@ __all__ = [
     "AnthropicCallResponse",
     "AnthropicCallResponseChunk",
     "anthropic_api_calculate_cost",
+    "bedrock_client_wrapper",
 ]

--- a/mirascope/anthropic/utils.py
+++ b/mirascope/anthropic/utils.py
@@ -1,8 +1,40 @@
 """A module for utility functions for working with Anthropic."""
 
-from typing import Optional
+from typing import Callable, Optional, Union
 
+from anthropic import Anthropic, AnthropicBedrock, AsyncAnthropic, AsyncAnthropicBedrock
+from anthropic._types import URL
 from anthropic.types import Usage
+
+
+def bedrock_client_wrapper(
+    aws_secret_key: Optional[str] = None,
+    aws_access_key: Optional[str] = None,
+    aws_region: Optional[str] = None,
+    aws_session_token: Optional[str] = None,
+    base_url: Optional[Union[str, URL]] = None,
+) -> Callable[
+    [Union[Anthropic, AsyncAnthropic]], Union[AnthropicBedrock, AsyncAnthropicBedrock]
+]:
+    """Returns a client wrapper for using Anthropic models on AWS Bedrock."""
+
+    def inner_wrapper(client: Union[Anthropic, AsyncAnthropic]):
+        """Returns matching `AnthropicBedrock` or `AsyncAnthropicBedrock` client."""
+        kwargs = {
+            "aws_secret_key": aws_secret_key,
+            "aws_access_key": aws_access_key,
+            "aws_region": aws_region,
+            "aws_session_token": aws_session_token,
+            "base_url": base_url,
+        }
+        if isinstance(client, Anthropic):
+            return AnthropicBedrock(**kwargs)
+        elif isinstance(client, AsyncAnthropic):
+            return AsyncAnthropicBedrock(**kwargs)
+        else:
+            raise ValueError(f"Unknown Anthropic client: {client}")
+
+    return inner_wrapper
 
 
 def anthropic_api_calculate_cost(

--- a/mirascope/anthropic/utils.py
+++ b/mirascope/anthropic/utils.py
@@ -28,11 +28,10 @@ def bedrock_client_wrapper(
             "base_url": base_url,
         }
         if isinstance(client, Anthropic):
-            return AnthropicBedrock(**kwargs)
+            client = AnthropicBedrock(**kwargs)  # type: ignore
         elif isinstance(client, AsyncAnthropic):
-            return AsyncAnthropicBedrock(**kwargs)
-        else:
-            raise ValueError(f"Unknown Anthropic client: {client}")
+            client = AsyncAnthropicBedrock(**kwargs)  # type: ignore
+        return client
 
     return inner_wrapper
 

--- a/mirascope/openai/__init__.py
+++ b/mirascope/openai/__init__.py
@@ -12,9 +12,10 @@ from .types import (
     OpenAIEmbeddingParams,
     OpenAIEmbeddingResponse,
 )
-from .utils import openai_api_calculate_cost
+from .utils import azure_client_wrapper, openai_api_calculate_cost
 
 __all__ = [
+    "azure_client_wrapper",
     "OpenAICall",
     "OpenAIEmbedder",
     "OpenAIExtractor",

--- a/tests/anthropic/test_utils.py
+++ b/tests/anthropic/test_utils.py
@@ -1,0 +1,26 @@
+"""Tests for Mirascope's Anthropic utils module."""
+
+from anthropic import Anthropic, AnthropicBedrock, AsyncAnthropic, AsyncAnthropicBedrock
+
+from mirascope.anthropic.utils import bedrock_client_wrapper
+
+
+def test_bedrock_client_wrapper():
+    """Tests the Anthropic client wrapper for AWS Bedrock."""
+    kwargs = {
+        "aws_secret_key": "TEST_SECRET_KEY",
+        "aws_access_key": "TEST_ACCESS_KEY",
+        "aws_region": "us-west-2",
+        "aws_session_token": "TEST_SESSION_TOKEN",
+        "base_url": "TEST_BASE_URL/",
+    }
+    wrapper = bedrock_client_wrapper(**kwargs)
+    client = Anthropic()
+    wrapped_client = wrapper(client)
+    assert isinstance(wrapped_client, AnthropicBedrock)
+    async_client = AsyncAnthropic()
+    wrapped_async_client = wrapper(async_client)
+    assert isinstance(wrapped_async_client, AsyncAnthropicBedrock)
+    for key, value in kwargs.items():
+        assert getattr(wrapped_client, key) == value
+        assert getattr(wrapped_async_client, key) == value

--- a/tests/openai/test_utils.py
+++ b/tests/openai/test_utils.py
@@ -1,0 +1,34 @@
+"""Tests for Mirascope's OpenAI utils module."""
+
+from openai import AsyncAzureOpenAI, AsyncOpenAI, AzureOpenAI, OpenAI
+
+from mirascope.openai.utils import azure_client_wrapper
+
+
+def test_azure_client_wrapper():
+    """Tests the OpenAI client wrapper for Microsoft Azure."""
+    kwargs = {
+        "azure_endpoint": "TEST_AZURE_ENDPOINT",
+        "azure_deployment": "TEST_AZURE_DEPLOYMENT",
+        "api_version": "TEST_API_VERSION",
+        "api_key": "TEST_API_KEY",
+        "azure_ad_token": "TEST_AZURE_AD_TOKEN",
+        "azure_ad_token_provider": None,
+        "organization": "TEST_ORGANIZATION",
+    }
+    wrapper = azure_client_wrapper(**kwargs)
+    client = OpenAI()
+    wrapped_client = wrapper(client)
+    assert isinstance(wrapped_client, AzureOpenAI)
+    async_client = AsyncOpenAI()
+    wrapped_async_client = wrapper(async_client)
+    assert isinstance(wrapped_async_client, AsyncAzureOpenAI)
+    kwargs.pop("azure_endpoint")
+    kwargs.pop("azure_deployment")
+    kwargs["base_url"] = "TEST_AZURE_ENDPOINT/openai/deployments/TEST_AZURE_DEPLOYMENT/"
+    kwargs["_api_version"] = kwargs.pop("api_version")
+    kwargs["_azure_ad_token"] = kwargs.pop("azure_ad_token")
+    kwargs["_azure_ad_token_provider"] = kwargs.pop("azure_ad_token_provider")
+    for key, value in kwargs.items():
+        assert getattr(wrapped_client, key) == value
+        assert getattr(wrapped_async_client, key) == value


### PR DESCRIPTION
Closes #224 
Closes #225 

- Add `bedrock_client_wrapper` to `anthropic` module for wrapping `Anthropic` and `AsyncAnthropic` to use AWS Bedrock.
- Add `azure_client_wrapper` to `openai` module for wrapping `OpenAI` and `AsyncOpenAI` to use Microsoft Azure deployments.