### PR TITLE
fix: tool.args issue

### DIFF
--- a/mirascope/base/tools.py
+++ b/mirascope/base/tools.py
@@ -44,7 +44,11 @@ class BaseTool(BaseModel, Generic[ToolCallT], ABC):
     @property
     def args(self) -> dict[str, Any]:
         """The arguments of the tool as a dictionary."""
-        return self.model_dump(exclude={"tool_call"})
+        return {
+            field: getattr(self, field)
+            for field in self.model_fields
+            if field != "tool_call"
+        }
 
     @property
     def fn(self) -> Callable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mirascope"
-version = "0.16.0"
+version = "0.16.1"
 description = "An intuitive approach to building with LLMs"
 license = "MIT"
 authors = [


### PR DESCRIPTION
Issue was that we were calling `model_dump` but we really should be grabbing the top level fields as the key/value pairs.