### PR TITLE
feat: otel llm updates

### DIFF
--- a/mirascope/anthropic/types.py
+++ b/mirascope/anthropic/types.py
@@ -148,6 +148,16 @@ class AnthropicCallResponse(
         return block.text if block.type == "text" else ""
 
     @property
+    def id(self) -> str:
+        """Returns the id of the response."""
+        return self.response.id
+
+    @property
+    def finish_reasons(self) -> Optional[list[str]]:
+        """Returns the finish reason of the response."""
+        return [self.response.stop_reason]
+
+    @property
     def usage(self) -> Usage:
         """Returns the usage of the message."""
         return self.response.usage

--- a/mirascope/anthropic/types.py
+++ b/mirascope/anthropic/types.py
@@ -8,6 +8,7 @@ from anthropic.types import (
     ContentBlockDeltaEvent,
     ContentBlockStartEvent,
     Message,
+    MessageStartEvent,
     MessageStreamEvent,
     TextBlock,
     TextDelta,
@@ -148,6 +149,11 @@ class AnthropicCallResponse(BaseCallResponse[Message, AnthropicTool]):
         return block.text if block.type == "text" else ""
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        return self.response.model
+
+    @property
     def id(self) -> str:
         """Returns the id of the response."""
         return self.response.id
@@ -155,7 +161,7 @@ class AnthropicCallResponse(BaseCallResponse[Message, AnthropicTool]):
     @property
     def finish_reasons(self) -> Optional[list[str]]:
         """Returns the finish reason of the response."""
-        return [self.response.stop_reason]
+        return [str(self.response.stop_reason)]
 
     @property
     def usage(self) -> Usage:
@@ -245,3 +251,45 @@ class AnthropicCallResponseChunk(
                 self.chunk.delta.text if isinstance(self.chunk.delta, TextDelta) else ""
             )
         return ""
+
+    @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        if isinstance(self.chunk, MessageStartEvent):
+            return self.chunk.message.model
+        return None
+
+    @property
+    def id(self) -> Optional[str]:
+        """Returns the id of the response."""
+        if isinstance(self.chunk, MessageStartEvent):
+            return self.chunk.message.id
+        return None
+
+    @property
+    def finish_reasons(self) -> Optional[list[str]]:
+        """Returns the finish reason of the response."""
+        if isinstance(self.chunk, MessageStartEvent):
+            return [self.chunk.message.stop_reason]
+        return None
+
+    @property
+    def usage(self) -> Optional[Usage]:
+        """Returns the usage of the message."""
+        if isinstance(self.chunk, MessageStartEvent):
+            return self.chunk.message.usage
+        return None
+
+    @property
+    def input_tokens(self) -> Optional[int]:
+        """Returns the number of input tokens."""
+        if self.usage:
+            return self.usage.input_tokens
+        return None
+
+    @property
+    def output_tokens(self) -> Optional[int]:
+        """Returns the number of output tokens."""
+        if self.usage:
+            return self.usage.output_tokens
+        return None

--- a/mirascope/anthropic/types.py
+++ b/mirascope/anthropic/types.py
@@ -253,7 +253,7 @@ class AnthropicCallResponseChunk(
         return ""
 
     @property
-    def model(self) -> str:
+    def model(self) -> Optional[str]:
         """Returns the name of the response model."""
         if isinstance(self.chunk, MessageStartEvent):
             return self.chunk.message.model
@@ -270,7 +270,7 @@ class AnthropicCallResponseChunk(
     def finish_reasons(self) -> Optional[list[str]]:
         """Returns the finish reason of the response."""
         if isinstance(self.chunk, MessageStartEvent):
-            return [self.chunk.message.stop_reason]
+            return [str(self.chunk.message.stop_reason)]
         return None
 
     @property

--- a/mirascope/base/types.py
+++ b/mirascope/base/types.py
@@ -260,3 +260,30 @@ class BaseCallResponseChunk(BaseModel, Generic[ChunkT, BaseToolT], ABC):
         If there is no finish reason, this method must return None.
         """
         ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def usage(self) -> Any:
+        """Should return the usage of the response.
+
+        If there is no usage, this method must return None.
+        """
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def input_tokens(self) -> Optional[Union[int, float]]:
+        """Should return the number of input tokens.
+
+        If there is no input_tokens, this method must return None.
+        """
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def output_tokens(self) -> Optional[Union[int, float]]:
+        """Should return the number of output tokens.
+
+        If there is no output_tokens, this method must return None.
+        """
+        ...  # pragma: no cover

--- a/mirascope/base/types.py
+++ b/mirascope/base/types.py
@@ -165,11 +165,17 @@ class BaseCallResponse(BaseModel, Generic[ResponseT, BaseToolT], ABC):
 
     @property
     @abstractmethod
-    def finish_reasons(self) -> list[str]:
+    def finish_reasons(self) -> Union[None, list[str]]:
         """Should return the finish reasons of the response.
 
         If there is no finish reason, this method must return None.
         """
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def model(self) -> Optional[str]:
+        """Should return the name of the response model."""
         ...  # pragma: no cover
 
     @property
@@ -236,15 +242,21 @@ class BaseCallResponseChunk(BaseModel, Generic[ChunkT, BaseToolT], ABC):
 
     @property
     @abstractmethod
-    def finish_reasons(self) -> list[str]:
-        """Should return the finish reasons of the response.
-
-        If there is no finish reason, this method must return None.
-        """
+    def model(self) -> Optional[str]:
+        """Should return the name of the response model."""
         ...  # pragma: no cover
 
     @property
     @abstractmethod
     def id(self) -> Optional[str]:
         """Should return the id of the response."""
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def finish_reasons(self) -> Union[None, list[str]]:
+        """Should return the finish reasons of the response.
+
+        If there is no finish reason, this method must return None.
+        """
         ...  # pragma: no cover

--- a/mirascope/base/types.py
+++ b/mirascope/base/types.py
@@ -165,6 +165,21 @@ class BaseCallResponse(BaseModel, Generic[ResponseT, BaseToolT], ABC):
 
     @property
     @abstractmethod
+    def finish_reasons(self) -> list[str]:
+        """Should return the finish reasons of the response.
+
+        If there is no finish reason, this method must return None.
+        """
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def id(self) -> Optional[str]:
+        """Should return the id of the response."""
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
     def usage(self) -> Any:
         """Should return the usage of the response.
 
@@ -217,4 +232,19 @@ class BaseCallResponseChunk(BaseModel, Generic[ChunkT, BaseToolT], ABC):
         If there is no string content (e.g. when using tools), this method must return
         the empty string.
         """
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def finish_reasons(self) -> list[str]:
+        """Should return the finish reasons of the response.
+
+        If there is no finish reason, this method must return None.
+        """
+        ...  # pragma: no cover
+
+    @property
+    @abstractmethod
+    def id(self) -> Optional[str]:
+        """Should return the id of the response."""
         ...  # pragma: no cover

--- a/mirascope/cohere/types.py
+++ b/mirascope/cohere/types.py
@@ -122,6 +122,16 @@ class CohereCallResponse(BaseCallResponse[NonStreamedChatResponse, CohereTool]):
         return self.response.text
 
     @property
+    def id(self) -> Optional[str]:
+        """Returns the id of the response."""
+        return self.response.generation_id
+
+    @property
+    def finish_reasons(self) -> Optional[list[str]]:
+        """Returns the finish reasons of the response."""
+        return [self.response.finish_reason]
+
+    @property
     def search_queries(self) -> Optional[list[ChatSearchQuery]]:
         """Returns the search queries for the 0th choice message."""
         return self.response.search_queries

--- a/mirascope/cohere/types.py
+++ b/mirascope/cohere/types.py
@@ -7,6 +7,7 @@ from cohere import (
     StreamedChatResponse_SearchQueriesGeneration,
     StreamedChatResponse_SearchResults,
     StreamedChatResponse_StreamEnd,
+    StreamedChatResponse_StreamStart,
     StreamedChatResponse_ToolCallsGeneration,
 )
 from cohere.types import (
@@ -122,6 +123,14 @@ class CohereCallResponse(BaseCallResponse[NonStreamedChatResponse, CohereTool]):
         return self.response.text
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model.
+
+        Cohere does not return model, so we return None
+        """
+        return None
+
+    @property
     def id(self) -> Optional[str]:
         """Returns the id of the response."""
         return self.response.generation_id
@@ -129,7 +138,7 @@ class CohereCallResponse(BaseCallResponse[NonStreamedChatResponse, CohereTool]):
     @property
     def finish_reasons(self) -> Optional[list[str]]:
         """Returns the finish reasons of the response."""
-        return [self.response.finish_reason]
+        return [str(self.response.finish_reason)]
 
     @property
     def search_queries(self) -> Optional[list[ChatSearchQuery]]:
@@ -309,6 +318,28 @@ class CohereCallResponseChunk(BaseCallResponseChunk[StreamedChatResponse, Cohere
         return None
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model.
+
+        Cohere does not return model, so we return None
+        """
+        return None
+
+    @property
+    def id(self) -> Optional[str]:
+        """Returns the id of the response."""
+        if isinstance(self.chunk, StreamedChatResponse_StreamStart):
+            return self.chunk.generation_id
+        return None
+
+    @property
+    def finish_reasons(self) -> Optional[list[str]]:
+        """Returns the finish reasons of the response."""
+        if isinstance(self.chunk, StreamedChatResponse_StreamEnd):
+            return [str(self.chunk.finish_reason)]
+        return None
+
+    @property
     def response(self) -> Optional[NonStreamedChatResponse]:
         """Returns the full response for the stream-end event type else None."""
         if isinstance(self.chunk, StreamedChatResponse_StreamEnd):
@@ -320,6 +351,28 @@ class CohereCallResponseChunk(BaseCallResponseChunk[StreamedChatResponse, Cohere
         """Returns the partial tool calls for the 0th choice message."""
         if isinstance(self.chunk, StreamedChatResponse_ToolCallsGeneration):
             return self.chunk.tool_calls
+        return None
+
+    @property
+    def usage(self) -> Optional[ApiMetaBilledUnits]:
+        """Returns the usage of the response."""
+        if isinstance(self.chunk, StreamedChatResponse_StreamEnd):
+            if self.chunk.response.meta:
+                return self.chunk.response.meta.billed_units
+        return None
+
+    @property
+    def input_tokens(self) -> Optional[float]:
+        """Returns the number of input tokens."""
+        if self.usage:
+            return self.usage.input_tokens
+        return None
+
+    @property
+    def output_tokens(self) -> Optional[float]:
+        """Returns the number of output tokens."""
+        if self.usage:
+            return self.usage.output_tokens
         return None
 
 

--- a/mirascope/cohere/types.py
+++ b/mirascope/cohere/types.py
@@ -123,7 +123,7 @@ class CohereCallResponse(BaseCallResponse[NonStreamedChatResponse, CohereTool]):
         return self.response.text
 
     @property
-    def model(self) -> str:
+    def model(self) -> Optional[str]:
         """Returns the name of the response model.
 
         Cohere does not return model, so we return None
@@ -318,7 +318,7 @@ class CohereCallResponseChunk(BaseCallResponseChunk[StreamedChatResponse, Cohere
         return None
 
     @property
-    def model(self) -> str:
+    def model(self) -> Optional[str]:
         """Returns the name of the response model.
 
         Cohere does not return model, so we return None

--- a/mirascope/gemini/types.py
+++ b/mirascope/gemini/types.py
@@ -121,6 +121,31 @@ class GeminiCallResponse(
         return self.response.candidates[0].content.parts[0].text
 
     @property
+    def id(self) -> Optional[str]:
+        """Returns the id of the response.
+
+        google.generativeai does not return an id
+        """
+        return None
+
+    @property
+    def finish_reasons(self) -> list[str]:
+        """Returns the finish reasons of the response."""
+        finish_reasons = [
+            "FINISH_REASON_UNSPECIFIED",
+            "STOP",
+            "MAX_TOKENS",
+            "SAFETY",
+            "RECITATION",
+            "OTHER",
+        ]
+
+        return [
+            finish_reasons[candidate.finish_reason]
+            for candidate in self.response.candidates
+        ]
+
+    @property
     def usage(self) -> None:
         """Returns the usage of the chat completion.
 

--- a/mirascope/gemini/types.py
+++ b/mirascope/gemini/types.py
@@ -146,6 +146,14 @@ class GeminiCallResponse(
         ]
 
     @property
+    def model(self) -> None:
+        """Returns the model name.
+
+        google.generativeai does not return model, so we return None
+        """
+        return None
+
+    @property
     def usage(self) -> None:
         """Returns the usage of the chat completion.
 
@@ -211,3 +219,54 @@ class GeminiCallResponseChunk(
     def content(self) -> str:
         """Returns the chunk content for the 0th choice."""
         return self.chunk.candidates[0].content.parts[0].text
+
+    @property
+    def id(self) -> Optional[str]:
+        """Returns the id of the response.
+
+        google.generativeai does not return an id
+        """
+        return None
+
+    @property
+    def finish_reasons(self) -> list[str]:
+        """Returns the finish reasons of the response."""
+        finish_reasons = [
+            "FINISH_REASON_UNSPECIFIED",
+            "STOP",
+            "MAX_TOKENS",
+            "SAFETY",
+            "RECITATION",
+            "OTHER",
+        ]
+
+        return [
+            finish_reasons[candidate.finish_reason]
+            for candidate in self.chunk.candidates
+        ]
+
+    @property
+    def model(self) -> None:
+        """Returns the model name.
+
+        google.generativeai does not return model, so we return None
+        """
+        return None
+
+    @property
+    def usage(self) -> None:
+        """Returns the usage of the chat completion.
+
+        google.generativeai does not have Usage, so we return None
+        """
+        return None
+
+    @property
+    def input_tokens(self) -> None:
+        """Returns the number of input tokens."""
+        return None
+
+    @property
+    def output_tokens(self) -> None:
+        """Returns the number of output tokens."""
+        return None

--- a/mirascope/groq/types.py
+++ b/mirascope/groq/types.py
@@ -189,6 +189,16 @@ class GroqCallResponse(BaseCallResponse[ChatCompletion, GroqTool]):
         return None
 
     @property
+    def id(self) -> str:
+        """Returns the id of the response."""
+        return self.response.id
+
+    @property
+    def finish_reasons(self) -> list[str]:
+        """Returns the finish reasons of the response."""
+        return [choice.finish_reason for choice in self.choices]
+
+    @property
     def usage(self) -> Optional[Usage]:
         """Returns the usage of the chat completion."""
         return self.response.usage

--- a/mirascope/groq/types.py
+++ b/mirascope/groq/types.py
@@ -194,6 +194,11 @@ class GroqCallResponse(BaseCallResponse[ChatCompletion, GroqTool]):
         return None
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        return self.response.model
+
+    @property
     def id(self) -> str:
         """Returns the id of the response."""
         return self.response.id
@@ -201,7 +206,7 @@ class GroqCallResponse(BaseCallResponse[ChatCompletion, GroqTool]):
     @property
     def finish_reasons(self) -> list[str]:
         """Returns the finish reasons of the response."""
-        return [choice.finish_reason for choice in self.choices]
+        return [str(choice.finish_reason) for choice in self.choices]
 
     @property
     def usage(self) -> Optional[CompletionUsage]:
@@ -287,6 +292,21 @@ class GroqCallResponseChunk(BaseCallResponseChunk[ChatCompletionChunk, GroqTool]
         return self.delta.content if self.delta.content is not None else ""
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        return self.chunk.model
+
+    @property
+    def id(self) -> str:
+        """Returns the id of the response."""
+        return self.chunk.id
+
+    @property
+    def finish_reasons(self) -> list[str]:
+        """Returns the finish reasons of the response."""
+        return [str(choice.finish_reason) for choice in self.chunk.choices]
+
+    @property
     def tool_calls(self) -> Optional[list[ChoiceDeltaToolCall]]:
         """Returns the partial tool calls for the 0th choice message.
 
@@ -297,3 +317,22 @@ class GroqCallResponseChunk(BaseCallResponseChunk[ChatCompletionChunk, GroqTool]
         `list[ChoiceDeltaToolCall]` will be None indicating end of stream.
         """
         return self.delta.tool_calls
+
+    @property
+    def usage(self) -> Optional[CompletionUsage]:
+        """Returns the usage of the chat completion."""
+        return self.chunk.usage
+
+    @property
+    def input_tokens(self) -> Optional[int]:
+        """Returns the number of input tokens."""
+        if self.usage:
+            return self.usage.prompt_tokens
+        return None
+
+    @property
+    def output_tokens(self) -> Optional[int]:
+        """Returns the number of output tokens."""
+        if self.usage:
+            return self.usage.completion_tokens
+        return None

--- a/mirascope/logfire/logfire.py
+++ b/mirascope/logfire/logfire.py
@@ -4,6 +4,7 @@ from contextlib import (
     contextmanager,
 )
 from string import Formatter
+from textwrap import dedent
 from typing import Any, Callable, Optional, Union, overload
 
 import logfire
@@ -243,6 +244,7 @@ def handle_before_call(self: BaseModel, fn: Callable, **kwargs):
             for _, var, _, _ in Formatter().parse(self.prompt_template)
             if var is not None
         }
+        class_vars["prompt_template"] = dedent(self.prompt_template)
     span_data = {
         "class_vars": class_vars,
         "template_variables": template_variables,

--- a/mirascope/mistral/types.py
+++ b/mirascope/mistral/types.py
@@ -92,14 +92,22 @@ class MistralCallResponse(BaseCallResponse[ChatCompletionResponse, MistralTool])
         return content if isinstance(content, str) else content[0]
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        return self.response.model
+
+    @property
     def id(self) -> str:
         """Returns the id of the response."""
         return self.response.id
 
     @property
-    def finish_reasons(self) -> list[Optional[str]]:
+    def finish_reasons(self) -> list[str]:
         """Returns the finish reasons of the response."""
-        return [choice.finish_reason for choice in self.choices]
+        return [
+            choice.finish_reason if choice.finish_reason else ""
+            for choice in self.choices
+        ]
 
     @property
     def tool_calls(self) -> Optional[list[ToolCall]]:
@@ -224,6 +232,39 @@ class MistralCallResponseChunk(
         return self.delta.content if self.delta.content is not None else ""
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        return self.chunk.model
+
+    @property
+    def id(self) -> str:
+        """Returns the id of the response."""
+        return self.chunk.id
+
+    @property
+    def finish_reasons(self) -> list[str]:
+        """Returns the finish reasons of the response."""
+        return [
+            choice.finish_reason if choice.finish_reason else ""
+            for choice in self.choices
+        ]
+
+    @property
     def tool_calls(self) -> Optional[list[ToolCall]]:
         """Returns the partial tool calls for the 0th choice message."""
         return self.delta.tool_calls
+
+    @property
+    def usage(self) -> UsageInfo:
+        """Returns the usage of the chat completion."""
+        return self.chunk.usage
+
+    @property
+    def input_tokens(self) -> int:
+        """Returns the number of input tokens."""
+        return self.usage.prompt_tokens
+
+    @property
+    def output_tokens(self) -> Optional[int]:
+        """Returns the number of output tokens."""
+        return self.usage.completion_tokens

--- a/mirascope/mistral/types.py
+++ b/mirascope/mistral/types.py
@@ -255,16 +255,20 @@ class MistralCallResponseChunk(
         return self.delta.tool_calls
 
     @property
-    def usage(self) -> UsageInfo:
+    def usage(self) -> Optional[UsageInfo]:
         """Returns the usage of the chat completion."""
         return self.chunk.usage
 
     @property
-    def input_tokens(self) -> int:
+    def input_tokens(self) -> Optional[int]:
         """Returns the number of input tokens."""
-        return self.usage.prompt_tokens
+        if self.usage:
+            return self.usage.prompt_tokens
+        return None
 
     @property
     def output_tokens(self) -> Optional[int]:
         """Returns the number of output tokens."""
-        return self.usage.completion_tokens
+        if self.usage:
+            return self.usage.completion_tokens
+        return None

--- a/mirascope/mistral/types.py
+++ b/mirascope/mistral/types.py
@@ -92,6 +92,16 @@ class MistralCallResponse(BaseCallResponse[ChatCompletionResponse, MistralTool])
         return content if isinstance(content, str) else content[0]
 
     @property
+    def id(self) -> str:
+        """Returns the id of the response."""
+        return self.response.id
+
+    @property
+    def finish_reasons(self) -> list[Optional[str]]:
+        """Returns the finish reasons of the response."""
+        return [choice.finish_reason for choice in self.choices]
+
+    @property
     def tool_calls(self) -> Optional[list[ToolCall]]:
         """Returns the tool calls for the 0th choice message."""
         return self.message.tool_calls

--- a/mirascope/openai/types.py
+++ b/mirascope/openai/types.py
@@ -125,6 +125,11 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         return self.message.content if self.message.content is not None else ""
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        return self.response.model
+
+    @property
     def id(self) -> str:
         """Returns the id of the response."""
         return self.response.id
@@ -132,7 +137,7 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
     @property
     def finish_reasons(self) -> list[str]:
         """Returns the finish reasons of the response."""
-        return [choice.finish_reason for choice in self.response.choices]
+        return [str(choice.finish_reason) for choice in self.response.choices]
 
     @property
     def tool_calls(self) -> Optional[list[ChatCompletionMessageToolCall]]:
@@ -293,6 +298,11 @@ class OpenAICallResponseChunk(BaseCallResponseChunk[ChatCompletionChunk, OpenAIT
         )
 
     @property
+    def model(self) -> str:
+        """Returns the name of the response model."""
+        return self.chunk.model
+
+    @property
     def id(self) -> str:
         """Returns the id of the response."""
         return self.chunk.id
@@ -300,7 +310,7 @@ class OpenAICallResponseChunk(BaseCallResponseChunk[ChatCompletionChunk, OpenAIT
     @property
     def finish_reasons(self) -> list[str]:
         """Returns the finish reasons of the response."""
-        return [choice.finish_reason for choice in self.chunk.choices]
+        return [str(choice.finish_reason) for choice in self.chunk.choices]
 
     @property
     def tool_calls(self) -> Optional[list[ChoiceDeltaToolCall]]:

--- a/mirascope/openai/types.py
+++ b/mirascope/openai/types.py
@@ -125,6 +125,16 @@ class OpenAICallResponse(BaseCallResponse[ChatCompletion, OpenAITool]):
         return self.message.content if self.message.content is not None else ""
 
     @property
+    def id(self) -> str:
+        """Returns the id of the response."""
+        return self.response.id
+
+    @property
+    def finish_reasons(self) -> list[str]:
+        """Returns the finish reasons of the response."""
+        return [choice.finish_reason for choice in self.response.choices]
+
+    @property
     def tool_calls(self) -> Optional[list[ChatCompletionMessageToolCall]]:
         """Returns the tool calls for the 0th choice message."""
         return self.message.tool_calls
@@ -281,6 +291,16 @@ class OpenAICallResponseChunk(BaseCallResponseChunk[ChatCompletionChunk, OpenAIT
         return (
             self.delta.content if self.delta is not None and self.delta.content else ""
         )
+
+    @property
+    def id(self) -> str:
+        """Returns the id of the response."""
+        return self.chunk.id
+
+    @property
+    def finish_reasons(self) -> list[str]:
+        """Returns the finish reasons of the response."""
+        return [choice.finish_reason for choice in self.chunk.choices]
 
     @property
     def tool_calls(self) -> Optional[list[ChoiceDeltaToolCall]]:

--- a/mirascope/otel/otel.py
+++ b/mirascope/otel/otel.py
@@ -14,6 +14,7 @@ from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
 )
 from opentelemetry.trace import (
+    SpanKind,
     Tracer,
     get_tracer,
     get_tracer_provider,
@@ -44,8 +45,118 @@ STEAMING_MSG_TEMPLATE: LiteralString = (
 )
 
 
-def mirascope_otel() -> Callable:
+def _set_response_attributes(
+    span: Span, response: BaseCallResponse, messages: list[dict[str, Any]]
+) -> None:
+    """Sets the response attributes"""
+    response_attributes = {
+        "gen_ai.response.id": response.id,
+        "gen_ai.response.model": response.content,
+        "gen_ai.response.finish_reasons": response.finish_reasons,
+        "gen_ai.usage.completion_tokens": response.output_tokens,
+        "gen_ai.usage.prompt_tokens": response.input_tokens,
+    }
+    span.set_attributes(response_attributes)
+    event_attributes = {"gen_ai.completion": json.dumps(messages)}
+    span.add_event(
+        "gen_ai.content.completion",
+        attributes=event_attributes,
+    )
+
+
+def mirascope_otel(cls) -> Callable:
     tracer = get_tracer("otel")
+
+    def _set_span_data(
+        span: Span,
+        suffix: str,
+        is_async: bool,
+        model_name: Optional[str],
+        args: tuple[Any],
+    ) -> None:
+        prompt = args[0]
+        if suffix == "gemini":
+            prompt = {
+                "messages": [
+                    {"role": message["role"], "content": message["parts"][0]}
+                    for message in prompt
+                ]
+            }
+
+        max_tokens = None
+        temperature = None
+        top_p = None
+        if hasattr(cls, "call_params"):
+            call_params = cls.call_params
+            max_tokens = getattr(call_params, "max_tokens", None)
+            temperature = getattr(call_params, "temperature", None)
+            top_p = getattr(call_params, "top_p", None)
+        attributes = {
+            "async": is_async,
+            "gen_ai.request.model": model_name,
+            "gen_ai.system": suffix,
+            "gen_ai.request.max_tokens": max_tokens,
+            "gen_ai.request.temperature": temperature,
+            "gen_ai.request.top_p": top_p,
+        }
+        events = {
+            "gen_ai.prompt": json.dumps(prompt),
+        }
+        span.set_attributes(attributes)
+        span.add_event("gen_ai.content.prompt", attributes=events)
+
+    @contextmanager
+    def _mirascope_llm_span(
+        fn: Callable,
+        suffix: str,
+        is_async: bool,
+        model_name: Optional[str],
+        args: tuple[Any],
+        kwargs: dict[str, Any],
+    ):
+        """Wraps a pydantic class method with a OTel span."""
+        tracer = get_tracer("otel")
+        model = kwargs.get("model", "") or model_name
+        with tracer.start_as_current_span(
+            f"{suffix}.{fn.__name__} with {model}", kind=SpanKind.CLIENT
+        ) as span:
+            _set_span_data(span, suffix, is_async, model, args)
+            yield span
+
+    @contextmanager
+    def record_streaming(
+        span: Span,
+        content_from_stream: Callable[
+            [ChunkT, type[BaseCallResponseChunk]], Union[str, None]
+        ],
+    ):
+        """OTel record_streaming with Mirascope providers"""
+        content: list[str] = []
+
+        def record_chunk(
+            chunk: ChunkT, response_chunk_type: type[BaseCallResponseChunk]
+        ) -> Any:
+            """Handles all provider chunk_types instead of only OpenAI"""
+            chunk_content = content_from_stream(chunk, response_chunk_type)
+            if chunk_content is not None:
+                content.append(chunk_content)
+
+        try:
+            yield record_chunk
+        finally:
+            attributes = {
+                "response_data": {
+                    "combined_chunk_content": "".join(content),
+                    "chunk_count": len(content),
+                },
+            }
+        span.set_attributes(attributes)
+
+    def _extract_chunk_content(
+        chunk: ChunkT, response_chunk_type: type[BaseCallResponseChunk]
+    ) -> str:
+        """Extracts the content from a chunk."""
+        return response_chunk_type(chunk=chunk).content
 
     def mirascope_otel_decorator(
         fn: Callable,
@@ -83,9 +194,7 @@ def mirascope_otel() -> Callable:
                         ]
                         message["tool_calls"] = tool_calls
                         message.pop("content")
-                    span.set_attribute(
-                        "response_data", json.dumps({"message": message})
-                    )
+                    _set_response_attributes(span, response, [message])
                 return result
 
         async def wrapper_async(*args, **kwargs):
@@ -112,20 +221,16 @@ def mirascope_otel() -> Callable:
                         ]
                         message["tool_calls"] = tool_calls
                         message.pop("content")
-                    span.set_attribute(
-                        "response_data", json.dumps({"message": message})
-                    )
+                    _set_response_attributes(span, response, [message])
                 return result
 
         def wrapper_generator(*args, **kwargs):
-            span_data = _get_span_data(suffix, is_async, model_name, args, kwargs)
             model = kwargs.get("model", "") or model_name
             with tracer.start_as_current_span(
                 f"{suffix}.{fn.__name__} with {model}"
             ) as span:
-                with record_streaming(
-                    span, span_data, _extract_chunk_content
-                ) as record_chunk:
+                _set_span_data(span, suffix, is_async, model, args)
+                with record_streaming(span, _extract_chunk_content) as record_chunk:
                     stream = fn(*args, **kwargs)
                     if isinstance(stream, AbstractContextManager):
                         with stream as s:
@@ -138,14 +243,12 @@ def mirascope_otel() -> Callable:
                             yield chunk
 
         async def wrapper_generator_async(*args, **kwargs):
-            span_data = _get_span_data(suffix, is_async, model_name, args, kwargs)
             model = kwargs.get("model", "") or model_name
             with tracer.start_as_current_span(
                 f"{suffix}.{fn.__name__} with {model}"
             ) as span:
-                with record_streaming(
-                    span, span_data, _extract_chunk_content
-                ) as record_chunk:
+                _set_span_data(span, suffix, is_async, model, args)
+                with record_streaming(span, _extract_chunk_content) as record_chunk:
                     stream = fn(*args, **kwargs)
                     if inspect.iscoroutine(stream):
                         stream = await stream
@@ -170,86 +273,6 @@ def mirascope_otel() -> Callable:
         raise ValueError("No response type or chunk type provided")
 
     return mirascope_otel_decorator
-
-
-def _extract_chunk_content(
-    chunk: ChunkT, response_chunk_type: type[BaseCallResponseChunk]
-) -> str:
-    """Extracts the content from a chunk."""
-    return response_chunk_type(chunk=chunk).content
-
-
-def _get_span_data(
-    suffix: str,
-    is_async: bool,
-    model_name: Optional[str],
-    args: tuple[Any],
-    kwargs: dict[str, Any],
-) -> dict[str, Any]:
-    additional_request_data = {}
-    if suffix == "gemini":
-        gemini_messages = args[0]
-        additional_request_data = {
-            "messages": [
-                {"role": message["role"], "content": message["parts"][0]}
-                for message in gemini_messages
-            ],
-            "model": model_name,
-        }
-    return {
-        "async": is_async,
-        "request_data": json.dumps(kwargs | additional_request_data),
-    }
-
-
-@contextmanager
-def _mirascope_llm_span(
-    fn: Callable,
-    suffix: str,
-    is_async: bool,
-    model_name: Optional[str],
-    args: tuple[Any],
-    kwargs: dict[str, Any],
-):
-    """Wraps a pydantic class method with a Logfire span."""
-    tracer = get_tracer("otel")
-    model = kwargs.get("model", "") or model_name
-    span_data = _get_span_data(suffix, is_async, model, args, kwargs)
-    with tracer.start_as_current_span(f"{suffix}.{fn.__name__} with {model}") as span:
-        span.set_attributes(span_data)
-        yield span
-
-
-@contextmanager
-def record_streaming(
-    span: Span,
-    span_data: dict[str, Any],
-    content_from_stream: Callable[
-        [ChunkT, type[BaseCallResponseChunk]], Union[str, None]
-    ],
-):
-    """Logfire record_streaming with Mirascope providers"""
-    content: list[str] = []
-
-    def record_chunk(
-        chunk: ChunkT, response_chunk_type: type[BaseCallResponseChunk]
-    ) -> Any:
-        """Handles all provider chunk_types instead of only OpenAI"""
-        chunk_content = content_from_stream(chunk, response_chunk_type)
-        if chunk_content is not None:
-            content.append(chunk_content)
-
-    try:
-        yield record_chunk
-    finally:
-        attributes = {
-            **span_data,
-            "response_data": {
-                "combined_chunk_content": "".join(content),
-                "chunk_count": len(content),
-            },
-        }
-        span.set_attributes(attributes)
 
 
 @contextmanager
@@ -330,7 +353,7 @@ def with_otel(cls: type[BaseEmbedderT]) -> type[BaseEmbedderT]:
 
 
 def with_otel(cls):
-    """Wraps a pydantic class with a Logfire span."""
+    """Wraps a pydantic class with a OTel span."""
 
     provider = get_tracer_provider()
     if not isinstance(provider, TracerProvider):
@@ -342,6 +365,6 @@ def with_otel(cls):
     )
     if hasattr(cls, "configuration"):
         cls.configuration = cls.configuration.model_copy(
-            update={"llm_ops": [*cls.configuration.llm_ops, mirascope_otel()]}
+            update={"llm_ops": [*cls.configuration.llm_ops, mirascope_otel(cls)]}
         )
     return cls

--- a/tests/anthropic/conftest.py
+++ b/tests/anthropic/conftest.py
@@ -60,6 +60,7 @@ def fixture_anthropic_message() -> Message:
         role="assistant",
         type="message",
         usage=Usage(input_tokens=0, output_tokens=0),
+        stop_reason="end_turn",
     )
 
 

--- a/tests/anthropic/test_types.py
+++ b/tests/anthropic/test_types.py
@@ -8,7 +8,9 @@ from anthropic.types import (
     ContentBlockStartEvent,
     ContentBlockStopEvent,
     Message,
+    MessageStartEvent,
     TextBlock,
+    Usage,
 )
 
 from mirascope.anthropic.tools import AnthropicTool
@@ -26,6 +28,9 @@ def test_anthropic_call_response(fixture_anthropic_message: Message):
     assert response.usage is not None
     assert response.output_tokens is not None
     assert response.input_tokens is not None
+    assert response.model == fixture_anthropic_message.model
+    assert response.id == fixture_anthropic_message.id
+    assert response.finish_reasons == [fixture_anthropic_message.stop_reason]
     assert response.dump() == {
         "start_time": 0,
         "end_time": 1,
@@ -89,3 +94,24 @@ def test_anthropic_call_response_chunk(
     )
     assert chunk.content == ""
     assert chunk.type == "content_block_stop"
+
+    chunk = AnthropicCallResponseChunk(
+        chunk=MessageStartEvent(
+            message=Message(
+                id="test_id",
+                model="test_model",
+                role="assistant",
+                type="message",
+                content=[TextBlock(text="test", type="text")],
+                stop_reason="end_turn",
+                usage=Usage(input_tokens=1, output_tokens=1),
+            ),
+            type="message_start",
+        )
+    )
+    assert chunk.usage is not None
+    assert chunk.output_tokens == 1
+    assert chunk.input_tokens == 1
+    assert chunk.model == "test_model"
+    assert chunk.id == "test_id"
+    assert chunk.finish_reasons == ["end_turn"]

--- a/tests/cohere/test_types.py
+++ b/tests/cohere/test_types.py
@@ -11,6 +11,7 @@ from cohere.types import (
     StreamedChatResponse_SearchQueriesGeneration,
     StreamedChatResponse_SearchResults,
     StreamedChatResponse_StreamEnd,
+    StreamedChatResponse_StreamStart,
     StreamedChatResponse_TextGeneration,
     StreamedChatResponse_ToolCallsGeneration,
     ToolCall,
@@ -124,10 +125,16 @@ def test_cohere_call_response_chunk_properties(
     assert call_chunk.event_type == "text-generation"
     assert call_chunk.content == "Test response"
     assert call_chunk.response is None
+    call_chunk.chunk = StreamedChatResponse_StreamStart(
+        generation_id="test_id",
+        event_type="stream-start",
+        **fixture_non_streamed_response.dict(exclude={"event_type"}),
+    )
+    assert call_chunk.id == "test_id"
 
     call_chunk.chunk = StreamedChatResponse_SearchQueriesGeneration(
         event_type="search-queries-generation",
-        **chunk.dict(exclude={"event_type"}),
+        **fixture_non_streamed_response.dict(exclude={"event_type"}),
     )
     assert call_chunk.search_queries == [fixture_chat_search_query]
     assert call_chunk.search_results is None
@@ -178,3 +185,7 @@ def test_cohere_call_response_chunk_properties(
     assert call_chunk.documents is None
     assert call_chunk.citations is None
     assert call_chunk.content == ""
+    assert call_chunk.finish_reasons == ["COMPLETE"]
+    assert call_chunk.usage is not None
+    assert call_chunk.input_tokens is not None
+    assert call_chunk.output_tokens is not None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -436,9 +436,10 @@ def fixture_generate_content_response():
         GenerateContentResponse(
             candidates=[
                 Candidate(
+                    finish_reason=1,
                     content=Content(
                         parts=[Part(text="Who is the author?")], role="model"
-                    )
+                    ),
                 )
             ]
         )

--- a/tests/gemini/conftest.py
+++ b/tests/gemini/conftest.py
@@ -92,18 +92,26 @@ def fixture_expected_book_tool_instance() -> BookTool:
 
 
 @pytest.fixture()
-def fixture_generate_content_chunks():
+def fixture_generate_content_chunks() -> GenerateContentResponse:
     """Returns a list of `GenerateContentResponse` chunks."""
     return GenerateContentResponseType.from_iterator(
         [
             GenerateContentResponse(
                 candidates=[
-                    Candidate(content=Content(parts=[{"text": "first"}], role="model"))
+                    Candidate(
+                        finish_reason=1,
+                        index=0,
+                        content=Content(parts=[{"text": "first"}], role="model"),
+                    )
                 ]
             ),
             GenerateContentResponse(
                 candidates=[
-                    Candidate(content=Content(parts=[{"text": "second"}], role="model"))
+                    Candidate(
+                        finish_reason=1,
+                        index=0,
+                        content=Content(parts=[{"text": "second"}], role="model"),
+                    )
                 ]
             ),
         ]

--- a/tests/gemini/test_types.py
+++ b/tests/gemini/test_types.py
@@ -109,9 +109,7 @@ def test_gemini_call_response_chunk(
 ) -> None:
     """Tests the `GeminiCallResponseChunk` class."""
     response = GeminiCallResponseChunk(
-        chunk=fixture_generate_content_response_with_tools,
-        start_time=0,
-        end_time=0,
+        chunk=fixture_generate_content_response_with_tools
     )
     assert response.chunk is not None
     assert response.id is None

--- a/tests/gemini/test_types.py
+++ b/tests/gemini/test_types.py
@@ -6,7 +6,7 @@ import pytest
 from google.generativeai.types import GenerateContentResponse  # type: ignore
 
 from mirascope.gemini.tools import GeminiTool
-from mirascope.gemini.types import GeminiCallResponse
+from mirascope.gemini.types import GeminiCallResponse, GeminiCallResponseChunk
 
 
 def test_gemini_call_response(
@@ -102,3 +102,21 @@ def test_gemini_call_response_with_no_tools(
 
     assert response.tools is None
     assert response.tool is None
+
+
+def test_gemini_call_response_chunk(
+    fixture_generate_content_response_with_tools: GenerateContentResponse,
+) -> None:
+    """Tests the `GeminiCallResponseChunk` class."""
+    response = GeminiCallResponseChunk(
+        chunk=fixture_generate_content_response_with_tools,
+        start_time=0,
+        end_time=0,
+    )
+    assert response.chunk is not None
+    assert response.id is None
+    assert response.finish_reasons == ["STOP"]
+    assert response.usage is None
+    assert response.model is None
+    assert response.input_tokens is None
+    assert response.output_tokens is None

--- a/tests/groq/conftest.py
+++ b/tests/groq/conftest.py
@@ -250,6 +250,7 @@ def fixture_chat_completion_stream_response_with_tools() -> list[ChatCompletionC
             object="chat.completion.chunk",
             system_fingerprint="",
             x_groq=None,
+            usage=CompletionUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
         ),
         ChatCompletionChunk(
             id="test",
@@ -270,6 +271,7 @@ def fixture_chat_completion_stream_response_with_tools() -> list[ChatCompletionC
             object="chat.completion.chunk",
             system_fingerprint="",
             x_groq=None,
+            usage=None,
         ),
     ]
 

--- a/tests/groq/test_types.py
+++ b/tests/groq/test_types.py
@@ -25,6 +25,11 @@ def test_groq_call_response(
     assert response.content == "test content"
     assert response.tools is None
     assert response.tool is None
+    assert response.model == fixture_chat_completion_response.model
+    assert response.id == fixture_chat_completion_response.id
+    assert response.finish_reasons == [
+        fixture_chat_completion_response.choices[0].finish_reason
+    ]
     assert response.usage is not None
     assert response.input_tokens is not None
     assert response.output_tokens is not None
@@ -162,3 +167,19 @@ def test_groq_stream_response_with_tools(
         .choices[0]
         .delta.tool_calls
     )
+    assert response.model == fixture_chat_completion_stream_response_with_tools[0].model
+    assert response.id == fixture_chat_completion_stream_response_with_tools[0].id
+    assert response.finish_reasons == [
+        fixture_chat_completion_stream_response_with_tools[0].choices[0].finish_reason
+    ]
+    assert response.usage is not None
+    assert response.input_tokens == 1
+    assert response.output_tokens == 1
+
+    response = GroqCallResponseChunk(
+        chunk=fixture_chat_completion_stream_response_with_tools[1],
+        tool_types=[fixture_book_tool],
+    )
+    assert response.usage is None
+    assert response.input_tokens is None
+    assert response.output_tokens is None

--- a/tests/mistral/conftest.py
+++ b/tests/mistral/conftest.py
@@ -40,7 +40,7 @@ def fixture_chat_completion_response(
         model="open-mixtral-8x7b",
         choices=[
             ChatCompletionResponseChoice(
-                index=0, message=fixture_chat_message, finish_reason=None
+                index=0, message=fixture_chat_message, finish_reason=FinishReason.stop
             )
         ],
         usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),
@@ -173,7 +173,7 @@ def fixture_chat_completion_stream_response_with_tools() -> (
                         role="assistant",
                         tool_calls=[tool_call],
                     ),
-                    finish_reason=None,
+                    finish_reason=FinishReason.tool_calls,
                 )
             ],
             usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),
@@ -188,7 +188,7 @@ def fixture_chat_completion_stream_response_with_tools() -> (
                         role="assistant",
                         tool_calls=[tool_call],
                     ),
-                    finish_reason=None,
+                    finish_reason=FinishReason.tool_calls,
                 )
             ],
             usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),

--- a/tests/mistral/conftest.py
+++ b/tests/mistral/conftest.py
@@ -191,6 +191,6 @@ def fixture_chat_completion_stream_response_with_tools() -> (
                     finish_reason=FinishReason.tool_calls,
                 )
             ],
-            usage=UsageInfo(prompt_tokens=1, total_tokens=2, completion_tokens=1),
+            usage=None,
         ),
     ]

--- a/tests/mistral/test_types.py
+++ b/tests/mistral/test_types.py
@@ -150,3 +150,12 @@ def test_mistral_stream_response_with_tools(
     assert response.usage is not None
     assert response.input_tokens is not None
     assert response.output_tokens is not None
+
+    response = MistralCallResponseChunk(
+        chunk=fixture_chat_completion_stream_response_with_tools[1],
+        tool_types=[fixture_book_tool],
+    )
+
+    assert response.usage is None
+    assert response.input_tokens is None
+    assert response.output_tokens is None

--- a/tests/mistral/test_types.py
+++ b/tests/mistral/test_types.py
@@ -27,6 +27,11 @@ def test_mistral_call_response(
     assert response.content == "test content"
     assert response.tools is None
     assert response.tool is None
+    assert response.model == fixture_chat_completion_response.model
+    assert response.id == fixture_chat_completion_response.id
+    assert response.finish_reasons == [
+        fixture_chat_completion_response.choices[0].finish_reason
+    ]
     assert response.usage is not None
     assert response.input_tokens is not None
     assert response.output_tokens is not None
@@ -137,3 +142,11 @@ def test_mistral_stream_response_with_tools(
         .choices[0]
         .delta.tool_calls
     )
+    assert response.model == fixture_chat_completion_stream_response_with_tools[0].model
+    assert response.id == fixture_chat_completion_stream_response_with_tools[0].id
+    assert response.finish_reasons == [
+        fixture_chat_completion_stream_response_with_tools[0].choices[0].finish_reason
+    ]
+    assert response.usage is not None
+    assert response.input_tokens is not None
+    assert response.output_tokens is not None

--- a/tests/openai/test_types.py
+++ b/tests/openai/test_types.py
@@ -32,6 +32,9 @@ def test_openai_call_response(fixture_chat_completion: ChatCompletion):
     assert response.choice == choices[0]
     assert response.message == choices[0].message
     assert response.content == choices[0].message.content
+    assert response.model == fixture_chat_completion.model
+    assert response.finish_reasons == ["stop", "stop"]
+    assert response.id == fixture_chat_completion.id
     assert response.tools is None
     assert response.tool is None
 
@@ -134,6 +137,9 @@ def test_openai_chat_completion_chunk(
     assert openai_chat_completion_chunk.choice == choices[0]
     assert openai_chat_completion_chunk.delta == choices[0].delta
     assert openai_chat_completion_chunk.content == choices[0].delta.content
+    assert openai_chat_completion_chunk.model == fixture_chat_completion_chunk.model
+    assert openai_chat_completion_chunk.id == fixture_chat_completion_chunk.id
+    assert openai_chat_completion_chunk.finish_reasons == ["stop"]
 
 
 def test_openai_chat_completion_last_chunk(

--- a/tests/otel/test_otel.py
+++ b/tests/otel/test_otel.py
@@ -62,7 +62,9 @@ def test_openai_call_with_otel(
     class MyNestedCall(MyCall):
         prompt_template = "test"
 
-        call_params = OpenAICallParams(model="gpt-3.5-turbo")
+        call_params = OpenAICallParams(
+            model="gpt-3.5-turbo", temperature=0.1, top_p=0.9
+        )
         configuration = BaseConfig(llm_ops=[], client_wrappers=[])
 
     MyNestedCall().call()
@@ -337,7 +339,7 @@ def test_value_error_on_mirascope_otel():
         def foo():
             ...  # pragma: no cover
 
-        mirascope_otel()(foo, "test")
+        mirascope_otel(BaseModel)(foo, "test")
 
 
 @patch("cohere.Client.chat", new_callable=MagicMock)


### PR DESCRIPTION
* Updated otel wrapper to use experimental LLM conventions https://opentelemetry.io/docs/specs/semconv/gen-ai/llm-spans/
* Added more properties to `BaseCallResponse` and `BaseCallResponseChunk`
  * model, id, usage, input_tokens, output_tokens, finish_reasons
* Fixed set_attributes warnings
* Fixed markdown styling on Logfire
* Closes #309 
* Partially implements #218 