### PR TITLE
GCP Wrapper

### DIFF
--- a/mirascope/anthropic/utils.py
+++ b/mirascope/anthropic/utils.py
@@ -2,7 +2,14 @@
 
 from typing import Callable, Optional, Union
 
-from anthropic import Anthropic, AnthropicBedrock, AsyncAnthropic, AsyncAnthropicBedrock
+from anthropic import (
+    Anthropic,
+    AnthropicBedrock,
+    AnthropicVertex,
+    AsyncAnthropic,
+    AsyncAnthropicBedrock,
+    AsyncAnthropicVertex,
+)
 from anthropic._types import URL
 from anthropic.types import Usage
 
@@ -31,6 +38,26 @@ def bedrock_client_wrapper(
             client = AnthropicBedrock(**kwargs)  # type: ignore
         elif isinstance(client, AsyncAnthropic):
             client = AsyncAnthropicBedrock(**kwargs)  # type: ignore
+        return client
+
+    return inner_wrapper
+
+
+def vertex_client_wrapper(
+    project_id: Optional[str] = None,
+    region: Optional[str] = None,
+) -> Callable[
+    [Union[Anthropic, AsyncAnthropic]], Union[AnthropicVertex, AsyncAnthropicVertex]
+]:
+    """Returns a client wrapper for using Anthropic models on GCP Vertex."""
+
+    def inner_wrapper(client: Union[Anthropic, AsyncAnthropic]):
+        """Returns matching `AnthropicVertex` or `AsyncAnthropicVertex` client."""
+        kwargs = {"project_id": project_id, "region": region}
+        if isinstance(client, Anthropic):
+            client = AnthropicVertex(**kwargs)  # type: ignore
+        elif isinstance(client, AsyncAnthropic):
+            client = AsyncAnthropicVertex(**kwargs)  # type: ignore
         return client
 
     return inner_wrapper

--- a/tests/anthropic/test_utils.py
+++ b/tests/anthropic/test_utils.py
@@ -1,8 +1,15 @@
 """Tests for Mirascope's Anthropic utils module."""
 
-from anthropic import Anthropic, AnthropicBedrock, AsyncAnthropic, AsyncAnthropicBedrock
+from anthropic import (
+    Anthropic,
+    AnthropicBedrock,
+    AnthropicVertex,
+    AsyncAnthropic,
+    AsyncAnthropicBedrock,
+    AsyncAnthropicVertex,
+)
 
-from mirascope.anthropic.utils import bedrock_client_wrapper
+from mirascope.anthropic.utils import bedrock_client_wrapper, vertex_client_wrapper
 
 
 def test_bedrock_client_wrapper():
@@ -21,6 +28,24 @@ def test_bedrock_client_wrapper():
     async_client = AsyncAnthropic()
     wrapped_async_client = wrapper(async_client)
     assert isinstance(wrapped_async_client, AsyncAnthropicBedrock)
+    for key, value in kwargs.items():
+        assert getattr(wrapped_client, key) == value
+        assert getattr(wrapped_async_client, key) == value
+
+
+def test_vertex_client_wrapper():
+    """Tests the Anthropic client wrapper for GCP Vertex."""
+    kwargs = {
+        "project_id": "TEST_PROJECT_ID",
+        "region": "us-east5",
+    }
+    wrapper = vertex_client_wrapper(**kwargs)
+    client = Anthropic()
+    wrapped_client = wrapper(client)
+    assert isinstance(wrapped_client, AnthropicVertex)
+    async_client = AsyncAnthropic()
+    wrapped_async_client = wrapper(async_client)
+    assert isinstance(wrapped_async_client, AsyncAnthropicVertex)
     for key, value in kwargs.items():
         assert getattr(wrapped_client, key) == value
         assert getattr(wrapped_async_client, key) == value


### PR DESCRIPTION
Fixes #321 

Added `vertex_client_wrapper` to the `anthropic.utils` to extend support for inferencing against Anthropic models hosted on GCP. 