### PR TITLE
fix: issue with `BaseCallKwargs` typing

### DIFF
--- a/mirascope/core/anthropic/call_kwargs.py
+++ b/mirascope/core/anthropic/call_kwargs.py
@@ -1,12 +1,11 @@
 """This module contains the type definition for the Anthropic call keyword arguments."""
 
-from anthropic.types import MessageParam
+from anthropic.types import MessageParam, ToolParam
 
 from ..base import BaseCallKwargs
 from .call_params import AnthropicCallParams
-from .tool import AnthropicTool
 
 
-class AnthropicCallKwargs(AnthropicCallParams, BaseCallKwargs[AnthropicTool]):
+class AnthropicCallKwargs(AnthropicCallParams, BaseCallKwargs[ToolParam]):
     model: str
     messages: list[MessageParam]

--- a/mirascope/core/anthropic/call_response.py
+++ b/mirascope/core/anthropic/call_response.py
@@ -3,7 +3,13 @@
 usage docs: learn/calls.md#handling-responses
 """
 
-from anthropic.types import Message, MessageParam, ToolResultBlockParam, Usage
+from anthropic.types import (
+    Message,
+    MessageParam,
+    ToolParam,
+    ToolResultBlockParam,
+    Usage,
+)
 from pydantic import SerializeAsAny, computed_field
 
 from ..base import BaseCallResponse
@@ -17,6 +23,7 @@ class AnthropicCallResponse(
     BaseCallResponse[
         Message,
         AnthropicTool,
+        ToolParam,
         AnthropicDynamicConfig,
         MessageParam,
         AnthropicCallParams,

--- a/mirascope/core/anthropic/stream.py
+++ b/mirascope/core/anthropic/stream.py
@@ -3,7 +3,14 @@
 usage docs: learn/streams.md
 """
 
-from anthropic.types import Message, MessageParam, TextBlock, ToolUseBlock, Usage
+from anthropic.types import (
+    Message,
+    MessageParam,
+    TextBlock,
+    ToolParam,
+    ToolUseBlock,
+    Usage,
+)
 from anthropic.types.content_block import ContentBlock
 from anthropic.types.text_block_param import TextBlockParam
 from anthropic.types.tool_use_block_param import ToolUseBlockParam
@@ -29,6 +36,7 @@ class AnthropicStream(
         MessageParam,
         MessageParam,
         AnthropicTool,
+        ToolParam,
         AnthropicDynamicConfig,
         AnthropicCallParams,
         FinishReason,

--- a/mirascope/core/base/_utils/_setup_call.py
+++ b/mirascope/core/base/_utils/_setup_call.py
@@ -29,7 +29,7 @@ def setup_call(
     str | None,
     list[BaseMessageParam | Any],
     list[type[_BaseToolT]] | None,
-    BaseCallKwargs[_BaseToolT],
+    BaseCallKwargs,
 ]:
     call_kwargs = cast(BaseCallKwargs[_BaseToolT], dict(call_params))
     prompt_template, messages, computed_fields = None, None, None

--- a/mirascope/core/base/call_kwargs.py
+++ b/mirascope/core/base/call_kwargs.py
@@ -6,8 +6,8 @@ from typing_extensions import NotRequired
 
 from .call_params import BaseCallParams
 
-_BaseToolT = TypeVar("_BaseToolT")
+_ToolSchemaT = TypeVar("_ToolSchemaT")
 
 
-class BaseCallKwargs(Generic[_BaseToolT], BaseCallParams):
-    tools: NotRequired[list[_BaseToolT]]
+class BaseCallKwargs(BaseCallParams, Generic[_ToolSchemaT]):
+    tools: NotRequired[list[_ToolSchemaT]]

--- a/mirascope/core/base/call_response.py
+++ b/mirascope/core/base/call_response.py
@@ -22,6 +22,7 @@ from .tool import BaseTool
 
 _ResponseT = TypeVar("_ResponseT", bound=Any)
 _BaseToolT = TypeVar("_BaseToolT", bound=BaseTool)
+_ToolSchemaT = TypeVar("_ToolSchemaT")
 _BaseDynamicConfigT = TypeVar("_BaseDynamicConfigT", bound=BaseDynamicConfig)
 _MessageParamT = TypeVar("_MessageParamT", bound=Any)
 _CallParamsT = TypeVar("_CallParamsT", bound=BaseCallParams)
@@ -33,6 +34,7 @@ class BaseCallResponse(
     Generic[
         _ResponseT,
         _BaseToolT,
+        _ToolSchemaT,
         _BaseDynamicConfigT,
         _MessageParamT,
         _CallParamsT,
@@ -66,7 +68,7 @@ class BaseCallResponse(
     dynamic_config: _BaseDynamicConfigT
     messages: SkipValidation[list[_MessageParamT]]
     call_params: SkipValidation[_CallParamsT]
-    call_kwargs: BaseCallKwargs[_BaseToolT]
+    call_kwargs: BaseCallKwargs[_ToolSchemaT]
     user_message_param: _UserMessageParamT | None = None
     start_time: float
     end_time: float

--- a/mirascope/core/base/stream.py
+++ b/mirascope/core/base/stream.py
@@ -39,6 +39,7 @@ _AssistantMessageParamT = TypeVar("_AssistantMessageParamT")
 _ToolMessageParamT = TypeVar("_ToolMessageParamT")
 _MessageParamT = TypeVar("_MessageParamT")
 _BaseToolT = TypeVar("_BaseToolT", bound=BaseTool)
+_ToolSchemaT = TypeVar("_ToolSchemaT")
 _BaseCallParamsT = TypeVar("_BaseCallParamsT", bound=BaseCallParams)
 _BaseDynamicConfigT = TypeVar("_BaseDynamicConfigT", bound=BaseDynamicConfig)
 _FinishReason = TypeVar("_FinishReason")
@@ -53,6 +54,7 @@ class BaseStream(
         _ToolMessageParamT,
         _MessageParamT,
         _BaseToolT,
+        _ToolSchemaT,
         _BaseDynamicConfigT,
         _BaseCallParamsT,
         _FinishReason,
@@ -78,7 +80,7 @@ class BaseStream(
     dynamic_config: _BaseDynamicConfigT
     messages: list[_MessageParamT]
     call_params: _BaseCallParamsT
-    call_kwargs: BaseCallKwargs[_BaseToolT]
+    call_kwargs: BaseCallKwargs[_ToolSchemaT]
     user_message_param: _UserMessageParamT | None = None
     message_param: _AssistantMessageParamT
     input_tokens: int | float | None = None
@@ -107,7 +109,7 @@ class BaseStream(
         dynamic_config: _BaseDynamicConfigT,
         messages: list[_MessageParamT],
         call_params: _BaseCallParamsT,
-        call_kwargs: BaseCallKwargs[_BaseToolT],
+        call_kwargs: BaseCallKwargs[_ToolSchemaT],
     ) -> None:
         """Initializes an instance of `BaseStream`."""
         self.content = ""

--- a/mirascope/core/cohere/call_kwargs.py
+++ b/mirascope/core/cohere/call_kwargs.py
@@ -1,10 +1,11 @@
 """This module contains the type definition for the Cohere call keyword arguments."""
 
+from cohere.types import Tool
+
 from ..base import BaseCallKwargs
 from .call_params import CohereCallParams
-from .tool import CohereTool
 
 
-class CohereCallKwargs(CohereCallParams, BaseCallKwargs[CohereTool]):
+class CohereCallKwargs(CohereCallParams, BaseCallKwargs[Tool]):
     model: str
     message: str

--- a/mirascope/core/cohere/call_response.py
+++ b/mirascope/core/cohere/call_response.py
@@ -7,6 +7,7 @@ from cohere.types import (
     ApiMetaBilledUnits,
     ChatMessage,
     NonStreamedChatResponse,
+    Tool,
     ToolResult,
 )
 from pydantic import SkipValidation, computed_field
@@ -22,6 +23,7 @@ class CohereCallResponse(
     BaseCallResponse[
         SkipValidation[NonStreamedChatResponse],
         CohereTool,
+        Tool,
         CohereDynamicConfig,
         SkipValidation[ChatMessage],
         CohereCallParams,

--- a/mirascope/core/cohere/stream.py
+++ b/mirascope/core/cohere/stream.py
@@ -9,6 +9,7 @@ from cohere.types import (
     ChatMessage,
     ChatStreamEndEventFinishReason,
     NonStreamedChatResponse,
+    Tool,
     ToolCall,
 )
 
@@ -30,6 +31,7 @@ class CohereStream(
         ChatMessage,
         ChatMessage,
         CohereTool,
+        Tool,
         CohereDynamicConfig,
         CohereCallParams,
         ChatStreamEndEventFinishReason,

--- a/mirascope/core/gemini/call_kwargs.py
+++ b/mirascope/core/gemini/call_kwargs.py
@@ -1,11 +1,10 @@
 """This module contains the type definition for the Gemini call keyword arguments."""
 
-from google.generativeai.types import ContentDict
+from google.generativeai.types import ContentDict, Tool
 
 from ..base import BaseCallKwargs
 from .call_params import GeminiCallParams
-from .tool import GeminiTool
 
 
-class GeminiCallKwargs(GeminiCallParams, BaseCallKwargs[GeminiTool]):
+class GeminiCallKwargs(GeminiCallParams, BaseCallKwargs[Tool]):
     contents: list[ContentDict]

--- a/mirascope/core/gemini/call_response.py
+++ b/mirascope/core/gemini/call_response.py
@@ -4,11 +4,12 @@ usage docs: learn/calls.md#handling-responses
 """
 
 from google.generativeai.protos import FunctionResponse  # type: ignore
-from google.generativeai.types import (  # type: ignore
+from google.generativeai.types import (
     AsyncGenerateContentResponse,
     ContentDict,
-    ContentsType,  # type: ignore
+    ContentsType,
     GenerateContentResponse,
+    Tool,
 )
 from pydantic import computed_field
 
@@ -23,6 +24,7 @@ class GeminiCallResponse(
     BaseCallResponse[
         GenerateContentResponse | AsyncGenerateContentResponse,
         GeminiTool,
+        Tool,
         GeminiDynamicConfig,
         ContentsType,
         GeminiCallParams,

--- a/mirascope/core/gemini/stream.py
+++ b/mirascope/core/gemini/stream.py
@@ -13,9 +13,10 @@ from google.ai.generativelanguage import (
 )
 from google.generativeai.types import (
     ContentDict,
-    ContentsType,  # type: ignore
+    ContentsType,
+    Tool,
 )
-from google.generativeai.types import (  # type: ignore
+from google.generativeai.types import (
     GenerateContentResponse as GenerateContentResponseType,
 )
 from google.generativeai.types.content_types import PartType
@@ -38,6 +39,7 @@ class GeminiStream(
         ContentDict,
         ContentsType,
         GeminiTool,
+        Tool,
         GeminiDynamicConfig,
         GeminiCallParams,
         Candidate.FinishReason,

--- a/mirascope/core/gemini/tool.py
+++ b/mirascope/core/gemini/tool.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from typing import Any
 
 from google.ai.generativelanguage import FunctionCall
-from google.generativeai.types import (  # type: ignore
+from google.generativeai.types import (
     FunctionDeclaration,
     Tool,
 )

--- a/mirascope/core/groq/call_kwargs.py
+++ b/mirascope/core/groq/call_kwargs.py
@@ -1,12 +1,11 @@
 """This module contains the type definition for the Groq call keyword arguments."""
 
-from groq.types.chat import ChatCompletionMessageParam
+from groq.types.chat import ChatCompletionMessageParam, ChatCompletionToolParam
 
 from ..base import BaseCallKwargs
 from .call_params import GroqCallParams
-from .tool import GroqTool
 
 
-class GroqCallKwargs(GroqCallParams, BaseCallKwargs[GroqTool]):
+class GroqCallKwargs(GroqCallParams, BaseCallKwargs[ChatCompletionToolParam]):
     model: str
     messages: list[ChatCompletionMessageParam]

--- a/mirascope/core/groq/call_response.py
+++ b/mirascope/core/groq/call_response.py
@@ -8,6 +8,7 @@ from groq.types.chat import (
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessageParam,
     ChatCompletionToolMessageParam,
+    ChatCompletionToolParam,
     ChatCompletionUserMessageParam,
 )
 from groq.types.completion_usage import CompletionUsage
@@ -24,6 +25,7 @@ class GroqCallResponse(
     BaseCallResponse[
         ChatCompletion,
         GroqTool,
+        ChatCompletionToolParam,
         GroqDynamicConfig,
         ChatCompletionMessageParam,
         GroqCallParams,

--- a/mirascope/core/groq/stream.py
+++ b/mirascope/core/groq/stream.py
@@ -9,6 +9,7 @@ from groq.types.chat import (
     ChatCompletionMessageParam,
     ChatCompletionMessageToolCallParam,
     ChatCompletionToolMessageParam,
+    ChatCompletionToolParam,
     ChatCompletionUserMessageParam,
 )
 from groq.types.chat.chat_completion import Choice
@@ -35,6 +36,7 @@ class GroqStream(
         ChatCompletionToolMessageParam,
         ChatCompletionMessageParam,
         GroqTool,
+        ChatCompletionToolParam,
         GroqDynamicConfig,
         GroqCallParams,
         FinishReason,

--- a/mirascope/core/mistral/call_kwargs.py
+++ b/mirascope/core/mistral/call_kwargs.py
@@ -1,12 +1,13 @@
 """This module contains the type definition for the Mistral call keyword arguments."""
 
+from typing import Any
+
 from mistralai.models.chat_completion import ChatMessage
 
 from ..base import BaseCallKwargs
 from .call_params import MistralCallParams
-from .tool import MistralTool
 
 
-class MistralCallKwargs(MistralCallParams, BaseCallKwargs[MistralTool]):
+class MistralCallKwargs(MistralCallParams, BaseCallKwargs[dict[str, Any]]):
     model: str
     messages: list[ChatMessage]

--- a/mirascope/core/mistral/call_response.py
+++ b/mirascope/core/mistral/call_response.py
@@ -3,6 +3,8 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from typing import Any
+
 from mistralai.models.chat_completion import ChatCompletionResponse, ChatMessage
 from mistralai.models.common import UsageInfo
 from pydantic import computed_field
@@ -18,6 +20,7 @@ class MistralCallResponse(
     BaseCallResponse[
         ChatCompletionResponse,
         MistralTool,
+        dict[str, Any],
         MistralDynamicConfig,
         ChatMessage,
         MistralCallParams,

--- a/mirascope/core/mistral/stream.py
+++ b/mirascope/core/mistral/stream.py
@@ -3,6 +3,8 @@
 usage docs: learn/streams.md
 """
 
+from typing import Any
+
 from mistralai.models.chat_completion import (
     ChatCompletionResponse,
     ChatCompletionResponseChoice,
@@ -29,6 +31,7 @@ class MistralStream(
         ChatMessage,
         ChatMessage,
         MistralTool,
+        dict[str, Any],
         MistralDynamicConfig,
         MistralCallParams,
         FinishReason,

--- a/mirascope/core/openai/call_kwargs.py
+++ b/mirascope/core/openai/call_kwargs.py
@@ -1,12 +1,11 @@
 """This module contains the type definition for the OpenAI call keyword arguments."""
 
-from openai.types.chat import ChatCompletionMessageParam
+from openai.types.chat import ChatCompletionMessageParam, ChatCompletionToolParam
 
 from ..base import BaseCallKwargs
 from .call_params import OpenAICallParams
-from .tool import OpenAITool
 
 
-class OpenAICallKwargs(OpenAICallParams, BaseCallKwargs[OpenAITool]):
+class OpenAICallKwargs(OpenAICallParams, BaseCallKwargs[ChatCompletionToolParam]):
     model: str
     messages: list[ChatCompletionMessageParam]

--- a/mirascope/core/openai/call_response.py
+++ b/mirascope/core/openai/call_response.py
@@ -8,6 +8,7 @@ from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
     ChatCompletionMessageParam,
     ChatCompletionToolMessageParam,
+    ChatCompletionToolParam,
     ChatCompletionUserMessageParam,
 )
 from openai.types.completion_usage import CompletionUsage
@@ -24,6 +25,7 @@ class OpenAICallResponse(
     BaseCallResponse[
         ChatCompletion,
         OpenAITool,
+        ChatCompletionToolParam,
         OpenAIDynamicConfig,
         ChatCompletionMessageParam,
         OpenAICallParams,

--- a/mirascope/core/openai/stream.py
+++ b/mirascope/core/openai/stream.py
@@ -11,6 +11,7 @@ from openai.types.chat import (
     ChatCompletionMessageToolCall,
     ChatCompletionMessageToolCallParam,
     ChatCompletionToolMessageParam,
+    ChatCompletionToolParam,
     ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion import Choice
@@ -37,6 +38,7 @@ class OpenAIStream(
         ChatCompletionToolMessageParam,
         ChatCompletionMessageParam,
         OpenAITool,
+        ChatCompletionToolParam,
         OpenAIDynamicConfig,
         OpenAICallParams,
         FinishReason,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirascope"
-version = "1.1.0"
+version = "1.1.1"
 description = "LLM abstractions that aren't obstructions"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
It was taking the actual tool type as the generic making pydantic fail on validation because it was expecting `call_kwargs` to have actual tool instances. Updating this to the correct type of the provider-specific tool schema (with which we actually call the provider's API i.e. the call kwargs) fixes this issue.