### PR TITLE
Fix cohere with response_model

### DIFF
--- a/mirascope/core/cohere/call_response.py
+++ b/mirascope/core/cohere/call_response.py
@@ -3,11 +3,12 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from typing import Any
+
 from cohere.types import (
     ApiMetaBilledUnits,
     ChatMessage,
     NonStreamedChatResponse,
-    Tool,
     ToolResult,
 )
 from pydantic import SkipValidation, computed_field
@@ -23,7 +24,7 @@ class CohereCallResponse(
     BaseCallResponse[
         SkipValidation[NonStreamedChatResponse],
         CohereTool,
-        Tool,
+        Any,
         CohereDynamicConfig,
         SkipValidation[ChatMessage],
         CohereCallParams,


### PR DESCRIPTION
This PR fixes an issue where passing a response_model to `cohere.call` results in a Pydantic error.

Root cause: When a `response_model` is specified, Cohere's `Tool` model is subjected to `Pydantic` v2 validation. However, the Tool model inherits from Pydantic v1's `BaseModel`, causing a compatibility error.

As a workaround, we will pass Any instead of Tool to avoid this issue.

cohere's `Tool`
https://github.com/cohere-ai/cohere-python/blob/c21dde92cb91767004869fc2a927513aa9b8fe51/src/cohere/types/tool.py#L12

Error
```python
...
  File "/Users/koudai/PycharmProjects/mirascope/mirascope/core/base/_extract.py", line 124, in inner
    call_response = create_decorator(fn=fn, **create_decorator_kwargs)(
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/koudai/PycharmProjects/mirascope/mirascope/core/base/_create.py", line 148, in inner
    output = TCallResponse(
             ^^^^^^^^^^^^^^
  File "/Users/koudai/PycharmProjects/mirascope/.venv/lib/python3.12/site-packages/pydantic/main.py", line 176, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
TypeError: BaseModel.validate() takes 2 positional arguments but 3 were given
```