### PR TITLE
support for `data:` and `file://` image uri schemes

### DIFF
--- a/mirascope/core/base/_utils/_parse_content_template.py
+++ b/mirascope/core/base/_utils/_parse_content_template.py
@@ -67,7 +67,7 @@ def _load_media(source: str | bytes) -> bytes:
         # in a type hint of `str | bytearray | memoryview` for source in the else.
         if isinstance(source, bytes | bytearray | memoryview):
             data = source
-        elif source.startswith(("http://", "https://")):
+        elif source.startswith(("http://", "https://", "data:", "file://")):
             with urllib.request.urlopen(source) as response:
                 data = response.read()
         else:


### PR DESCRIPTION
This PR adds support for image uris that (A) use a `data:` scheme to directly embed the base64 encoded image data or (B) use a `file:// ` scheme to reference an image on disk.

For example in a prompt template with `{url:image}` where `url=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACkAAAApCAIAAAAnApehAAABEUlEQVR4nO2W7Q2EIAyG6+UmYQV3qiMwgyPQnViBVbwfXAxiLR9CTO54fxFRH9ryFqZt2+AhvZ4CD/ZgD3Z3vZv8xVog+o61dkqpnK+m+31tWU6PEMzcn82AwzUgzNeLqK+3cy4CGwPGHJ4QgbVN2Z66roeiIsaDHd+MbW1M3RnOuXDTJVVWb7m6rISS53qsKKBdst+y4q4IFyDed2el690JnGb3AyfYdeDIYzXsOjCA1Miy2EIzaiiGLdsJsSCrshh/yz72sx5f4fhQlWcJERDxCciv1617C4uXz65QTF8rbZ+Il+/LRmfizjeJFxFo7dgpOQF8zo0p2MyIoJRi8XL+GtzXqvWv9/PBHuzB/l32B6QdbKuN3JZvAAAAAElFTkSuQmCC`