### PR TITLE
feat: concept for streaming tool calls

### DIFF
--- a/mirascope/core/base/call_response_chunk.py
+++ b/mirascope/core/base/call_response_chunk.py
@@ -10,6 +10,11 @@ from typing import Any, Generic, TypeVar
 
 from pydantic import BaseModel, ConfigDict
 
+from mirascope.core.base.tool_call_response_chunk import (
+    ToolCallArgumentsResponseChunk,
+    ToolCallNameResponseChunk,
+)
+
 _ChunkT = TypeVar("_ChunkT", bound=Any)
 _FinishReasonT = TypeVar("_FinishReasonT", bound=Any)
 
@@ -40,6 +45,13 @@ class BaseCallResponseChunk(BaseModel, Generic[_ChunkT, _FinishReasonT], ABC):
         If there is no string content (e.g. when using tools), this method must return
         the empty string.
         """
+        ...
+
+    @property
+    def tool_call_chunk(
+        self,
+    ) -> ToolCallNameResponseChunk | ToolCallArgumentsResponseChunk | None:
+        """Should return the tool call chunk of the response."""
         ...
 
     @property

--- a/mirascope/core/base/tool_call_response_chunk.py
+++ b/mirascope/core/base/tool_call_response_chunk.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+
+class ToolCallNameResponseChunk(BaseModel):
+    """
+    A chunk that contains the name and ID of a streamed tool call.
+    """
+
+    name: str
+    id: str
+
+
+class ToolCallArgumentsResponseChunk(BaseModel):
+    """
+    A chunk that contains a delta in the function arguments of a streamed tool call.
+    """
+
+    delta: str


### PR DESCRIPTION
Hi, I've been trying out mirascope with my current project. I'm loving the SDK and interface so far but I need tool call streaming to return chunk-by-chunk, which `mirascope` doesn't seem to support currently (Referencing https://github.com/Mirascope/mirascope/blob/main/mirascope/core/openai/_utils/_handle_stream.py#L70C5-L70C18, `yield` only happens when there is a finished tool call).

This PR is a proposal for an approach that I understand could solve my problem. However, I've only just started looking at mirascope so don't have full context of implications.