### PR TITLE
handle empty tool call function arguments

### DIFF
--- a/mirascope/beta/openai/realtime/tool.py
+++ b/mirascope/beta/openai/realtime/tool.py
@@ -107,6 +107,7 @@ class OpenAIRealtimeTool(BaseTool):
         Args:
             tool_call: The OpenAI tool call from which to construct this tool instance.
         """
-        model_json = jiter.from_json(tool_call["arguments"].encode())
-        model_json["tool_call"] = tool_call.copy()
+        model_json = {"tool_call": tool_call.copy()}
+        if args := tool_call.get("arguments", None):
+            model_json |= jiter.from_json(args.encode())
         return cls.model_validate(model_json)

--- a/mirascope/core/azure/tool.py
+++ b/mirascope/core/azure/tool.py
@@ -87,9 +87,7 @@ class AzureTool(BaseTool):
         Args:
             tool_call: The Azure tool call from which to construct this tool instance.
         """
-        if tool_call.function.arguments:
-            model_json = jiter.from_json(tool_call.function.arguments.encode())
-        else:
-            model_json = {}
-        model_json["tool_call"] = tool_call
+        model_json = {"tool_call": tool_call}
+        if args := tool_call.function.arguments:
+            model_json |= jiter.from_json(args.encode())
         return cls.model_validate(model_json)

--- a/mirascope/core/azure/tool.py
+++ b/mirascope/core/azure/tool.py
@@ -87,6 +87,9 @@ class AzureTool(BaseTool):
         Args:
             tool_call: The Azure tool call from which to construct this tool instance.
         """
-        model_json = jiter.from_json(tool_call.function.arguments.encode())
+        if tool_call.function.arguments:
+            model_json = jiter.from_json(tool_call.function.arguments.encode())
+        else:
+            model_json = {}
         model_json["tool_call"] = tool_call
         return cls.model_validate(model_json)

--- a/mirascope/core/gemini/tool.py
+++ b/mirascope/core/gemini/tool.py
@@ -98,8 +98,7 @@ class GeminiTool(BaseTool):
         Args:
             tool_call: The Gemini tool call from which to construct this tool instance.
         """
-        if not tool_call.args:
-            raise ValueError("Tool call doesn't have any arguments.")
-        model_json: dict[str, Any] = dict(tool_call.args.items())
-        model_json["tool_call"] = tool_call
+        model_json = {"tool_call": tool_call}
+        if tool_call.args:
+            model_json |= dict(tool_call.args.items())
         return cls.model_validate(model_json)

--- a/mirascope/core/groq/tool.py
+++ b/mirascope/core/groq/tool.py
@@ -74,6 +74,9 @@ class GroqTool(BaseTool):
         Args:
             tool_call: The Groq tool call from which to construct this tool instance.
         """
-        model_json = jiter.from_json(tool_call.function.arguments.encode())
+        if tool_call.function.arguments:
+            model_json = jiter.from_json(tool_call.function.arguments.encode())
+        else:
+            model_json = {}
         model_json["tool_call"] = tool_call.model_dump()
         return cls.model_validate(model_json)

--- a/mirascope/core/groq/tool.py
+++ b/mirascope/core/groq/tool.py
@@ -74,9 +74,7 @@ class GroqTool(BaseTool):
         Args:
             tool_call: The Groq tool call from which to construct this tool instance.
         """
-        if tool_call.function.arguments:
-            model_json = jiter.from_json(tool_call.function.arguments.encode())
-        else:
-            model_json = {}
-        model_json["tool_call"] = tool_call.model_dump()
+        model_json = {"tool_call": tool_call}
+        if args := tool_call.function.arguments:
+            model_json |= jiter.from_json(args.encode())
         return cls.model_validate(model_json)

--- a/mirascope/core/mistral/tool.py
+++ b/mirascope/core/mistral/tool.py
@@ -72,7 +72,9 @@ class MistralTool(BaseTool):
         Args:
             tool_call: The Mistral tool call from which to construct this tool instance.
         """
-        model_json = {"tool_call": tool_call.model_dump()}
-        if (args := tool_call.function.arguments) and isinstance(args, str):
-            model_json |= jiter.from_json(args.encode())
+        model_json = {"tool_call": tool_call}
+        if args := tool_call.function.arguments:
+            model_json |= (
+                jiter.from_json(args.encode()) if isinstance(args, str) else args
+            )
         return cls.model_validate(model_json)

--- a/mirascope/core/mistral/tool.py
+++ b/mirascope/core/mistral/tool.py
@@ -73,6 +73,6 @@ class MistralTool(BaseTool):
             tool_call: The Mistral tool call from which to construct this tool instance.
         """
         model_json = {"tool_call": tool_call.model_dump()}
-        if args := tool_call.function.arguments and isinstance(args, str):
+        if (args := tool_call.function.arguments) and isinstance(args, str):
             model_json |= jiter.from_json(args.encode())
         return cls.model_validate(model_json)

--- a/mirascope/core/mistral/tool.py
+++ b/mirascope/core/mistral/tool.py
@@ -72,8 +72,7 @@ class MistralTool(BaseTool):
         Args:
             tool_call: The Mistral tool call from which to construct this tool instance.
         """
-        model_json = tool_call.function.arguments
-        if isinstance(model_json, str):
-            model_json = jiter.from_json(model_json.encode())
-        model_json["tool_call"] = tool_call.model_dump()
+        model_json = {"tool_call": tool_call.model_dump()}
+        if args := tool_call.function.arguments and isinstance(args, str):
+            model_json |= jiter.from_json(args.encode())
         return cls.model_validate(model_json)

--- a/mirascope/core/openai/tool.py
+++ b/mirascope/core/openai/tool.py
@@ -90,9 +90,7 @@ class OpenAITool(BaseTool):
         Args:
             tool_call: The OpenAI tool call from which to construct this tool instance.
         """
-        if tool_call.function.arguments:
-            model_json = jiter.from_json(tool_call.function.arguments.encode())
-        else:
-            model_json = {}
-        model_json["tool_call"] = tool_call.model_dump()
+        model_json = {"tool_call": tool_call.model_dump()}
+        if args := tool_call.function.arguments:
+            model_json |= jiter.from_json(args.encode())
         return cls.model_validate(model_json)

--- a/mirascope/core/openai/tool.py
+++ b/mirascope/core/openai/tool.py
@@ -90,6 +90,9 @@ class OpenAITool(BaseTool):
         Args:
             tool_call: The OpenAI tool call from which to construct this tool instance.
         """
-        model_json = jiter.from_json(tool_call.function.arguments.encode())
+        if tool_call.function.arguments:
+            model_json = jiter.from_json(tool_call.function.arguments.encode())
+        else:
+            model_json = {}
         model_json["tool_call"] = tool_call.model_dump()
         return cls.model_validate(model_json)

--- a/mirascope/core/openai/tool.py
+++ b/mirascope/core/openai/tool.py
@@ -90,7 +90,7 @@ class OpenAITool(BaseTool):
         Args:
             tool_call: The OpenAI tool call from which to construct this tool instance.
         """
-        model_json = {"tool_call": tool_call.model_dump()}
+        model_json = {"tool_call": tool_call}
         if args := tool_call.function.arguments:
             model_json |= jiter.from_json(args.encode())
         return cls.model_validate(model_json)

--- a/mirascope/core/vertex/tool.py
+++ b/mirascope/core/vertex/tool.py
@@ -95,8 +95,7 @@ class VertexTool(BaseTool):
         Args:
             tool_call: The Vertex tool call from which to construct this tool instance.
         """
-        if not tool_call.args:
-            raise ValueError("Tool call doesn't have any arguments.")
-        model_json: dict[str, Any] = dict(tool_call.args.items())
-        model_json["tool_call"] = tool_call
+        model_json = {"tool_call": tool_call}
+        if tool_call.args:
+            model_json |= dict(tool_call.args.items())
         return cls.model_validate(model_json)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirascope"
-version = "1.10.0"
+version = "1.10.1"
 description = "LLM abstractions that aren't obstructions"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/core/gemini/test_tool.py
+++ b/tests/core/gemini/test_tool.py
@@ -85,9 +85,3 @@ def test_gemini_tool_no_nesting() -> None:
         "with \\$defs.",
     ):
         Nested.tool_schema()
-
-
-def test_gemini_tool_no_args() -> None:
-    """Tests the `GeminiTool` class with no arguments."""
-    with pytest.raises(ValueError, match="Tool call doesn't have any arguments."):
-        FormatBook.from_tool_call(FunctionCall(name="FormatBook", args={}))

--- a/tests/core/vertex/test_tool.py
+++ b/tests/core/vertex/test_tool.py
@@ -83,9 +83,3 @@ def test_vertex_tool_no_nesting() -> None:
         "with \\$defs.",
     ):
         Nested.tool_schema()
-
-
-def test_vertex_tool_no_args() -> None:
-    """Tests the `VertexTool` class with no arguments."""
-    with pytest.raises(ValueError, match="Tool call doesn't have any arguments."):
-        FormatBook.from_tool_call(FunctionCall({"name": "FormatBook", "args": {}}))

--- a/uv.lock
+++ b/uv.lock
@@ -3139,7 +3139,7 @@ wheels = [
 
 [[package]]
 name = "mirascope"
-version = "1.9.5"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -3738,8 +3738,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/07/8cbb75d6cfbe8712d8f7f6a5615f083c6e710ab916b748fbb20373ddb142/multiprocess-0.70.17-py311-none-any.whl", hash = "sha256:2884701445d0177aec5bd5f6ee0df296773e4fb65b11903b94c613fb46cfb7d1", size = 144346 },
     { url = "https://files.pythonhosted.org/packages/a4/69/d3f343a61a2f86ef10ed7865a26beda7c71554136ce187b0384b1c2c9ca3/multiprocess-0.70.17-py312-none-any.whl", hash = "sha256:2818af14c52446b9617d1b0755fa70ca2f77c28b25ed97bdaa2c69a22c47b46c", size = 147990 },
     { url = "https://files.pythonhosted.org/packages/c8/b7/2e9a4fcd871b81e1f2a812cd5c6fb52ad1e8da7bf0d7646c55eaae220484/multiprocess-0.70.17-py313-none-any.whl", hash = "sha256:20c28ca19079a6c879258103a6d60b94d4ffe2d9da07dda93fb1c8bc6243f522", size = 149843 },
-    { url = "https://files.pythonhosted.org/packages/ae/d7/fd7a092fc0ab1845a1a97ca88e61b9b7cc2e9d6fcf0ed24e9480590c2336/multiprocess-0.70.17-py38-none-any.whl", hash = "sha256:1d52f068357acd1e5bbc670b273ef8f81d57863235d9fbf9314751886e141968", size = 132635 },
-    { url = "https://files.pythonhosted.org/packages/f9/41/0618ac724b8a56254962c143759e04fa01c73b37aa69dd433f16643bd38b/multiprocess-0.70.17-py39-none-any.whl", hash = "sha256:c3feb874ba574fbccfb335980020c1ac631fbf2a3f7bee4e2042ede62558a021", size = 133359 },
 ]
 
 [[package]]
@@ -4678,6 +4676,8 @@ version = "6.0.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/18/c7/8c6872f7372eb6a6b2e4708b88419fb46b857f7a2e1892966b851cc79fc9/psutil-6.0.0.tar.gz", hash = "sha256:8faae4f310b6d969fa26ca0545338b21f73c6b15db7c4a8d934a5482faa818f2", size = 508067 }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/66/78c9c3020f573c58101dc43a44f6855d01bbbd747e24da2f0c4491200ea3/psutil-6.0.0-cp27-none-win32.whl", hash = "sha256:02b69001f44cc73c1c5279d02b30a817e339ceb258ad75997325e0e6169d8b35", size = 249766 },
+    { url = "https://files.pythonhosted.org/packages/e1/3f/2403aa9558bea4d3854b0e5e567bc3dd8e9fbc1fc4453c0aa9aafeb75467/psutil-6.0.0-cp27-none-win_amd64.whl", hash = "sha256:21f1fb635deccd510f69f485b87433460a603919b45e2a324ad65b0cc74f8fb1", size = 253024 },
     { url = "https://files.pythonhosted.org/packages/0b/37/f8da2fbd29690b3557cca414c1949f92162981920699cd62095a984983bf/psutil-6.0.0-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:c588a7e9b1173b6e866756dde596fd4cad94f9399daf99ad8c3258b3cb2b47a0", size = 250961 },
     { url = "https://files.pythonhosted.org/packages/35/56/72f86175e81c656a01c4401cd3b1c923f891b31fbcebe98985894176d7c9/psutil-6.0.0-cp36-abi3-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6ed2440ada7ef7d0d608f20ad89a04ec47d2d3ab7190896cd62ca5fc4fe08bf0", size = 287478 },
     { url = "https://files.pythonhosted.org/packages/19/74/f59e7e0d392bc1070e9a70e2f9190d652487ac115bb16e2eff6b22ad1d24/psutil-6.0.0-cp36-abi3-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5fd9a97c8e94059b0ef54a7d4baf13b405011176c3b6ff257c247cae0d560ecd", size = 290455 },


### PR DESCRIPTION
This pull request includes changes to improve the handling of tool calls in the `mirascope/core` package. The updates ensure that the `model_json` is properly initialized even when `tool_call.function.arguments` is empty.

**Background:**
LLMs sometimes use pass an empty string for tool call function args, which was causing an unhandled exception when deserializing the function arguments string to json with jiter.

**Solution:**
Now, we detect that `tool_call.function.arguments`  is empty and simply initialize an empty dictionary (instead of trying to deserialize an empty string).

Changes to tool call handling:

* [`mirascope/core/azure/tool.py`](diffhunk://#diff-eda7cd9a429405537fae526d49224241b435b8b5b732dfd6f120a2b282fbd29eR90-R93): Added a check to initialize `model_json` to an empty dictionary if `tool_call.function.arguments` is empty in the `from_tool_call` method.
* [`mirascope/core/groq/tool.py`](diffhunk://#diff-11161bc2a645bb46031b9fb51034df763f83b3249b81132a2343142206836cb7R77-R80): Added a check to initialize `model_json` to an empty dictionary if `tool_call.function.arguments` is empty in the `from_tool_call` method.
* [`mirascope/core/openai/tool.py`](diffhunk://#diff-816e8c0e5aeca294a4f157000998421180c9a28022c93ef85b6d570e53b7717eR93-R96): Added a check to initialize `model_json` to an empty dictionary if `tool_call.function.arguments` is empty in the `from_tool_call` method.