### PR TITLE
fix: fix stream with response_model

### DIFF
--- a/mirascope/core/base/stream.py
+++ b/mirascope/core/base/stream.py
@@ -337,7 +337,7 @@ def stream_factory(  # noqa: ANN201
         json_mode: bool,
         client: _SameSyncAndAsyncClientT | _SyncBaseClientT | _AsyncBaseClientT | None,
         call_params: _BaseCallParamsT,
-        partial_tools: bool,
+        partial_tools: bool = False,
     ) -> Callable[_P, BaseStream] | Callable[_P, Awaitable[BaseStream]]:
         if not is_prompt_template(fn):
             fn = cast(

--- a/tests/core/base/test_stream.py
+++ b/tests/core/base/test_stream.py
@@ -18,7 +18,6 @@ def mock_stream_decorator_kwargs() -> dict:
         "json_mode": True,
         "client": MagicMock(),
         "call_params": MagicMock(),
-        "partial_tools": False,
     }
 
 


### PR DESCRIPTION
The PR fixes the error.

```python
Traceback (most recent call last):
  File "/Users/koudai/Library/Application Support/JetBrains/PyCharm2024.3/scratches/scratch_52.py", line 15, in <module>
    book_stream = recommend_book("fantasy")
  File "/Users/koudai/PycharmProjects/mirascope/mirascope/core/base/structured_stream.py", line 289, in inner
    stream=stream_decorator(fn=fn, **stream_decorator_kwargs)(
TypeError: stream_factory.<locals>.decorator() missing 1 required positional argument: 'partial_tools'
```

```python
from mirascope.core import openai, prompt_template
from pydantic import BaseModel


class Book(BaseModel):
    title: str
    author: str


@openai.call("gpt-4o-mini", stream=True, response_model=Book)
def recommend_book(genre: str) -> str:
    return f"Recommend a {genre} book"


book_stream = recommend_book("fantasy")
for partial_book in book_stream:
    print(partial_book)
```