### PR TITLE
[Don't merge!!]  Override parameters for provider agnostic call decorator

### DIFF
--- a/examples/learn/calls/provider_agnostic/anthropic/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/anthropic/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="anthropic", model="claude-3-5-sonnet-20240620")
+@llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/anthropic/messages.py
+++ b/examples/learn/calls/provider_agnostic/anthropic/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="anthropic", model="claude-3-5-sonnet-20240620")
+@llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/anthropic/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/anthropic/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="anthropic", model="claude-3-5-sonnet-20240620")
+@llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/anthropic/string_template.py
+++ b/examples/learn/calls/provider_agnostic/anthropic/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="anthropic", model="claude-3-5-sonnet-20240620")
+@llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/azure/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/azure/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="azure", model="gpt-4o-mini")
+@llm.call(provider="azure", model="gpt-4o-mini")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/azure/messages.py
+++ b/examples/learn/calls/provider_agnostic/azure/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="azure", model="gpt-4o-mini")
+@llm.call(provider="azure", model="gpt-4o-mini")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/azure/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/azure/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="azure", model="gpt-4o-mini")
+@llm.call(provider="azure", model="gpt-4o-mini")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/azure/string_template.py
+++ b/examples/learn/calls/provider_agnostic/azure/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="azure", model="gpt-4o-mini")
+@llm.call(provider="azure", model="gpt-4o-mini")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/bedrock/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/bedrock/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
+@llm.call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/bedrock/messages.py
+++ b/examples/learn/calls/provider_agnostic/bedrock/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
+@llm.call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/bedrock/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/bedrock/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
+@llm.call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/bedrock/string_template.py
+++ b/examples/learn/calls/provider_agnostic/bedrock/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
+@llm.call(provider="bedrock", model="anthropic.claude-3-haiku-20240307-v1:0")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/cohere/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/cohere/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="cohere", model="command-r-plus")
+@llm.call(provider="cohere", model="command-r-plus")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/cohere/messages.py
+++ b/examples/learn/calls/provider_agnostic/cohere/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="cohere", model="command-r-plus")
+@llm.call(provider="cohere", model="command-r-plus")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/cohere/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/cohere/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="cohere", model="command-r-plus")
+@llm.call(provider="cohere", model="command-r-plus")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/cohere/string_template.py
+++ b/examples/learn/calls/provider_agnostic/cohere/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="cohere", model="command-r-plus")
+@llm.call(provider="cohere", model="command-r-plus")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/gemini/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/gemini/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="gemini", model="gemini-1.5-flash")
+@llm.call(provider="gemini", model="gemini-1.5-flash")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/gemini/messages.py
+++ b/examples/learn/calls/provider_agnostic/gemini/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="gemini", model="gemini-1.5-flash")
+@llm.call(provider="gemini", model="gemini-1.5-flash")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/gemini/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/gemini/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="gemini", model="gemini-1.5-flash")
+@llm.call(provider="gemini", model="gemini-1.5-flash")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/gemini/string_template.py
+++ b/examples/learn/calls/provider_agnostic/gemini/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="gemini", model="gemini-1.5-flash")
+@llm.call(provider="gemini", model="gemini-1.5-flash")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/groq/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/groq/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="groq", model="llama-3.1-70b-versatile")
+@llm.call(provider="groq", model="llama-3.1-70b-versatile")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/groq/messages.py
+++ b/examples/learn/calls/provider_agnostic/groq/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="groq", model="llama-3.1-70b-versatile")
+@llm.call(provider="groq", model="llama-3.1-70b-versatile")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/groq/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/groq/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="groq", model="llama-3.1-70b-versatile")
+@llm.call(provider="groq", model="llama-3.1-70b-versatile")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/groq/string_template.py
+++ b/examples/learn/calls/provider_agnostic/groq/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="groq", model="llama-3.1-70b-versatile")
+@llm.call(provider="groq", model="llama-3.1-70b-versatile")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/litellm/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/litellm/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="litellm", model="gpt-4o-mini")
+@llm.call(provider="litellm", model="gpt-4o-mini")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/litellm/messages.py
+++ b/examples/learn/calls/provider_agnostic/litellm/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="litellm", model="gpt-4o-mini")
+@llm.call(provider="litellm", model="gpt-4o-mini")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/litellm/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/litellm/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="litellm", model="gpt-4o-mini")
+@llm.call(provider="litellm", model="gpt-4o-mini")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/litellm/string_template.py
+++ b/examples/learn/calls/provider_agnostic/litellm/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="litellm", model="gpt-4o-mini")
+@llm.call(provider="litellm", model="gpt-4o-mini")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/mistral/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/mistral/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="mistral", model="mistral-large-latest")
+@llm.call(provider="mistral", model="mistral-large-latest")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/mistral/messages.py
+++ b/examples/learn/calls/provider_agnostic/mistral/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="mistral", model="mistral-large-latest")
+@llm.call(provider="mistral", model="mistral-large-latest")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/mistral/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/mistral/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="mistral", model="mistral-large-latest")
+@llm.call(provider="mistral", model="mistral-large-latest")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/mistral/string_template.py
+++ b/examples/learn/calls/provider_agnostic/mistral/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="mistral", model="mistral-large-latest")
+@llm.call(provider="mistral", model="mistral-large-latest")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/examples/learn/calls/provider_agnostic/openai/base_message_param.py
+++ b/examples/learn/calls/provider_agnostic/openai/base_message_param.py
@@ -1,8 +1,8 @@
 from mirascope.core import BaseMessageParam
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="openai", model="gpt-4o-mini")
+@llm.call(provider="openai", model="gpt-4o-mini")
 def recommend_book(genre: str) -> list[BaseMessageParam]:
     return [BaseMessageParam(role="user", content=f"Recommend a {genre} book")]
 

--- a/examples/learn/calls/provider_agnostic/openai/messages.py
+++ b/examples/learn/calls/provider_agnostic/openai/messages.py
@@ -1,8 +1,8 @@
 from mirascope.core import Messages
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="openai", model="gpt-4o-mini")
+@llm.call(provider="openai", model="gpt-4o-mini")
 def recommend_book(genre: str) -> Messages.Type:
     return Messages.User(f"Recommend a {genre} book")
 

--- a/examples/learn/calls/provider_agnostic/openai/shorthand.py
+++ b/examples/learn/calls/provider_agnostic/openai/shorthand.py
@@ -1,7 +1,7 @@
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="openai", model="gpt-4o-mini")
+@llm.call(provider="openai", model="gpt-4o-mini")
 def recommend_book(genre: str) -> str:
     return f"Recommend a {genre} book"
 

--- a/examples/learn/calls/provider_agnostic/openai/string_template.py
+++ b/examples/learn/calls/provider_agnostic/openai/string_template.py
@@ -1,8 +1,8 @@
 from mirascope.core import prompt_template
-from mirascope.llm import call
+from mirascope import llm
 
 
-@call(provider="openai", model="gpt-4o-mini")
+@llm.call(provider="openai", model="gpt-4o-mini")
 @prompt_template("Recommend a {genre} book")
 def recommend_book(genre: str): ...
 

--- a/mirascope/llm/__init__.py
+++ b/mirascope/llm/__init__.py
@@ -1,3 +1,4 @@
 from .llm_call import call
+from .llm_override import override
 
-__all__ = ["call"]
+__all__ = ["call", "override"]

--- a/mirascope/llm/_protocols.py
+++ b/mirascope/llm/_protocols.py
@@ -2,14 +2,11 @@
 
 from collections.abc import (
     AsyncIterable,
-    Awaitable,
     Callable,
-    Coroutine,
     Iterable,
 )
 from enum import Enum
 from typing import (
-    TYPE_CHECKING,
     Any,
     Literal,
     NoReturn,
@@ -22,13 +19,17 @@ from typing import (
 
 from pydantic import BaseModel
 
-from mirascope.core import BaseDynamicConfig, BaseTool, Messages
+from mirascope.core import BaseDynamicConfig, BaseTool
 from mirascope.core.base import (
-    BaseCallParams,
     BaseCallResponse,
     BaseCallResponseChunk,
     BaseType,
     CommonCallParams,
+)
+from mirascope.core.base._utils._protocols import (
+    AsyncLLMFunctionDecorator,
+    LLMFunctionDecorator,
+    SyncLLMFunctionDecorator,
 )
 from mirascope.core.base.stream_config import StreamConfig
 from mirascope.llm.call_response import CallResponse
@@ -51,7 +52,6 @@ _InvariantResponseChunkT = TypeVar("_InvariantResponseChunkT", contravariant=Tru
 _BaseToolT = TypeVar("_BaseToolT", bound=BaseTool)
 _ParsedOutputT = TypeVar("_ParsedOutputT")
 _P = ParamSpec("_P")
-_R_co = TypeVar("_R_co", covariant=True)
 _R = TypeVar("_R", contravariant=True)
 _BaseCallResponseT = TypeVar(
     "_BaseCallResponseT", bound=BaseCallResponse, covariant=True
@@ -73,231 +73,6 @@ Provider: TypeAlias = Literal[
     "openai",
     "vertex",
 ]
-
-if TYPE_CHECKING:
-    from mirascope.core.anthropic import AnthropicCallParams
-    from mirascope.core.azure import AzureCallParams
-    from mirascope.core.bedrock import BedrockCallParams
-    from mirascope.core.cohere import CohereCallParams
-    from mirascope.core.gemini import GeminiCallParams
-    from mirascope.core.groq import GroqCallParams
-    from mirascope.core.litellm import LiteLLMCallParams
-    from mirascope.core.mistral import MistralCallParams
-    from mirascope.core.openai import OpenAICallParams
-    from mirascope.core.vertex import VertexCallParams
-else:
-    AnthropicCallParams = AzureCallParams = BedrockCallParams = CohereCallParams = (
-        GeminiCallParams
-    ) = GroqCallParams = LiteLLMCallParams = MistralCallParams = OpenAICallParams = (
-        VertexCallParams
-    ) = None
-
-
-class DecoratedCall(Protocol[_P, _R_co]):
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["anthropic"] = "anthropic",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | AnthropicCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["azure"] = "azure",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | AzureCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["bedrock"] = "bedrock",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | BedrockCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["cohere"] = "cohere",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | CohereCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["gemini"] = "gemini",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | GeminiCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["groq"] = "groq",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | GroqCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["litellm"] = "litellm",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | LiteLLMCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["mistral"] = "mistral",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | MistralCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["openai"] = "openai",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | OpenAICallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Literal["vertex"] = "vertex",
-        model_override: str | None = None,
-        call_params_override: CommonCallParams | VertexCallParams | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    @overload
-    def __call__(
-        self,
-        provider_override: Provider | None,
-        model_override: str | None,
-        call_params_override: BaseCallParams | dict[str, Any],
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-    @overload
-    def __call__(
-        self,
-        provider_override: Provider | None,
-        model_override: str | None,
-        call_params_override: BaseCallParams | dict[str, Any],
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-    def __call__(
-        self,
-        provider_override: Provider | None = None,
-        model_override: str | None = None,
-        call_params_override: BaseCallParams | dict[str, Any] | None = None,
-        *args: _P.args,
-        **kwargs: _P.kwargs,
-    ) -> _R_co: ...
-
-
-class AsyncLLMFunctionDecorator(Protocol[_AsyncBaseDynamicConfigT, _AsyncResponseT]):
-    @overload
-    def __call__(
-        self,
-        fn: Callable[
-            _P,
-            Awaitable[_AsyncBaseDynamicConfigT]
-            | Coroutine[Any, Any, _AsyncBaseDynamicConfigT],
-        ],
-    ) -> DecoratedCall[_P, Awaitable[_AsyncResponseT]]: ...
-
-    @overload
-    def __call__(
-        self,
-        fn: Callable[_P, Awaitable[Messages.Type] | Coroutine[Any, Any, Messages.Type]],
-    ) -> DecoratedCall[_P, Awaitable[_AsyncResponseT]]: ...
-
-    def __call__(
-        self,
-        fn: Callable[
-            _P,
-            Awaitable[_AsyncBaseDynamicConfigT]
-            | Coroutine[Any, Any, _AsyncBaseDynamicConfigT],
-        ]
-        | Callable[_P, Awaitable[Messages.Type] | Coroutine[Any, Any, Messages.Type]],
-    ) -> DecoratedCall[_P, Awaitable[_AsyncResponseT]]: ...  # pragma: no cover
-
-
-class SyncLLMFunctionDecorator(Protocol[_BaseDynamicConfigT, _ResponseT]):
-    @overload
-    def __call__(
-        self, fn: Callable[_P, _BaseDynamicConfigT]
-    ) -> DecoratedCall[_P, _ResponseT]: ...
-
-    @overload
-    def __call__(
-        self, fn: Callable[_P, Messages.Type]
-    ) -> DecoratedCall[_P, _ResponseT]: ...
-
-    def __call__(
-        self, fn: Callable[_P, _BaseDynamicConfigT] | Callable[_P, Messages.Type]
-    ) -> DecoratedCall[_P, _ResponseT]: ...  # pragma: no cover
-
-
-class LLMFunctionDecorator(
-    Protocol[_BaseDynamicConfigT, _AsyncBaseDynamicConfigT, _ResponseT, _AsyncResponseT]
-):
-    @overload
-    def __call__(
-        self, fn: Callable[_P, _BaseDynamicConfigT]
-    ) -> DecoratedCall[_P, _ResponseT]: ...
-
-    @overload
-    def __call__(
-        self, fn: Callable[_P, Messages.Type]
-    ) -> DecoratedCall[_P, _ResponseT]: ...
-
-    @overload
-    def __call__(
-        self, fn: Callable[_P, Awaitable[_AsyncBaseDynamicConfigT]]
-    ) -> DecoratedCall[_P, Awaitable[_AsyncResponseT]]: ...
-
-    @overload
-    def __call__(
-        self, fn: Callable[_P, Awaitable[Messages.Type]]
-    ) -> DecoratedCall[_P, Awaitable[_AsyncResponseT]]: ...
-
-    def __call__(
-        self,
-        fn: Callable[_P, _BaseDynamicConfigT]
-        | Callable[_P, Awaitable[_AsyncBaseDynamicConfigT]]
-        | Callable[_P, Messages.Type]
-        | Callable[_P, Awaitable[Messages.Type]],
-    ) -> DecoratedCall[
-        _P, _ResponseT | Awaitable[_AsyncResponseT]
-    ]: ...  # pragma: no cover
 
 
 class _CallDecorator(

--- a/mirascope/llm/llm_call.py
+++ b/mirascope/llm/llm_call.py
@@ -185,11 +185,11 @@ def _call(
         @wraps(decorated)
         def inner(
             *args: _P.args,
+            provider_override: str | None = None,
+            model_override: str | None = None,
+            call_params_override: dict | None = None,
             **kwargs: _P.kwargs,
         ) -> CallResponse | Stream | Awaitable[CallResponse | Stream]:
-            provider_override = kwargs.pop("provider_override", None)
-            model_override = kwargs.pop("model_override", None)
-            call_params_override = kwargs.pop("call_params_override", None)
             if provider_override or model_override or call_params_override is None:
                 if provider_override:
                     provider_call_override = _get_provider_call(provider_override)

--- a/mirascope/llm/llm_call.py
+++ b/mirascope/llm/llm_call.py
@@ -203,9 +203,9 @@ def _call(
 
                 return sync_wrapper()
 
-        inner._original_args = _original_args # pyright: ignore [reportAttributeAccessIssue]
-        inner._original_provider_call = provider_call # pyright: ignore [reportAttributeAccessIssue]
-        inner._original_fn = fn # pyright: ignore [reportAttributeAccessIssue]
+        inner._original_args = _original_args  # pyright: ignore [reportAttributeAccessIssue]
+        inner._original_provider_call = provider_call  # pyright: ignore [reportAttributeAccessIssue]
+        inner._original_fn = fn  # pyright: ignore [reportAttributeAccessIssue]
         inner._original_provider = provider  # pyright: ignore [reportAttributeAccessIssue]
         return inner
 

--- a/mirascope/llm/llm_override.py
+++ b/mirascope/llm/llm_override.py
@@ -1,18 +1,30 @@
-from collections.abc import Callable
-from typing import Any, Literal, ParamSpec, TypeVar, overload
+from __future__ import annotations
 
-from mirascope.core.anthropic import AnthropicCallParams
-from mirascope.core.azure import AzureCallParams
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Literal, ParamSpec, TypeVar, overload
+
 from mirascope.core.base import CommonCallParams
-from mirascope.core.bedrock import BedrockCallParams
-from mirascope.core.cohere import CohereCallParams
-from mirascope.core.gemini import GeminiCallParams
-from mirascope.core.groq import GroqCallParams
-from mirascope.core.mistral import MistralCallParams
-from mirascope.core.openai import OpenAICallParams
-from mirascope.core.vertex import VertexCallParams
 from mirascope.llm._protocols import Provider
 from mirascope.llm.llm_call import _call
+
+if TYPE_CHECKING:
+    from mirascope.core.anthropic import AnthropicCallParams
+    from mirascope.core.azure import AzureCallParams
+    from mirascope.core.bedrock import BedrockCallParams
+    from mirascope.core.cohere import CohereCallParams
+    from mirascope.core.gemini import GeminiCallParams
+    from mirascope.core.groq import GroqCallParams
+    from mirascope.core.litellm import LiteLLMCallParams
+    from mirascope.core.mistral import MistralCallParams
+    from mirascope.core.openai import OpenAICallParams
+    from mirascope.core.vertex import VertexCallParams
+else:
+    AnthropicCallParams = AzureCallParams = BedrockCallParams = CohereCallParams = (
+        GeminiCallParams
+    ) = GroqCallParams = LiteLLMCallParams = MistralCallParams = OpenAICallParams = (
+        VertexCallParams
+    ) = None
+
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -96,7 +108,7 @@ def override(
     *,
     provider_override: Literal["litellm"],
     model_override: str | None = None,
-    call_params_override: CommonCallParams | OpenAICallParams | None = None,
+    call_params_override: CommonCallParams | LiteLLMCallParams | None = None,
     client_override: Any = None,  # noqa: ANN401
 ) -> Callable[_P, _R]: ...
 @overload
@@ -151,7 +163,7 @@ def override(
             "If provider_override is specified, model_override or call_params_override must also be specified."
         )
 
-    return _call(
+    return _call(  # pyright: ignore [reportReturnType]
         provider=provider_override or provider_agnostic_call._original_provider,  # pyright: ignore [reportFunctionMemberAccess]
         model=model_override or _original_args["model"],
         stream=_original_args["stream"],

--- a/mirascope/llm/llm_override.py
+++ b/mirascope/llm/llm_override.py
@@ -1,0 +1,164 @@
+from collections.abc import Callable
+from typing import Any, Literal, ParamSpec, TypeVar, overload
+
+from mirascope.core.anthropic import AnthropicCallParams
+from mirascope.core.azure import AzureCallParams
+from mirascope.core.base import CommonCallParams
+from mirascope.core.bedrock import BedrockCallParams
+from mirascope.core.cohere import CohereCallParams
+from mirascope.core.gemini import GeminiCallParams
+from mirascope.core.groq import GroqCallParams
+from mirascope.core.mistral import MistralCallParams
+from mirascope.core.openai import OpenAICallParams
+from mirascope.core.vertex import VertexCallParams
+from mirascope.llm._protocols import Provider
+from mirascope.llm.llm_call import _call
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+
+
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["anthropic"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | AnthropicCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["azure"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | AzureCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["bedrock"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | BedrockCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["cohere"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | CohereCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["gemini"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | GeminiCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["groq"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | GroqCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["mistral"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | MistralCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["openai"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | OpenAICallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["litellm"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | OpenAICallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+@overload
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Literal["vertex"],
+    model_override: str | None = None,
+    call_params_override: CommonCallParams | VertexCallParams | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]: ...
+
+
+def override(
+    provider_agnostic_call: Callable[_P, _R],
+    *,
+    provider_override: Provider | None = None,
+    model_override: str | None = None,
+    call_params_override: CommonCallParams
+    | AnthropicCallParams
+    | GeminiCallParams
+    | AzureCallParams
+    | BedrockCallParams
+    | CohereCallParams
+    | GroqCallParams
+    | MistralCallParams
+    | OpenAICallParams
+    | VertexCallParams
+    | None = None,
+    client_override: Any = None,  # noqa: ANN401
+) -> Callable[_P, _R]:
+    """Overrides the provider-specific call with the specified provider.
+
+    Args:
+        provider_agnostic_call: The provider-agnostic call to override.
+        provider_override: The provider to override with.
+        model_override: The model to override with.
+        call_params_override: The call params to override with.
+        client_override: The client to override with.
+
+    Returns:
+        The overridden function.
+    """
+    _original_args = provider_agnostic_call._original_args  # pyright: ignore [reportFunctionMemberAccess]
+    if (
+        provider_override is not None
+        and not model_override
+        and call_params_override is None
+        and client_override is None
+    ):
+        raise ValueError(
+            "If provider_override is specified, model_override or call_params_override must also be specified."
+        )
+
+    return _call(
+        provider=provider_override or provider_agnostic_call._original_provider,  # pyright: ignore [reportFunctionMemberAccess]
+        model=model_override or _original_args["model"],
+        stream=_original_args["stream"],
+        tools=_original_args["tools"],
+        response_model=_original_args["response_model"],
+        output_parser=_original_args["output_parser"],
+        json_mode=_original_args["json_mode"],
+        client=client_override or _original_args["client"],
+        call_params=call_params_override or _original_args["call_params"],
+    )(provider_agnostic_call._original_fn)  # pyright: ignore [reportFunctionMemberAccess]

--- a/tests/llm/test_override.py
+++ b/tests/llm/test_override.py
@@ -1,0 +1,126 @@
+from unittest.mock import patch
+
+import pytest
+
+from mirascope.core.base import (
+    BaseCallResponse,
+    CommonCallParams,
+)
+from mirascope.core.openai import OpenAICallParams
+from mirascope.llm.llm_call import call
+from mirascope.llm.llm_override import override
+
+
+class ConcreteMockResponse(BaseCallResponse):
+    @property
+    def content(self): ...  # pyright: ignore [reportIncompatibleMethodOverride]
+
+    @property
+    def finish_reasons(self): ...
+
+    @property
+    def model(self): ...
+
+    @property
+    def id(self): ...
+
+    @property
+    def usage(self): ...
+
+    @property
+    def input_tokens(self): ...
+
+    @property
+    def output_tokens(self): ...
+
+    @property
+    def cost(self): ...
+
+    @property
+    def message_param(self): ...  # pyright: ignore [reportIncompatibleVariableOverride]
+
+    @property
+    def tools(self): ...  # pyright: ignore [reportIncompatibleVariableOverride]
+
+    @property
+    def tool(self): ...  # pyright: ignore [reportIncompatibleVariableOverride]
+
+    @classmethod
+    def tool_message_params(cls, tools_and_outputs): ...  # pyright: ignore [reportIncompatibleMethodOverride]
+
+    @property
+    def common_finish_reasons(self): ...
+
+    @property
+    def common_message_param(self): ...  # pyright: ignore [reportIncompatibleMethodOverride]
+
+    @property
+    def common_tools(self): ...
+
+    @property
+    def common_usage(self): ...
+
+    def common_construct_call_response(self): ...
+
+    def common_construct_message_param(self, tool_calls, content): ...
+
+
+@pytest.fixture
+def dummy_provider_agnostic_call():
+    @call(provider="openai", model="gpt-4o-mini")
+    def dummy_sync_function(book: str) -> str: ...
+
+    return dummy_sync_function
+
+
+def test_override_error_if_only_provider_override(dummy_provider_agnostic_call):
+    with pytest.raises(ValueError, match="must also be specified"):
+        override(
+            provider_agnostic_call=dummy_provider_agnostic_call,
+            provider_override="anthropic",
+            model_override=None,
+            call_params_override=None,
+        )
+
+
+def test_override_with_model_override(dummy_provider_agnostic_call):
+    with patch("mirascope.llm.llm_override._call") as mock_call:
+        override(
+            provider_agnostic_call=dummy_provider_agnostic_call,
+            provider_override="openai",
+            model_override="overridden-model",
+            call_params_override=CommonCallParams(),
+        )
+        mock_call.assert_called_once()
+        _, kwargs = mock_call.call_args
+        assert kwargs["provider"] == "openai"
+        assert kwargs["model"] == "overridden-model"
+
+
+def test_override_with_callparams_override(dummy_provider_agnostic_call):
+    new_call_params = OpenAICallParams(temperature=0.7, max_tokens=1111)
+    with patch("mirascope.llm.llm_override._call") as mock_call:
+        override(
+            provider_agnostic_call=dummy_provider_agnostic_call,
+            provider_override="openai",
+            model_override=None,
+            call_params_override=new_call_params,
+        )
+        mock_call.assert_called_once()
+        _, kwargs = mock_call.call_args
+        assert kwargs["call_params"] is new_call_params
+
+
+def test_override_with_client_override(dummy_provider_agnostic_call):
+    new_client = object()
+    with patch("mirascope.llm.llm_override._call") as mock_call:
+        override(
+            provider_agnostic_call=dummy_provider_agnostic_call,
+            provider_override="openai",
+            model_override="overridden-model",
+            call_params_override=CommonCallParams(),
+            client_override=new_client,
+        )
+        mock_call.assert_called_once()
+        _, kwargs = mock_call.call_args
+        assert kwargs["client"] is new_client


### PR DESCRIPTION
Current Python spec doesn't support to add keyword argument to `def func(*args: P.args, **kwarga: P.kwargs)`.
