### PR TITLE
docs: remember to import prompt_template in Text Classification Tutorial

### DIFF
--- a/docs/tutorials/more_advanced/text_classification.ipynb
+++ b/docs/tutorials/more_advanced/text_classification.ipynb
@@ -193,7 +193,7 @@
    "source": [
     "from enum import Enum\n",
     "\n",
-    "from mirascope.core import openai\n",
+    "from mirascope.core import openai, prompt_template\n",
     "from pydantic import BaseModel\n",
     "\n",
     "\n",


### PR DESCRIPTION
In the Text Classification tutorial, there is a tiny code error because forgetting to import prompt_template. 

While prompt_template is imported in the Binary Classification section, it is unclear whether or not prompt_template should be imported because "openai" is _reimported_ without prompt_template, so to clear all confusion, just adding prompt_template back to match the same import sentence from the first section above.