### PR TITLE
fix: remove exclamation mark OR add exclamation mark to both `pip ins…

### DIFF
--- a/docs/blog/posts/langchain-rag.md
+++ b/docs/blog/posts/langchain-rag.md
@@ -176,7 +176,7 @@ The goal of our RAG application is to answer questions about a publicly availabl
 First, we install Mirascope and LangChain.
 
 ```py
-!pip install "mirascope[openai]"
+pip install "mirascope[openai]"
 pip install -qU langchain-openai
 ```
 


### PR DESCRIPTION
…tall` lines

It appears the exclamation mark should be on neither or both of these, but not on only one