### PR TITLE
fix: Preserve leading newlines in prompt template parsing

### DIFF
--- a/mirascope/core/base/_utils/_format_template.py
+++ b/mirascope/core/base/_utils/_format_template.py
@@ -7,23 +7,26 @@ from ._get_template_values import get_template_values
 from ._get_template_variables import get_template_variables
 
 
-def format_template(template: str, attrs: dict[str, Any]) -> str:
+def format_template(template: str, attrs: dict[str, Any], strip: bool = True) -> str:
     """Formats the given prompt `template`
 
     Args:
         template: The template to format.
         attrs: The attributes to use for formatting.
+        strip: Whether to strip the formatted template.
 
     Returns:
         The formatted template.
 
     """
-    dedented_template = dedent(template).strip()
+    dedented_template = dedent(template)
+    if strip:
+        dedented_template = dedented_template.strip()
     template_vars = get_template_variables(dedented_template, True)
 
     values = get_template_values(template_vars, attrs)
 
     # Remove any special format specs that are actually invalid normally
     dedented_template = dedented_template.replace(":lists", "").replace(":list", "")
-
-    return dedented_template.format(**values).strip()
+    result = dedented_template.format(**values)
+    return result.strip() if strip else result

--- a/tests/core/base/_utils/test_parse_content_template.py
+++ b/tests/core/base/_utils/test_parse_content_template.py
@@ -22,6 +22,7 @@ def test_parse_content_template() -> None:
     assert parse_content_template("user", "", {}) is None
     assert parse_content_template("user", " ", {}) is None
     assert parse_content_template("system", "", {}) is None
+    assert parse_content_template("system", " \u200b ", {}) is None
     template = "This is a {var1} template with {var2} variables."
     values = {"var1": "test", "var2": "two"}
     expected = BaseMessageParam(

--- a/tests/core/base/_utils/test_parse_prompt_messages.py
+++ b/tests/core/base/_utils/test_parse_prompt_messages.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+from mirascope.core.base import TextPart
 from mirascope.core.base._utils._parse_prompt_messages import parse_prompt_messages
 
 
@@ -70,3 +71,45 @@ def test_parse_prompt_messages_invalid_messages() -> None:
             template="MESSAGES: {messages}",
             attrs={"messages": "not a list"},
         )
+
+
+def test_parse_prompt_messages_preserves_leading_newlines() -> None:
+    """
+    Test that parse_prompt_messages preserves leading newlines in the prompt text
+    after splitting by roles.
+    """
+    template = """
+    Caption this image: {text:text}
+    Your caption should be concise.
+    """
+    messages = parse_prompt_messages(
+        roles=["user"], template=template, attrs={"text": "foo"}
+    )
+    assert len(messages) == 1  # Only one user message
+    assert messages[0].role == "user"
+    assert messages[0].content == [
+        TextPart(type="text", text="Caption this image:"),
+        TextPart(type="text", text="foo"),
+        TextPart(type="text", text="\nYour caption should be concise."),
+    ]
+
+
+def test_parse_prompt_messages_preserves_internal_newlines() -> None:
+    """
+    Test that parse_prompt_messages preserves internal newlines within a single role section.
+    """
+    template = """USER: First line
+                Second line
+
+                Third line
+                """
+    messages = parse_prompt_messages(roles=["user"], template=template, attrs={})
+    assert len(messages) == 1
+    user_message = messages[0]
+
+    assert user_message.role == "user"
+
+    expected_text = "First line\nSecond line\n\nThird line"
+    assert (
+        user_message.content == expected_text
+    ), f"Expected:\n{repr(expected_text)}\nGot:\n{repr(user_message.content)}"


### PR DESCRIPTION
Fixes: https://github.com/Mirascope/mirascope/issues/789