### PR TITLE
feat: provider-agnostic Get Started docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,6 +146,7 @@ venv.bak/
 /site
 docs/**/*.html.md
 docs/llms.txt
+build/snippets/
 
 # mypy
 .mypy_cache/

--- a/docs/WELCOME.md
+++ b/docs/WELCOME.md
@@ -73,9 +73,8 @@ Make your first call to an LLM to extract the title and author of a book from th
         === "{{ provider }}"
 
             ```python hl_lines="10 15 17"
-            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:3:3"
-            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:5:8"
-            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:11:22"
+            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:3:7"
+            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:10:21"
             ```
         {% endfor %}
 

--- a/docs/WELCOME.md
+++ b/docs/WELCOME.md
@@ -39,8 +39,8 @@ Install Mirascope, specifying the provider(s) you intend to use, and set your AP
         {% else %}export CO_API_KEY=XXXXX
         {% endif %}
         {% elif provider == "LiteLLM" %}
-        {% if os == "Windows" %}set OPENAI_API_KEY=XXXXX  # set keys for providers you will use
-        {% else %}export OPENAI_API_KEY=XXXXX  # set keys for providers you will use
+        {% if os == "Windows" %}set OPENAI_API_KEY=XXXXX 
+        {% else %}export OPENAI_API_KEY=XXXXX 
         {% endif %}
         {% elif provider == "Azure AI" %}
         {% if os == "Windows" %}set AZURE_INFERENCE_ENDPOINT=XXXXX
@@ -72,9 +72,10 @@ Make your first call to an LLM to extract the title and author of a book from th
         {% for provider in supported_llm_providers %}
         === "{{ provider }}"
 
-            ```python hl_lines="10 12 17"
-            --8<-- "examples/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:3:7"
-            --8<-- "examples/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:10:21"
+            ```python hl_lines="10 15 17"
+            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:3:3"
+            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:5:8"
+            --8<-- "build/snippets/learn/response_models/basic_usage/{{ provider | provider_dir }}/{{ method }}.py:11:22"
             ```
         {% endfor %}
 

--- a/docs/generate_provider_examples.py
+++ b/docs/generate_provider_examples.py
@@ -31,7 +31,7 @@ PROVIDER_INFO: dict[Provider, ProviderInfo] = {
     "bedrock": ProviderInfo(
         provider="bedrock",
         title="Bedrock",
-        model="anthropic.claude-3-haiku-20240307-v1:0",
+        model="amazon.nova-lite-v1:0",
     ),
 }
 
@@ -45,8 +45,8 @@ def substitute_provider_import(content: str, provider: Provider) -> str:
     )
 
 
-def substitute_provider_cast(content: str, provider: Provider) -> str:
-    """Substitute provider in cast statement."""
+def substitute_provider_type(content: str, provider: Provider) -> str:
+    """Substitute provider in type names (e.g. openai.OpenAICallResponse)."""
     provider_name = provider.capitalize()
 
     if provider == "litellm":
@@ -55,8 +55,8 @@ def substitute_provider_cast(content: str, provider: Provider) -> str:
         provider_name = "OpenAI"
 
     return re.sub(
-        r"cast\(openai\.OpenAICallResponse,",
-        f"cast({provider}.{provider_name}CallResponse,",
+        r"openai\.OpenAI",
+        f"{provider}.{provider_name}",
         content,
     )
 
@@ -103,7 +103,7 @@ def substitute_provider_specific_content(content: str, provider: Provider) -> st
 
     content = substitute_llm_call_decorator(content, provider)
     content = substitute_provider_import(content, provider)
-    content = substitute_provider_cast(content, provider)
+    content = substitute_provider_type(content, provider)
     return content
 
 

--- a/docs/generate_provider_examples.py
+++ b/docs/generate_provider_examples.py
@@ -1,0 +1,150 @@
+import re
+from pathlib import Path
+
+from mirascope.llm import Provider
+from pydantic import BaseModel
+
+EXAMPLES_ROOT = Path("examples")
+SNIPPETS_DIR = Path("build/snippets")
+
+
+class ProviderInfo(BaseModel):
+    """Provider information for UI and substitutions."""
+
+    provider: Provider
+    title: str
+    model: str
+
+
+PROVIDER_INFO: dict[Provider, ProviderInfo] = {
+    "openai": ProviderInfo(provider="openai", title="OpenAI", model="gpt-4o-mini"),
+    "anthropic": ProviderInfo(
+        provider="anthropic", title="Anthropic", model="claude-3-5-sonnet-20240620"
+    ),
+    "mistral": ProviderInfo(
+        provider="mistral", title="Mistral", model="mistral-large-latest"
+    ),
+    "google": ProviderInfo(provider="google", title="Google", model="gemini-1.5-flash"),
+    "groq": ProviderInfo(
+        provider="groq", title="Groq", model="llama-3.1-70b-versatile"
+    ),
+    "cohere": ProviderInfo(provider="cohere", title="Cohere", model="command-r-plus"),
+    "litellm": ProviderInfo(provider="litellm", title="LiteLLM", model="gpt-4o-mini"),
+    "azure": ProviderInfo(provider="azure", title="Azure AI", model="gpt-4o-mini"),
+    "bedrock": ProviderInfo(
+        provider="bedrock",
+        title="Bedrock",
+        model="anthropic.claude-3-haiku-20240307-v1:0",
+    ),
+}
+
+
+def substitute_provider_import(content: str, provider: Provider) -> str:
+    """Substitute provider in import statement."""
+    return re.sub(
+        r"(from mirascope.core import .*?)openai(.*?)",
+        rf"\1{provider}\2",
+        content,
+    )
+
+
+def substitute_provider_cast(content: str, provider: Provider) -> str:
+    """Substitute provider in cast statement."""
+    provider_name = provider.capitalize()
+
+    if provider == "litellm":
+        provider_name = "LiteLLM"
+    if provider == "openai":
+        provider_name = "OpenAI"
+
+    return re.sub(
+        r"cast\(openai\.OpenAICallResponse,",
+        f"cast({provider}.{provider_name}CallResponse,",
+        content,
+    )
+
+
+def substitute_llm_call_decorator(content: str, provider: Provider) -> str:
+    """Substitute provider and model into @llm.call decorator."""
+    subs = PROVIDER_INFO[provider]
+
+    # Use regex with re.DOTALL to match across lines
+    decorator_pattern = r"@llm\.call\((.*?)\)"
+
+    def replace_decorator(match: re.Match) -> str:
+        decorator_args = match.group(1)
+
+        # Check if we found the expected parameters
+        if 'provider="openai"' not in decorator_args:
+            raise ValueError(
+                f"Could not find provider='openai' in decorator: {decorator_args}"
+            )
+        if 'model="gpt-4o-mini"' not in decorator_args:
+            raise ValueError(
+                f"Could not find model='gpt-4o-mini' in decorator: {decorator_args}"
+            )
+
+        # Make substitutions, preserving whitespace
+        updated_args = decorator_args.replace(
+            'provider="openai"', f'provider="{subs.provider}"'
+        ).replace('model="gpt-4o-mini"', f'model="{subs.model}"')
+
+        return f"@llm.call({updated_args})"
+
+    # Perform substitution with re.DOTALL flag
+    new_content, _ = re.subn(
+        decorator_pattern, replace_decorator, content, flags=re.DOTALL
+    )
+
+    return new_content
+
+
+def substitute_provider_specific_content(content: str, provider: Provider) -> str:
+    """Apply all provider-specific substitutions."""
+    if provider not in PROVIDER_INFO:
+        raise ValueError(f"Provider {provider} not found in {PROVIDER_INFO}")
+
+    content = substitute_llm_call_decorator(content, provider)
+    content = substitute_provider_import(content, provider)
+    content = substitute_provider_cast(content, provider)
+    return content
+
+
+SNIPPETS_DIR = Path("build/snippets")
+
+
+def get_supported_providers() -> list[ProviderInfo]:
+    return list(PROVIDER_INFO.values())
+
+
+def generate_provider_examples(config: dict) -> None:
+    """Generate provider-specific examples for python files in configured paths."""
+    # Clear/create snippets directory
+    if SNIPPETS_DIR.exists():
+        for file in SNIPPETS_DIR.rglob("*.py"):
+            file.unlink()
+    SNIPPETS_DIR.mkdir(exist_ok=True)
+    supported_providers = get_supported_providers()
+
+    example_dirs = config["extra"]["provider_example_dirs"]
+    for example_dir in example_dirs:
+        source_dir = EXAMPLES_ROOT / example_dir
+
+        for base_file in source_dir.glob("*.py"):
+            content = base_file.read_text()
+
+            # Generate for each provider
+            for info in supported_providers:
+                # Create provider directory
+                output_dir = SNIPPETS_DIR / example_dir / info.provider
+
+                output_dir.mkdir(parents=True, exist_ok=True)
+
+                # Generate provider-specific version
+                substituted = substitute_provider_specific_content(
+                    content, info.provider
+                )
+
+                # Write to temporary file
+                out_file = output_dir / base_file.name
+                out_file.write_text(substituted)

--- a/docs/generate_provider_examples.py
+++ b/docs/generate_provider_examples.py
@@ -4,9 +4,6 @@ from pathlib import Path
 from mirascope.llm import Provider
 from pydantic import BaseModel
 
-EXAMPLES_ROOT = Path("examples")
-SNIPPETS_DIR = Path("build/snippets")
-
 
 class ProviderInfo(BaseModel):
     """Provider information for UI and substitutions."""
@@ -19,12 +16,12 @@ class ProviderInfo(BaseModel):
 PROVIDER_INFO: dict[Provider, ProviderInfo] = {
     "openai": ProviderInfo(provider="openai", title="OpenAI", model="gpt-4o-mini"),
     "anthropic": ProviderInfo(
-        provider="anthropic", title="Anthropic", model="claude-3-5-sonnet-20240620"
+        provider="anthropic", title="Anthropic", model="claude-3-5-sonnet-latest"
     ),
     "mistral": ProviderInfo(
         provider="mistral", title="Mistral", model="mistral-large-latest"
     ),
-    "google": ProviderInfo(provider="google", title="Google", model="gemini-1.5-flash"),
+    "google": ProviderInfo(provider="google", title="Google", model="gemini-2.0-flash"),
     "groq": ProviderInfo(
         provider="groq", title="Groq", model="llama-3.1-70b-versatile"
     ),
@@ -117,18 +114,20 @@ def get_supported_providers() -> list[ProviderInfo]:
     return list(PROVIDER_INFO.values())
 
 
-def generate_provider_examples(config: dict) -> None:
+def generate_provider_examples(
+    *, config: dict, examples_root: Path, snippets_dir: Path
+) -> None:
     """Generate provider-specific examples for python files in configured paths."""
     # Clear/create snippets directory
-    if SNIPPETS_DIR.exists():
-        for file in SNIPPETS_DIR.rglob("*.py"):
+    if snippets_dir.exists():
+        for file in snippets_dir.rglob("*.py"):
             file.unlink()
-    SNIPPETS_DIR.mkdir(exist_ok=True)
+    snippets_dir.mkdir(exist_ok=True, parents=True)
     supported_providers = get_supported_providers()
 
     example_dirs = config["extra"]["provider_example_dirs"]
     for example_dir in example_dirs:
-        source_dir = EXAMPLES_ROOT / example_dir
+        source_dir = examples_root / example_dir
 
         for base_file in source_dir.glob("*.py"):
             content = base_file.read_text()
@@ -136,7 +135,7 @@ def generate_provider_examples(config: dict) -> None:
             # Generate for each provider
             for info in supported_providers:
                 # Create provider directory
-                output_dir = SNIPPETS_DIR / example_dir / info.provider
+                output_dir = snippets_dir / example_dir / info.provider
 
                 output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -85,7 +85,11 @@ def on_pre_build(config, **kwargs):
     """
 
     try:
-        generate_provider_examples(config)
+        generate_provider_examples(
+            config=config,
+            examples_root=Path("examples"),
+            snippets_dir=Path("build/snippets"),
+        )
         print("Successfully generated provider examples")
     except Exception as e:
         print(f"Error generating provider examples: {e}")

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,6 +1,8 @@
 import shutil
 from pathlib import Path
 
+from docs.generate_provider_examples import generate_provider_examples
+
 
 def get_output_path(input_path: Path) -> Path:
     """
@@ -74,3 +76,17 @@ def on_post_build(config, **kwargs):
         print("Successfully copied generated .html.md files to site directory")
     except Exception as e:
         print(f"Error copying .html.md files: {e}")
+
+
+def on_pre_build(config, **kwargs):
+    """
+    Hook that runs before the build.
+    Generate provider specific examples.
+    """
+
+    try:
+        generate_provider_examples(config)
+        print("Successfully generated provider examples")
+    except Exception as e:
+        print(f"Error generating provider examples: {e}")
+        raise e

--- a/examples/learn/response_models/basic_usage/base_message_param.py
+++ b/examples/learn/response_models/basic_usage/base_message_param.py
@@ -1,0 +1,26 @@
+from typing import cast
+
+from mirascope import BaseMessageParam, llm
+from mirascope.core import openai
+from pydantic import BaseModel
+
+
+class Book(BaseModel):
+    """An extracted book."""
+
+    title: str
+    author: str
+
+
+@llm.call(provider="openai", model="gpt-4o-mini", response_model=Book)
+def extract_book(text: str) -> list[BaseMessageParam]:
+    return [BaseMessageParam(role="user", content=f"Extract {text}")]
+
+
+book = extract_book("The Name of the Wind by Patrick Rothfuss")
+print(book)
+# Output: title='The Name of the Wind' author='Patrick Rothfuss'
+
+response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+print(response.model_dump())
+# > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/examples/learn/response_models/basic_usage/base_message_param.py
+++ b/examples/learn/response_models/basic_usage/base_message_param.py
@@ -1,7 +1,6 @@
 from typing import cast
 
 from mirascope import BaseMessageParam, llm
-from mirascope.core import openai
 from pydantic import BaseModel
 
 
@@ -21,6 +20,6 @@ book = extract_book("The Name of the Wind by Patrick Rothfuss")
 print(book)
 # Output: title='The Name of the Wind' author='Patrick Rothfuss'
 
-response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+response = cast(llm.CallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
 print(response.model_dump())
 # > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/examples/learn/response_models/basic_usage/messages.py
+++ b/examples/learn/response_models/basic_usage/messages.py
@@ -1,7 +1,6 @@
 from typing import cast
 
 from mirascope import Messages, llm
-from mirascope.core import openai
 from pydantic import BaseModel
 
 
@@ -21,6 +20,6 @@ book = extract_book("The Name of the Wind by Patrick Rothfuss")
 print(book)
 # Output: title='The Name of the Wind' author='Patrick Rothfuss'
 
-response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+response = cast(llm.CallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
 print(response.model_dump())
 # > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/examples/learn/response_models/basic_usage/messages.py
+++ b/examples/learn/response_models/basic_usage/messages.py
@@ -1,0 +1,26 @@
+from typing import cast
+
+from mirascope import Messages, llm
+from mirascope.core import openai
+from pydantic import BaseModel
+
+
+class Book(BaseModel):
+    """An extracted book."""
+
+    title: str
+    author: str
+
+
+@llm.call(provider="openai", model="gpt-4o-mini", response_model=Book)
+def extract_book(text: str) -> Messages.Type:
+    return Messages.User(f"Extract {text}")
+
+
+book = extract_book("The Name of the Wind by Patrick Rothfuss")
+print(book)
+# Output: title='The Name of the Wind' author='Patrick Rothfuss'
+
+response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+print(response.model_dump())
+# > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/examples/learn/response_models/basic_usage/shorthand.py
+++ b/examples/learn/response_models/basic_usage/shorthand.py
@@ -1,7 +1,6 @@
 from typing import cast
 
 from mirascope import llm
-from mirascope.core import openai
 from pydantic import BaseModel
 
 
@@ -21,6 +20,6 @@ book = extract_book("The Name of the Wind by Patrick Rothfuss")
 print(book)
 # Output: title='The Name of the Wind' author='Patrick Rothfuss'
 
-response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+response = cast(llm.CallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
 print(response.model_dump())
 # > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/examples/learn/response_models/basic_usage/shorthand.py
+++ b/examples/learn/response_models/basic_usage/shorthand.py
@@ -1,0 +1,26 @@
+from typing import cast
+
+from mirascope import llm
+from mirascope.core import openai
+from pydantic import BaseModel
+
+
+class Book(BaseModel):
+    """An extracted book."""
+
+    title: str
+    author: str
+
+
+@llm.call(provider="openai", model="gpt-4o-mini", response_model=Book)
+def extract_book(text: str) -> str:
+    return f"Extract {text}"
+
+
+book = extract_book("The Name of the Wind by Patrick Rothfuss")
+print(book)
+# Output: title='The Name of the Wind' author='Patrick Rothfuss'
+
+response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+print(response.model_dump())
+# > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/examples/learn/response_models/basic_usage/string_template.py
+++ b/examples/learn/response_models/basic_usage/string_template.py
@@ -1,0 +1,26 @@
+from typing import cast
+
+from mirascope import llm, prompt_template
+from mirascope.core import openai
+from pydantic import BaseModel
+
+
+class Book(BaseModel):
+    """An extracted book."""
+
+    title: str
+    author: str
+
+
+@llm.call(provider="openai", model="gpt-4o-mini", response_model=Book)
+@prompt_template("Extract {text}")
+def extract_book(text: str): ...
+
+
+book = extract_book("The Name of the Wind by Patrick Rothfuss")
+print(book)
+# Output: title='The Name of the Wind' author='Patrick Rothfuss'
+
+response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+print(response.model_dump())
+# > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/examples/learn/response_models/basic_usage/string_template.py
+++ b/examples/learn/response_models/basic_usage/string_template.py
@@ -1,7 +1,6 @@
 from typing import cast
 
 from mirascope import llm, prompt_template
-from mirascope.core import openai
 from pydantic import BaseModel
 
 
@@ -21,6 +20,6 @@ book = extract_book("The Name of the Wind by Patrick Rothfuss")
 print(book)
 # Output: title='The Name of the Wind' author='Patrick Rothfuss'
 
-response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+response = cast(llm.CallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
 print(response.model_dump())
 # > {'metadata': {}, 'response': {'id': ...}, ...}

--- a/mirascope/core/__init__.py
+++ b/mirascope/core/__init__.py
@@ -54,6 +54,7 @@ __all__ = [
     "anthropic",
     "azure",
     "base",
+    "BaseCallResponse",
     "BaseDynamicConfig",
     "BaseMessageParam",
     "BasePrompt",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,9 @@ site_description: Mirascope streamlines LLM development with a unified interface
 repo_name: mirascope
 repo_url: https://github.com/Mirascope/mirascope/
 strict: true
+watch:
+  - docs/
+  - examples/
 theme:
   name: material
   custom_dir: docs/overrides
@@ -79,6 +82,8 @@ extra:
     - Messages
     - String Template
     - BaseMessageParam
+  provider_example_dirs:
+    - learn/response_models/basic_usage
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/tests/docs/test_generate_provider_examples.py
+++ b/tests/docs/test_generate_provider_examples.py
@@ -1,0 +1,238 @@
+import inspect
+from typing import Any
+
+import pytest
+
+from docs.generate_provider_examples import (
+    PROVIDER_INFO,
+    get_supported_providers,
+    substitute_llm_call_decorator,
+    substitute_provider_cast,
+    substitute_provider_import,
+    substitute_provider_specific_content,
+)
+
+
+def test_substitute_llm_call_decorator_single_line():
+    content = inspect.cleandoc("""
+        from mirascope import llm
+
+        @llm.call(provider="openai", model="gpt-4o-mini", response_model=Book)
+        def extract_book(text: str):
+            pass
+        """)
+    expected = inspect.cleandoc("""
+        from mirascope import llm
+
+        @llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620", response_model=Book)
+        def extract_book(text: str):
+            pass
+        """)
+    result = substitute_llm_call_decorator(content, "anthropic")
+    assert result == expected
+
+
+def test_substitute_llm_call_decorator_multi_line():
+    content = inspect.cleandoc("""
+        from mirascope import llm
+
+        @llm.call(
+            provider="openai",
+            model="gpt-4o-mini",
+            response_model=Book
+        )
+        def extract_book(text: str):
+            pass
+        """)
+    expected = inspect.cleandoc("""
+        from mirascope import llm
+
+        @llm.call(
+            provider="anthropic",
+            model="claude-3-5-sonnet-20240620",
+            response_model=Book
+        )
+        def extract_book(text: str):
+            pass
+        """)
+    result = substitute_llm_call_decorator(content, "anthropic")
+    assert result == expected
+
+
+def test_substitute_llm_call_decorator_wrong_provider():
+    content = inspect.cleandoc("""
+        @llm.call(provider="azure", model="gpt-4o-mini", response_model=Book)
+        def extract_book(text: str):
+            pass
+        """)
+    with pytest.raises(ValueError, match="Could not find provider='openai'"):
+        substitute_llm_call_decorator(content, "anthropic")
+
+
+def test_substitute_llm_call_decorator_wrong_model():
+    content = inspect.cleandoc("""
+        @llm.call(provider="openai", model="wrong-model", response_model=Book)
+        def extract_book(text: str):
+            pass
+        """)
+    with pytest.raises(ValueError, match="Could not find model='gpt-4o-mini'"):
+        substitute_llm_call_decorator(content, "anthropic")
+
+
+def test_substitute_llm_call_decorator_multiple_decorators():
+    content = inspect.cleandoc("""
+        @llm.call(provider="openai", model="gpt-4o-mini")
+        def func1(): pass
+
+        @llm.call(provider="openai", model="gpt-4o-mini")
+        def func2(): pass
+        """)
+    expected = inspect.cleandoc("""
+        @llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620")
+        def func1(): pass
+
+        @llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620")
+        def func2(): pass
+        """)
+    result = substitute_llm_call_decorator(content, "anthropic")
+    assert result == expected
+
+
+def test_substitute_provider_import():
+    content = inspect.cleandoc("""
+        from mirascope.core import openai
+        """)
+    expected = inspect.cleandoc("""
+        from mirascope.core import anthropic
+        """)
+    result = substitute_provider_import(content, "anthropic")
+    assert result == expected
+
+
+def test_substitute_provider_import_multi_import():
+    content = inspect.cleandoc("""
+        from mirascope.core import Foo, openai, Bar
+        """)
+    expected = inspect.cleandoc("""
+        from mirascope.core import Foo, anthropic, Bar
+        """)
+    result = substitute_provider_import(content, "anthropic")
+    assert result == expected
+
+
+def test_substitute_provider_cast():
+    content = inspect.cleandoc("""
+        cast(openai.OpenAICallResponse, response)
+        """)
+    expected = inspect.cleandoc("""
+        cast(anthropic.AnthropicCallResponse, response)
+        """)
+    result = substitute_provider_cast(content, "anthropic")
+    assert result == expected
+
+
+def test_substitute_provider_cast_litellm():
+    content = inspect.cleandoc("""
+        cast(openai.OpenAICallResponse, response)
+        """)
+    expected = inspect.cleandoc("""
+        cast(litellm.LiteLLMCallResponse, response)
+        """)
+    result = substitute_provider_cast(content, "litellm")
+    assert result == expected
+
+
+def test_substitute_provider_specific_content():
+    content = inspect.cleandoc("""
+        from mirascope import BaseMessageParam, llm
+        from mirascope.core import openai
+        from pydantic import BaseModel
+
+
+        class Book(BaseModel):
+            title: str
+            author: str
+
+
+        @llm.call(provider="openai", model="gpt-4o-mini", response_model=Book)
+        def extract_book(text: str) -> list[BaseMessageParam]:
+            return [BaseMessageParam(role="user", content=f"Extract {text}")]
+
+
+        book = extract_book("The Name of the Wind by Patrick Rothfuss")
+        print(book)
+        # Output: title='The Name of the Wind' author='Patrick Rothfuss'
+
+        response = cast(openai.OpenAICallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+        print(response.model_dump())
+        # > {'metadata': {}, 'response': {'id': ...}, ...}
+        """)
+    expected = inspect.cleandoc("""
+        from mirascope import BaseMessageParam, llm
+        from mirascope.core import anthropic
+        from pydantic import BaseModel
+
+
+        class Book(BaseModel):
+            title: str
+            author: str
+
+
+        @llm.call(provider="anthropic", model="claude-3-5-sonnet-20240620", response_model=Book)
+        def extract_book(text: str) -> list[BaseMessageParam]:
+            return [BaseMessageParam(role="user", content=f"Extract {text}")]
+
+
+        book = extract_book("The Name of the Wind by Patrick Rothfuss")
+        print(book)
+        # Output: title='The Name of the Wind' author='Patrick Rothfuss'
+
+        response = cast(anthropic.AnthropicCallResponse, book._response)  # pyright: ignore[reportAttributeAccessIssue]
+        print(response.model_dump())
+        # > {'metadata': {}, 'response': {'id': ...}, ...}
+        """)
+    result = substitute_provider_specific_content(content, "anthropic")
+    assert result == expected
+
+
+def test_substitute_fails_invalid_provider():
+    content = inspect.cleandoc("""
+        @llm.call(provider="openai", model="gpt-4o-mini")
+        def func(): pass
+        """)
+    bad_provider: Any = "InvalidProvider"
+    with pytest.raises(ValueError, match="Provider InvalidProvider not found"):
+        substitute_provider_specific_content(content, bad_provider)
+
+
+def test_supported_providers_matches_mkdocs():
+    actual = []
+
+    with open("mkdocs.yml") as f:
+        in_extra = False
+        in_providers = False
+        for line in f:
+            if line.strip() == "extra:":
+                in_extra = True
+            elif in_extra and "supported_llm_providers:" in line:
+                in_providers = True
+            elif in_providers and line.strip().startswith("- "):
+                actual.append(line.strip()[2:])
+            elif in_providers and not line.strip().startswith("- "):
+                break
+    assert set(actual) == {info.title for info in PROVIDER_INFO.values()}
+
+
+def test_substitute_llm_call_decorator_all_providers():
+    base_content = inspect.cleandoc("""
+        @llm.call(provider="openai", model="gpt-4o-mini")
+        def func(): pass
+        """)
+
+    providers = get_supported_providers()
+
+    for info in providers:
+        result = substitute_llm_call_decorator(base_content, info.provider)
+        assert info.provider in result
+        assert info.model in result
+        assert "func(): pass" in result

--- a/tests/docs/test_generate_provider_examples.py
+++ b/tests/docs/test_generate_provider_examples.py
@@ -10,9 +10,9 @@ from docs.generate_provider_examples import (
     generate_provider_examples,
     get_supported_providers,
     substitute_llm_call_decorator,
-    substitute_provider_cast,
     substitute_provider_import,
     substitute_provider_specific_content,
+    substitute_provider_type,
 )
 
 
@@ -123,26 +123,26 @@ def test_substitute_provider_import_multi_import():
     assert result == expected
 
 
-def test_substitute_provider_cast():
+def test_substitute_provider_type():
     content = inspect.cleandoc("""
         cast(openai.OpenAICallResponse, response)
         """)
     expected = inspect.cleandoc("""
         cast(anthropic.AnthropicCallResponse, response)
         """)
-    result = substitute_provider_cast(content, "anthropic")
+    result = substitute_provider_type(content, "anthropic")
     assert result == expected
 
 
-def test_substitute_provider_cast_litellm():
+def test_substitute_provider_type_special_caps():
     content = inspect.cleandoc("""
         cast(openai.OpenAICallResponse, response)
         """)
     expected = inspect.cleandoc("""
         cast(litellm.LiteLLMCallResponse, response)
         """)
-    result = substitute_provider_cast(content, "litellm")
-    assert result == expected
+    assert substitute_provider_type(content, "litellm") == expected
+    assert substitute_provider_type(content, "openai") == content
 
 
 def test_substitute_provider_specific_content():
@@ -194,8 +194,8 @@ def test_substitute_provider_specific_content():
         print(response.model_dump())
         # > {'metadata': {}, 'response': {'id': ...}, ...}
         """)
-    result = substitute_provider_specific_content(content, "anthropic")
-    assert result == expected
+    assert substitute_provider_specific_content(content, "anthropic") == expected
+    assert substitute_provider_specific_content(content, "openai") == content
 
 
 def test_substitute_fails_invalid_provider():


### PR DESCRIPTION
This commit converts the get started docs to show provider-agnostic API usage (via @llm.call), while still showing the specific code usage for each provider.

In the UI, I kept showing provider-specific code, both for consistency with the "Official SDK" comparison that's already included, but also because it's a very direct way of showing off Mirascope's wide range of supported providers.

Since the code is now nearly identical for each provider, we can unify to a single implementation (using openai gpt-4o-mini by default), and then substitute in provider-specific logic at docs build time. I've added logic for doing so (`generate_provider_examples.py`), and a pre-build hook that invokes it. The substitution logic is tested, and ensures that we get a build time error if the provider substitution fails (e.g. because an example didn't use openai/gpt-4o-mini as expected). Also, `mkdocs` is updated to watch the examples directory for file changes.

I haven't deleted any of the provider-specific implementations, since they're also used for `response_model.md`, and I wanted to get a minimal conversion out for review without leaving `response_model` in a half-switched state. However, if we move forward with this approach, we can delete most of the provider example files, leaving only cases like the sdk usage.

For cases where we don't have any provider-specific code to compare to, we could keep the per-provider tabbed structure, or we could drop it and just use openai or anthropic as consistent examples. I can see benefits to either approach, and I'm curious which you prefer.

Along the way, I made one API change, to expose `BaseCallResponse` in `mirascope.core`. This avoids bloating the example code with an extra import from `mirascope.core.base`, and seems very consistent with the other exports in `mirascope.core`. I think it'd be nice if we could get down to one import line in the standard case of using llm call, though I'm not sure if there's a principled way to do it. (Maybe expose `call` and `override` as `llm_call` and `llm_override` inside core?) 

Progress on #811 