### PR TITLE
pyright excludes .venv

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         run: uv run ruff check .
 
       - name: Run Pyright
-        run: uv run pyright mirascope tests examples
+        run: uv run pyright .
 
       - name: Minimize uv cache
         run: uv cache prune --ci

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -209,6 +209,7 @@ exclude = [
     "examples/learn/calls/basic_usage/bedrock/official_sdk_call.py",
     "examples/learn/tools/basic_usage/bedrock/official_sdk.py",
     "examples/learn/response_models/basic_usage/bedrock/official_sdk.py",
+    ".venv"
 ]
 venvPath = "."
 venv = ".venv"


### PR DESCRIPTION
This PR modifies pyproject.toml so that pyright excludes the `.venv` directory, and modifies the lint GitHub workflow so as to run `pyright .` rather than `pyright mirascope test examples`.

Regarding the venv exclusion: The CONTRIBUTING.md docs say to invoke pyright via 

`uv run pyright .`

However, on my machine this hangs interminably (>5 mins). The issue is type checking the .venv directory. Per the [pyright docs](https://github.com/microsoft/pyright/blob/main/docs/configuration.md#environment-options), .venv is excluded automatically *by pylance*, but apparently not by pyright, so it appears that manually excluding .venv is intended. After making this change, `uv run pyright .` finishes on my machine in about 16s.

With this change made, I updated the GitHub workflow to use `uv run pyright .`, which seems desirable both to match the contributing guidelines, and ensures proper type checking in other top level directories, such as docs. (This is relevant as the docs directory has some python scripts, and #825 may add more.)