### PR TITLE
feat: check that all docs code snippets resolve

### DIFF
--- a/docs/find_missing_snippets.py
+++ b/docs/find_missing_snippets.py
@@ -1,0 +1,141 @@
+"""Scope:
+Finds every code import in docs/learn/**/*.md, and checks that the target file exists.
+
+Usage: python -m docs.find_missing_snippets
+
+Note: The script depends on hand-maintained substitutions
+in FILE_SPECIFIC_SUBSTITUTUTIONS, which may require updates as documents
+are changed or updated. There is automated testing to ensure that all new
+imports exist, which will fail if FILE_SPECIFIC_SUBSTITUTUTIONS is not updated.
+"""
+
+import re
+from collections.abc import Iterable
+from itertools import product
+from pathlib import Path
+
+# Define the namedtuple
+from typing import Dict, List, NamedTuple
+
+import yaml
+from docs.generate_provider_examples import (
+    generate_provider_examples,
+)
+
+Substitutions = Dict[str, List[str]]
+
+
+# Hardcoded list of which docs files have non-standard substitutions,
+# which we maintain by hand because this changes infrequently and implementing a general
+# solution via parsing the jinja2 templates and environment is overkill.
+FILE_SPECIFIC_SUBSTITUTIONS: dict[str, Substitutions] = {
+    "docs/learn/tools.md": {
+        "{{ tool_method }}": ["base_tool", "function"],
+        "{{ pre_made_tool_method }}": ["basic_usage", "custom_config"],
+    },
+    "docs/learn/local_models.md": {
+        "{{ provider.lower() }}": ["ollama", "vllm"],
+    },
+    "docs/learn/prompts.md": {
+        "{{ audio_pkg }}": ["pydub", "wave"],
+        "{{ filename }}": ["lists", "texts", "parts"],
+    },
+}
+
+
+def extact_yaml_section(file_path, section_name):
+    # Manually get some info from yaml files, as mkdocs.yml is not easy to parse
+    section_lines = []
+    in_section = False
+    section_indent = None
+
+    with open(file_path, "r") as file:
+        section_indent = 0
+        for line in file:
+            if line.lstrip().startswith(section_name + ":"):
+                in_section = True
+                section_indent = len(line) - len(line.lstrip())
+                continue
+
+            if in_section:
+                current_indent = len(line) - len(line.lstrip())
+                if current_indent > section_indent:
+                    section_lines.append(line)
+                else:
+                    break
+
+    section_content = "\n".join(section_lines)
+    return yaml.safe_load(section_content) if section_lines else []
+
+
+CONFIG_FILE = Path("mkdocs.yml")
+PROVIDERS = [
+    p.split()[0].lower()
+    for p in extact_yaml_section(CONFIG_FILE, "supported_llm_providers")
+]
+BASE_SUBSTITUTIONS = {
+    "{{ provider | provider_dir }}": PROVIDERS,
+    "{{ method }}": extact_yaml_section(CONFIG_FILE, "prompt_writing_methods"),
+}
+
+
+class Snippet(NamedTuple):
+    path: Path
+    source_file: Path
+
+
+def substituted_snippet_paths(
+    markdown_content: str, substitutions: dict[str, list[str]]
+) -> Iterable[Path]:
+    pattern = r'--8<--\s*"([^"]+\.py(?::\d+(?::\d+)?)?)"'
+    # Extract paths and strip line numbers
+    paths = {
+        match.group(1).split(":")[0] for match in re.finditer(pattern, markdown_content)
+    }
+
+    for path in paths:
+        # Find all keys in the import path that need substitution
+        keys_to_substitute = [key for key in substitutions if key in path]
+
+        # Generate all combinations of substitutions for the keys
+        substitution_combinations = product(
+            *(substitutions[key] for key in keys_to_substitute)
+        )
+
+        for combination in substitution_combinations:
+            # Create a new path with all substitutions applied
+            new_path = path
+            for key, value in zip(keys_to_substitute, combination):
+                new_path = new_path.replace(key, value)
+
+            yield Path(new_path)
+
+
+def missing_snippets_for_file(
+    markdown_path: Path, substitutions: dict[str, list[str]]
+) -> Iterable[Snippet]:
+    markdown_content = markdown_path.read_text()
+    for path in substituted_snippet_paths(markdown_content, substitutions):
+        if not path.exists():
+            yield Snippet(path, markdown_path)
+
+
+def all_missing_snippets(root_dir: Path) -> Iterable[Snippet]:
+    provider_example_dirs = extact_yaml_section(CONFIG_FILE, "provider_example_dirs")
+    generate_provider_examples(
+        example_dirs=provider_example_dirs,
+        examples_root=root_dir / "examples",
+        snippets_dir=root_dir / "build/snippets",
+    )
+    for md_path in root_dir.glob("docs/**/*.md"):
+        relative_path = md_path.relative_to(root_dir)
+        substitutions = {
+            **BASE_SUBSTITUTIONS,
+            **FILE_SPECIFIC_SUBSTITUTIONS.get(str(relative_path), {}),
+        }
+        yield from missing_snippets_for_file(md_path, substitutions)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    for imp in all_missing_snippets(Path(".")):
+        print(f"Missing import: {imp.path} (from {imp.source_file})")

--- a/docs/generate_provider_examples.py
+++ b/docs/generate_provider_examples.py
@@ -153,7 +153,7 @@ def get_supported_providers() -> list[ProviderInfo]:
 
 
 def generate_provider_examples(
-    *, config: dict, examples_root: Path, snippets_dir: Path
+    *, example_dirs: list[str], examples_root: Path, snippets_dir: Path
 ) -> None:
     """Generate provider-specific examples for python files in configured paths."""
     # Clear/create snippets directory
@@ -163,7 +163,6 @@ def generate_provider_examples(
     snippets_dir.mkdir(exist_ok=True, parents=True)
     supported_providers = get_supported_providers()
 
-    example_dirs = config["extra"]["provider_example_dirs"]
     for example_dir in example_dirs:
         source_dir = examples_root / example_dir
 

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -85,8 +85,9 @@ def on_pre_build(config, **kwargs):
     """
 
     try:
+        example_dirs = config["extra"]["provider_example_dirs"]
         generate_provider_examples(
-            config=config,
+            example_dirs=example_dirs,
             examples_root=Path("examples"),
             snippets_dir=Path("build/snippets"),
         )

--- a/docs/learn/tools.md
+++ b/docs/learn/tools.md
@@ -479,8 +479,8 @@ Example using DuckDuckGoSearch:
 
 !!! mira ""
 
-    {% for tool_method, tool_method_title in [["basic_usage", "Basic Usage"], ["custom_config", "Custom Config"]] %}
-    === "{{ tool_method_title }}"
+    {% for pre_made_tool_method, pre_made_tool_method_title in [["basic_usage", "Basic Usage"], ["custom_config", "Custom Config"]] %}
+    === "{{ pre_made_tool_method_title }}"
 
         {% for method, method_title in zip(prompt_writing_methods, prompt_writing_method_titles) %}
         === "{{ method_title }}"
@@ -488,12 +488,12 @@ Example using DuckDuckGoSearch:
             {% for provider in supported_llm_providers %}
             === "{{ provider }}"
 
-                {% if tool_method == "basic_usage" %}
+                {% if pre_made_tool_method == "basic_usage" %}
                 ```python hl_lines="2 5"
                 {% else %}
                 ```python hl_lines="2 4-5 8"
                 {% endif %}
-                --8<-- "build/snippets/learn/tools/pre_made_tools/{{ tool_method }}/{{ provider | provider_dir }}/{{ method }}.py"
+                --8<-- "build/snippets/learn/tools/pre_made_tools/{{ pre_made_tool_method }}/{{ provider | provider_dir }}/{{ method }}.py"
                 ```
             {% endfor %}
 

--- a/tests/docs/test_generate_provider_examples.py
+++ b/tests/docs/test_generate_provider_examples.py
@@ -356,10 +356,11 @@ def test_generate_provider_example():
         examples_root = Path("examples")
         example = "learn/response_models/basic_usage"
         assert (examples_root / example / "shorthand.py").exists()
-        config = {"extra": {"provider_example_dirs": [example]}}
         snippets_dir = temp_path / "build/snippets"
         generate_provider_examples(
-            config=config, examples_root=examples_root, snippets_dir=snippets_dir
+            example_dirs=[example],
+            examples_root=examples_root,
+            snippets_dir=snippets_dir,
         )
 
         anthropic_example = snippets_dir / example / "anthropic" / "shorthand.py"
@@ -378,13 +379,14 @@ def test_generate_provider_example_removes_existing_files():
         examples_root = Path("../examples")
         example = "learn/response_models/basic_usage"
 
-        config = {"extra": {"provider_example_dirs": [example]}}
         snippets_dir = temp_path / "build/snippets"
         errata = snippets_dir / "learn/response_models/basic_usage/anthropic/errata.py"
         errata.parent.mkdir(parents=True, exist_ok=True)
         errata.touch()
         generate_provider_examples(
-            config=config, examples_root=examples_root, snippets_dir=snippets_dir
+            example_dirs=[example],
+            examples_root=examples_root,
+            snippets_dir=snippets_dir,
         )
 
         assert not errata.exists()
@@ -410,10 +412,11 @@ def test_generate_provider_example_overrides():
         # anthropic also has a special sdk file
         (example_dir / "anthropic" / "special_sdk.py").write_text("# Special Sauce")
 
-        config = {"extra": {"provider_example_dirs": [example]}}
         snippets_dir = temp_path / "build/snippets"
         generate_provider_examples(
-            config=config, examples_root=examples_root, snippets_dir=snippets_dir
+            example_dirs=[example],
+            examples_root=examples_root,
+            snippets_dir=snippets_dir,
         )
 
         snippet_example = snippets_dir / example

--- a/tests/docs/test_missing_snippets.py
+++ b/tests/docs/test_missing_snippets.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from docs.find_missing_snippets import all_missing_snippets
+
+
+def test_no_missing_snippets():
+    missing_snippets = []
+    for snippet in all_missing_snippets(Path(".")):
+        str_path = str(snippet.path)
+        if "xai" in str_path:
+            # TODO: Remove this once the xai snippets are fixed (after finishing #811)
+            continue
+        if "google" in str_path and "integrations" in str_path:
+            # TODO: Remove this once missing google integration snippets are added
+            continue
+        missing_snippets.append(snippet)  # pragma: no cover
+    assert len(missing_snippets) == 0


### PR DESCRIPTION
There are a lot of docs, and a lot of code snippets in those docs - over 2300. They are split between checked-in and autogenerated files, and often parameterized by provider, by API style, and others.

As a result, it's really easy to add missing imports (or break existing ones)—especially when adding a new provider. As a testament to that, there are currently 95 missing snippets. Most are related to the addition of the xai provider, but there are also broken google examples in the integrations docs.

This PR doesn't fix all of the missing snippets (it makes sense to wrap up #811 first as that will resolve many but not all missing xai snippets on its own). Instead, it adds a tool for enumerating all missing snippets, and an automated test to ensure no new missing snippets are added. I grandfathered in existing missing snippets so that the build passes.

Note: Doing this "properly" would require parsing the jinja2 templates to figure out what variables are in scope, for the cases were we have non-standard variables like `{{ tool_method }}` in `docs/learn/tools.md`. This seemed really hard, so I took the expedient approach of hardcoding in the non-standard variables. Whenever new nonstandard variables are used in snippet path definitions in documentation, this file will need to be updated, too... which will happen organically due to test failures. 