### PR TITLE
test: explicitly count missing docs imports

### DIFF
--- a/tests/docs/test_missing_snippets.py
+++ b/tests/docs/test_missing_snippets.py
@@ -5,13 +5,19 @@ from docs.find_missing_snippets import all_missing_snippets
 
 def test_no_missing_snippets():
     missing_snippets = []
+    xai_missing_snippets = 0
+    google_missing_snippets = 0
     for snippet in all_missing_snippets(Path(".")):
         str_path = str(snippet.path)
         if "xai" in str_path:
             # TODO: Remove this once the xai snippets are fixed (after finishing #811)
+            xai_missing_snippets += 1
             continue
         if "google" in str_path and "integrations" in str_path:
             # TODO: Remove this once missing google integration snippets are added
+            google_missing_snippets += 1
             continue
         missing_snippets.append(snippet)  # pragma: no cover
+    assert xai_missing_snippets == 79
+    assert google_missing_snippets == 16
     assert len(missing_snippets) == 0


### PR DESCRIPTION
This is a minor change to the test code for tracking missing snippets (#877) so we keep track of exactly how many missing examples there are. This has a few implications:

1. We won't inadvertently add any more missing imports in any of the grandfathered categories
2. I'll get slight satisfaction with each additional docs migration PR that makes number go down (at the cost of slightly more test maintenance)
3. It makes the test code self documenting about the scope of the issue