### PR TITLE
fix: make llm.context work for async functions

### DIFF
--- a/mirascope/llm/_context.py
+++ b/mirascope/llm/_context.py
@@ -114,10 +114,10 @@ def _context(
     client: Any | None = None,  # noqa: ANN401
     call_params: CommonCallParams | Any | None = None,  # noqa: ANN401
 ) -> LLMContext:
-    """Context manager for synchronous LLM API calls.
+    """Context manager for LLM API calls.
 
     This is an internal method that allows both setting and structural overrides
-    for synchronous functions.
+    for LLM functions.
 
     Unfortunately we have not yet identified a way to properly type hint this because
     providing no structural overrides means the return type is that of the original
@@ -138,7 +138,7 @@ def _context(
         client: The client to use for the LLM API call.
         call_params: The call parameters for the LLM API call.
 
-    Yields:
+    Returns:
         The context object that can be used to apply the context to a function.
     """
     old_context: LLMContext | None = getattr(_current_context_local, "context", None)
@@ -171,16 +171,19 @@ def _context(
         )
 
 
-def apply_context_overrides_to_call_args(call_args: CallArgs) -> CallArgs:
+def apply_context_overrides_to_call_args(
+    call_args: CallArgs, context_override: LLMContext | None = None
+) -> CallArgs:
     """Apply any active context overrides to the call arguments.
 
     Args:
         call_args: The original call arguments.
+        context_override: Optional explicit context to use instead of the current thread context.
 
     Returns:
         The call arguments with any context overrides applied.
     """
-    context = get_current_context()
+    context = context_override or get_current_context()
     if not context:
         return call_args
 

--- a/tests/llm/test_context.py
+++ b/tests/llm/test_context.py
@@ -338,3 +338,50 @@ def test_context_function_with_client_and_params():
             client=mock_client,
             call_params=call_params,
         )
+
+
+def test_apply_context_overrides_to_call_args_with_explicit_context():
+    """Test applying context overrides with an explicitly provided context."""
+    # Original call args
+    call_args: CallArgs = {
+        "provider": "openai",
+        "model": "gpt-4",
+        "stream": False,
+        "tools": None,
+        "response_model": None,
+        "output_parser": None,
+        "json_mode": False,
+        "client": None,
+        "call_params": None,
+    }
+
+    # Create an explicit context
+    explicit_context = LLMContext(
+        provider="anthropic",
+        model="claude-3-5-sonnet",
+        stream=True,
+    )
+
+    # Apply the explicit context
+    result = apply_context_overrides_to_call_args(
+        call_args, context_override=explicit_context
+    )
+
+    # Check that the explicit context was applied
+    assert result["provider"] == "anthropic"
+    assert result["model"] == "claude-3-5-sonnet"
+    assert result["stream"] is True
+
+    # Test that it takes precedence over the current context
+    with _context(
+        provider="openai",
+        model="gpt-4o",
+        stream=False,
+    ):
+        # The explicit context should be used, not the current context
+        result = apply_context_overrides_to_call_args(
+            call_args, context_override=explicit_context
+        )
+        assert result["provider"] == "anthropic"
+        assert result["model"] == "claude-3-5-sonnet"
+        assert result["stream"] is True


### PR DESCRIPTION
As presently implemented, the new `llm.context` api (#884) does not consistently work for async functions. Consider the following two examples:


```python
import asyncio

from mirascope import llm


@llm.call(provider="openai", model="gpt-4o-mini")
async def introspect_model() -> str:
    return f"What model are you?"


async def example1():
    print("example1:")
    openai_response = await introspect_model()
    print(openai_response.content)

    with llm.context(provider="anthropic", model="claude-3-5-sonnet-latest"):
        anthropic_response = await introspect_model()
        print(anthropic_response.content)


async def example2():
    print("example2:")
    openai_response_future = introspect_model()

    with llm.context(provider="anthropic", model="claude-3-5-sonnet-latest"):
        anthropic_response_future = introspect_model()

    openai_response, anthropic_response = await asyncio.gather(
        openai_response_future, anthropic_response_future
    )

    print(openai_response.content)
    print(anthropic_response.content)


async def main():
    await example1()
    await example2()


if __name__ == "__main__":
    asyncio.run(main())
```

Right now example 1 works but example 2 doesn't:

```
example1:
I am based on OpenAI's GPT-3 model. How can I assist you today?
I'm Claude, an AI assistant created by Anthropic. I aim to be direct and honest in my communications.

example2:
I am based on OpenAI's GPT-3 model, specifically designed for providing information and answering questions across a wide range of topics. If you have any specific questions or need assistance, feel free to ask!
I am based on OpenAI's GPT-3.5 architecture. How can I assist you today?
```

The issue being in the second example, when we actually execute the code, we're no longer inside the context of the context manager.

This commit fixes the issue by capturing the context into a closure at call time for the decorated function. I've added tests: specifically two tests to `test_call.py`, of which only the first one passes under the current implementation, and both pass with the fixed implementation. 

Note, in the present implementation `llm.override` works fine. However, I added a similar test case to `test_override` for caution.