### PR TITLE
feat: serve_docs_dev.py for fast docs development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,7 @@ venv.bak/
 docs/**/*.html.md
 docs/llms.txt
 build/snippets/
+mkdocs.dev.yml
 
 # mypy
 .mypy_cache/

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -149,11 +149,22 @@ We care deeply about maintaining high-quality, up-to-date documentation. This me
 
 The documentation lives in the [docs/](https://github.com/Mirascope/mirascope/tree/main/docs) directory, which can be built by running `uv run mkdocs serve`.
 
-A few key things to note:
+### Fast Docs Development
+
+For faster local documentation development, we provide a script that automatically creates a modified configuration without slow plugins. It can be invoked via: 
+
+```shell
+# Run the fast docs development server
+uv run python scripts/serve_docs_dev.py
+```
+
+Under the hood, this script disables the `social` and `mkdocs-jupyter` plugins, and sets `strict: false`, which significantly speeds up rebuild times during development.
+
+### Documentation Notes
 
 1. We have code examples in the `examples` folder for all code snippets in the documentation, and we maintain snippets for every option (e.g. prompt writing methods, providers, etc.). While this seems unnecessarily cumbersome, these examples operate as tests for type hints because we run `pyright` on all of the examples. When writing documentation that changes existing examples or requires new examples, make sure to properly update the actual code in the `examples/` directory to match the existing structure.
 2. The API reference is generated automatically, but things like new modules still need to be included in the `docs/api` structure for generation to work.
-3. The `docs/tutorials` are written as Jupyter notebooks that get converted into markdown. This conversion will happen on every save when running the server locally, which can make writing docs slow. We recommend setting `strict: false` and commenting out the `mkdocs-jupyter` plugin in `mkdocs.yml` to skip the conversion.
+3. The `docs/tutorials` are written as Jupyter notebooks that get converted into markdown. This conversion will happen on every save when running the server locally, which can make writing docs slow. We recommend using the fast docs development script to address this.
 
 !!! tip "MacOS Users Will Need `cairo`
 

--- a/scripts/serve_docs_dev.py
+++ b/scripts/serve_docs_dev.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""
+Script to run a faster version of mkdocs serve for local documentation development.
+This creates a temporary modified mkdocs config that disables slow plugins.
+"""
+
+import os
+import re
+import subprocess
+from pathlib import Path
+
+# Define paths
+root_dir = Path(__file__).parent.parent
+original_file = root_dir / "mkdocs.yml"
+dev_config_file = root_dir / "mkdocs.dev.yml"
+
+
+def comment_out_plugin(lines: list[str], plugin_name: str) -> list[str]:
+    """Comment out a plugin and its configuration block in the mkdocs.yml file."""
+    # We process the mkdocs.yml file line-by-line rather than trying to parse the YAML
+    # because mkdocs.yml is difficult to parse correctly.
+    in_plugin_block = False
+    modified_lines = lines.copy()
+
+    for i, line in enumerate(modified_lines):
+        stripped_line = line.strip()
+        if stripped_line.startswith("-") and plugin_name in stripped_line:
+            in_plugin_block = True
+            modified_lines[i] = f"# {line}"
+        elif in_plugin_block:
+            if stripped_line.startswith("-") or not stripped_line:
+                in_plugin_block = False
+            else:
+                modified_lines[i] = f"# {line}"
+
+    return modified_lines
+
+
+def main() -> None:
+    print("📚 Setting up fast documentation development server...")  # noqa: T201
+
+    # Read the original mkdocs.yml
+    with open(original_file) as f:
+        lines = f.readlines()
+
+    # Comment out slow plugins
+    lines = comment_out_plugin(lines, "social")
+    lines = comment_out_plugin(lines, "mkdocs-jupyter")
+
+    # Set strict to false for faster builds
+    content = "".join(lines)
+    if "strict:" in content:
+        content = re.sub(r"strict:\s*true", "strict: false", content)
+    else:
+        # If strict isn't found, raise a helpful error
+        raise ValueError(
+            "Could not find 'strict:' setting in mkdocs.yml. "
+            "Please ensure mkdocs.yml contains this setting."
+        )
+
+    # Write the modified configuration to mkdocs.dev.yml
+    with open(dev_config_file, "w") as f:
+        f.write(content)
+
+    print("📝 Created development config at mkdocs.dev.yml")  # noqa: T201
+    print("🚀 Starting mkdocs development server with fast configuration...")  # noqa: T201
+
+    # Run mkdocs serve with the development config
+    try:
+        subprocess.run(["mkdocs", "serve", "-f", str(dev_config_file)])
+    except KeyboardInterrupt:
+        print("\n🛑 Development server stopped")  # noqa: T201
+    finally:
+        # Clean up the temporary file
+        if dev_config_file.exists():
+            os.remove(dev_config_file)
+            print("🧹 Removed temporary config file")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently, doing docs development in a performant way requires modifying the `mkdocs.yml` config file by hand, which is tedious and can lead to unintended changes getting checked in. This PR adds `scripts/serve_docs_dev.py`, which generates a gitignored `mkdocs.dev.yml` file that has fast development configuration changes already made. Thus, users can just use `uv run python scripts/serve_docs_dev.py` and not need to modify the file by hand. The file is automatically cleaned up when the script is done. 

CONTRIBUTING.md has been updated accordingly.