### PR TITLE
feat: add `llm.prompt`

### DIFF
--- a/mirascope/llm/__init__.py
+++ b/mirascope/llm/__init__.py
@@ -2,6 +2,7 @@ from ..core import CostMetadata, LocalProvider, Provider, calculate_cost
 from ._call import call
 from ._context import context
 from ._override import override
+from ._prompt import prompt
 from .call_response import CallResponse
 from .stream import Stream
 from .tool import Tool
@@ -17,4 +18,5 @@ __all__ = [
     "call",
     "context",
     "override",
+    "prompt",
 ]

--- a/mirascope/llm/_prompt.py
+++ b/mirascope/llm/_prompt.py
@@ -1,0 +1,265 @@
+"""This module contains the `prompt` decorator for making provider-agnostic LLM API calls with a typed function.
+
+The prompt decorator is similar to the call decorator, but defers provider and model specification to a context manager.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterable, Awaitable, Callable, Iterable
+from enum import Enum
+from functools import wraps
+from typing import Any, ParamSpec, TypeVar, cast
+
+from pydantic import BaseModel
+
+from ..core import BaseTool
+from ..core.base import (
+    BaseCallResponse,
+    BaseCallResponseChunk,
+    BaseType,
+    CommonCallParams,
+)
+from ..core.base._utils import fn_is_async
+from ..core.base.stream_config import StreamConfig
+from ..core.base.types import Provider
+from ._call import CallResponse, Stream, call
+from ._context import get_current_context
+from ._protocols import (
+    AsyncLLMFunctionDecorator,
+    LLMFunctionDecorator,
+    PromptDecorator,
+    SyncLLMFunctionDecorator,
+)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_ParsedOutputT = TypeVar("_ParsedOutputT")
+_ResponseModelT = TypeVar("_ResponseModelT", bound=BaseModel | BaseType | Enum)
+_BaseCallResponseT = TypeVar(
+    "_BaseCallResponseT", covariant=True, bound=BaseCallResponse
+)
+_AsyncBaseDynamicConfigT = TypeVar("_AsyncBaseDynamicConfigT", contravariant=True)
+_BaseDynamicConfigT = TypeVar("_BaseDynamicConfigT", contravariant=True)
+
+_BaseCallResponseChunkT = TypeVar(
+    "_BaseCallResponseChunkT", covariant=True, bound=BaseCallResponseChunk
+)
+_BaseStreamT = TypeVar("_BaseStreamT", covariant=True)
+_ResultT = TypeVar("_ResultT")
+
+
+def _prompt(
+    *,
+    stream: bool | StreamConfig = False,
+    tools: list[type[BaseTool] | Callable] | None = None,
+    response_model: type[Any] | None = None,
+    output_parser: Callable[[Any], Any] | None = None,
+    json_mode: bool = False,
+    client: Any = None,  # noqa: ANN401
+    call_params: CommonCallParams | Any = None,  # noqa: ANN401
+) -> (
+    AsyncLLMFunctionDecorator[
+        _AsyncBaseDynamicConfigT,
+        _BaseCallResponseT
+        | _ParsedOutputT
+        | _BaseStreamT
+        | _ResponseModelT
+        | AsyncIterable[_ResponseModelT],
+    ]
+    | SyncLLMFunctionDecorator[
+        _BaseDynamicConfigT,
+        _BaseCallResponseT
+        | _ParsedOutputT
+        | _BaseStreamT
+        | _ResponseModelT
+        | Iterable[_ResponseModelT],
+    ]
+    | LLMFunctionDecorator[
+        _BaseDynamicConfigT,
+        _AsyncBaseDynamicConfigT,
+        _BaseCallResponseT
+        | _ParsedOutputT
+        | _BaseStreamT
+        | _ResponseModelT
+        | Iterable[_ResponseModelT],
+        _BaseCallResponseT
+        | _ParsedOutputT
+        | _BaseStreamT
+        | _ResponseModelT
+        | AsyncIterable[_ResponseModelT],
+    ]
+):
+    """Decorator for defining a function that calls a language model, deferring provider and model to context."""
+
+    def decorator(
+        fn: Callable[_P, _R | Awaitable[_R]],
+    ) -> Callable[
+        _P,
+        CallResponse
+        | Stream
+        | _ResponseModelT
+        | _ParsedOutputT
+        | (_ResponseModelT | CallResponse)
+        | Awaitable[CallResponse]
+        | Awaitable[Stream]
+        | Awaitable[_ResponseModelT]
+        | Awaitable[_ParsedOutputT]
+        | Awaitable[(_ResponseModelT | CallResponse)],
+    ]:
+        if fn_is_async(fn):
+
+            @wraps(fn)
+            def wrapper_with_context(
+                *args: _P.args, **kwargs: _P.kwargs
+            ) -> Awaitable[
+                CallResponse
+                | Stream
+                | _ResponseModelT
+                | _ParsedOutputT
+                | (_ResponseModelT | CallResponse)
+            ]:
+                # Capture the context at call time, not await time
+                current_context = get_current_context()
+
+                # Define an async function that uses the captured context
+                async def context_bound_inner_async() -> (
+                    CallResponse
+                    | Stream
+                    | _ResponseModelT
+                    | _ParsedOutputT
+                    | (_ResponseModelT | CallResponse)
+                ):
+                    if current_context is None:
+                        raise ValueError(
+                            "Prompt can only be called within a llm.context"
+                        )
+
+                    provider = current_context.provider
+                    model = current_context.model
+                    if provider is None:
+                        raise ValueError("Provider must be specified in the context")
+                    if model is None:
+                        raise ValueError("Model must be specified in the context")
+
+                    # Get provider-specific overrides from context
+                    client_override = current_context.client or client
+                    call_params_override = current_context.call_params or call_params
+
+                    # Create a dynamically decorated version of our function
+                    decorated = call(  # type: ignore[reportCallIssue]
+                        provider=cast(Provider, provider),
+                        model=model,
+                        stream=stream,  # type: ignore[reportArgumentType]
+                        tools=tools,
+                        response_model=response_model,  # type: ignore[reportArgumentType]
+                        output_parser=output_parser,
+                        json_mode=json_mode,
+                        client=client_override,
+                        call_params=call_params_override,
+                    )(fn)
+
+                    # Call the decorated function with the original arguments
+                    return await decorated(*args, **kwargs)
+
+                # Return the inner async function immediately
+                return context_bound_inner_async()
+
+            return wrapper_with_context  # type: ignore[return-value]
+        else:
+
+            @wraps(fn)
+            def wrapper(
+                *args: _P.args, **kwargs: _P.kwargs
+            ) -> (
+                CallResponse
+                | Stream
+                | _ResponseModelT
+                | _ParsedOutputT
+                | (_ResponseModelT | CallResponse)
+            ):
+                context = get_current_context()
+                if context is None:
+                    raise ValueError("Prompt can only be called within a llm.context")
+
+                provider = context.provider
+                model = context.model
+                if provider is None:
+                    raise ValueError("Provider must be specified in the context")
+                if model is None:
+                    raise ValueError("Model must be specified in the context")
+
+                # Get provider-specific overrides from context
+                client_override = context.client or client
+                call_params_override = context.call_params or call_params
+
+                # Create a dynamically decorated version of our function
+                decorated = call(  # type: ignore[reportCallIssue]
+                    provider=cast(Provider, provider),
+                    model=model,
+                    stream=stream,  # type: ignore[reportArgumentType]
+                    tools=tools,
+                    response_model=response_model,  # type: ignore[reportArgumentType]
+                    output_parser=output_parser,
+                    json_mode=json_mode,
+                    client=client_override,
+                    call_params=call_params_override,
+                )(fn)
+
+                # Call the decorated function with the original arguments
+                return decorated(*args, **kwargs)
+
+            return wrapper
+
+    return decorator  # type: ignore[return-value]
+
+
+# Create a single instance to use as the decorator
+prompt = cast(PromptDecorator, _prompt)
+
+"""A decorator for making provider-agnostic LLM API calls with a typed function.
+
+The provider and model are specified via a context manager at call time.
+
+usage docs: learn/prompts.md
+
+This decorator enables writing provider-agnostic code by wrapping a typed function 
+that can call any supported LLM provider's API. It parses the prompt template of 
+the wrapped function as messages and templates the input arguments into each message's 
+template.
+
+Example:
+
+```python
+from mirascope import llm
+
+
+@llm.prompt()
+def recommend_book(genre: str) -> str:
+    return f"Recommend a {genre} book"
+
+
+with llm.context(provider="openai", model="gpt-4o-mini"):
+    response = recommend_book("fantasy")
+    print(response.content)
+```
+
+Args:
+    stream (bool): Whether to stream the response from the API call.  
+    tools (list[BaseTool | Callable]): The tools available for the LLM to use.
+    response_model (BaseModel | BaseType): The response model into which the response
+        should be structured.
+    output_parser (Callable[[CallResponse | ResponseModelT], Any]): A function for
+        parsing the call response whose value will be returned in place of the
+        original call response.
+    json_mode (bool): Whether to use JSON Mode.
+    client (object): An optional custom client to use in place of the default client.
+    call_params (CommonCallParams): Provider-specific parameters to use in the API call.
+
+Returns:
+    decorator (Callable): A decorator that transforms a typed function into a
+        provider-agnostic LLM API call that returns standardized response types
+        regardless of the underlying provider used.
+
+Raises:
+    ValueError: If provider and model are not specified in the context when the function is called.
+"""

--- a/mirascope/llm/_protocols.py
+++ b/mirascope/llm/_protocols.py
@@ -498,3 +498,334 @@ CallDecorator: TypeAlias = _CallDecorator[
     Any,
     Any,
 ]
+
+
+class PromptDecorator(
+    Protocol[
+        _BaseCallResponseT,
+        _BaseCallResponseChunkT,
+        _BaseDynamicConfigT,
+        _AsyncBaseDynamicConfigT,
+        _BaseCallParamsT,
+        _BaseStreamT,
+        _SyncBaseClientT,
+        _AsyncBaseClientT,
+        _SameSyncAndAsyncClientT,
+    ],
+):
+    """Protocol for the prompt decorator.
+
+    Similar to the CallDecorator, but without provider and model at definition time.
+    """
+
+    @overload
+    def __call__(  # pyright: ignore[reportOverlappingOverload]
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> LLMFunctionDecorator[
+        _BaseDynamicConfigT,
+        _AsyncBaseDynamicConfigT,
+        _BaseCallResponseT,
+        _BaseCallResponseT,
+    ]: ...
+
+    @overload
+    def __call__(  # pyright: ignore[reportOverlappingOverload]
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _AsyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> AsyncLLMFunctionDecorator[_AsyncBaseDynamicConfigT, _BaseCallResponseT]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> SyncLLMFunctionDecorator[_BaseDynamicConfigT, _BaseCallResponseT]: ...
+
+    @overload
+    def __call__(  # pyright: ignore[reportOverlappingOverload]
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: Callable[[_BaseCallResponseT], _ParsedOutputT],
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> LLMFunctionDecorator[
+        _BaseDynamicConfigT, _AsyncBaseDynamicConfigT, _ParsedOutputT, _ParsedOutputT
+    ]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: Callable[[_BaseCallResponseT], _ParsedOutputT],
+        json_mode: bool = False,
+        client: _AsyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> AsyncLLMFunctionDecorator[_AsyncBaseDynamicConfigT, _ParsedOutputT]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: Callable[[_BaseCallResponseT], _ParsedOutputT],
+        json_mode: bool = False,
+        client: _SyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> SyncLLMFunctionDecorator[_BaseDynamicConfigT, _ParsedOutputT]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: Callable[[_BaseCallResponseChunkT], _ParsedOutputT],
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT
+        | _SyncBaseClientT
+        | _AsyncBaseClientT
+        | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> NoReturn: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[True] | StreamConfig = True,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> LLMFunctionDecorator[
+        _BaseDynamicConfigT, _AsyncBaseDynamicConfigT, _BaseStreamT, _BaseStreamT
+    ]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[True] | StreamConfig = True,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _AsyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> AsyncLLMFunctionDecorator[_AsyncBaseDynamicConfigT, _BaseStreamT]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[True] | StreamConfig = True,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: None = None,
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> SyncLLMFunctionDecorator[_BaseDynamicConfigT, _BaseStreamT]: ...
+
+    # Response model overloads
+    @overload
+    def __call__(  # pyright: ignore[reportOverlappingOverload]
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: None = None,
+        response_model: type[_ResponseModelT],
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> LLMFunctionDecorator[
+        _BaseDynamicConfigT, _AsyncBaseDynamicConfigT, _ResponseModelT, _ResponseModelT
+    ]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: None = None,
+        response_model: type[_ResponseModelT],
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _AsyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> AsyncLLMFunctionDecorator[_AsyncBaseDynamicConfigT, _ResponseModelT]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: None = None,
+        response_model: type[_ResponseModelT],
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> SyncLLMFunctionDecorator[_BaseDynamicConfigT, _ResponseModelT]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: None = None,
+        response_model: type[_ResponseModelT],
+        output_parser: Callable[[_ResponseModelT], _ParsedOutputT],
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> LLMFunctionDecorator[
+        _BaseDynamicConfigT, _AsyncBaseDynamicConfigT, _ParsedOutputT, _ParsedOutputT
+    ]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: None = None,
+        response_model: type[_ResponseModelT],
+        output_parser: Callable[[_ResponseModelT], _ParsedOutputT],
+        json_mode: bool = False,
+        client: _AsyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> AsyncLLMFunctionDecorator[_AsyncBaseDynamicConfigT, _ParsedOutputT]: ...
+
+    @overload
+    def __call__(
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: None = None,
+        response_model: type[_ResponseModelT],
+        output_parser: Callable[[_ResponseModelT], _ParsedOutputT],
+        json_mode: bool = False,
+        client: _SyncBaseClientT = ...,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> SyncLLMFunctionDecorator[_BaseDynamicConfigT, _ParsedOutputT]: ...
+
+    # Tools and response model combinations
+    @overload
+    def __call__(  # pyright: ignore[reportOverlappingOverload]
+        self,
+        *,
+        stream: Literal[False] = False,
+        tools: list[type[BaseTool] | Callable],
+        response_model: type[_ResponseModelT],
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> LLMFunctionDecorator[
+        _BaseDynamicConfigT,
+        _AsyncBaseDynamicConfigT,
+        _ResponseModelT | _BaseCallResponseT,
+        _ResponseModelT | _BaseCallResponseT,
+    ]: ...
+
+    # Streaming and response model combinations
+    @overload
+    def __call__(  # pyright: ignore[reportOverlappingOverload]
+        self,
+        *,
+        stream: Literal[True] | StreamConfig,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: type[_ResponseModelT],
+        output_parser: None = None,
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> LLMFunctionDecorator[
+        _BaseDynamicConfigT,
+        _AsyncBaseDynamicConfigT,
+        Iterable[_ResponseModelT],
+        AsyncIterable[_ResponseModelT],
+    ]: ...
+
+    def __call__(
+        self,
+        *,
+        stream: bool | StreamConfig = False,
+        tools: list[type[BaseTool] | Callable] | None = None,
+        response_model: type[_ResponseModelT] | None = None,
+        output_parser: Callable[[_BaseCallResponseT], _ParsedOutputT]
+        | Callable[[_BaseCallResponseChunkT], _ParsedOutputT]
+        | Callable[[_ResponseModelT], _ParsedOutputT]
+        | None = None,
+        json_mode: bool = False,
+        client: _SameSyncAndAsyncClientT
+        | _AsyncBaseClientT
+        | _SyncBaseClientT
+        | None = None,
+        call_params: _BaseCallParamsT | None = None,
+    ) -> (
+        AsyncLLMFunctionDecorator[
+            _AsyncBaseDynamicConfigT,
+            _BaseCallResponseT
+            | _ParsedOutputT
+            | _BaseStreamT
+            | _ResponseModelT
+            | AsyncIterable[_ResponseModelT],
+        ]
+        | SyncLLMFunctionDecorator[
+            _BaseDynamicConfigT,
+            _BaseCallResponseT
+            | _ParsedOutputT
+            | _BaseStreamT
+            | _ResponseModelT
+            | Iterable[_ResponseModelT],
+        ]
+        | LLMFunctionDecorator[
+            _BaseDynamicConfigT,
+            _AsyncBaseDynamicConfigT,
+            _BaseCallResponseT
+            | _ParsedOutputT
+            | _BaseStreamT
+            | _ResponseModelT
+            | Iterable[_ResponseModelT],
+            _BaseCallResponseT
+            | _ParsedOutputT
+            | _BaseStreamT
+            | _ResponseModelT
+            | AsyncIterable[_ResponseModelT],
+        ]
+    ): ...

--- a/tests/llm/test_prompt.py
+++ b/tests/llm/test_prompt.py
@@ -34,8 +34,7 @@ def test_prompt_decorator_requires_context():
     """Test that decorated functions can only be called within a context manager."""
 
     @llm.prompt()
-    def hello_world():
-        return "Hello, world!"
+    def hello_world(): ...
 
     with pytest.raises(ValueError) as excinfo:
         hello_world()
@@ -48,8 +47,7 @@ async def test_async_prompt_decorator_requires_context():
     """Test that async decorated functions can only be called within a context manager."""
 
     @llm.prompt()
-    async def hello_world():
-        return "Hello, world!"
+    async def hello_world(): ...
 
     with pytest.raises(ValueError) as excinfo:
         await hello_world()
@@ -61,8 +59,7 @@ def test_prompt_with_context():
     """Test that we can call decorated functions within a context manager."""
 
     @llm.prompt()
-    def hello_world() -> str:
-        return "Hello, world!"
+    def hello_world(): ...
 
     # Create a mock for CallResponse
     mock_response = mock.MagicMock()
@@ -94,8 +91,7 @@ async def test_async_prompt_with_context():
     """Test that we can call async decorated functions within a context manager."""
 
     @llm.prompt()
-    async def hello_world() -> str:
-        return "Hello, world!"
+    async def hello_world(): ...
 
     # Create a mock for CallResponse
     mock_response = mock.MagicMock()
@@ -129,8 +125,7 @@ def test_prompt_with_structural_args():
         message: str
 
     @llm.prompt(response_model=Response)
-    def hello_world() -> str:
-        return "Hello, world!"
+    def hello_world(): ...
 
     # Define patched provider call
     def patched_openai_call(**kwargs):
@@ -165,8 +160,7 @@ async def test_async_prompt_with_structural_args():
         message: str
 
     @llm.prompt(response_model=Response)
-    async def hello_world() -> str:
-        return "Hello, world!"
+    async def hello_world(): ...
 
     # Define patched provider call
     def patched_openai_call(**kwargs):
@@ -197,8 +191,7 @@ def test_prompt_with_context_overrides():
     """Test that context overrides non-structural params."""
 
     @llm.prompt()
-    def hello_world() -> str:
-        return "Hello, world!"
+    def hello_world(): ...
 
     # Track which provider was used
     calls = []
@@ -256,8 +249,7 @@ async def test_async_prompt_with_context_overrides():
     """Test that context overrides non-structural params with async functions."""
 
     @llm.prompt()
-    async def hello_world() -> str:
-        return "Hello, world!"
+    async def hello_world(): ...
 
     # Track which provider was used
     calls = []
@@ -315,8 +307,7 @@ async def test_async_prompt():
     """Test that async prompts work correctly."""
 
     @llm.prompt()
-    async def hello_world() -> str:
-        return "Hello, world!"
+    async def hello_world(): ...
 
     # Create a mock response for async calls
     mock_response = mock.MagicMock()
@@ -348,8 +339,7 @@ async def test_async_prompt_with_gather():
     """Test that context is properly applied in async functions when using asyncio.gather."""
 
     @llm.prompt()
-    async def hello_world() -> str:
-        return "Hello, world!"
+    async def hello_world(): ...
 
     # Track which provider was used for each call
     calls = []
@@ -419,8 +409,7 @@ def test_prompt_with_streaming():
     """Test that streaming works correctly."""
 
     @llm.prompt(stream=True)
-    def hello_world() -> str:
-        return "Hello, world!"
+    def hello_world(): ...
 
     # Create chunks and mock stream
     chunks = [MockChunk("Hello "), MockChunk("from the AI!")]
@@ -461,8 +450,7 @@ async def test_async_prompt_with_streaming():
     """Test that streaming works correctly with async prompts."""
 
     @llm.prompt(stream=True)
-    async def hello_world() -> str:
-        return "Hello, world!"
+    async def hello_world(): ...
 
     # Create chunks and mock stream
     chunks = [MockChunk("Hello "), MockChunk("from the AI!")]

--- a/tests/llm/test_prompt.py
+++ b/tests/llm/test_prompt.py
@@ -1,0 +1,498 @@
+import asyncio
+import unittest.mock as mock
+from collections.abc import Iterator
+
+import pytest
+from pydantic import BaseModel
+
+from mirascope import llm
+
+
+class MockChunk:
+    """Mock chunk for streaming."""
+
+    def __init__(self, content: str):
+        self.content = content
+
+
+class MockStream:
+    """Simple mock for Stream."""
+
+    def __init__(self, chunks: list[MockChunk]):
+        self.chunks = chunks
+
+    def __iter__(self) -> Iterator[tuple[MockChunk, str | None]]:
+        for chunk in self.chunks:
+            yield chunk, None
+
+    async def __aiter__(self):
+        for chunk in self.chunks:
+            yield chunk, None
+
+
+def test_prompt_decorator_requires_context():
+    """Test that decorated functions can only be called within a context manager."""
+
+    @llm.prompt()
+    def hello_world():
+        return "Hello, world!"
+
+    with pytest.raises(ValueError) as excinfo:
+        hello_world()
+
+    assert "Prompt can only be called within a llm.context" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_decorator_requires_context():
+    """Test that async decorated functions can only be called within a context manager."""
+
+    @llm.prompt()
+    async def hello_world():
+        return "Hello, world!"
+
+    with pytest.raises(ValueError) as excinfo:
+        await hello_world()
+
+    assert "Prompt can only be called within a llm.context" in str(excinfo.value)
+
+
+def test_prompt_with_context():
+    """Test that we can call decorated functions within a context manager."""
+
+    @llm.prompt()
+    def hello_world() -> str:
+        return "Hello, world!"
+
+    # Create a mock for CallResponse
+    mock_response = mock.MagicMock()
+    mock_response.content = "Hello from the AI!"
+    mock_response.finish_reasons = ["stop"]
+
+    # Define patched provider call
+    def patched_openai_call(**kwargs):
+        def decorator(fn):
+            def wrapper(*args, **kwargs):
+                return mock_response
+
+            return wrapper
+
+        return decorator
+
+    # Setup the patch and context
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        llm.context(provider="openai", model="gpt-4o-mini"),
+    ):
+        # Call the prompt function
+        response = hello_world()
+        assert response.content == "Hello from the AI!"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_with_context():
+    """Test that we can call async decorated functions within a context manager."""
+
+    @llm.prompt()
+    async def hello_world() -> str:
+        return "Hello, world!"
+
+    # Create a mock for CallResponse
+    mock_response = mock.MagicMock()
+    mock_response.content = "Hello from the AI!"
+    mock_response.finish_reasons = ["stop"]
+
+    # Define patched provider call
+    def patched_openai_call(**kwargs):
+        def decorator(fn):
+            async def wrapper(*args, **kwargs):
+                return mock_response
+
+            return wrapper
+
+        return decorator
+
+    # Setup the patch and context
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        llm.context(provider="openai", model="gpt-4o-mini"),
+    ):
+        # Call the prompt function
+        response = await hello_world()
+        assert response.content == "Hello from the AI!"
+
+
+def test_prompt_with_structural_args():
+    """Test that we can use structural args with prompt."""
+
+    class Response(BaseModel):
+        message: str
+
+    @llm.prompt(response_model=Response)
+    def hello_world() -> str:
+        return "Hello, world!"
+
+    # Define patched provider call
+    def patched_openai_call(**kwargs):
+        # Verify that response_model was passed correctly
+        assert kwargs.get("response_model") == Response
+
+        def decorator(fn):
+            def wrapper(*args, **kwargs):
+                # Return a Response object directly
+                return Response(message="Hello from the AI!")
+
+            return wrapper
+
+        return decorator
+
+    # Setup the patch and context
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        llm.context(provider="openai", model="gpt-4o-mini"),
+    ):
+        # Call the prompt function
+        response = hello_world()
+        assert isinstance(response, Response)
+        assert response.message == "Hello from the AI!"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_with_structural_args():
+    """Test that we can use structural args with async prompt."""
+
+    class Response(BaseModel):
+        message: str
+
+    @llm.prompt(response_model=Response)
+    async def hello_world() -> str:
+        return "Hello, world!"
+
+    # Define patched provider call
+    def patched_openai_call(**kwargs):
+        # Verify that response_model was passed correctly
+        assert kwargs.get("response_model") == Response
+
+        def decorator(fn):
+            async def wrapper(*args, **kwargs):
+                # Return a Response object directly
+                return Response(message="Hello from the AI!")
+
+            return wrapper
+
+        return decorator
+
+    # Setup the patch and context
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        llm.context(provider="openai", model="gpt-4o-mini"),
+    ):
+        # Call the prompt function
+        result = await hello_world()  # type: ignore[reportAwaitableType]
+        assert isinstance(result, Response)
+        assert result.message == "Hello from the AI!"
+
+
+def test_prompt_with_context_overrides():
+    """Test that context overrides non-structural params."""
+
+    @llm.prompt()
+    def hello_world() -> str:
+        return "Hello, world!"
+
+    # Track which provider was used
+    calls = []
+
+    # Create mock responses
+    openai_response = mock.MagicMock()
+    openai_response.content = "Hello from OpenAI!"
+    openai_response.finish_reasons = ["stop"]
+
+    anthropic_response = mock.MagicMock()
+    anthropic_response.content = "Hello from Anthropic!"
+    anthropic_response.finish_reasons = ["stop"]
+
+    # Create patched providers
+    def patched_openai_call(**kwargs):
+        def decorator(fn):
+            def wrapper(*args, **kwargs):
+                calls.append("openai")
+                return openai_response
+
+            return wrapper
+
+        return decorator
+
+    def patched_anthropic_call(**kwargs):
+        def decorator(fn):
+            def wrapper(*args, **kwargs):
+                calls.append("anthropic")
+                return anthropic_response
+
+            return wrapper
+
+        return decorator
+
+    # Setup patches for both providers
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        mock.patch("mirascope.core.anthropic.anthropic_call", patched_anthropic_call),
+    ):
+        # First with OpenAI
+        with llm.context(provider="openai", model="gpt-4o-mini"):
+            response = hello_world()
+            assert response.content == "Hello from OpenAI!"
+            assert calls[-1] == "openai"
+
+        # Then with Anthropic
+        with llm.context(provider="anthropic", model="claude-3-opus-20240229"):
+            response = hello_world()
+            assert response.content == "Hello from Anthropic!"
+            assert calls[-1] == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_with_context_overrides():
+    """Test that context overrides non-structural params with async functions."""
+
+    @llm.prompt()
+    async def hello_world() -> str:
+        return "Hello, world!"
+
+    # Track which provider was used
+    calls = []
+
+    # Create mock responses
+    openai_response = mock.MagicMock()
+    openai_response.content = "Hello from OpenAI!"
+    openai_response.finish_reasons = ["stop"]
+
+    anthropic_response = mock.MagicMock()
+    anthropic_response.content = "Hello from Anthropic!"
+    anthropic_response.finish_reasons = ["stop"]
+
+    # Create patched providers
+    def patched_openai_call(**kwargs):
+        def decorator(fn):
+            async def wrapper(*args, **kwargs):
+                calls.append("openai")
+                return openai_response
+
+            return wrapper
+
+        return decorator
+
+    def patched_anthropic_call(**kwargs):
+        def decorator(fn):
+            async def wrapper(*args, **kwargs):
+                calls.append("anthropic")
+                return anthropic_response
+
+            return wrapper
+
+        return decorator
+
+    # Setup patches for both providers
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        mock.patch("mirascope.core.anthropic.anthropic_call", patched_anthropic_call),
+    ):
+        # First with OpenAI
+        with llm.context(provider="openai", model="gpt-4o-mini"):
+            response = await hello_world()
+            assert response.content == "Hello from OpenAI!"
+            assert calls[-1] == "openai"
+
+        # Then with Anthropic
+        with llm.context(provider="anthropic", model="claude-3-opus-20240229"):
+            response = await hello_world()
+            assert response.content == "Hello from Anthropic!"
+            assert calls[-1] == "anthropic"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt():
+    """Test that async prompts work correctly."""
+
+    @llm.prompt()
+    async def hello_world() -> str:
+        return "Hello, world!"
+
+    # Create a mock response for async calls
+    mock_response = mock.MagicMock()
+    mock_response.content = "Hello from the AI!"
+    mock_response.finish_reasons = ["stop"]
+
+    # Define patched async provider call
+    def patched_openai_call(**kwargs):
+        def decorator(fn):
+            async def async_wrapper(*args, **kwargs):
+                return mock_response
+
+            return async_wrapper
+
+        return decorator
+
+    # Setup the patch and context
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        llm.context(provider="openai", model="gpt-4o-mini"),
+    ):
+        # Call the async prompt function and await the result
+        response = await hello_world()
+        assert response.content == "Hello from the AI!"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_with_gather():
+    """Test that context is properly applied in async functions when using asyncio.gather."""
+
+    @llm.prompt()
+    async def hello_world() -> str:
+        return "Hello, world!"
+
+    # Track which provider was used for each call
+    calls = []
+
+    # Create mock responses for different providers
+    openai_response = mock.MagicMock()
+    openai_response.content = "Hello from OpenAI!"
+    openai_response.finish_reasons = ["stop"]
+
+    anthropic_response = mock.MagicMock()
+    anthropic_response.content = "Hello from Anthropic!"
+    anthropic_response.finish_reasons = ["stop"]
+
+    # Create patched providers that track which provider was used
+    def patched_openai_call(**kwargs):
+        model = kwargs.get("model", "unknown")
+
+        def decorator(fn):
+            async def wrapper(*args, **kwargs):
+                calls.append(("openai", model))
+                return openai_response
+
+            return wrapper
+
+        return decorator
+
+    def patched_anthropic_call(**kwargs):
+        model = kwargs.get("model", "unknown")
+
+        def decorator(fn):
+            async def wrapper(*args, **kwargs):
+                calls.append(("anthropic", model))
+                return anthropic_response
+
+            return wrapper
+
+        return decorator
+
+    # Setup patches for both providers
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        mock.patch("mirascope.core.anthropic.anthropic_call", patched_anthropic_call),
+    ):
+        # Create the first future with OpenAI context
+        with llm.context(provider="openai", model="gpt-4o-mini"):
+            future1 = hello_world()
+
+        # Create the second future with Anthropic context
+        with llm.context(provider="anthropic", model="claude-3-opus-20240229"):
+            future2 = hello_world()
+
+        # Await both futures together
+        results = await asyncio.gather(future1, future2)
+
+        # Check that we have results from both providers
+        assert len(results) == 2
+        assert results[0].content == "Hello from OpenAI!"
+        assert results[1].content == "Hello from Anthropic!"
+
+        # Check that the correct providers and models were used
+        assert len(calls) == 2
+        assert calls[0] == ("openai", "gpt-4o-mini")
+        assert calls[1] == ("anthropic", "claude-3-opus-20240229")
+
+
+def test_prompt_with_streaming():
+    """Test that streaming works correctly."""
+
+    @llm.prompt(stream=True)
+    def hello_world() -> str:
+        return "Hello, world!"
+
+    # Create chunks and mock stream
+    chunks = [MockChunk("Hello "), MockChunk("from the AI!")]
+    mock_stream = MockStream(chunks)
+
+    # Define patched streaming provider call
+    def patched_openai_call(**kwargs):
+        # Verify that stream was passed correctly
+        assert kwargs.get("stream") is True
+
+        def decorator(fn):
+            def wrapper(*args, **kwargs):
+                return mock_stream
+
+            return wrapper
+
+        return decorator
+
+    # Setup the patch and context
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        llm.context(provider="openai", model="gpt-4o-mini"),
+    ):
+        # Call the streaming prompt function
+        stream = hello_world()
+
+        # Test iteration over the stream
+        collected_chunks = []
+        for chunk, _ in stream:
+            collected_chunks.append(chunk.content)
+
+        assert collected_chunks == ["Hello ", "from the AI!"]
+        assert "".join(collected_chunks) == "Hello from the AI!"
+
+
+@pytest.mark.asyncio
+async def test_async_prompt_with_streaming():
+    """Test that streaming works correctly with async prompts."""
+
+    @llm.prompt(stream=True)
+    async def hello_world() -> str:
+        return "Hello, world!"
+
+    # Create chunks and mock stream
+    chunks = [MockChunk("Hello "), MockChunk("from the AI!")]
+    mock_stream = MockStream(chunks)
+
+    # Define patched streaming provider call
+    def patched_openai_call(**kwargs):
+        # Verify that stream was passed correctly
+        assert kwargs.get("stream") is True
+
+        def decorator(fn):
+            async def wrapper(*args, **kwargs):
+                return mock_stream
+
+            return wrapper
+
+        return decorator
+
+    # Setup the patch and context
+    with (
+        mock.patch("mirascope.core.openai.openai_call", patched_openai_call),
+        llm.context(provider="openai", model="gpt-4o-mini"),
+    ):
+        # Call the streaming prompt function
+        stream = await hello_world()
+
+        # Test iteration over the stream
+        collected_chunks = []
+        async for chunk, _ in stream:
+            collected_chunks.append(chunk.content)
+
+        assert collected_chunks == ["Hello ", "from the AI!"]
+        assert "".join(collected_chunks) == "Hello from the AI!"


### PR DESCRIPTION
This is a first stab at implementing the `llm.prompt` api, as discussed in #884, particularly https://github.com/Mirascope/mirascope/issues/884#issuecomment-2701750473.

It is basically a sibling to `llm.call` that doesn't require providing the model and provider upfront, but rather assumes that they will be present via the `llm.context` context manager. Rather than re-implement the logic, under the hood it has some minimal wrapping and then calls `llm.call`. Once we implement performance benchmarking (as discussed in #896), we may find it's better not to wrap `llm.call` here, but for a proof of concept for the interface, this seemed fine.

I copied a lot of the (complex) type signature for `llm.call`, including making a `PromptDecorator` class, which may be cargo cult-y.

Initially, rather than taking a simple decorator approach, I wanted to return a callable `Prompt` class. This would have enabled nice APIs like chaining function calls on the prompt in order to change its structural parameters; e.g. if `prompt.stream(True)` would return a new `Prompt` that has streaming enabled, or `prompt.response_model(Book)` would make a new version of the same prompt with a response model configured. However, I found this to be a nightmare from a typing perspective, so I backed off to just implementing a decorator a-la call.

I think there's value in having a way to set up decorated llm calls while not providing the provider or model upfront, hence advocating for this API. Though, I wonder if having a separate `llm.prompt` api distinct from `llm.call` is worth it, versus just making the provider and model optional on `llm.call`, with an error thrown at runtime if no default model/provider are present, and it was called outside of a context.

I didn't update docs or examples in this PR, however here's a code snippet which both works and puts `llm.prompt` a bit through the paces:

```python
from mirascope import llm
from pydantic import BaseModel


# Simple example using the prompt decorator
@llm.prompt()
def recommend_book(genre: str) -> str:
    """Recommend a book in the given genre."""
    return f"Recommend a {genre} book."


# Example with response model
class Book(BaseModel):
    """An extracted book recommendation."""

    title: str
    author: str
    year: int
    description: str


@llm.prompt(response_model=Book)
def extract_book(genre: str) -> str:
    """Extract a structured book recommendation."""
    return f"""
    Recommend a {genre} book. Respond with a JSON object with the following fields:
    - title: the title of the book
    - author: the author of the book
    - year: the year the book was published
    - description: a brief description of the book
    """


# Example with streaming
@llm.prompt(stream=True)
def stream_book_review(book_title: str) -> str:
    """Generate a streaming review for the given book."""
    return f"Write a detailed review of the book '{book_title}'."


def main():
    print("Provider-agnostic LLM prompts with mirascope.llm.prompt\n")

    # Example 1: Simple prompt with OpenAI
    print("Example 1: Simple book recommendation with OpenAI")
    with llm.context(provider="openai", model="gpt-4o-mini"):
        openai_response: llm.CallResponse = recommend_book("fantasy")
        print(f"OpenAI Response: {openai_response.content}")

    # Example 2: Same prompt with Anthropic
    print("\nExample 2: Same prompt with Anthropic")
    with llm.context(provider="anthropic", model="claude-3-haiku-20240307"):
        anthropic_response: llm.CallResponse = recommend_book("science fiction")
        print(f"Anthropic Response: {anthropic_response.content}")

    # Example 3: Using a structured response model
    print("\nExample 3: Structured response with OpenAI")
    with llm.context(provider="openai", model="gpt-4o-mini"):
        book: Book = extract_book("mystery")
        print(f"Extracted Book: {book}")
        print(f"Book Title: {book.title}")
        print(f"Book Author: {book.author}")

    # Example 4: Streaming response
    print("\nExample 4: Streaming response")
    with llm.context(provider="openai", model="gpt-4o-mini"):
        stream: llm.Stream = stream_book_review("The Lord of the Rings")
        print("Streaming review:")
        for chunk, _ in stream:
            # Print without newline and flush to show streaming effect
            print(chunk.content, end="", flush=True)
        print()  # Add a newline at the end


if __name__ == "__main__":
    main()
```