### PR TITLE
feat: verify uv.lock is up-to-date in CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/0.3.0/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.6.10/install.sh | sh
 
       - name: Set up Python
         run: uv python install 3.10

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
         run: uv lock --check
 
       - name: Set Up Python Environment
-        run: uv python install 3.11
+        run: uv python install 3.10
 
       - name: Restore uv cache
         uses: actions/cache@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,8 +21,12 @@ jobs:
       - uses: codespell-project/actions-codespell@v2
         with:
           exclude_file: "docs/tutorials/evals/evaluating_web_search_agent.ipynb,docs/tutorials/agents/web_search_agent.ipynb,docs/tutorials/more_advanced/knowledge_graph.ipynb"
+
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/0.5.6/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.6.10/install.sh | sh
+
+      - name: Check uv lock file is up-to-date
+        run: uv lock --check
 
       - name: Set Up Python Environment
         run: uv python install 3.11

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/0.5.6/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.6.10/install.sh | sh
 
       - name: Set up Python
         run: uv python install 3.10

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up uv
-        run: curl -LsSf https://astral.sh/uv/0.5.6/install.sh | sh
+        run: curl -LsSf https://astral.sh/uv/0.6.10/install.sh | sh
 
       - name: Set up Python ${{ matrix.python-version }}
         run: |

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,4 @@
 version = 1
-revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
@@ -3170,7 +3169,7 @@ wheels = [
 
 [[package]]
 name = "mirascope"
-version = "1.22.0"
+version = "1.22.1"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -3324,7 +3323,6 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.10.0" },
     { name = "websockets", marker = "extra == 'realtime'", specifier = ">=13.1,<14" },
 ]
-provides-extras = ["anthropic", "azure", "bedrock", "cohere", "gemini", "google", "groq", "tenacity", "hyperdx", "langfuse", "litellm", "logfire", "mistral", "openai", "opentelemetry", "vertex", "realtime", "mcp", "xai"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
We recently [bumped the version #](https://github.com/Mirascope/mirascope/commit/7591658aba56fbd518698aa83356613db59ec1d7) without updating `uv.lock`, with the result that the lockfile is out of date, and any usage of uv will tend to produce a somewhat confusing extra diff to a checked in file.

This PR adds `uv lock --check` to the CI lint workflow so build will fail if `uv.lock` is outdated. I'm intentionally committing just the workflow change first, so we can verify that CI correctly fails and with a helpful error message. Afterwards, I'll update `uv.lock`, at which point this PR will be good to merge. 