### PR TITLE
fix: Tool usage with llm.call

### DIFF
--- a/mirascope/core/anthropic/call_response.py
+++ b/mirascope/core/anthropic/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 
 from anthropic.types import (
@@ -156,12 +157,12 @@ class AnthropicCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[AnthropicTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[AnthropicTool, str]]
     ) -> list[MessageParam]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/azure/call_response.py
+++ b/mirascope/core/azure/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 from typing import cast
 
@@ -175,12 +176,12 @@ class AzureCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[AzureTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[AzureTool, str]]
     ) -> list[ToolMessage]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/base/call_response.py
+++ b/mirascope/core/base/call_response.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import base64
 import json
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from functools import cached_property, wraps
 from typing import TYPE_CHECKING, Any, ClassVar, Generic, TypeVar, cast
 
@@ -47,17 +47,17 @@ _BaseMessageParamConverterT = TypeVar(
 
 def transform_tool_outputs(
     fn: Callable[
-        [type[_BaseCallResponseT], list[tuple[_BaseToolT, str]]],
+        [type[_BaseCallResponseT], Sequence[tuple[_BaseToolT, str]]],
         list[_ToolMessageParamT],
     ],
 ) -> Callable[
-    [type[_BaseCallResponseT], list[tuple[_BaseToolT, JsonableType]]],
+    [type[_BaseCallResponseT], Sequence[tuple[_BaseToolT, JsonableType]]],
     list[_ToolMessageParamT],
 ]:
     @wraps(fn)
     def wrapper(
         cls: type[_BaseCallResponseT],
-        tools_and_outputs: list[tuple[_BaseToolT, JsonableType]],
+        tools_and_outputs: Sequence[tuple[_BaseToolT, JsonableType]],
     ) -> list[_ToolMessageParamT]:
         def recursive_serializer(value: JsonableType) -> BaseType:
             if isinstance(value, str):
@@ -290,12 +290,12 @@ class BaseCallResponse(
     @abstractmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[_BaseToolT, str]]
+        cls, tools_and_outputs: Sequence[tuple[_BaseToolT, str]]
     ) -> list[Any]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
         """
         ...

--- a/mirascope/core/bedrock/call_response.py
+++ b/mirascope/core/bedrock/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 from typing import cast
 
@@ -197,12 +198,12 @@ class BedrockCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[BedrockTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[BedrockTool, str]]
     ) -> list[ToolResultBlockMessageTypeDef]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/cohere/call_response.py
+++ b/mirascope/core/cohere/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 
 from cohere.types import (
@@ -164,12 +165,12 @@ class CohereCallResponse(
     @transform_tool_outputs
     def tool_message_params(
         cls,
-        tools_and_outputs: list[tuple[CohereTool, str]],
+        tools_and_outputs: Sequence[tuple[CohereTool, str]],
     ) -> list[ToolResult]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/gemini/call_response.py
+++ b/mirascope/core/gemini/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 
 from google.generativeai.protos import FunctionResponse
@@ -173,12 +174,12 @@ class GeminiCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[GeminiTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[GeminiTool, str]]
     ) -> list[ContentDict]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/google/call_response.py
+++ b/mirascope/core/google/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 
 from google.genai.types import (
@@ -184,12 +185,12 @@ class GoogleCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[GoogleTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[GoogleTool, str]]
     ) -> list[ContentDict]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/groq/call_response.py
+++ b/mirascope/core/groq/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 from typing import cast
 
@@ -155,12 +156,12 @@ class GroqCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[GroqTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[GroqTool, str]]
     ) -> list[ChatCompletionToolMessageParam]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/mistral/call_response.py
+++ b/mirascope/core/mistral/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 from typing import Any, cast
 
@@ -163,12 +164,12 @@ class MistralCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[MistralTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[MistralTool, str]]
     ) -> list[ToolMessage]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/openai/call_response.py
+++ b/mirascope/core/openai/call_response.py
@@ -4,6 +4,7 @@ usage docs: learn/calls.md#handling-responses
 """
 
 import base64
+from collections.abc import Sequence
 from functools import cached_property
 from typing import cast
 
@@ -196,12 +197,12 @@ class OpenAICallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[OpenAITool, str]]
+        cls, tools_and_outputs: Sequence[tuple[OpenAITool, str]]
     ) -> list[ChatCompletionToolMessageParam]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/core/vertex/call_response.py
+++ b/mirascope/core/vertex/call_response.py
@@ -3,6 +3,7 @@
 usage docs: learn/calls.md#handling-responses
 """
 
+from collections.abc import Sequence
 from functools import cached_property
 
 from google.cloud.aiplatform_v1beta1.types import GenerateContentResponse
@@ -163,12 +164,12 @@ class VertexCallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[VertexTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[VertexTool, str]]
     ) -> list[Content]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
 
         Returns:

--- a/mirascope/llm/call_response.py
+++ b/mirascope/llm/call_response.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from functools import cached_property
 from typing import Any
 
@@ -133,12 +134,12 @@ class CallResponse(
     @classmethod
     @transform_tool_outputs
     def tool_message_params(
-        cls, tools_and_outputs: list[tuple[Tool, str]]
+        cls, tools_and_outputs: Sequence[tuple[BaseTool, str]]
     ) -> list[BaseMessageParam]:
         """Returns the tool message parameters for tool call results.
 
         Args:
-            tools_and_outputs: The list of tools and their outputs from which the tool
+            tools_and_outputs: The sequence of tools and their outputs from which the tool
                 message parameters should be constructed.
         """
 

--- a/mirascope/llm/call_response.py
+++ b/mirascope/llm/call_response.py
@@ -26,7 +26,7 @@ from .tool import Tool
 class CallResponse(
     BaseCallResponse[
         Any,
-        Tool,
+        BaseTool,
         Any,
         BaseDynamicConfig[Any, Any, Any],
         BaseMessageParam,
@@ -42,11 +42,11 @@ class CallResponse(
     We rely on _response having `common_` methods or properties for normalization.
     """
 
-    _response: BaseCallResponse[Any, Tool, Any, Any, Any, Any, Any, Any]
+    _response: BaseCallResponse[Any, BaseTool, Any, Any, Any, Any, Any, Any]
 
     def __init__(
         self,
-        response: BaseCallResponse[Any, Tool, Any, Any, Any, Any, Any, Any],
+        response: BaseCallResponse[Any, BaseTool, Any, Any, Any, Any, Any, Any],
     ) -> None:
         super().__init__(
             **{

--- a/tests/core/base/test_call_response.py
+++ b/tests/core/base/test_call_response.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+from collections.abc import Sequence
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -110,7 +111,9 @@ class NestedModel(BaseModel):
 @pytest.fixture
 def process_tools():
     @transform_tool_outputs
-    def _process_tools(cls: Any, tools_and_outputs: list[tuple[Any, str]]) -> list[str]:
+    def _process_tools(
+        cls: Any, tools_and_outputs: Sequence[tuple[Any, str]]
+    ) -> list[str]:
         return [output for _, output in tools_and_outputs]
 
     return _process_tools

--- a/tests/llm/test_call.py
+++ b/tests/llm/test_call.py
@@ -152,6 +152,50 @@ def test_wrap_result():
     assert output == "parsed output"
 
 
+def test_wrap_result_with_base_tool():
+    """Test that _wrap_result can handle a response containing a BaseTool."""
+
+    # Create a custom BaseTool for testing
+    class CustomBaseTool(BaseTool): ...
+
+    # Create a response instance
+    resp = ConcreteResponse(
+        metadata=Metadata(),
+        response={},
+        tool_types=[CustomBaseTool],  # Use the BaseTool subclass
+        prompt_template=None,
+        fn_args={},
+        dynamic_config={},
+        messages=[],
+        call_params=DummyCallParams(),
+        call_kwargs=BaseCallKwargs(),
+        user_message_param=None,
+        start_time=0,
+        end_time=0,
+    )
+
+    result = _wrap_result(resp)
+    assert isinstance(result, CallResponse)
+
+    # Create a stream instance
+    resp = ConcreteStream(
+        stream=Mock(),
+        metadata=Metadata(),
+        tool_types=[CustomBaseTool],  # Use the BaseTool subclass
+        call_response_type=Mock(),  # pyright: ignore [reportArgumentType]
+        model=Mock(),  # pyright: ignore [reportArgumentType]
+        prompt_template=Mock(),
+        fn_args={},
+        dynamic_config={},
+        messages=[],
+        call_params=DummyCallParams(),
+        call_kwargs=BaseCallKwargs(),
+    )
+
+    result = _wrap_result(resp)
+    assert isinstance(result, Stream)
+
+
 def test_get_provider_call_unsupported():
     with pytest.raises(ValueError, match="Unsupported provider: bad_provider"):
         _get_provider_call("bad_provider")  # pyright: ignore [reportArgumentType]

--- a/tests/llm/test_call.py
+++ b/tests/llm/test_call.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from functools import cached_property
 from typing import Any
 from unittest.mock import Mock, patch
@@ -71,7 +72,7 @@ class ConcreteResponse(BaseCallResponse[Any, Any, Any, Any, Any, Any, Any, Any])
     def tool(self) -> Any: ...
 
     @classmethod
-    def tool_message_params(cls, tools_and_outputs: list[tuple[BaseTool, str]]): ...  # pyright: ignore [reportIncompatibleMethodOverride]
+    def tool_message_params(cls, tools_and_outputs: Sequence[tuple[BaseTool, str]]): ...  # pyright: ignore [reportIncompatibleMethodOverride]
 
     @property
     def common_finish_reasons(self) -> list[FinishReason] | None:

--- a/tests/llm/test_call_response.py
+++ b/tests/llm/test_call_response.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from functools import cached_property
 from typing import Any, ClassVar, cast
 from unittest.mock import MagicMock, PropertyMock, patch
@@ -108,7 +109,7 @@ class DummyProviderCallResponse(
 
     @classmethod
     def tool_message_params(  # pyright: ignore [reportIncompatibleMethodOverride]
-        cls, tools_and_outputs: list[tuple[DummyTool, str]]
+        cls, tools_and_outputs: Sequence[tuple[DummyTool, str]]
     ) -> list[Any]: ...
 
     @property

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'linux'",
@@ -3169,7 +3170,7 @@ wheels = [
 
 [[package]]
 name = "mirascope"
-version = "1.22.1"
+version = "1.22.2"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -3323,6 +3324,7 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.10.0" },
     { name = "websockets", marker = "extra == 'realtime'", specifier = ">=13.1,<14" },
 ]
+provides-extras = ["anthropic", "azure", "bedrock", "cohere", "gemini", "google", "groq", "tenacity", "hyperdx", "langfuse", "litellm", "logfire", "mistral", "openai", "opentelemetry", "vertex", "realtime", "mcp", "xai"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This updates the llm.CallResponse class so it accepts BaseCallResponses with BaseTools. Since the tool() and tools() methods on llm.CallResponse are implemented in terms of BaseCallResponse.common_tools() (which converts to llm.Tool), no other changes are needed to maintain llm.CallResponse's API contract.

Added tests, which fail prior to this change.

Fixes #940