### PR TITLE
Fix google tool

### DIFF
--- a/mirascope/core/google/_utils/_message_param_converter.py
+++ b/mirascope/core/google/_utils/_message_param_converter.py
@@ -136,7 +136,7 @@ class GoogleMessageParamConverter(BaseMessageParamConverter):
                                     type="tool_result",
                                     name=part.function_response.name,  # pyright: ignore [reportArgumentType]
                                     content=part.function_response.response[  # pyright: ignore [reportArgumentType, reportOptionalSubscript]
-                                        "result"
+                                        "content"
                                     ],
                                     id=None,
                                     is_error=False,

--- a/mirascope/core/google/call_response.py
+++ b/mirascope/core/google/call_response.py
@@ -156,13 +156,12 @@ class GoogleCallResponse(
 
     @cached_property
     def tools(self) -> list[GoogleTool] | None:
-        """Returns the list of tools for the 0th candidate's 0th content part."""
+        """Returns the list of tools for the response."""
         if self.tool_types is None:
             return None
 
         extracted_tools = []
-        for part in self.response.candidates[0].content.parts:  # pyright: ignore [reportReturnType, reportOptionalSubscript, reportOptionalMemberAccess, reportOptionalIterable]
-            tool_call = part.function_call
+        for tool_call in self.response.function_calls or []:
             for tool_type in self.tool_types:
                 if tool_call.name == tool_type._name():  # pyright: ignore [reportOptionalMemberAccess]
                     extracted_tools.append(tool_type.from_tool_call(tool_call))  # pyright: ignore [reportArgumentType]

--- a/tests/core/google/_utils/test_convert_message_params.py
+++ b/tests/core/google/_utils/test_convert_message_params.py
@@ -97,7 +97,7 @@ def test_convert_message_params(mock_image_open: MagicMock) -> None:
 
     with pytest.raises(
         ValueError,
-        match="Google currently only supports text, image, and audio parts. Part provided: cache_control",
+        match="Google currently only supports text, tool_call, tool_result, image, and audio parts. Part provided: cache_control",
     ):
         convert_message_params(
             [

--- a/tests/core/google/_utils/test_message_param_converter.py
+++ b/tests/core/google/_utils/test_message_param_converter.py
@@ -191,7 +191,7 @@ def test_inline_data_unknown_mime_type():
 def test_function_response():
     part = PartDict(
         function_response=FunctionResponseDict(
-            name="some_tool", response={"result": "value"}
+            name="some_tool", response={"content": "value"}
         )
     )
     results = GoogleMessageParamConverter.from_provider(


### PR DESCRIPTION
There were two issues at play; not getting the function calls properly from the Google response, and not handling the tool_call and tool_result message parts.

Notes from my first commit message:
The prior docstring references checking the 0th candidate 0th's part. However, both our google sdk example and these google docs[1] show using response.function_calls instead.

https://googleapis.github.io/python-genai/#function-calling

Should fix the [second part of #940](https://github.com/Mirascope/mirascope/issues/940#issuecomment-2807360626).
There don't seem to be integration tests of this part of the code, so I didn't add any. 

