### PR TITLE
fix(MCP): default value for non-nullable fields should not be None

### DIFF
--- a/mirascope/mcp/_utils.py
+++ b/mirascope/mcp/_utils.py
@@ -226,14 +226,19 @@ def create_tool_from_mcp_tool(tool: MCPTool) -> type[BaseTool]:
     for field_name, field_schema in properties.items():
         field_type = json_schema_to_python_type(field_schema)
 
-        if field_name in required_fields:
-            default = Field(..., description=field_schema.get("description"))
-            annotation = field_type
-        else:
-            default = Field(None, description=field_schema.get("description"))
-            annotation = field_type | None
+        default = field_schema.get("default", ...)
+        nullable = field_schema.get("nullable", False)
 
-        fields[field_name] = (annotation, default)
+        if nullable:
+            field_type = field_type | None
+
+        if field_name in required_fields:
+            assigned = Field(..., description=field_schema.get("description"))
+        else:
+            default = field_schema.get("default", None)
+            assigned = Field(default, description=field_schema.get("description"))
+
+        fields[field_name] = (field_type, assigned)
 
     return create_model(snake_to_pascal(tool.name), __base__=BaseTool, **fields)
 


### PR DESCRIPTION
Fixes #979. non-nullable fields in MCP tool schemas are being assigned a default value of None, which breaks for MCP tools that have optional non-nullable fields with default values.

Based on [this SO answer](https://stackoverflow.com/questions/73841072/dynamically-generating-pydantic-model-from-a-schema-json-file), we change the logic for generating tool schemas:

- nullable fields have their type updated to `type | None`
- fields with a default in the JSON schema reflect this in the generated pydantic model
- non-nullable fields with a default in the schema use this default and no longer get `None` added to their type
- non-nullable fields *without* a default and that are *not* required will have their default set to `None`, but this sounds like undefined behavior