### PR TITLE
Implement thinking support for Google

### DIFF
--- a/mirascope/core/google/call_response.py
+++ b/mirascope/core/google/call_response.py
@@ -75,13 +75,13 @@ class GoogleCallResponse(
 
     def _parts(self) -> list[Part]:
         """Returns the parts of the 0th candidate."""
-        candidates = self.response.candidates
-        if not candidates:
-            raise ValueError("Google Response has no candidates")
-        content = candidates[0].content
-        if not content or not content.parts:
-            raise ValueError("Google Response Candidate has no content or parts")
-        return content.parts
+        if (
+            not (candidates := self.response.candidates)
+            or not (content := candidates[0].content)
+            or not (parts := content.parts)
+        ):
+            return []
+        return parts
 
     @computed_field
     @property

--- a/mirascope/core/google/call_response_chunk.py
+++ b/mirascope/core/google/call_response_chunk.py
@@ -52,10 +52,28 @@ class GoogleCallResponseChunk(
             not (candidates := self.chunk.candidates)
             or not (content := candidates[0].content)
             or not (parts := content.parts)
-            or not (text := parts[0].text)
         ):
             return ""
-        return text
+
+        for part in parts:
+            if not part.thought and part.text:
+                return part.text
+        return ""
+
+    @property
+    def thinking(self) -> str:
+        """Returns the thinking content from thinking parts."""
+        if (
+            not (candidates := self.chunk.candidates)
+            or not (content := candidates[0].content)
+            or not (parts := content.parts)
+        ):
+            return ""
+
+        for part in parts:
+            if part.thought and part.text:
+                return part.text
+        return ""
 
     @property
     def finish_reasons(self) -> list[GoogleFinishReason]:

--- a/tests/core/google/test_call_response.py
+++ b/tests/core/google/test_call_response.py
@@ -304,15 +304,14 @@ def test_google_call_response_multiple_thinking_parts() -> None:
     assert call_response.thinking == "First thinking step."
 
 
-def test_google_call_response_no_candidates() -> None:
-    """Tests that ValueError is raised when response has no candidates."""
-    import pytest
+def test_empty_call_responses() -> None:
+    """Test behavior on a call response with no candidates."""
 
-    response = GenerateContentResponse(candidates=[])
+    response_no_candidates = GenerateContentResponse(candidates=[])
 
-    call_response = GoogleCallResponse(
+    call_response_no_candidates = GoogleCallResponse(
         metadata={},
-        response=response,
+        response=response_no_candidates,
         tool_types=None,
         prompt_template="",
         fn_args={},
@@ -325,16 +324,10 @@ def test_google_call_response_no_candidates() -> None:
         end_time=0,
     )
 
-    with pytest.raises(ValueError, match="Google Response has no candidates"):
-        _ = call_response.content
-
-
-def test_google_call_response_no_content_or_parts() -> None:
-    """Tests that ValueError is raised when candidate has no content or parts."""
-    import pytest
+    assert call_response_no_candidates.content == ""
 
     # Test with no content
-    response = GenerateContentResponse(
+    response_no_content = GenerateContentResponse(
         candidates=[
             Candidate(
                 finish_reason=GoogleFinishReason.STOP,
@@ -343,9 +336,9 @@ def test_google_call_response_no_content_or_parts() -> None:
         ]
     )
 
-    call_response = GoogleCallResponse(
+    call_response_no_content = GoogleCallResponse(
         metadata={},
-        response=response,
+        response=response_no_content,
         tool_types=None,
         prompt_template="",
         fn_args={},
@@ -358,10 +351,7 @@ def test_google_call_response_no_content_or_parts() -> None:
         end_time=0,
     )
 
-    with pytest.raises(
-        ValueError, match="Google Response Candidate has no content or parts"
-    ):
-        _ = call_response.content
+    assert call_response_no_content.content == ""
 
     # Test with content but no parts
     response_no_parts = GenerateContentResponse(
@@ -387,8 +377,4 @@ def test_google_call_response_no_content_or_parts() -> None:
         start_time=0,
         end_time=0,
     )
-
-    with pytest.raises(
-        ValueError, match="Google Response Candidate has no content or parts"
-    ):
-        _ = call_response_no_parts.content
+    assert call_response_no_parts.content == ""

--- a/tests/core/google/test_call_response_chunk.py
+++ b/tests/core/google/test_call_response_chunk.py
@@ -43,3 +43,65 @@ def test_google_call_response_chunk() -> None:
         chunk=GenerateContentResponse(candidates=[])
     )
     assert call_response_chunk_no_candidates.content == ""
+
+
+def test_google_call_response_chunk_thinking() -> None:
+    """Tests the `GoogleCallResponseChunk` class with thinking parts."""
+    # Test thinking part chunk
+    thinking_chunk = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                finish_reason=GoogleFinishReason.STOP,
+                content=Content(
+                    parts=[
+                        Part(text="Let me think about this problem...", thought=True)
+                    ],
+                    role="model",
+                ),
+            )
+        ]
+    )
+    call_response_chunk = GoogleCallResponseChunk(chunk=thinking_chunk)
+    assert call_response_chunk.thinking == "Let me think about this problem..."
+    assert call_response_chunk.content == ""
+
+    # Test regular text part chunk (should have empty thinking)
+    text_chunk = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                finish_reason=GoogleFinishReason.STOP,
+                content=Content(
+                    parts=[Part(text="The answer is 42")],
+                    role="model",
+                ),
+            )
+        ]
+    )
+    call_response_chunk_text = GoogleCallResponseChunk(chunk=text_chunk)
+    assert call_response_chunk_text.thinking == ""
+    assert call_response_chunk_text.content == "The answer is 42"
+
+    # Test mixed parts (thinking + text)
+    mixed_chunk = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                finish_reason=GoogleFinishReason.STOP,
+                content=Content(
+                    parts=[
+                        Part(text="First I need to think...", thought=True),
+                        Part(text="The final answer"),
+                    ],
+                    role="model",
+                ),
+            )
+        ]
+    )
+    call_response_chunk_mixed = GoogleCallResponseChunk(chunk=mixed_chunk)
+    assert call_response_chunk_mixed.thinking == "First I need to think..."
+    assert call_response_chunk_mixed.content == "The final answer"
+
+    # Test chunk with no candidates
+    empty_chunk = GenerateContentResponse(candidates=[])
+    call_response_chunk_empty = GoogleCallResponseChunk(chunk=empty_chunk)
+    assert call_response_chunk_empty.thinking == ""
+    assert call_response_chunk_empty.content == ""


### PR DESCRIPTION
This PR adds thinking support for the Google provider, in a manner consistent to how I added it for Anthropic in #984.

Key changes:
- `GoogleCallResponse.content` now provides text content of the first non-thinking part
- `GoogleCallResponse.thinking` provides text content of the first thought part
- Refactored `GoogleCallResponse` to have a `_parts()` helper that throws ValueErrors rather than using type ignores (tested for coverage)
- `GoogleCallResponseChunk.thinking` added
- `GoogleStream` modified to reconstruct `GoogleCallResponse` with thinking

For test usage against the real APIs, consider the following two scripts:

## Tool Use Example

```py
from dotenv import load_dotenv
from google.genai import types

from mirascope import Messages
from mirascope.core import google
from mirascope.core.google import GoogleMessageParam

load_dotenv()


def list_primes(n_primes: int) -> list[int]:
    """List up to `n_primes` primes in order"""
    ps = [
        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71],
        [73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151],
        [157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233],
        [239, 241, 251, 257, 263, 269, 271],
    ]
    ps = [p for sublist in ps for p in sublist]

    if n_primes > len(ps):
        raise ValueError("n_primes is too large")
    return ps[:n_primes]


def sum_numbers(ns: list[int]) -> int:
    """Sum integers"""
    return sum(ns)


class PrimeCalculator:
    def __init__(self):
        self.history: list[GoogleMessageParam] = []

    @google.call(
        model="gemini-2.5-flash-preview-05-20",
        tools=[list_primes, sum_numbers],
        call_params={
            "config": types.GenerateContentConfig(
                thinking_config=types.ThinkingConfig(include_thoughts=True)
            ),
        },
    )
    def _call(self) -> Messages.Type:
        return self.history

    def _step(self, query: str) -> str:
        if query:
            self.history.append(Messages.User(query))

        response = self._call()

        if response.thinking:
            print("thinking:", response.thinking)

        # Add assistant response to history
        self.history.append(response.message_param)

        # Check if there are tools to call
        tools_and_outputs = []
        if tools := response.tools:
            print(f"[Calling {len(tools)} tool(s)]")
            for tool in tools:
                print(f"  - Calling '{tool._name()}' with args: {tool.args}")
                output = tool.call()
                print(f"    Result: {output}")
                tools_and_outputs.append((tool, output))

            # Add tool message parameters to history
            self.history += response.tool_message_params(tools_and_outputs)

            # Recursively call _step with empty query to continue the conversation
            return self._step("")
        else:
            # No more tools to call, return the final response
            return response.content

    def solve(self, question: str) -> str:
        return self._step(question)


# Usage
calculator = PrimeCalculator()
result = calculator.solve("What is the sum of the first 50 prime numbers?")

print("\n[Final Answer]:")
print(result)
```

## Streaming example:

```py
"""
Demo of Anthropic thinking support in Mirascope
"""

import os
from enum import Enum

from dotenv import load_dotenv
from google.genai import types
from pydantic import BaseModel

from mirascope import llm
from mirascope.core import google

# Load environment variables
load_dotenv()


# Example 2: Streaming thinking
@google.call(
    model="gemini-2.5-flash-preview-05-20",
    call_params={
        "config": types.GenerateContentConfig(
            thinking_config=types.ThinkingConfig(include_thoughts=True)
        ),
    },
    stream=True,
)
def stream_thinking_response(question: str):
    return f"Think through this carefully: {question}"


def demo_streaming_thinking():
    """Demo streaming thinking API usage."""
    print("=== Streaming Thinking Demo ===")

    stream = stream_thinking_response(
        "Describe your personality compared to other LLMs"
    )

    print("Thinking:")
    thinking = True

    for chunk, _ in stream:
        if chunk.thinking:
            print(chunk.thinking, end="", flush=True)

        if chunk.content:
            if thinking:
                thinking = False
                print("Done Thinking!")
            print(chunk.content, end="", flush=True)

    print("\n")

    call_response = stream.construct_call_response()
    print(f"Final thinking: {call_response.thinking}")
    print(f"Final content: {call_response.content}")
    print()


def main():
    """Run all thinking demos."""

    try:
        demo_streaming_thinking()

    except Exception as e:
        print(f"ERROR: {e}")
        import traceback

        traceback.print_exc()


if __name__ == "__main__":
    main()
```