### PR TITLE
feat: support response_model with anthropic thinking

### DIFF
--- a/mirascope/core/anthropic/_utils/_setup_call.py
+++ b/mirascope/core/anthropic/_utils/_setup_call.py
@@ -96,8 +96,10 @@ def setup_call(
     list[type[AnthropicTool]] | None,
     AnthropicCallKwargs,
 ]:
+    thinking_enabled = call_params.get("thinking") is not None
+
     # Validate thinking parameter before processing
-    if call_params.get("thinking") is not None and not HAS_THINKING_SUPPORT:
+    if thinking_enabled and not HAS_THINKING_SUPPORT:
         raise ValueError(  # pragma: no cover
             "Thinking parameter requires anthropic>=0.47.0. "
             "Please upgrade: pip install 'anthropic>=0.47.0'"
@@ -119,7 +121,9 @@ def setup_call(
     if messages[0]["role"] == "system":
         call_kwargs["system"] = messages.pop(0)["content"]  # pyright: ignore [reportGeneralTypeIssues]
 
-    if json_mode:
+    use_json_mode = json_mode or (response_model and thinking_enabled)
+
+    if use_json_mode:
         json_mode_content = _utils.json_mode_content(response_model)
         if isinstance(messages[-1]["content"], str):
             messages[-1]["content"] += json_mode_content


### PR DESCRIPTION
This builds on #984 to finish Anthropic-specific support for thinking by ensuring that it works even when response_model is set. We simply take the json_mode approach rather than forced tool calling.

We could log a warning that we're using json_mode under the hood, although I don't see a need to, especially as we don't have an existing pattern of e.g. warning that json_mode is implemented via prompt engineering rather than explicit support. I think this is a similar case.


Here is a small example repro showing the working behavior as of this change.

```python
from dotenv import load_dotenv
from pydantic import BaseModel

from mirascope import llm
from mirascope.core.anthropic import AnthropicCallParams
from mirascope.core.anthropic import call as anthropic_call

load_dotenv()


question = "What is the the result of sum(primes[i] * fibonacci[i] for i in range(10))?"


class Answer(BaseModel):
    """An answer to the question."""

    sum: int


@llm.call(provider="anthropic", model="claude-3-7-sonnet-latest", response_model=Answer)
def answer_without_thinking():
    return question


@anthropic_call(
    model="claude-3-7-sonnet-latest",
    response_model=Answer,
    call_params=AnthropicCallParams(
        max_tokens=2048, thinking={"type": "enabled", "budget_tokens": 1024}
    ),
)
def answer_with_thinking():
    return question


print(f"Answer without thinking: ${answer_without_thinking()}") # output: $sum=3121
print(f"Answer with thinking: ${answer_with_thinking()}") # output: $sum=1972
print("Correct answer: 1972")
```