### PR TITLE
fix langfuse integration bug?

### DIFF
--- a/mirascope/integrations/langfuse/_utils.py
+++ b/mirascope/integrations/langfuse/_utils.py
@@ -29,7 +29,7 @@ def _get_call_response_observation(
         "metadata": result.response,
         "tags": tags,
         "model": result.model,
-        "output": getattr(result.message_param, "content", None),
+        "output": result.content,
     }
 
 

--- a/tests/integrations/langfuse/test_utils.py
+++ b/tests/integrations/langfuse/test_utils.py
@@ -17,7 +17,7 @@ def test_get_call_response_observation() -> None:
     mock_result.model = "test_model"
     mock_result.messages = "test_messages"
     mock_result.response = "test_response"
-    mock_result.message_param = {"role": "assistant", "content": "test_content"}
+    mock_result.content = "test_content"
     mock_fn = MagicMock(__name__="mock_fn")
     mock_fn._metadata = Metadata(tags={"tag1"})
     call_response_observation = _utils._get_call_response_observation(


### PR DESCRIPTION

# our error, cursor's analysis:
## Summary
The issue you encountered was an AttributeError: 'BaseMessageParam' object has no attribute 'get' error occurring in the Mirascope-Langfuse integration. This was happening specifically with the dialectic_call and dialectic_stream functions that use the Anthropic provider.
## Root Cause:
The Langfuse integration code in Mirascope was trying to call .get("content", None) on a BaseMessageParam object
BaseMessageParam is a Pydantic model, not a dictionary, so it doesn't have a .get() method
This is a compatibility issue between Mirascope 1.25.0 and Langfuse 2.60.8

# fix
change the get to a getattr.
