### PR TITLE
V2 dev improvements

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,34 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(gh pr view:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(wc:*)",
+      "Bash(file:*)",
+      "Bash(which:*)",
+      "Bash(pwd:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(git show:*)",
+      "Bash(git branch:*)",
+      "Bash(bun run ci:*)",
+      "Bash(bun run lint:*)",
+      "Bash(bun run typecheck:*)",
+      "Bash(uv run pyright:*)",
+      "Bash(uv run ruff:*)",
+      "mcp__ide__getDiagnostics",
+      "WebFetch(domain:platform.openai.com)",
+      "WebFetch(domain:ai.google.dev)",
+      "WebFetch(domain:docs.anthropic.com)",
+      "WebFetch(domain:mirascope.com)"
+    ],
+    "deny": []
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "lint": "bun run codespell && bun run lint:python && bun run lint:typescript",
     "lint:python": "cd python && uv sync --all-extras --dev && uv run ruff check . && uv run pyright .",
     "lint:typescript": "cd typescript && bun i && bun run lint",
+    "fix": "bun run fix:python && bun run fix:typescript",
+    "fix:python": "cd python && uv run ruff check --fix .",
+    "fix:typescript": "cd typescript && bun i && bun run fix",
     "prepare": "husky"
   },
   "lint-staged": {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -10,6 +10,7 @@
     "lint:eslint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "fix": "bun run format && bun run lint:eslint:fix",
     "test": "bun run --cwd mirascope test"
   },
   "workspaces": [


### PR DESCRIPTION
Minor dev workflow improvements:
- Give claude various read-only permissions, as well as permissions to read relevant documentation. (Ironically openai blocks claude with 403, but maybe they'll change that sometime)
- Add a `bun run fix` command that auto-fixes all fixable errors in python and typescript. Probably not necessary because lint-staged does it for you, but may be nice to have.