### PR TITLE
feat: add examples of the resume API

### DIFF
--- a/python/examples/calls/chatbot/chatbot_context.py
+++ b/python/examples/calls/chatbot/chatbot_context.py
@@ -1,0 +1,29 @@
+from mirascope import llm
+
+SYSTEM_MESSAGE = "You are an insightful chatbot named Sazed. You prioritize..."
+
+
+@llm.call(model="openai:gpt-4o-mini")
+def sazed(ctx: llm.Context, query: str):
+    return [
+        llm.messages.system(SYSTEM_MESSAGE),
+        *ctx.messages,  # Automatically filters out system message
+        query,
+    ]
+
+
+def main():
+    user_input = input("What would you like to chat with Sazed about?")
+    with llm.context() as ctx:
+        response: llm.Response = sazed(ctx, user_input)
+        try:
+            while True:
+                print("[SAZED]: ", response.text)
+                user_input = input("[YOU]: ")
+                response = sazed(ctx, user_input)
+        except KeyboardInterrupt:
+            print("[SAZED]: Goodbye")
+            exit(0)
+
+
+main()

--- a/python/examples/calls/chatbot/chatbot_continuations.py
+++ b/python/examples/calls/chatbot/chatbot_continuations.py
@@ -1,0 +1,27 @@
+from mirascope import llm
+
+SYSTEM_MESSAGE = "You are an insightful chatbot named Sazed. You prioritize..."
+
+
+@llm.call(model="openai:gpt-4o-mini")
+def sazed(query: str):
+    return [
+        llm.messages.system(SYSTEM_MESSAGE),
+        query,
+    ]
+
+
+def main():
+    user_input = input("What would you like to chat with Sazed about?")
+    response: llm.Response = sazed(user_input)
+    try:
+        while True:
+            print("[SAZED]: ", response.text)
+            user_input = input("[YOU]: ")
+            response = sazed.resume(response, user_input)
+    except KeyboardInterrupt:
+        print("[SAZED]: Goodbye")
+        exit(0)
+
+
+main()

--- a/python/examples/calls/chatbot/chatbot_response_messages.py
+++ b/python/examples/calls/chatbot/chatbot_response_messages.py
@@ -1,0 +1,29 @@
+from mirascope import llm
+
+SYSTEM_MESSAGE = "You are an insightful chatbot named Sazed. You prioritize..."
+
+
+@llm.call(model="openai:gpt-4o-mini")
+def sazed(messages: list[llm.Message], query: str):
+    non_system_messages = [m for m in messages if m.role != "system"]
+    return [
+        llm.messages.system(SYSTEM_MESSAGE),
+        *non_system_messages,
+        query,
+    ]
+
+
+def main():
+    user_input = input("What would you like to chat with Sazed about?")
+    response: llm.Response = sazed([], user_input)
+    try:
+        while True:
+            print("[SAZED]: ", response.text)
+            user_input = input("[YOU]: ")
+            response = sazed(response.messages, user_input)
+    except KeyboardInterrupt:
+        print("[SAZED]: Goodbye")
+        exit(0)
+
+
+main()

--- a/python/examples/streams/chatbot/chatbot_stream_context.py
+++ b/python/examples/streams/chatbot/chatbot_stream_context.py
@@ -1,0 +1,32 @@
+from mirascope import llm
+
+SYSTEM_MESSAGE = "You are an insightful chatbot named Sazed. You prioritize..."
+
+
+@llm.call(model="openai:gpt-4o-mini")
+def sazed(ctx: llm.Context, query: str):
+    return [
+        llm.messages.system(SYSTEM_MESSAGE),
+        *ctx.messages,  # Automatically filters out system message
+        query,
+    ]
+
+
+def main():
+    user_input = input("What would you like to chat with Sazed about?")
+    with llm.context() as ctx:
+        stream: llm.Stream = sazed.stream(ctx, user_input)
+        try:
+            while True:
+                print("[SAZED]:", flush=True, end=None)
+                for chunk in stream:
+                    print(chunk, flush=True, end=None)
+                print("")
+                user_input = input("[YOU]: ")
+                stream = sazed.stream(ctx, user_input)
+        except KeyboardInterrupt:
+            print("[SAZED]: Goodbye")
+            exit(0)
+
+
+main()

--- a/python/examples/streams/chatbot/chatbot_stream_continuations.py
+++ b/python/examples/streams/chatbot/chatbot_stream_continuations.py
@@ -1,0 +1,30 @@
+from mirascope import llm
+
+SYSTEM_MESSAGE = "You are an insightful chatbot named Sazed. You prioritize..."
+
+
+@llm.call(model="openai:gpt-4o-mini")
+def sazed(query: str):
+    return [
+        llm.messages.system(SYSTEM_MESSAGE),
+        query,
+    ]
+
+
+def main():
+    user_input = input("What would you like to chat with Sazed about?")
+    stream: llm.Stream = sazed.stream(user_input)
+    try:
+        while True:
+            print("[SAZED]:", flush=True, end=None)
+            for chunk in stream:
+                print(chunk, flush=True, end=None)
+            print("")
+            user_input = input("[YOU]: ")
+            stream = sazed.resume_stream(stream.to_response(), user_input)
+    except KeyboardInterrupt:
+        print("[SAZED]: Goodbye")
+        exit(0)
+
+
+main()

--- a/python/examples/streams/chatbot/chatbot_stream_messages_prompt.py
+++ b/python/examples/streams/chatbot/chatbot_stream_messages_prompt.py
@@ -1,0 +1,33 @@
+from mirascope import llm
+
+SYSTEM_MESSAGE = "You are an insightful chatbot named Sazed. You prioritize..."
+
+
+@llm.call(model="openai:gpt-4o-mini")
+def sazed(messages: list[llm.Message], query: str):
+    non_system_messages = [m for m in messages if m.role != "system"]
+    return [
+        llm.messages.system(SYSTEM_MESSAGE),
+        *non_system_messages,
+        query,
+    ]
+
+
+def main():
+    user_input = input("What would you like to chat with Sazed about?")
+    stream: llm.Stream = sazed.stream([], user_input)
+    try:
+        while True:
+            print("[SAZED]:", flush=True, end=None)
+            for chunk in stream:
+                print(chunk, flush=True, end=None)
+            print("")
+            user_input = input("[YOU]: ")
+            messages = stream.to_response().messages
+            stream = sazed.stream(messages, user_input)
+    except KeyboardInterrupt:
+        print("[SAZED]: Goodbye")
+        exit(0)
+
+
+main()


### PR DESCRIPTION
I organized them under streams/ and calls/ examples and show alternative approaches to making a chatbot, including response.messages, context, and the resume API. I think resume API is cleanest and we should make that the default for this kind of case.