### PR TITLE
feat: add unified examples.mdx for LLM consumption

### DIFF
--- a/docs/content/_meta.json
+++ b/docs/content/_meta.json
@@ -12,6 +12,10 @@
             "label": "Welcome"
           },
           {
+            "slug": "examples",
+            "label": "Examples (For LLMs)"
+          },
+          {
             "slug": "learn",
             "label": "Learn",
             "children": [

--- a/docs/content/examples.mdx
+++ b/docs/content/examples.mdx
@@ -1,0 +1,155 @@
+---
+title: Examples
+description: Unified doc with diverse examples, intended as a primer for LLMs on common Mirascope patterns.
+---
+
+# Unified Examples
+
+This document contains a wide variety of Mirascope code examples, intended for feeding as context to LLMs to get a comprehensive primer of Mirascope v2 usage patterns.
+
+## Calls 
+
+### `calls/intro.py`
+
+<CodeExample file="examples/calls/intro.py" />
+
+### `calls/call_async.py`
+
+<CodeExample file="examples/calls/call_async.py" />
+
+### `calls/chatbot/chatbot_resume.py`
+
+<CodeExample file="examples/calls/chatbot/chatbot_resume.py" />
+
+### `calls/chatbot/chatbot_context.py`
+
+<CodeExample file="examples/calls/chatbot/chatbot_context.py" />
+
+### `calls/multimedia_response.py`
+
+<CodeExample file="examples/calls/multimedia_response.py" />
+
+
+### `calls/exceptions.py`
+
+<CodeExample file="examples/calls/exceptions.py" />
+
+
+## Streams
+
+### `streams/intro.py`
+
+<CodeExample file="examples/streams/intro.py" />
+
+### `streams/async_stream.py`
+
+<CodeExample file="examples/streams/async_stream.py" />
+
+### `streams/groups.py`
+
+<CodeExample file="examples/streams/groups.py" />
+
+### `streams/to_response.py`
+
+<CodeExample file="examples/streams/to_response.py" />
+
+### `streams/chatbot/chatbot_stream_resume.py`
+
+<CodeExample file="examples/streams/chatbot/chatbot_stream_resume.py" />
+
+### `streams/chatbot/chatbot_stream_context.py`
+
+<CodeExample file="examples/streams/chatbot/chatbot_stream_context.py" />
+
+
+### `streams/error_handling.py`
+
+<CodeExample file="examples/streams/error_handling.py" />
+
+## Tools
+
+### `tools/basic.py`
+
+<CodeExample file="examples/tools/basic.py" />
+
+### `tools/async_tools.py`
+
+<CodeExample file="examples/tools/async_tools.py" />
+
+### `tools/basic_context.py`
+
+<CodeExample file="examples/tools/basic_context.py" />
+
+### `tools/basic_stream.py`
+
+<CodeExample file="examples/tools/basic_stream.py" />
+
+### `tools/multi_tool.py`
+
+<CodeExample file="examples/tools/multi_tool.py" />
+
+### `tools/selective_handling.py`
+
+<CodeExample file="examples/tools/selective_handling.py" />
+
+### `tools/mixed_sync_async.py`
+
+<CodeExample file="examples/tools/mixed_sync_async.py" />
+
+## Agents
+
+### `agents/agent.py`
+
+<CodeExample file="examples/agents/agent.py" />
+
+### `agents/agent_async.py`
+
+<CodeExample file="examples/agents/agent_async.py" />
+
+### `agents/agent_context_tools.py`
+
+<CodeExample file="examples/agents/agent_context_tools.py" />
+
+### `agents/agent_stream.py`
+
+<CodeExample file="examples/agents/agent_stream.py" />
+
+### `agents/agent_tools.py`
+
+<CodeExample file="examples/agents/agent_tools.py" />
+
+### `agents/agent_multi_tool.py`
+
+<CodeExample file="examples/agents/agent_multi_tool.py" />
+
+### `agents/agent_structured.py`
+
+<CodeExample file="examples/agents/agent_structured.py" />
+
+### `agents/oneshot/oneshot_basic.py`
+
+<CodeExample file="examples/agents/oneshot/oneshot_basic.py" />
+
+## Structured Outputs
+
+### `structured_outputs/call.py`
+
+<CodeExample file="examples/structured_outputs/call.py" />
+
+### `structured_outputs/async_call.py`
+
+<CodeExample file="examples/structured_outputs/async_call.py" />
+
+### `structured_outputs/stream.py`
+
+<CodeExample file="examples/structured_outputs/stream.py" />
+
+### `structured_outputs/context_call.py`
+
+<CodeExample file="examples/structured_outputs/context_call.py" />
+
+### `structured_outputs/tools.py`
+
+<CodeExample file="examples/structured_outputs/tools.py" />
+
+


### PR DESCRIPTION
Adds a single mdx document (6k tokens) with a broad ranging set of
examples all concatenated together. The idea is that this is very
helpful as a unified content blog that can be passed to LLMs to prime
them on Mirascope's API design and philosophy (as demonstrated in
practice), so that said LLMs can then be better rubber ducks for
exploring interface changes or improvements.

Works pretty well (Claude gives helpful / plausible suggestions on how
to e.g. integrate MCP with Mirascope v2 given just this context for
priming)