### PR TITLE
feat: add llm.Partial for partial base models

### DIFF
--- a/python/examples/structured_outputs/calls/async_context_stream.py
+++ b/python/examples/structured_outputs/calls/async_context_stream.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 from dataclasses import dataclass
 
 from pydantic import BaseModel
@@ -31,11 +30,8 @@ async def main():
     ctx = llm.Context(deps=library)
     stream: llm.AsyncStream[Book] = await recommend_book.stream_async(ctx, "fantasy")
     async for _ in stream:
-        partial_book: Book | None = None
-        with contextlib.suppress(Exception):
-            partial_book = stream.format()
-        if partial_book is not None:
-            print("Partial book: ", partial_book)
+        partial_book: llm.Partial[Book] = stream.format(partial=True)
+        print("Partial book: ", partial_book)
 
     book: Book = stream.format()
     print("Book: ", book)

--- a/python/examples/structured_outputs/calls/async_stream.py
+++ b/python/examples/structured_outputs/calls/async_stream.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 
 from pydantic import BaseModel
 
@@ -20,11 +19,8 @@ def recommend_book(genre: str):
 async def main():
     stream: llm.AsyncStream[Book] = await recommend_book.stream_async("fantasy")
     async for _ in stream:
-        partial_book: Book | None = None
-        with contextlib.suppress(Exception):
-            partial_book = stream.format()
-        if partial_book is not None:
-            print("Partial book: ", partial_book)
+        partial_book: llm.Partial[Book] = stream.format(partial=True)
+        print("Partial book: ", partial_book)
 
     book: Book = stream.format()
     print("Book: ", book)

--- a/python/examples/structured_outputs/calls/context_stream.py
+++ b/python/examples/structured_outputs/calls/context_stream.py
@@ -1,4 +1,3 @@
-import contextlib
 from dataclasses import dataclass
 
 from pydantic import BaseModel
@@ -30,11 +29,8 @@ def main():
     ctx = llm.Context(deps=library)
     stream: llm.Stream[Book] = recommend_book.stream(ctx, "fantasy")
     for _ in stream:
-        partial_book: Book | None = None
-        with contextlib.suppress(Exception):
-            partial_book = stream.format()
-        if partial_book is not None:
-            print("Partial book: ", partial_book)
+        partial_book: llm.Partial[Book] = stream.format(partial=True)
+        print("Partial book: ", partial_book)
 
     book: Book = stream.format()
     print("Book: ", book)

--- a/python/examples/structured_outputs/calls/stream.py
+++ b/python/examples/structured_outputs/calls/stream.py
@@ -1,5 +1,3 @@
-import contextlib
-
 from pydantic import BaseModel
 
 from mirascope import llm
@@ -19,11 +17,8 @@ def recommend_book(genre: str):
 def main():
     stream: llm.Stream[Book] = recommend_book.stream("fantasy")
     for _ in stream:
-        partial_book: Book | None = None
-        with contextlib.suppress(Exception):
-            partial_book = stream.format()
-        if partial_book is not None:
-            print("Partial book: ", partial_book)
+        partial_book: llm.Partial[Book] = stream.format(partial=True)
+        print("Partial book: ", partial_book)
 
     book: Book = stream.format()
     print("Book: ", book)

--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -54,7 +54,7 @@ from .exceptions import (
     TimeoutError,
     ToolNotFoundError,
 )
-from .formatting import Format, format
+from .formatting import Format, Partial, format
 from .messages import AssistantMessage, Message, SystemMessage, UserMessage
 from .models import LLM, model
 from .prompts import prompt
@@ -94,6 +94,7 @@ __all__ = [
     "Message",
     "MirascopeError",
     "NotFoundError",
+    "Partial",
     "PermissionError",
     "RateLimitError",
     "Response",

--- a/python/mirascope/llm/formatting/__init__.py
+++ b/python/mirascope/llm/formatting/__init__.py
@@ -9,6 +9,7 @@ from .decorator import (
     format,
 )
 from .from_call_args import FromCallArgs
+from .partial import Partial
 from .types import Format, FormatT, Formattable, FormattingMode
 
 __all__ = [
@@ -17,5 +18,6 @@ __all__ = [
     "Formattable",
     "FormattingMode",
     "FromCallArgs",
+    "Partial",
     "format",
 ]

--- a/python/mirascope/llm/formatting/partial.py
+++ b/python/mirascope/llm/formatting/partial.py
@@ -1,0 +1,57 @@
+"""
+--------------------------------------------------------------------------------
+Source: https://github.com/pydantic/pydantic/issues/6381#issuecomment-1831607091
+By: silviumarcu
+
+This code is used in accordance with the repository's license, and this reference
+serves as an acknowledgment of the original author's contribution to this project.
+--------------------------------------------------------------------------------
+"""
+
+from typing import Generic, NoReturn
+
+from .types import FormatT
+
+
+class Partial(Generic[FormatT]):
+    """Generate a new class with all attributes optionals.
+
+    Notes:
+        This will wrap a class inheriting form BaseModel and will recursively
+        convert all its attributes and its children's attributes to optionals.
+
+    Example:
+        Partial[SomeModel]
+    """
+
+    def __new__(
+        cls,
+        *args: object,  # noqa :ARG003
+        **kwargs: object,  # noqa :ARG003
+    ) -> "Partial[FormatT]":
+        """Cannot instantiate.
+
+        Raises:
+            TypeError: Direct instantiation not allowed.
+        """
+        raise TypeError("Cannot instantiate abstract Partial class.")
+
+    def __init_subclass__(
+        cls,
+        *args: object,
+        **kwargs: object,
+    ) -> NoReturn:
+        """Cannot subclass.
+
+        Raises:
+           TypeError: Subclassing not allowed.
+        """
+        raise TypeError(f"Cannot subclass {cls.__module__}.Partial")
+
+    def __class_getitem__(  # type: ignore[override]
+        cls,
+        wrapped_class: type[FormatT],
+    ) -> type[FormatT]:
+        """Convert model to a partial model with all fields being optionals."""
+
+        raise NotImplementedError()


### PR DESCRIPTION
### TL;DR

Added `Partial[T]` type to properly type partial structured outputs in streaming responses.

### What changed?

- Added a new `Partial` generic type to the formatting module
- Updated type annotations in stream examples to use `llm.Partial[Book]` instead of `Book` for partial responses
- Added `Partial` to the public exports in the `__init__.py` files
- Updated the return type of the `format()` method in the base stream class to return `Partial[FormatT]` instead of `FormatT`

The Partial type is just the signature (no implementation or tests). Based on the equivalent code in v1, and copying the attribution header to the original GitHub comment.