### PR TITLE
refactor: cleanup response to remove singleton accessors (except text)

### DIFF
--- a/python/mirascope/llm/responses/response.py
+++ b/python/mirascope/llm/responses/response.py
@@ -6,7 +6,6 @@ including methods for formatting the response according to a specified format.
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Generic, Literal, overload
 
 from ..content import AssistantContent, Audio, Image, Thinking, ToolCall
@@ -61,35 +60,18 @@ class Response(Generic[FormatT]):
     usage: Usage | None
     """The token usage statistics for the request to the LLM."""
 
-    cost: Decimal | None
-    """The cost of the request to the LLM, if available."""
-
     tool_calls: Sequence[ToolCall]
     """The tools the LLM wants called on its behalf, if any."""
 
     @property
-    def tool_call(self) -> ToolCall | None:
-        """Returns the first tool used in the response, if any."""
-        raise NotImplementedError()
+    def text(self, delimiter: str = "\n") -> str:
+        """Returns the response's textual content.
 
-    @property
-    def text(self) -> str | None:
-        """Returns the first text in the response content, if any."""
-        raise NotImplementedError()
+        If the response has multiple Text parts, they will be concatenated together
+        using delimiter (default newline).
 
-    @property
-    def image(self) -> Image | None:
-        """Returns the first image in the response content, if any."""
-        raise NotImplementedError()
-
-    @property
-    def audio(self) -> Audio | None:
-        """Returns the first audio in the response content, if any."""
-        raise NotImplementedError()
-
-    @property
-    def thinking(self) -> Thinking | None:
-        """Returns the first thinking in the response content, if any."""
+        If the response has no text content, an empty string is returned.
+        """
         raise NotImplementedError()
 
     @overload

--- a/python/mirascope/llm/streams/base.py
+++ b/python/mirascope/llm/streams/base.py
@@ -1,6 +1,5 @@
 """Base interface for streaming responses from LLMs."""
 
-from decimal import Decimal
 from typing import Generic, Literal, overload
 
 from ..formatting import FormatT, Partial
@@ -17,9 +16,6 @@ class BaseStream(Generic[FormatT]):
 
     usage: Usage | None
     """The token usage statistics reflecting all chunks processed so far. Updates as chunks are consumed."""
-
-    cost: Decimal | None
-    """The cost reflecting all chunks processed so far. Updates as chunks are consumed."""
 
     def to_response(self) -> Response[FormatT]:
         """Convert the stream to a complete response.


### PR DESCRIPTION
In offline discussion, we agreed that having the singleton accessors for non-text content is a questionable affordance, users can write `.images[0]` if that's really what they want, and it is clearer that they may be skipping some. In particular `response.tool_call` encourages writing bad code that will miss parallel tool calling.

In the case of the `text` property, I updated docstring to show that it returns empty string if there is no text, and added a delimiter argument that defaults to `\n` for concatenating multiple text pieces.

Also removed cost tracking from response and stream.