### PR TITLE
refactor: clients only use generic llm.Message

### DIFF
--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -3,7 +3,6 @@
 from .anthropic import (
     ANTHROPIC_REGISTERED_LLMS,
     AnthropicClient,
-    AnthropicMessage,
     AnthropicParams,
 )
 from .base import (
@@ -11,10 +10,9 @@ from .base import (
     BaseParams,
     ClientT,
     ParamsT,
-    ProviderMessageT,
 )
-from .google import GOOGLE_REGISTERED_LLMS, GoogleClient, GoogleMessage, GoogleParams
-from .openai import OPENAI_REGISTERED_LLMS, OpenAIClient, OpenAIMessage, OpenAIParams
+from .google import GOOGLE_REGISTERED_LLMS, GoogleClient, GoogleParams
+from .openai import OPENAI_REGISTERED_LLMS, OpenAIClient, OpenAIParams
 from .registered_llms import (
     LLMT,
     REGISTERED_LLMS,
@@ -27,17 +25,13 @@ __all__ = [
     "OPENAI_REGISTERED_LLMS",
     "REGISTERED_LLMS",
     "AnthropicClient",
-    "AnthropicMessage",
     "AnthropicParams",
     "BaseClient",
     "BaseParams",
     "ClientT",
     "GoogleClient",
-    "GoogleMessage",
     "GoogleParams",
     "OpenAIClient",
-    "OpenAIMessage",
     "OpenAIParams",
     "ParamsT",
-    "ProviderMessageT",
 ]

--- a/python/mirascope/llm/clients/anthropic/__init__.py
+++ b/python/mirascope/llm/clients/anthropic/__init__.py
@@ -1,13 +1,11 @@
 """Anthropic client implementation."""
 
 from .client import AnthropicClient
-from .message import AnthropicMessage
 from .params import AnthropicParams
 from .registered_llms import ANTHROPIC_REGISTERED_LLMS
 
 __all__ = [
     "ANTHROPIC_REGISTERED_LLMS",
     "AnthropicClient",
-    "AnthropicMessage",
     "AnthropicParams",
 ]

--- a/python/mirascope/llm/clients/anthropic/client.py
+++ b/python/mirascope/llm/clients/anthropic/client.py
@@ -4,26 +4,24 @@ from collections.abc import Sequence
 
 from ...context import Context, DepsT
 from ...formatting import FormatT
+from ...messages import Message
 from ...responses import Response, StreamResponse
 from ...streams import AsyncStream, Stream
 from ...tools import AsyncContextTool, AsyncTool, ContextTool, Tool
 from ...types import Jsonable
 from ..base import BaseClient
-from .message import AnthropicMessage
 from .params import AnthropicParams
 from .registered_llms import ANTHROPIC_REGISTERED_LLMS
 
 
-class AnthropicClient(
-    BaseClient[AnthropicMessage, AnthropicParams, ANTHROPIC_REGISTERED_LLMS]
-):
+class AnthropicClient(BaseClient[AnthropicParams, ANTHROPIC_REGISTERED_LLMS]):
     """The client for the Anthropic LLM model."""
 
     def call(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: AnthropicParams | None = None,
     ) -> Response[None]:
@@ -34,7 +32,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: AnthropicParams | None = None,
     ) -> Response[None]:
@@ -44,7 +42,7 @@ class AnthropicClient(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: AnthropicParams | None = None,
@@ -56,7 +54,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: AnthropicParams | None = None,
@@ -67,7 +65,7 @@ class AnthropicClient(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: AnthropicParams | None = None,
     ) -> Response[None]:
@@ -78,7 +76,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: AnthropicParams | None = None,
     ) -> Response[None]:
@@ -88,7 +86,7 @@ class AnthropicClient(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: AnthropicParams | None = None,
@@ -100,7 +98,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: AnthropicParams | None = None,
@@ -111,7 +109,7 @@ class AnthropicClient(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: AnthropicParams | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -122,7 +120,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: AnthropicParams | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -132,7 +130,7 @@ class AnthropicClient(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: AnthropicParams | None = None,
@@ -144,7 +142,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: AnthropicParams | None = None,
@@ -155,7 +153,7 @@ class AnthropicClient(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: AnthropicParams | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -166,7 +164,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: AnthropicParams | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -176,7 +174,7 @@ class AnthropicClient(
         self,
         *,
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: AnthropicParams | None = None,
@@ -188,7 +186,7 @@ class AnthropicClient(
         *,
         ctx: Context[DepsT],
         model: ANTHROPIC_REGISTERED_LLMS,
-        messages: Sequence[AnthropicMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: AnthropicParams | None = None,

--- a/python/mirascope/llm/clients/anthropic/message.py
+++ b/python/mirascope/llm/clients/anthropic/message.py
@@ -4,6 +4,4 @@ from typing import TypeAlias
 
 from anthropic.types import MessageParam
 
-from ...messages import Message
-
-AnthropicMessage: TypeAlias = Message | MessageParam
+AnthropicMessage: TypeAlias = MessageParam

--- a/python/mirascope/llm/clients/base/__init__.py
+++ b/python/mirascope/llm/clients/base/__init__.py
@@ -1,6 +1,6 @@
 """Base client interfaces and types."""
 
-from .client import BaseClient, ClientT, ProviderMessageT
+from .client import BaseClient, ClientT
 from .params import BaseParams, ParamsT
 
 __all__ = [
@@ -8,5 +8,4 @@ __all__ = [
     "BaseParams",
     "ClientT",
     "ParamsT",
-    "ProviderMessageT",
 ]

--- a/python/mirascope/llm/clients/base/client.py
+++ b/python/mirascope/llm/clients/base/client.py
@@ -10,6 +10,7 @@ from typing_extensions import TypeVar
 
 from ...context import Context, DepsT
 from ...formatting import FormatT
+from ...messages import Message
 from ...responses import (
     Response,
     StreamResponse,
@@ -29,14 +30,7 @@ ClientT = TypeVar("ClientT", bound="BaseClient")
 """Type variable for an LLM client."""
 
 
-ProviderMessageT = TypeVar("ProviderMessageT")
-"""Type variable for an LLM that is usable by a specific LLM provider.
-
-May often be the union of generic `llm.Message` and a provider-specific message representation.
-"""
-
-
-class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
+class BaseClient(Generic[ParamsT, LLMT], ABC):
     """Base abstract client for provider-specific implementations.
 
     This class defines explicit methods for each type of call, eliminating
@@ -48,7 +42,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: ParamsT | None = None,
     ) -> Response[None]:
@@ -61,7 +55,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: ParamsT | None = None,
     ) -> Response[None]:
@@ -73,7 +67,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: ParamsT | None = None,
@@ -87,7 +81,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: ParamsT | None = None,
@@ -100,7 +94,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: ParamsT | None = None,
     ) -> Response[None]:
@@ -113,7 +107,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: ParamsT | None = None,
     ) -> Response[None]:
@@ -125,7 +119,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: ParamsT | None = None,
@@ -139,7 +133,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: ParamsT | None = None,
@@ -152,7 +146,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: ParamsT | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -165,7 +159,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: ParamsT | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -177,7 +171,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: ParamsT | None = None,
@@ -191,7 +185,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: ParamsT | None = None,
@@ -204,7 +198,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: ParamsT | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -217,7 +211,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: ParamsT | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -229,7 +223,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         self,
         *,
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: ParamsT | None = None,
@@ -243,7 +237,7 @@ class BaseClient(Generic[ProviderMessageT, ParamsT, LLMT], ABC):
         *,
         ctx: Context[DepsT],
         model: LLMT,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: ParamsT | None = None,

--- a/python/mirascope/llm/clients/google/__init__.py
+++ b/python/mirascope/llm/clients/google/__init__.py
@@ -1,8 +1,7 @@
 """Google client implementation."""
 
 from .client import GoogleClient
-from .message import GoogleMessage
 from .params import GoogleParams
 from .registered_llms import GOOGLE_REGISTERED_LLMS
 
-__all__ = ["GOOGLE_REGISTERED_LLMS", "GoogleClient", "GoogleMessage", "GoogleParams"]
+__all__ = ["GOOGLE_REGISTERED_LLMS", "GoogleClient", "GoogleParams"]

--- a/python/mirascope/llm/clients/google/client.py
+++ b/python/mirascope/llm/clients/google/client.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 
 from ...context import Context, DepsT
 from ...formatting import FormatT
+from ...messages import Message
 from ...responses import (
     Response,
     StreamResponse,
@@ -12,19 +13,18 @@ from ...streams import AsyncStream, Stream
 from ...tools import AsyncContextTool, AsyncTool, ContextTool, Tool
 from ...types import Jsonable
 from ..base import BaseClient
-from .message import GoogleMessage
 from .params import GoogleParams
 from .registered_llms import GOOGLE_REGISTERED_LLMS
 
 
-class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLMS]):
+class GoogleClient(BaseClient[GoogleParams, GOOGLE_REGISTERED_LLMS]):
     """The client for the Google LLM model."""
 
     def call(
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: GoogleParams | None = None,
     ) -> Response[None]:
@@ -35,7 +35,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: GoogleParams | None = None,
     ) -> Response[None]:
@@ -45,7 +45,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: GoogleParams | None = None,
@@ -57,7 +57,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: GoogleParams | None = None,
@@ -68,7 +68,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: GoogleParams | None = None,
     ) -> Response[None]:
@@ -79,7 +79,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: GoogleParams | None = None,
     ) -> Response[None]:
@@ -89,7 +89,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: GoogleParams | None = None,
@@ -101,7 +101,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: GoogleParams | None = None,
@@ -112,7 +112,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: GoogleParams | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -123,7 +123,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: GoogleParams | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -133,7 +133,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: GoogleParams | None = None,
@@ -145,7 +145,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: GoogleParams | None = None,
@@ -156,7 +156,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: GoogleParams | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -167,7 +167,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: GoogleParams | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -177,7 +177,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         self,
         *,
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: GoogleParams | None = None,
@@ -189,7 +189,7 @@ class GoogleClient(BaseClient[GoogleMessage, GoogleParams, GOOGLE_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: GOOGLE_REGISTERED_LLMS,
-        messages: Sequence[GoogleMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: GoogleParams | None = None,

--- a/python/mirascope/llm/clients/google/message.py
+++ b/python/mirascope/llm/clients/google/message.py
@@ -4,6 +4,4 @@ from typing import TypeAlias
 
 from google.genai.types import ContentDict, FunctionResponse
 
-from ...messages import Message
-
-GoogleMessage: TypeAlias = Message | ContentDict | FunctionResponse
+GoogleMessage: TypeAlias = ContentDict | FunctionResponse

--- a/python/mirascope/llm/clients/openai/__init__.py
+++ b/python/mirascope/llm/clients/openai/__init__.py
@@ -1,8 +1,7 @@
 """OpenAI client implementation."""
 
 from .client import OpenAIClient
-from .message import OpenAIMessage
 from .params import OpenAIParams
 from .registered_llms import OPENAI_REGISTERED_LLMS
 
-__all__ = ["OPENAI_REGISTERED_LLMS", "OpenAIClient", "OpenAIMessage", "OpenAIParams"]
+__all__ = ["OPENAI_REGISTERED_LLMS", "OpenAIClient", "OpenAIParams"]

--- a/python/mirascope/llm/clients/openai/client.py
+++ b/python/mirascope/llm/clients/openai/client.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 
 from ...context import Context, DepsT
 from ...formatting import FormatT
+from ...messages import Message
 from ...responses import (
     Response,
     StreamResponse,
@@ -12,19 +13,18 @@ from ...streams import AsyncStream, Stream
 from ...tools import AsyncContextTool, AsyncTool, ContextTool, Tool
 from ...types import Jsonable
 from ..base import BaseClient
-from .message import OpenAIMessage
 from .params import OpenAIParams
 from .registered_llms import OPENAI_REGISTERED_LLMS
 
 
-class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLMS]):
+class OpenAIClient(BaseClient[OpenAIParams, OPENAI_REGISTERED_LLMS]):
     """The client for the OpenAI LLM model."""
 
     def call(
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: OpenAIParams | None = None,
     ) -> Response[None]:
@@ -35,7 +35,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: OpenAIParams | None = None,
     ) -> Response[None]:
@@ -45,7 +45,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: OpenAIParams | None = None,
@@ -57,7 +57,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: OpenAIParams | None = None,
@@ -68,7 +68,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: OpenAIParams | None = None,
     ) -> Response[None]:
@@ -79,7 +79,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: OpenAIParams | None = None,
     ) -> Response[None]:
@@ -89,7 +89,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: OpenAIParams | None = None,
@@ -101,7 +101,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: OpenAIParams | None = None,
@@ -112,7 +112,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         params: OpenAIParams | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -123,7 +123,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         params: OpenAIParams | None = None,
     ) -> StreamResponse[Stream, None]:
@@ -133,7 +133,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormatT],
         params: OpenAIParams | None = None,
@@ -145,7 +145,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: OpenAIParams | None = None,
@@ -156,7 +156,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         params: OpenAIParams | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -167,7 +167,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         params: OpenAIParams | None = None,
     ) -> StreamResponse[AsyncStream, None]:
@@ -177,7 +177,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         self,
         *,
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormatT],
         params: OpenAIParams | None = None,
@@ -189,7 +189,7 @@ class OpenAIClient(BaseClient[OpenAIMessage, OpenAIParams, OPENAI_REGISTERED_LLM
         *,
         ctx: Context[DepsT],
         model: OPENAI_REGISTERED_LLMS,
-        messages: Sequence[OpenAIMessage],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]],
         format: type[FormatT],
         params: OpenAIParams | None = None,

--- a/python/mirascope/llm/clients/openai/message.py
+++ b/python/mirascope/llm/clients/openai/message.py
@@ -4,6 +4,4 @@ from typing import TypeAlias
 
 from openai.types.chat import ChatCompletionMessageParam
 
-from ...messages import Message
-
-OpenAIMessage: TypeAlias = Message | ChatCompletionMessageParam
+OpenAIMessage: TypeAlias = ChatCompletionMessageParam

--- a/python/mirascope/llm/models/base.py
+++ b/python/mirascope/llm/models/base.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Generic
 
-from ..clients import ClientT, ParamsT, ProviderMessageT
+from ..clients import ClientT, ParamsT
 from ..context import Context
+from ..messages import Message
 from ..responses import (
     Response,
     StreamResponse,
@@ -22,7 +23,7 @@ from ..formatting import FormatT
 from ..types import Jsonable
 
 
-class LLM(Generic[ProviderMessageT, ParamsT, ClientT]):
+class LLM(Generic[ParamsT, ClientT]):
     """The unified LLM interface that delegates to provider-specific clients.
 
     This class provides a consistent interface for interacting with language models
@@ -54,7 +55,7 @@ class LLM(Generic[ProviderMessageT, ParamsT, ClientT]):
         self,
         *,
         ctx: Context[DepsT] | None = None,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool]
         | Sequence[Tool | ContextTool[..., Jsonable, DepsT]]
         | None = None,
@@ -68,7 +69,7 @@ class LLM(Generic[ProviderMessageT, ParamsT, ClientT]):
         self,
         *,
         ctx: Context[DepsT] | None = None,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool]
         | Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]]
         | None = None,
@@ -82,7 +83,7 @@ class LLM(Generic[ProviderMessageT, ParamsT, ClientT]):
         self,
         *,
         ctx: Context[DepsT] | None = None,
-        messages: Sequence[ProviderMessageT],
+        messages: Sequence[Message],
         tools: Sequence[Tool]
         | Sequence[Tool | ContextTool[..., Jsonable, DepsT]]
         | None = None,
@@ -96,7 +97,7 @@ class LLM(Generic[ProviderMessageT, ParamsT, ClientT]):
         self,
         *,
         ctx: Context[DepsT] | None = None,
-        messages: list[ProviderMessageT],
+        messages: list[Message],
         tools: Sequence[AsyncTool]
         | Sequence[AsyncTool | AsyncContextTool[..., Jsonable, DepsT]]
         | None = None,

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -2,25 +2,22 @@
 
 from ..clients import (
     AnthropicClient,
-    AnthropicMessage,
     AnthropicParams,
     GoogleClient,
-    GoogleMessage,
     GoogleParams,
     OpenAIClient,
-    OpenAIMessage,
     OpenAIParams,
 )
 from .base import LLM
 
 
-class OpenAI(LLM[OpenAIMessage, OpenAIParams, OpenAIClient]):
+class OpenAI(LLM[OpenAIParams, OpenAIClient]):
     """The OpenAI-specific implementation of the `LLM` interface."""
 
 
-class Anthropic(LLM[AnthropicMessage, AnthropicParams, AnthropicClient]):
+class Anthropic(LLM[AnthropicParams, AnthropicClient]):
     """The Anthropic-specific implementation of the `LLM` interface."""
 
 
-class Google(LLM[GoogleMessage, GoogleParams, GoogleClient]):
+class Google(LLM[GoogleParams, GoogleClient]):
     """The Google-specific implementation of the `LLM` interface."""


### PR DESCRIPTION
In offline discussion, we agreed that trying to support provider-specific messages creates a leaky abstraction / incomplete abstraction, especially since the Response will only have generic messages. 

Supporting provider-specific input messages also raises the unaddressed question of what we do with provider-specific output messages and potentially unsupported content.

I left the `AnthropicMessage`, `GoogleMessage` etc type aliases, as I think it'll be a nice convention to alias whatever the provider-specific message representation may be, to a consistent type alias. 