### PR TITLE
refactor: store tool call args as string in content

### DIFF
--- a/python/mirascope/llm/clients/anthropic/_utils.py
+++ b/python/mirascope/llm/clients/anthropic/_utils.py
@@ -1,5 +1,6 @@
 """Anthropic message types and conversion utilities."""
 
+import json
 from collections.abc import Sequence
 from functools import lru_cache
 
@@ -56,7 +57,7 @@ def _encode_content(
                     type="tool_use",
                     id=part.id,
                     name=part.name,
-                    input=part.args,
+                    input=json.loads(part.args),
                 )
             )
         else:
@@ -75,7 +76,7 @@ def _decode_assistant_content(
         return ToolCall(
             id=content.id,
             name=content.name,
-            args=dict(content.input),  # type: ignore[arg-type]
+            args=json.dumps(content.input),
         )
     else:
         raise NotImplementedError(

--- a/python/mirascope/llm/clients/google/_utils.py
+++ b/python/mirascope/llm/clients/google/_utils.py
@@ -1,5 +1,6 @@
 """Google message types and conversion utilities."""
 
+import json
 from collections.abc import Iterator, Sequence
 from functools import lru_cache
 from typing import Literal
@@ -47,7 +48,7 @@ def _encode_content(content: Sequence[ContentPart]) -> list[genai_types.PartDict
                 {
                     "function_call": {
                         "name": part.name,
-                        "args": part.args,
+                        "args": json.loads(part.args),
                         "id": part.id,
                     }
                 }
@@ -97,7 +98,7 @@ def _decode_content_part(part: genai_types.Part) -> AssistantContentPart | None:
             )  # pragma: no cover
         if not id:
             id = name  # Google treats tool call ids as optional
-        return ToolCall(id=id, name=name, args=args)
+        return ToolCall(id=id, name=name, args=json.dumps(args))
     elif part.function_response:
         raise NotImplementedError(
             "function_response part does not decode to AssistantContent."

--- a/python/mirascope/llm/clients/openai/_utils.py
+++ b/python/mirascope/llm/clients/openai/_utils.py
@@ -1,6 +1,5 @@
 """OpenAI message types and conversion utilities."""
 
-import json
 from collections.abc import Sequence
 from functools import lru_cache
 from typing import Literal
@@ -77,7 +76,7 @@ def _encode_assistant_message(
                 openai_types.ChatCompletionMessageToolCallParam(
                     id=part.id,
                     type="function",
-                    function={"name": part.name, "arguments": json.dumps(part.args)},
+                    function={"name": part.name, "arguments": part.args},
                 )
             )
         else:
@@ -134,7 +133,7 @@ def _decode_assistant_message(
                 ToolCall(
                     id=tool_call.id,
                     name=tool_call.function.name,
-                    args=json.loads(tool_call.function.arguments),
+                    args=tool_call.function.arguments,
                 )
             )
 

--- a/python/mirascope/llm/content/tool_call.py
+++ b/python/mirascope/llm/content/tool_call.py
@@ -3,8 +3,6 @@
 from dataclasses import dataclass
 from typing import Literal
 
-from ..types import Jsonable
-
 
 @dataclass(kw_only=True)
 class ToolCall:
@@ -25,8 +23,8 @@ class ToolCall:
     name: str
     """The name of the tool to call."""
 
-    args: dict[str, Jsonable]
-    """The arguments to pass to the tool."""
+    args: str
+    """The arguments to pass to the tool, stored as stringified json."""
 
 
 @dataclass(kw_only=True)

--- a/python/mirascope/llm/tools/tool.py
+++ b/python/mirascope/llm/tools/tool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import TypeVar
@@ -50,7 +51,8 @@ class Tool(ToolSchema[P, JsonableCovariantT]):
 
     def execute(self, tool_call: ToolCall) -> ToolOutput[JsonableCovariantT]:
         """Execute the tool using an LLM-provided `ToolCall`."""
-        result = self.fn(**tool_call.args)  # type: ignore[reportCallIssue]
+        args = json.loads(tool_call.args)
+        result = self.fn(**args)  # type: ignore[reportCallIssue]
         return ToolOutput(id=tool_call.id, value=result, name=self.name)
 
     def __hash__(self) -> int:
@@ -93,7 +95,8 @@ class AsyncTool(ToolSchema[P, JsonableCovariantT]):
 
     async def execute(self, tool_call: ToolCall) -> ToolOutput[JsonableCovariantT]:
         """Execute the async tool using an LLM-provided `ToolCall`."""
-        result = await self.fn(**tool_call.args)  # type: ignore[reportCallIssue]
+        args = json.loads(tool_call.args)
+        result = await self.fn(**args)  # type: ignore[reportCallIssue]
         return ToolOutput(id=tool_call.id, value=result, name=self.name)
 
     def __hash__(self) -> int:

--- a/python/tests/llm/clients/anthropic/test_anthropic_client.py
+++ b/python/tests/llm/clients/anthropic/test_anthropic_client.py
@@ -163,7 +163,7 @@ def test_tool_usage(anthropic_client: llm.AnthropicClient) -> None:
         inspect.cleandoc("""\
         I'll help you multiply those numbers using the multiply_numbers tool.
 
-        **ToolCall (multiply_numbers):** {'a': 1337, 'b': 4242}
+        **ToolCall (multiply_numbers):** {"a": 1337, "b": 4242}
         """)
     )
 
@@ -173,7 +173,7 @@ def test_tool_usage(anthropic_client: llm.AnthropicClient) -> None:
         llm.ToolCall(
             id="toolu_01EcyDhLAzjUwsiXJrJieL1p",
             name="multiply_numbers",
-            args={"a": 1337, "b": 4242},
+            args='{"a": 1337, "b": 4242}',
         )
     )
 

--- a/python/tests/llm/clients/google/test_google_client.py
+++ b/python/tests/llm/clients/google/test_google_client.py
@@ -202,7 +202,7 @@ def test_tool_usage(google_client: llm.GoogleClient) -> None:
 
     assert isinstance(response, llm.Response)
     assert response.pretty() == snapshot(
-        "**ToolCall (multiply_numbers):** {'b': 4242, 'a': 1337}"
+        '**ToolCall (multiply_numbers):** {"b": 4242, "a": 1337}'
     )
 
     assert len(response.tool_calls) == 1
@@ -211,7 +211,7 @@ def test_tool_usage(google_client: llm.GoogleClient) -> None:
         llm.ToolCall(
             id="multiply_numbers",
             name="multiply_numbers",
-            args={"a": 1337, "b": 4242},
+            args='{"b": 4242, "a": 1337}',
         )
     )
 

--- a/python/tests/llm/clients/openai/cassettes/test_tool_usage.yaml
+++ b/python/tests/llm/clients/openai/cassettes/test_tool_usage.yaml
@@ -41,19 +41,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFPLbtswELzrK4g9W4UtK46gW/pAkeaQY4DUgUBTK4kpXyYpt67hfy9E
-        2ZLsJEB1EIgdzuzsg4eIEOAl5ARYQz2TRsRflvp+y75+3/nVM5e6aah8Vb8fhXn+9tfArGPozSsy
-        f2Z9YloagZ5r1cPMIvXYqS5ub27mSbrM0gBIXaLoaLXxcapjyRWPk3mSxvPbeJGd2I3mDB3k5GdE
-        CCGH8O98qhL/QE7ms3NEonO0RsiHS4SA1aKLAHWOO0+Vh9kIMq08qs66aoWYAF5rUTAqxJi4/w6T
-        89gsKkSRLsyT32V3Tz/Uw4O/397JR739TOeTfL303gRDVavY0KQJPsTzq2SEgKIycGUrPDdiX6hW
-        btC6Kw1CgNq6lah85x8Oa6BryBfL5e1sDZs15GmSJke4IB2j984vk6ZYrFpHxdtuUaW0p53p0K6X
-        E3IcJiN0bazeuCsqVFxx1xQWqQsFT/senY0EC9BejBaM1dL4wutfGJKusl4Uxu0bweS0I+C1p2KM
-        Z2fShVpRoqc8TH5YNkZZg+XIHJeOtiXXEyCaVP7WzHvaffVc1f8jPwKMofFYFsZiydllweM1i93b
-        /Oja0ONgGBzaHWdYeI62m0aJFW1F/2LA7Z1HWVRc1WiN5eHZQGWKVUKTJc0WWEF0jP4BAAD//wMA
-        5IizkkQEAAA=
+        H4sIAAAAAAAAAwAAAP//jFNdb5swFH3nV1j3OUyEkJDx2Kqa9iFV2UM2aamQYy7EnbE927TNovz3
+        CpMASTtpPCDrHp9zz/3wISAEeAEZAbajjtVahLez55/f3c1LKuO79eLb+kZ83U8Xa0Wf088OJi1D
+        bR+RuTPrA1O1Fui4kh3MDFKHreo0nc+j+SJKph6oVYGipVXahYkKay55GEdxEkZpOF2e2DvFGVrI
+        yK+AEEIO/t/6lAW+QEaiyTlSo7W0Qsj6S4SAUaKNALWWW0dl5/kEMiUdyta6bIQYAU4pkTMqxJC4
+        +w6j89AsKkSuVolepl/u1n/+Pt7TH6v7VfR0+6ncjfJ10nvtDZWNZH2TRngfz66SEQKS1p5bN8Jx
+        Lfa5bOotGnulQQhQUzU1Stf6h8MG6Aay6WyWTjaw3UCWxEl8hAvSMXjv/DBqisGysVS87RaVUjna
+        mvbtejghx34yQlXaqK29okLJJbe73CC1vuBx34OzEW8BmovRgjaq1i536jf6pItlJwrD9g1gfNoR
+        cMpRMcSXZ9KFWl6go9xPvl82RtkOi4E5LB1tCq5GQDCq/K2Z97S76rms/kd+ABhD7bDItcGCs8uC
+        h2sG27f5r2t9j71hsGieOMPccTTtNAosaSNOr9zurcM6L7ms0GjD/bOBUuezhM4Tih9nDIJj8AoA
+        AP//AwBA84MKRAQAAA==
     headers:
       CF-RAY:
-      - 96e222a118f708ba-SEA
+      - 96e5277fe893df23-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -61,14 +61,11 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 18:46:25 GMT
+      - Wed, 13 Aug 2025 03:34:01 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=Q5cFj8PAzGvG1xZehNinvI0ZC3G3tFYjZZNyhRADIPw-1755024385-1.0.1.1-XYcnbzl1Q3MzqXa3_YIh1wTmeAYRLG7o2mZsyVOBmYiKVgNY8wuNxo8uHry0BJEiD6yvxt9TbiwQ8lu.QMP11kkdUPZDnCg7Kqfs2s4JcL0;
-        path=/; expires=Tue, 12-Aug-25 19:16:25 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=G0IJ8SHIEbMLS0mTxjf1QeAKa.lpuV4ZRqB3.ntSG20-1755024385644-0.0.1.1-604800000;
+      - _cfuvid=OAaWaUzofyge3idcBymI3f8_9BoOpBqcewbmv0U0lK8-1755056041852-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -85,13 +82,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '781'
+      - '637'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1118'
+      - '682'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -105,14 +102,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_22976c778eb84fe7b23b4528cfab59f9
+      - req_1def7fac933845cb90ec01ecf715cf59
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"What is 1337 * 4242? Please use
-      the multiply_numbers tool."},{"role":"assistant","content":null,"tool_calls":[{"id":"call_41pWtv8AWJnKKtIqAmOoqBa0","type":"function","function":{"name":"multiply_numbers","arguments":"{\"a\":
-      1337, \"b\": 4242}"}}]},{"role":"tool","content":"42","tool_call_id":"call_41pWtv8AWJnKKtIqAmOoqBa0"}],"model":"gpt-4o-mini","tools":[{"type":"function","function":{"name":"multiply_numbers","description":"Multiply
+      the multiply_numbers tool."},{"role":"assistant","content":null,"tool_calls":[{"id":"call_oQ4p87JEVqzjOaWQOQ0vCGfh","type":"function","function":{"name":"multiply_numbers","arguments":"{\"a\":1337,\"b\":4242}"}}]},{"role":"tool","content":"42","tool_call_id":"call_oQ4p87JEVqzjOaWQOQ0vCGfh"}],"model":"gpt-4o-mini","tools":[{"type":"function","function":{"name":"multiply_numbers","description":"Multiply
       two numbers together.","parameters":{"properties":{"a":{"title":"A","type":"integer"},"b":{"title":"B","type":"integer"}},"required":["a","b"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
       accept:
@@ -122,12 +118,11 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '686'
+      - '683'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=Q5cFj8PAzGvG1xZehNinvI0ZC3G3tFYjZZNyhRADIPw-1755024385-1.0.1.1-XYcnbzl1Q3MzqXa3_YIh1wTmeAYRLG7o2mZsyVOBmYiKVgNY8wuNxo8uHry0BJEiD6yvxt9TbiwQ8lu.QMP11kkdUPZDnCg7Kqfs2s4JcL0;
-        _cfuvid=G0IJ8SHIEbMLS0mTxjf1QeAKa.lpuV4ZRqB3.ntSG20-1755024385644-0.0.1.1-604800000
+      - _cfuvid=OAaWaUzofyge3idcBymI3f8_9BoOpBqcewbmv0U0lK8-1755056041852-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -155,17 +150,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJJBa9wwEIXv/hWDjmUd1rI33t1jSg+hUCi09FCCUaSxrVbWqJIcGsL+
-        9yJ7s3bSFHrxYb554/dG85QBMK3YEZjsRZSDM/n7km49/9zdfP1Uc/z28Otw6w/Xj9XNx+KDY5uk
-        oPsfKOOz6krS4AxGTXbG0qOImKYW9W635VW5301gIIUmyToX84ryQVud8y2v8m2dF/uzuictMbAj
-        fM8AAJ6mb/JpFf5mR9hunisDhiA6ZMdLEwDzZFKFiRB0iMJGtlmgJBvRTta/9Agew2giUAtFWdbw
-        DipecdABKn61lnlsxyCSdTsaswLCWooiRZ8M353J6WLRUOc83YdXUtZqq0PfeBSBbLITIjk20VMG
-        cDetYnyRjjlPg4tNpJ84/e5Qz+PY8gALLHZnGCkKs6oXfPPGuEZhFNqE1S6ZFLJHtUiXxYtRaVqB
-        bBX6bzdvzZ6Da9v9z/gFSIkuomqcR6Xly8RLm8d0n/9quyx5MswC+gctsYkafXoIha0YzXw1LDyG
-        iEPTatuhd17Pp9O65poLXop9gS3LTtkfAAAA//8DANwQUMZIAwAA
+        H4sIAAAAAAAAAwAAAP//jFJNb9QwEL3nV4x8AmlT5Wsbdq8gOCBxaStVIlXkdSaJi2Mbe9IC1f53
+        5GS7SaFIXKJo3rzn92bmKQJgsmF7YKLnJAar4vf54+1Vue1vvP71+Tp9vPfZw4cvH2+vvn+6ObBN
+        YJjDPQp6Zl0IM1iFJI2eYeGQEwbVtNxuk+1lUmQTMJgGVaB1luLCxIPUMs6SrIiTMk7fndi9kQI9
+        28PXCADgafoGn7rBH2wPyea5MqD3vEO2PzcBMGdUqDDuvfTENbHNAgqjCfVk/bpHcOhHRWBaqKo3
+        kOZ5CVVFckAPRVZkUFVvQYb/i7WIw3b0PATRo1IrgGttiIdBTPbvTsjxbFiZzjpz8H9QWSu19H3t
+        kHujgzlPxrIJPUYAd9NgxhdZmXVmsFST+YbTc7tylmPLOhYw3Z1AMsTVqp5ebl6RqxskLpVfTZYJ
+        LnpsFuqyBj420qyAaBX6bzevac/Bpe7+R34BhEBL2NTWYSPFy8RLm8Nwrf9qOw95Msw8ugcpsCaJ
+        LiyiwZaPar4h5n96wqFupe7QWSfnQ2ptnRd8W3Dc5YJFx+g3AAAA//8DAKUgDnlWAwAA
     headers:
       CF-RAY:
-      - 96e222aa797f08ba-SEA
+      - 96e52785fdcfdf23-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -173,7 +168,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 12 Aug 2025 18:46:26 GMT
+      - Wed, 13 Aug 2025 03:34:02 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -191,13 +186,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '620'
+      - '550'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '676'
+      - '705'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -211,7 +206,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_02673766d17c4708b229cbe38dfe76a8
+      - req_7c3caff788924f45942d94f6534d1f92
     status:
       code: 200
       message: OK

--- a/python/tests/llm/clients/openai/test_openai_client.py
+++ b/python/tests/llm/clients/openai/test_openai_client.py
@@ -237,16 +237,16 @@ def test_tool_usage(openai_client: llm.OpenAIClient) -> None:
 
     assert isinstance(response, llm.Response)
     assert response.pretty() == snapshot(
-        "**ToolCall (multiply_numbers):** {'a': 1337, 'b': 4242}"
+        '**ToolCall (multiply_numbers):** {"a":1337,"b":4242}'
     )
 
     assert len(response.tool_calls) == 1
     tool_call = response.tool_calls[0]
     assert tool_call == snapshot(
         llm.ToolCall(
-            id="call_41pWtv8AWJnKKtIqAmOoqBa0",
+            id="call_oQ4p87JEVqzjOaWQOQ0vCGfh",
             name="multiply_numbers",
-            args={"a": 1337, "b": 4242},
+            args='{"a":1337,"b":4242}',
         )
     )
 
@@ -259,7 +259,9 @@ def test_tool_usage(openai_client: llm.OpenAIClient) -> None:
         tools=[multiply_numbers],
     )
 
-    assert final_response.pretty() == snapshot("The result of 1337 * 4242 is 42.")
+    assert final_response.pretty() == snapshot(
+        "The result of \\( 1337 \\times 4242 \\) is 42."
+    )
 
 
 @pytest.mark.vcr()

--- a/python/tests/llm/responses/test_response.py
+++ b/python/tests/llm/responses/test_response.py
@@ -58,7 +58,7 @@ def test_response_initialization_with_mixed_content() -> None:
     # Create final assistant message with mixed content
     mixed_content = [
         llm.Text(text="I'll help you with that."),
-        llm.ToolCall(id="call_1", name="test_tool", args={"param": "value"}),
+        llm.ToolCall(id="call_1", name="test_tool", args='{"param": "value"}'),
         llm.Thinking(thinking="Let me think about this", signature=None),
         llm.Text(text="Here's the result."),
     ]
@@ -81,7 +81,7 @@ def test_response_initialization_with_mixed_content() -> None:
 
     assert len(response.tool_calls) == 1
     assert response.tool_calls[0].name == "test_tool"
-    assert response.tool_calls[0].args == {"param": "value"}
+    assert response.tool_calls[0].args == '{"param": "value"}'
 
     assert len(response.thinkings) == 1
     assert response.thinkings[0].thinking == "Let me think about this"
@@ -197,7 +197,7 @@ def test_mixed_content_response_pretty() -> None:
                 signature="math_helper_v1",
             ),
             llm.ToolCall(
-                id="call_abc123", name="multiply_numbers", args={"a": 1337, "b": 4242}
+                id="call_abc123", name="multiply_numbers", args='{"a": 1337, "b": 4242}'
             ),
         ]
     )
@@ -212,14 +212,16 @@ def test_mixed_content_response_pretty() -> None:
     )
 
     assert response.pretty() == snapshot(
-        inspect.cleandoc("""
+        inspect.cleandoc(
+            """\
             I need to calculate something for you.
 
             **Thinking:**
               Let me think about this calculation step by step...
 
-            **ToolCall (multiply_numbers):** {'a': 1337, 'b': 4242}
-        """)
+            **ToolCall (multiply_numbers):** {"a": 1337, "b": 4242}
+            """
+        )
     )
 
 

--- a/python/tests/llm/tools/test_tool_decorator.py
+++ b/python/tests/llm/tools/test_tool_decorator.py
@@ -26,7 +26,7 @@ def test_sync_tool_basic() -> None:
 
     assert add_numbers(2, 3) == 5
 
-    tool_call = llm.ToolCall(id="call_123", name="add_numbers", args={"a": 5, "b": 7})
+    tool_call = llm.ToolCall(id="call_123", name="add_numbers", args='{"a": 5, "b": 7}')
     output = add_numbers.execute(tool_call)
     expected = llm.ToolOutput(id="call_123", value=12, name="add_numbers")
     assert output == expected
@@ -75,7 +75,7 @@ async def test_async_tool_basic() -> None:
 
     assert await async_add(3, 4) == 7
 
-    tool_call = llm.ToolCall(id="call_456", name="async_add", args={"a": 10, "b": 15})
+    tool_call = llm.ToolCall(id="call_456", name="async_add", args='{"a": 10, "b": 15}')
     output = await async_add.execute(tool_call)
     expected = llm.ToolOutput(id="call_456", value=25, name="async_add")
     assert output == expected


### PR DESCRIPTION
intention: ensure that processing a LLM response with tool calls can't
cause a validation error (even if llm provided invalid json). instead,
the validation error may occur when calling the tool, or potentially
(depending on provider) when attempting to include the malformed tool
call in a subsequent messsage to the llm.