### PR TITLE
nit: tweak ruff lint rules

### DIFF
--- a/python/mirascope/__init__.py
+++ b/python/mirascope/__init__.py
@@ -1,6 +1,5 @@
 """Mirascope v2 Beta."""
 
-from . import graphs as graphs
-from . import llm as llm
+from . import graphs as graphs, llm as llm
 
 __all__ = ["graphs", "llm"]

--- a/python/mirascope/graphs/finite_state_machine.py
+++ b/python/mirascope/graphs/finite_state_machine.py
@@ -7,7 +7,6 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from functools import wraps
 from typing import Any, Generic, ParamSpec, Protocol, overload
-
 from typing_extensions import TypeVar
 
 NoneType = type(None)

--- a/python/mirascope/llm/agents/decorator.py
+++ b/python/mirascope/llm/agents/decorator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol, overload
-
 from typing_extensions import Unpack
 
 from ..prompts import (

--- a/python/mirascope/llm/calls/_utils.py
+++ b/python/mirascope/llm/calls/_utils.py
@@ -15,8 +15,7 @@ from ..clients import (
     OpenAIParams,
     Provider,
 )
-from ..models import LLM
-from ..models import model as llm_factory
+from ..models import LLM, model as llm_factory
 
 
 def assumed_safe_llm_create(

--- a/python/mirascope/llm/calls/call_decorator.py
+++ b/python/mirascope/llm/calls/call_decorator.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Generic, Literal, cast, overload
-
 from typing_extensions import Unpack
 
 from ..models import LLM
-from ..prompts import AsyncPrompt, Prompt
-from ..prompts import _utils as _prompt_utils
+from ..prompts import AsyncPrompt, Prompt, _utils as _prompt_utils
 from ..tools import AsyncTool, Tool, ToolT
 from . import _utils
 from .call import AsyncCall, Call

--- a/python/mirascope/llm/calls/context_call_decorator.py
+++ b/python/mirascope/llm/calls/context_call_decorator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol, overload
-
 from typing_extensions import Unpack
 
 from ..prompts import (

--- a/python/mirascope/llm/clients/anthropic/_utils.py
+++ b/python/mirascope/llm/clients/anthropic/_utils.py
@@ -4,8 +4,7 @@ import json
 from collections.abc import Sequence
 from functools import lru_cache
 
-from anthropic import NotGiven
-from anthropic import types as anthropic_types
+from anthropic import NotGiven, types as anthropic_types
 from anthropic.lib.streaming import MessageStreamManager
 
 from ...content import (

--- a/python/mirascope/llm/clients/base/client.py
+++ b/python/mirascope/llm/clients/base/client.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from typing import Generic
-
 from typing_extensions import TypeVar
 
 from ...context import Context, DepsT

--- a/python/mirascope/llm/clients/openai/_utils.py
+++ b/python/mirascope/llm/clients/openai/_utils.py
@@ -5,8 +5,7 @@ from functools import lru_cache
 from typing import Literal
 
 from openai import NotGiven, Stream
-from openai.types import chat as openai_types
-from openai.types import shared_params as shared_openai_types
+from openai.types import chat as openai_types, shared_params as shared_openai_types
 from openai.types.shared_params.response_format_json_schema import JSONSchema
 
 from ...content import (

--- a/python/mirascope/llm/clients/openai/client.py
+++ b/python/mirascope/llm/clients/openai/client.py
@@ -7,13 +7,11 @@ import httpx
 from openai import OpenAI
 
 from ...context import Context, DepsT
-from ...formatting import FormatT
-from ...formatting import _utils as _formatting_utils
+from ...formatting import FormatT, _utils as _formatting_utils
 from ...messages import Message
 from ...responses import AsyncStreamResponse, Response, StreamResponse
 from ...tools import AsyncContextTool, AsyncTool, ContextTool, Tool
-from ..base import BaseClient
-from ..base import _utils as _base_utils
+from ..base import BaseClient, _utils as _base_utils
 from . import _utils
 from .models import OpenAIModel
 from .params import OpenAIParams

--- a/python/mirascope/llm/context/context.py
+++ b/python/mirascope/llm/context/context.py
@@ -3,7 +3,6 @@
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Generic
-
 from typing_extensions import TypeVar
 
 from ..messages import Message

--- a/python/mirascope/llm/formatting/types.py
+++ b/python/mirascope/llm/formatting/types.py
@@ -2,9 +2,9 @@
 
 from dataclasses import dataclass
 from typing import Literal, Protocol, runtime_checkable
+from typing_extensions import TypeVar
 
 from pydantic import BaseModel
-from typing_extensions import TypeVar
 
 FormatT = TypeVar("FormatT", bound=BaseModel | None, default=None)
 """Type variable for structured response format types.

--- a/python/mirascope/llm/models/model.py
+++ b/python/mirascope/llm/models/model.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, overload
-
 from typing_extensions import Unpack
 
 from ..clients import get_client

--- a/python/mirascope/llm/prompts/_utils.py
+++ b/python/mirascope/llm/prompts/_utils.py
@@ -1,5 +1,4 @@
 import inspect
-
 from typing_extensions import TypeIs
 
 from ..messages import (

--- a/python/mirascope/llm/streams/__init__.py
+++ b/python/mirascope/llm/streams/__init__.py
@@ -1,7 +1,6 @@
 """Streaming response classes."""
 
 from typing import TypeAlias
-
 from typing_extensions import TypeVar
 
 from .text_stream import AsyncTextStream, TextStream

--- a/python/mirascope/llm/tools/context_tool.py
+++ b/python/mirascope/llm/tools/context_tool.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 from collections.abc import Awaitable
 from typing import Any, Generic, Protocol, cast
-
 from typing_extensions import TypeVar
 
 from ..content import ToolCall, ToolOutput

--- a/python/mirascope/llm/tools/context_tool_decorator.py
+++ b/python/mirascope/llm/tools/context_tool_decorator.py
@@ -3,7 +3,6 @@
 import inspect
 from dataclasses import dataclass
 from typing import overload
-
 from typing_extensions import TypeIs
 
 from ..context import RequiredDepsT

--- a/python/mirascope/llm/tools/tool_decorator.py
+++ b/python/mirascope/llm/tools/tool_decorator.py
@@ -3,7 +3,6 @@
 import inspect
 from dataclasses import dataclass
 from typing import overload
-
 from typing_extensions import TypeIs
 
 from ..types import JsonableCovariantT, P

--- a/python/mirascope/llm/types/jsonable.py
+++ b/python/mirascope/llm/types/jsonable.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Mapping, Sequence
 from typing import Protocol, TypeAlias
-
 from typing_extensions import TypeVar
 
 

--- a/python/mirascope/llm/types/type_vars.py
+++ b/python/mirascope/llm/types/type_vars.py
@@ -1,7 +1,6 @@
 """Common TypeVar definitions for the LLM module."""
 
 from typing import TypeVar
-
 from typing_extensions import ParamSpec
 
 P = ParamSpec("P")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -135,6 +135,8 @@ line-ending = "auto"
 
 [tool.ruff.lint.isort]
 known-first-party = ['mirascope', 'tests', 'examples']
+extra-standard-library = ["typing_extensions"]
+combine-as-imports = true
 
 [tool.pyright]
 exclude = [".venv", "docs/node_modules", "build"]

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -5,10 +5,10 @@ mirascope test suite, including VCR configuration for HTTP recording/playback.
 """
 
 import os
+from typing_extensions import TypedDict
 
 import pytest
 from dotenv import load_dotenv
-from typing_extensions import TypedDict
 
 from mirascope import llm
 

--- a/python/typechecking/stream.py
+++ b/python/typechecking/stream.py
@@ -1,5 +1,4 @@
 from collections.abc import AsyncIterator, Iterator
-
 from typing_extensions import assert_never, assert_type
 
 from mirascope import llm


### PR DESCRIPTION
Adds the following ruff lint rules:

length-sort = true
length-sort-straight = true
combine-as-imports = true
extra-standard-library = ["typing_extensions"]