### PR TITLE
chore: remove agents from llm package (for now)

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -6,7 +6,6 @@ code that works with multiple LLM providers without changing your application lo
 """
 
 from . import (
-    agents,
     calls,
     clients,
     content,
@@ -21,7 +20,6 @@ from . import (
     tools,
     types,
 )
-from .agents import Agent, AgentTemplate, AsyncAgent, AsyncAgentTemplate, agent
 from .calls import call, context_call
 from .clients import AnthropicClient, GoogleClient, OpenAIClient
 from .content import (
@@ -94,14 +92,10 @@ from .tools import (
 __all__ = [
     "LLM",
     "APIError",
-    "Agent",
-    "AgentTemplate",
     "AnthropicClient",
     "AssistantContentChunk",
     "AssistantContentPart",
     "AssistantMessage",
-    "AsyncAgent",
-    "AsyncAgentTemplate",
     "AsyncChunkIterator",
     "AsyncContextResponse",
     "AsyncContextStreamResponse",
@@ -161,8 +155,6 @@ __all__ = [
     "Toolkit",
     "UserContentPart",
     "UserMessage",
-    "agent",
-    "agents",
     "call",
     "calls",
     "clients",

--- a/python/typechecking/agent.py
+++ b/python/typechecking/agent.py
@@ -1,4 +1,4 @@
-from mirascope import llm
+from mirascope.llm import agents
 
 from .utils import (
     Deps,
@@ -15,76 +15,78 @@ from .utils import (
 
 
 def test_agent_prompt_deps():
-    x1: llm.AgentTemplate[None] = llm.agent(  # noqa: F841
+    x1: agents.AgentTemplate[None] = agents.agent(  # noqa: F841
         provider="openai",
         model="gpt-4o-mini",
     )(prompt)
-    x2: llm.AgentTemplate[None] = llm.agent(  # noqa: F841
+    x2: agents.AgentTemplate[None] = agents.agent(  # noqa: F841
         provider="openai",
         model="gpt-4o-mini",
     )(context_prompt)
-    x3: llm.AgentTemplate[Deps] = llm.agent(  # noqa: F841
+    x3: agents.AgentTemplate[Deps] = agents.agent(  # noqa: F841
         provider="openai",
         model="gpt-4o-mini",
     )(context_prompt_deps)
 
 
 def test_sync_async_agent():
-    def expect_sync(x: llm.AgentTemplate): ...
-    def expect_async(x: llm.AsyncAgentTemplate): ...
+    def expect_sync(x: agents.AgentTemplate): ...
+    def expect_async(x: agents.AsyncAgentTemplate): ...
 
     expect_sync(
-        llm.agent(
+        agents.agent(
             provider="openai",
             model="gpt-4o-mini",
         )(prompt)
     )
-    expect_sync(llm.agent(provider="openai", model="gpt-4o-mini", tools=[tool])(prompt))
+    expect_sync(
+        agents.agent(provider="openai", model="gpt-4o-mini", tools=[tool])(prompt)
+    )
 
     # Expected type error: async tool can't be used with sync prompt
-    llm.agent(provider="openai", model="gpt-4o-mini", tools=[async_tool])(prompt)  # pyright: ignore[reportArgumentType]
+    agents.agent(provider="openai", model="gpt-4o-mini", tools=[async_tool])(prompt)  # pyright: ignore[reportArgumentType]
 
     expect_async(
-        llm.agent(
+        agents.agent(
             provider="openai",
             model="gpt-4o-mini",
         )(async_prompt)
     )
     expect_async(
-        llm.agent(provider="openai", model="gpt-4o-mini", tools=[async_tool])(
+        agents.agent(provider="openai", model="gpt-4o-mini", tools=[async_tool])(
             async_prompt
         )
     )
 
     # Expected type error: sync tool can't be used with async prompt
-    llm.agent(provider="openai", model="gpt-4o-mini", tools=[tool])(async_prompt)  # pyright: ignore[reportArgumentType]
+    agents.agent(provider="openai", model="gpt-4o-mini", tools=[tool])(async_prompt)  # pyright: ignore[reportArgumentType]
 
 
 def test_agent_tool_deps():
-    x1: llm.AgentTemplate[None] = llm.agent(  # noqa: F841
+    x1: agents.AgentTemplate[None] = agents.agent(  # noqa: F841
         provider="openai", model="gpt-4o-mini", tools=[context_tool]
     )(context_prompt)
 
-    x2: llm.AgentTemplate[Deps] = llm.agent(  # noqa: F841
+    x2: agents.AgentTemplate[Deps] = agents.agent(  # noqa: F841
         provider="openai", model="gpt-4o-mini", tools=[context_tool_deps]
     )(context_prompt_deps)
 
     # deps mismatch between the context_tool and the context_prompt_deps
-    llm.AgentTemplate = llm.agent(
+    agents.AgentTemplate = agents.agent(
         provider="openai", model="gpt-4o-mini", tools=[context_tool]
     )(
         context_prompt_deps  # pyright: ignore[reportArgumentType]
     )
 
     # type mismatch between tool_other_deps and context_prompt_deps
-    llm.AgentTemplate = llm.agent(
+    agents.AgentTemplate = agents.agent(
         provider="openai", model="gpt-4o-mini", tools=[tool_other_deps]
     )(
         context_prompt_deps  # pyright: ignore[reportArgumentType]
     )
 
     # deps mismatch between context_tool_deps and tool_other_deps
-    llm.AgentTemplate = llm.agent(
+    agents.AgentTemplate = agents.agent(
         provider="openai",
         model="gpt-4o-mini",
         tools=[context_tool_deps, tool_other_deps],


### PR DESCRIPTION
Forward prep for an experimental release where we will not want anyone
taking dependencies on agent decorator while we don't consider the
interface stable.

As shown in typepechcking examples, it's still possible to import
directly if really desired for testing purposes.