### PR TITLE
refactor: remove client arg from call decorator

### DIFF
--- a/python/mirascope/llm/calls/call_decorator.py
+++ b/python/mirascope/llm/calls/call_decorator.py
@@ -4,34 +4,27 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Generic, Literal, cast, overload
+from typing import Generic, Literal, cast, overload
 from typing_extensions import Unpack
 
+from ..clients import (
+    AnthropicModelId,
+    AnthropicParams,
+    BaseParams,
+    GoogleModelId,
+    GoogleParams,
+    ModelId,
+    OpenAIModelId,
+    OpenAIParams,
+    Provider,
+    get_client,
+)
+from ..formatting import FormatT
 from ..models import Model, _utils as _model_utils
 from ..prompts import AsyncPrompt, Prompt, _utils as _prompt_utils
-from ..tools import AsyncTool, Tool, ToolT
-from .call import AsyncCall, Call
-
-if TYPE_CHECKING:
-    from ..clients import (
-        AnthropicClient,
-        AnthropicModelId,
-        AnthropicParams,
-        BaseParams,
-        GoogleClient,
-        GoogleModelId,
-        GoogleParams,
-        ModelId,
-        OpenAIClient,
-        OpenAIModelId,
-        OpenAIParams,
-        Provider,
-    )
-
-
-from ..formatting import FormatT
-from ..tools import AsyncToolkit, Toolkit
+from ..tools import AsyncTool, AsyncToolkit, Tool, Toolkit, ToolT
 from ..types import P
+from .call import AsyncCall, Call
 
 
 @dataclass(kw_only=True)
@@ -83,7 +76,6 @@ def call(
     model_id: AnthropicModelId,
     tools: list[ToolT] | None = None,
     format: type[FormatT] | None = None,
-    client: AnthropicClient | None = None,
     **params: Unpack[AnthropicParams],
 ) -> CallDecorator[ToolT, FormatT]:
     """Decorate a prompt into a Call using Anthropic models."""
@@ -97,7 +89,6 @@ def call(
     model_id: GoogleModelId,
     tools: list[ToolT] | None = None,
     format: type[FormatT] | None = None,
-    client: GoogleClient | None = None,
     **params: Unpack[GoogleParams],
 ) -> CallDecorator[ToolT, FormatT]:
     """Decorate a prompt into a Call using Google models."""
@@ -111,7 +102,6 @@ def call(
     model_id: OpenAIModelId,
     tools: list[ToolT] | None = None,
     format: type[FormatT] | None = None,
-    client: OpenAIClient | None = None,
     **params: Unpack[OpenAIParams],
 ) -> CallDecorator[ToolT, FormatT]:
     """Decorate a prompt into a Call using OpenAI models."""
@@ -124,7 +114,6 @@ def call(
     model_id: ModelId,
     tools: list[ToolT] | None = None,
     format: type[FormatT] | None = None,
-    client: AnthropicClient | GoogleClient | OpenAIClient | None = None,
     **params: Unpack[BaseParams],
 ) -> CallDecorator[ToolT, FormatT]:
     """Returns a decorator for turning prompt template functions into generations.
@@ -146,6 +135,6 @@ def call(
         ```
     """
     llm = _model_utils.assumed_safe_llm_create(
-        provider=provider, model_id=model_id, client=client, params=params
+        provider=provider, model_id=model_id, client=get_client(provider), params=params
     )
     return CallDecorator(model=llm, tools=tools, format=format)

--- a/python/mirascope/llm/models/_utils.py
+++ b/python/mirascope/llm/models/_utils.py
@@ -53,7 +53,7 @@ def assumed_safe_llm_create(
                 model_id=model_id,
                 **params,
             )
-        case _:
+        case _:  # pragma: no cover
             raise ValueError(f"Unknown provider: {provider}")
 
     return model

--- a/python/tests/llm/calls/test_call_decorator.py
+++ b/python/tests/llm/calls/test_call_decorator.py
@@ -1,7 +1,5 @@
 """Tests for the call decorator function."""
 
-from unittest.mock import Mock
-
 import pytest
 from inline_snapshot import snapshot
 from pydantic import BaseModel
@@ -38,18 +36,12 @@ def async_tools() -> list[llm.AsyncTool]:
 
 
 @pytest.fixture
-def mock_client() -> Mock:
-    """Create a mock client for testing."""
-    return Mock()
-
-
-@pytest.fixture
 def params() -> llm.clients.BaseParams:
     return {"temperature": 0.7, "max_tokens": 100}
 
 
 def test_call_decorator_creation_openai(
-    tools: list[llm.Tool], mock_client: Mock, params: llm.clients.BaseParams
+    tools: list[llm.Tool], params: llm.clients.BaseParams
 ) -> None:
     """Test that call decorator creates CallDecorator with correct parameters for OpenAI."""
 
@@ -58,20 +50,18 @@ def test_call_decorator_creation_openai(
         model_id="gpt-4o-mini",
         tools=tools,
         format=Format,
-        client=mock_client,
         **params,
     )
 
     assert decorator.tools is tools
     assert decorator.format is Format
-    assert decorator.model.client is mock_client
     assert decorator.model.provider == "openai"
     assert decorator.model.model_id == "gpt-4o-mini"
     assert decorator.model.params == params
 
 
 def test_creating_sync_call(
-    tools: list[llm.Tool], mock_client: Mock, params: llm.clients.BaseParams
+    tools: list[llm.Tool], params: llm.clients.BaseParams
 ) -> None:
     """Test that call decorator creates CallDecorator with correct parameters for OpenAI."""
 
@@ -83,13 +73,11 @@ def test_creating_sync_call(
         model_id="gpt-4o-mini",
         tools=tools,
         format=Format,
-        client=mock_client,
         **params,
     )(prompt)
 
     assert isinstance(call, llm.calls.Call)
 
-    assert call.model.client is mock_client
     assert call.model.provider == "openai"
     assert call.model.model_id == "gpt-4o-mini"
     assert call.model.params == params
@@ -101,7 +89,7 @@ def test_creating_sync_call(
 
 @pytest.mark.asyncio
 async def test_creating_async_call(
-    async_tools: list[llm.AsyncTool], mock_client: Mock, params: llm.clients.BaseParams
+    async_tools: list[llm.AsyncTool], params: llm.clients.BaseParams
 ) -> None:
     """Test that call decorator creates CallDecorator with correct parameters for OpenAI."""
 
@@ -113,13 +101,11 @@ async def test_creating_async_call(
         model_id="gpt-4o-mini",
         tools=async_tools,
         format=Format,
-        client=mock_client,
         **params,
     )(async_prompt)
 
     assert isinstance(call, llm.calls.AsyncCall)
 
-    assert call.model.client is mock_client
     assert call.model.provider == "openai"
     assert call.model.model_id == "gpt-4o-mini"
     assert call.model.params == params


### PR DESCRIPTION
This is just a footgun since response.resume will not respect the client
passed to the call decorator. We will implement the client context
manager as the correct way to do this.

For now I left the client arg to llm.model as it does not present the same problem, however in the interest of just having one way to do things, it might be nice to unify on the client context manager as the only way to set the client.