### PR TITLE
fix: response.messages reflects format tool transformations

### DIFF
--- a/python/tests/llm/clients/anthropic/test_anthropic_client.py
+++ b/python/tests/llm/clients/anthropic/test_anthropic_client.py
@@ -119,34 +119,6 @@ The book is engaging for general readers while still being scholarly, making it 
                     ),
                 ],
             },
-            "tool_parallel_calls_scenario": {
-                "provider": "anthropic",
-                "model_id": "claude-sonnet-4-0",
-                "params": None,
-                "finish_reason": FinishReason.TOOL_USE,
-                "messages": [
-                    UserMessage(
-                        content=[Text(text="What's the weather in SF and NYC?")]
-                    ),
-                    AssistantMessage(
-                        content=[
-                            Text(
-                                text="I'll check the weather in both San Francisco (SF) and New York City (NYC) for you."
-                            ),
-                            ToolCall(
-                                id="toolu_01EbRtubydzFBtzduTciwJBv",
-                                name="get_weather",
-                                args='{"location": "SF"}',
-                            ),
-                            ToolCall(
-                                id="toolu_01YL2D6pdx5UL4zv17aMee5a",
-                                name="get_weather",
-                                args='{"location": "NYC"}',
-                            ),
-                        ]
-                    ),
-                ],
-            },
             "tool_single_output_scenario": {
                 "provider": "anthropic",
                 "model_id": "claude-sonnet-4-0",
@@ -177,6 +149,34 @@ The book is engaging for general readers while still being scholarly, making it 
                             Text(
                                 text="The weather in San Francisco (SF) is currently overcast with a temperature of 64°F."
                             )
+                        ]
+                    ),
+                ],
+            },
+            "tool_parallel_calls_scenario": {
+                "provider": "anthropic",
+                "model_id": "claude-sonnet-4-0",
+                "params": None,
+                "finish_reason": FinishReason.TOOL_USE,
+                "messages": [
+                    UserMessage(
+                        content=[Text(text="What's the weather in SF and NYC?")]
+                    ),
+                    AssistantMessage(
+                        content=[
+                            Text(
+                                text="I'll check the weather in both San Francisco (SF) and New York City (NYC) for you."
+                            ),
+                            ToolCall(
+                                id="toolu_01EbRtubydzFBtzduTciwJBv",
+                                name="get_weather",
+                                args='{"location": "SF"}',
+                            ),
+                            ToolCall(
+                                id="toolu_01YL2D6pdx5UL4zv17aMee5a",
+                                name="get_weather",
+                                args='{"location": "NYC"}',
+                            ),
                         ]
                     ),
                 ],

--- a/python/tests/llm/responses/test_response.py
+++ b/python/tests/llm/responses/test_response.py
@@ -393,6 +393,7 @@ def test_response_format_tool_handling() -> None:
     assert response.content[1] == llm.Text(
         text='{"title": "The Hobbit", "author": "J.R.R. Tolkien"}'
     )
+    assert response.messages[-1].content == response.content
 
     assert response.finish_reason == llm.FinishReason.END_TURN
 
@@ -437,6 +438,8 @@ def test_response_mixed_regular_and_format_tool() -> None:
     )
     assert response.content[1] == llm.Text(text='{"formatted": "output"}')
     assert response.content[2] == llm.Text(text="Done!")
+
+    assert response.messages[-1].content == response.content
 
     assert response.finish_reason == llm.FinishReason.END_TURN
 

--- a/python/tests/llm/responses/test_stream_response.py
+++ b/python/tests/llm/responses/test_stream_response.py
@@ -1177,12 +1177,11 @@ class TestFormatToolHandling:
         streamed_chunks = list(stream_response.chunk_stream())
 
         assert streamed_chunks == example_format_tool_chunks_processed
-        assert len(stream_response.texts) == 1
-        assert (
-            stream_response.texts[0].text
-            == '{"title": "The Hobbit", "author": "Tolkien"}'
+        assert stream_response.content == snapshot(
+            [llm.Text(text='{"title": "The Hobbit", "author": "Tolkien"}')]
         )
-        assert len(stream_response.tool_calls) == 0
+        assert stream_response.messages[-1].content == stream_response.content
+
         assert stream_response.finish_reason == llm.FinishReason.END_TURN
 
     def test_sync_mixed_regular_and_format_tools(
@@ -1197,14 +1196,18 @@ class TestFormatToolHandling:
         streamed_chunks = list(stream_response.chunk_stream())
 
         assert streamed_chunks == example_format_tool_chunks_mixed_processed
-        assert len(stream_response.tool_calls) == 1
-        assert stream_response.tool_calls[0].name == "ring_tool"
-        assert len(stream_response.texts) == 2
-        assert (
-            stream_response.texts[0].text
-            == '{"title": "The Hobbit", "author": "Tolkien"}'
+        assert stream_response.content == snapshot(
+            [
+                llm.ToolCall(
+                    id="call_007",
+                    name="ring_tool",
+                    args='{"ring_purpose": "to_rule_them_all"}',
+                ),
+                llm.Text(text='{"title": "The Hobbit", "author": "Tolkien"}'),
+                llm.Text(text="A wizard is never late."),
+            ]
         )
-        assert stream_response.texts[1].text == "A wizard is never late."
+        assert stream_response.messages[-1].content == stream_response.content
         assert stream_response.finish_reason == llm.FinishReason.END_TURN
 
     def test_sync_format_tool_no_finish_reason_change(
@@ -1241,12 +1244,10 @@ class TestFormatToolHandling:
         streamed_chunks = [chunk async for chunk in stream_response.chunk_stream()]
 
         assert streamed_chunks == example_format_tool_chunks_processed
-        assert len(stream_response.texts) == 1
-        assert (
-            stream_response.texts[0].text
-            == '{"title": "The Hobbit", "author": "Tolkien"}'
+        assert stream_response.content == snapshot(
+            [llm.Text(text='{"title": "The Hobbit", "author": "Tolkien"}')]
         )
-        assert len(stream_response.tool_calls) == 0
+        assert stream_response.messages[-1].content == stream_response.content
         assert stream_response.finish_reason == llm.FinishReason.END_TURN
 
     @pytest.mark.asyncio
@@ -1264,14 +1265,18 @@ class TestFormatToolHandling:
         streamed_chunks = [chunk async for chunk in stream_response.chunk_stream()]
 
         assert streamed_chunks == example_format_tool_chunks_mixed_processed
-        assert len(stream_response.tool_calls) == 1
-        assert stream_response.tool_calls[0].name == "ring_tool"
-        assert len(stream_response.texts) == 2
-        assert (
-            stream_response.texts[0].text
-            == '{"title": "The Hobbit", "author": "Tolkien"}'
+        assert stream_response.content == snapshot(
+            [
+                llm.ToolCall(
+                    id="call_007",
+                    name="ring_tool",
+                    args='{"ring_purpose": "to_rule_them_all"}',
+                ),
+                llm.Text(text='{"title": "The Hobbit", "author": "Tolkien"}'),
+                llm.Text(text="A wizard is never late."),
+            ]
         )
-        assert stream_response.texts[1].text == "A wizard is never late."
+        assert stream_response.messages[-1].content == stream_response.content
         assert stream_response.finish_reason == llm.FinishReason.END_TURN
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This was already the case for StreamResponse, updating Response to
match.