### PR TITLE
refactor: add union overloads to client/llm apis

### DIFF
--- a/python/mirascope/llm/clients/anthropic/client.py
+++ b/python/mirascope/llm/clients/anthropic/client.py
@@ -74,6 +74,17 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         params: AnthropicParams | None = None,
     ) -> Response[FormatT]: ...
 
+    @overload
+    def call(
+        self,
+        *,
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> Response | Response[FormatT]: ...
+
     def call(
         self,
         *,
@@ -140,6 +151,18 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         params: AnthropicParams | None = None,
     ) -> ContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormatT]: ...
+
     def context_call(
         self,
         *,
@@ -173,6 +196,17 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         format: type[FormatT],
         params: AnthropicParams | None = None,
     ) -> AsyncResponse[FormatT]: ...
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> AsyncResponse | AsyncResponse[FormatT]: ...
 
     async def call_async(
         self,
@@ -209,6 +243,18 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         params: AnthropicParams | None = None,
     ) -> AsyncContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormatT]: ...
+
     async def context_call_async(
         self,
         *,
@@ -242,6 +288,17 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         format: type[FormatT],
         params: AnthropicParams | None = None,
     ) -> StreamResponse[FormatT]: ...
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
 
     def stream(
         self,
@@ -309,6 +366,18 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         params: AnthropicParams | None = None,
     ) -> StreamResponse[FormatT]: ...
 
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
+
     def context_stream(
         self,
         *,
@@ -342,6 +411,17 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         format: type[FormatT],
         params: AnthropicParams | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     async def stream_async(
         self,
@@ -377,6 +457,18 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         format: type[FormatT],
         params: AnthropicParams | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: AnthropicModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: AnthropicParams | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     async def context_stream_async(
         self,

--- a/python/mirascope/llm/clients/base/client.py
+++ b/python/mirascope/llm/clients/base/client.py
@@ -61,6 +61,18 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         params: ParamsT | None = None,
     ) -> Response[FormatT]: ...
 
+    @overload
+    @abstractmethod
+    def call(
+        self,
+        *,
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> Response | Response[FormatT]: ...
+
     @abstractmethod
     def call(
         self,
@@ -100,6 +112,19 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         params: ParamsT | None = None,
     ) -> ContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    @abstractmethod
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormatT]: ...
+
     @abstractmethod
     def context_call(
         self,
@@ -137,6 +162,18 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         format: type[FormatT],
         params: ParamsT | None = None,
     ) -> AsyncResponse[FormatT]: ...
+
+    @overload
+    @abstractmethod
+    async def call_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> AsyncResponse | AsyncResponse[FormatT]: ...
 
     @abstractmethod
     async def call_async(
@@ -177,6 +214,19 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         params: ParamsT | None = None,
     ) -> AsyncContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    @abstractmethod
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormatT]: ...
+
     @abstractmethod
     async def context_call_async(
         self,
@@ -214,6 +264,18 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         format: type[FormatT],
         params: ParamsT | None = None,
     ) -> StreamResponse[FormatT]: ...
+
+    @overload
+    @abstractmethod
+    def stream(
+        self,
+        *,
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
 
     @abstractmethod
     def stream(
@@ -254,6 +316,19 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         params: ParamsT | None = None,
     ) -> StreamResponse[FormatT]: ...
 
+    @overload
+    @abstractmethod
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
+
     @abstractmethod
     def context_stream(
         self,
@@ -291,6 +366,18 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         format: type[FormatT],
         params: ParamsT | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    @abstractmethod
+    async def stream_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     @abstractmethod
     async def stream_async(
@@ -330,6 +417,19 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
         format: type[FormatT],
         params: ParamsT | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    @abstractmethod
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: ParamsT | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     @abstractmethod
     async def context_stream_async(

--- a/python/mirascope/llm/clients/google/client.py
+++ b/python/mirascope/llm/clients/google/client.py
@@ -78,6 +78,17 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         params: GoogleParams | None = None,
     ) -> Response[FormatT]: ...
 
+    @overload
+    def call(
+        self,
+        *,
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> Response | Response[FormatT]: ...
+
     def call(
         self,
         *,
@@ -139,6 +150,18 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         params: GoogleParams | None = None,
     ) -> ContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormatT]: ...
+
     def context_call(
         self,
         *,
@@ -172,6 +195,17 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         format: type[FormatT],
         params: GoogleParams | None = None,
     ) -> AsyncResponse[FormatT]: ...
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> AsyncResponse | AsyncResponse[FormatT]: ...
 
     async def call_async(
         self,
@@ -208,6 +242,18 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         params: GoogleParams | None = None,
     ) -> AsyncContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormatT]: ...
+
     async def context_call_async(
         self,
         *,
@@ -241,6 +287,17 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         format: type[FormatT],
         params: GoogleParams | None = None,
     ) -> StreamResponse[FormatT]: ...
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
 
     def stream(
         self,
@@ -300,6 +357,18 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         params: GoogleParams | None = None,
     ) -> StreamResponse[FormatT]: ...
 
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
+
     def context_stream(
         self,
         *,
@@ -333,6 +402,17 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         format: type[FormatT],
         params: GoogleParams | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     async def stream_async(
         self,
@@ -368,6 +448,18 @@ class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
         format: type[FormatT],
         params: GoogleParams | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GoogleModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: GoogleParams | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     async def context_stream_async(
         self,

--- a/python/mirascope/llm/clients/openai/client.py
+++ b/python/mirascope/llm/clients/openai/client.py
@@ -74,6 +74,17 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         params: OpenAIParams | None = None,
     ) -> Response[FormatT]: ...
 
+    @overload
+    def call(
+        self,
+        *,
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> Response | Response[FormatT]: ...
+
     def call(
         self,
         *,
@@ -139,6 +150,18 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         params: OpenAIParams | None = None,
     ) -> ContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormatT]: ...
+
     def context_call(
         self,
         *,
@@ -172,6 +195,17 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         format: type[FormatT],
         params: OpenAIParams | None = None,
     ) -> AsyncResponse[FormatT]: ...
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> AsyncResponse | AsyncResponse[FormatT]: ...
 
     async def call_async(
         self,
@@ -208,6 +242,18 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         params: OpenAIParams | None = None,
     ) -> AsyncContextResponse[DepsT, FormatT]: ...
 
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormatT]: ...
+
     async def context_call_async(
         self,
         *,
@@ -241,6 +287,17 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         format: type[FormatT],
         params: OpenAIParams | None = None,
     ) -> StreamResponse[FormatT]: ...
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
 
     def stream(
         self,
@@ -306,6 +363,18 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         params: OpenAIParams | None = None,
     ) -> StreamResponse[FormatT]: ...
 
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
+
     def context_stream(
         self,
         *,
@@ -339,6 +408,17 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         format: type[FormatT],
         params: OpenAIParams | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     async def stream_async(
         self,
@@ -374,6 +454,18 @@ class OpenAIClient(BaseClient[OpenAIParams, OpenAIModelId, OpenAI]):
         format: type[FormatT],
         params: OpenAIParams | None = None,
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]],
+        format: type[FormatT] | None,
+        params: OpenAIParams | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     async def context_stream_async(
         self,

--- a/python/mirascope/llm/models/model.py
+++ b/python/mirascope/llm/models/model.py
@@ -129,6 +129,15 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT],
     ) -> Response[FormatT]: ...
 
+    @overload
+    def call(
+        self,
+        *,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+    ) -> Response | Response[FormatT]: ...
+
     def call(
         self,
         *,
@@ -137,18 +146,11 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT] | None = None,
     ) -> Response | Response[FormatT]:
         """Generate a response using the model."""
-        if format:
-            return self.client.call(
-                model_id=self.model_id,
-                messages=messages,
-                tools=tools,
-                format=format,
-                params=self.params,
-            )
         return self.client.call(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
+            format=format,
             params=self.params,
         )
 
@@ -170,6 +172,15 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT],
     ) -> AsyncResponse[FormatT]: ...
 
+    @overload
+    async def call_async(
+        self,
+        *,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+    ) -> AsyncResponse | AsyncResponse[FormatT]: ...
+
     async def call_async(
         self,
         *,
@@ -178,19 +189,12 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT] | None = None,
     ) -> AsyncResponse | AsyncResponse[FormatT]:
         """Generate a response asynchronously using the model."""
-        if format:
-            return await self.client.call_async(
-                model_id=self.model_id,
-                messages=messages,
-                tools=tools,
-                format=format,
-                params=self.params,
-            )
         return await self.client.call_async(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
             params=self.params,
+            format=format,
         )
 
     @overload
@@ -211,6 +215,15 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT],
     ) -> StreamResponse[FormatT]: ...
 
+    @overload
+    def stream(
+        self,
+        *,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | None = None,
+        format: type[FormatT] | None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
+
     def stream(
         self,
         *,
@@ -219,18 +232,11 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT] | None = None,
     ) -> StreamResponse | StreamResponse[FormatT]:
         """Stream a response using the model."""
-        if format:
-            return self.client.stream(
-                model_id=self.model_id,
-                messages=messages,
-                tools=tools,
-                format=format,
-                params=self.params,
-            )
         return self.client.stream(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
+            format=format,
             params=self.params,
         )
 
@@ -252,6 +258,15 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT],
     ) -> AsyncStreamResponse[FormatT]: ...
 
+    @overload
+    async def stream_async(
+        self,
+        *,
+        messages: list[Message],
+        tools: Sequence[AsyncTool] | None = None,
+        format: type[FormatT] | None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
+
     async def stream_async(
         self,
         *,
@@ -260,18 +275,11 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT] | None = None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]:
         """Stream a response asynchronously using the model."""
-        if format:
-            return await self.client.stream_async(
-                model_id=self.model_id,
-                messages=messages,
-                tools=tools,
-                format=format,
-                params=self.params,
-            )
         return await self.client.stream_async(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
+            format=format,
             params=self.params,
         )
 
@@ -294,6 +302,16 @@ class Model(Generic[ClientT, ParamsT]):
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: type[FormatT],
     ) -> Response[FormatT]: ...
+
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        format: type[FormatT] | None,
+    ) -> Response | Response[FormatT]: ...
 
     def context_call(
         self,
@@ -326,6 +344,16 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT],
     ) -> Response[FormatT]: ...
 
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        format: type[FormatT] | None,
+    ) -> Response | Response[FormatT]: ...
+
     async def context_call_async(
         self,
         *,
@@ -357,6 +385,16 @@ class Model(Generic[ClientT, ParamsT]):
         format: type[FormatT],
     ) -> StreamResponse[FormatT]: ...
 
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        format: type[FormatT] | None,
+    ) -> StreamResponse | StreamResponse[FormatT]: ...
+
     def context_stream(
         self,
         *,
@@ -387,6 +425,16 @@ class Model(Generic[ClientT, ParamsT]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: type[FormatT],
     ) -> AsyncStreamResponse[FormatT]: ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        messages: list[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        format: type[FormatT] | None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormatT]: ...
 
     async def context_stream_async(
         self,

--- a/python/tests/llm/models/test_llm.py
+++ b/python/tests/llm/models/test_llm.py
@@ -102,13 +102,14 @@ def test_call(
     """Test that call method passes parameters correctly to client.call."""
     mock_client.call.return_value = mock_response
 
-    result = mocked_llm.call(messages=messages, tools=tools)
+    result: llm.Response = mocked_llm.call(messages=messages, tools=tools)
 
     mock_client.call.assert_called_once_with(
         model_id="gpt-4o-mini",
         messages=messages,
         tools=tools,
         params=params,
+        format=None,
     )
     assert result is mock_response
 
@@ -124,7 +125,9 @@ def test_structured_call(
     """Test that call method passes format parameter correctly to client.call."""
     mock_client.call.return_value = mock_response
 
-    result = mocked_llm.call(messages=messages, tools=tools, format=Format)
+    result: llm.Response[Format] = mocked_llm.call(
+        messages=messages, tools=tools, format=Format
+    )
 
     mock_client.call.assert_called_once_with(
         model_id="gpt-4o-mini",
@@ -148,13 +151,16 @@ async def test_call_async(
     """Test that call_async method passes parameters correctly to client.call_async."""
     mock_client.call_async = AsyncMock(return_value=mock_response)
 
-    result = await mocked_llm.call_async(messages=messages, tools=async_tools)
+    result: llm.AsyncResponse = await mocked_llm.call_async(
+        messages=messages, tools=async_tools
+    )
 
     mock_client.call_async.assert_called_once_with(
         model_id="gpt-4o-mini",
         messages=messages,
         tools=async_tools,
         params=params,
+        format=None,
     )
     assert result is mock_response
 
@@ -171,7 +177,7 @@ async def test_structured_call_async(
     """Test that call_async method passes format parameters correctly to client.call_async."""
     mock_client.call_async = AsyncMock(return_value=mock_response)
 
-    result = await mocked_llm.call_async(
+    result: llm.AsyncResponse[Format] = await mocked_llm.call_async(
         messages=messages, tools=async_tools, format=Format
     )
 
@@ -196,13 +202,14 @@ def test_stream(
     """Test that stream method passes parameters correctly to client.stream."""
     mock_client.stream.return_value = mock_stream_response
 
-    result = mocked_llm.stream(messages=messages, tools=tools)
+    result: llm.StreamResponse = mocked_llm.stream(messages=messages, tools=tools)
 
     mock_client.stream.assert_called_once_with(
         model_id="gpt-4o-mini",
         messages=messages,
         tools=tools,
         params=params,
+        format=None,
     )
     assert result is mock_stream_response
 
@@ -218,7 +225,9 @@ def test_structured_stream(
     """Test that stream method passes format parameters correctly to client.stream."""
     mock_client.stream.return_value = mock_stream_response
 
-    result = mocked_llm.stream(messages=messages, tools=tools, format=Format)
+    result: llm.StreamResponse[Format] = mocked_llm.stream(
+        messages=messages, tools=tools, format=Format
+    )
 
     mock_client.stream.assert_called_once_with(
         model_id="gpt-4o-mini",
@@ -242,13 +251,16 @@ async def test_stream_async(
     """Test that stream_async method passes parameters correctly to client.stream_async."""
     mock_client.stream_async = AsyncMock(return_value=mock_async_stream_response)
 
-    result = await mocked_llm.stream_async(messages=messages, tools=async_tools)
+    result: llm.AsyncStreamResponse = await mocked_llm.stream_async(
+        messages=messages, tools=async_tools
+    )
 
     mock_client.stream_async.assert_called_once_with(
         model_id="gpt-4o-mini",
         messages=messages,
         tools=async_tools,
         params=params,
+        format=None,
     )
     assert result is mock_async_stream_response
 
@@ -265,7 +277,7 @@ async def test_structured_stream_async(
     """Test that stream_async method passes format parameters correctly to client.stream_async."""
     mock_client.stream_async = AsyncMock(return_value=mock_async_stream_response)
 
-    result = await mocked_llm.stream_async(
+    result: llm.AsyncStreamResponse[Format] = await mocked_llm.stream_async(
         messages=messages, tools=async_tools, format=Format
     )
 


### PR DESCRIPTION
Rationale: This makes it actually type safe to write code like
`client.call(**kwargs)` where kwargs may include format.

We were already using this pattern in our test code, however the type
error was obscured because we were getting the kwargs typed as `Any` via
`request.getfixturevalue()`. Since the pattern is actually useful, we
should support it in a type-safe way. As an upside, we can also clean up
the LLM implementation.