### PR TITLE
nit: sazed examples don't specify mode

### DIFF
--- a/python/examples/sazed/sazed_async_context_structured.py
+++ b/python/examples/sazed/sazed_async_context_structured.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_async_stream_context_structured.py
+++ b/python/examples/sazed/sazed_async_stream_context_structured.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_async_stream_structured.py
+++ b/python/examples/sazed/sazed_async_stream_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_async_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_context_structured.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_async_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_async_structured.py
+++ b/python/examples/sazed/sazed_async_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_async_tools_context_structured.py
+++ b/python/examples/sazed/sazed_async_tools_context_structured.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_async_tools_structured.py
+++ b/python/examples/sazed/sazed_async_tools_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_context_structured.py
+++ b/python/examples/sazed/sazed_context_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_stream_context_structured.py
+++ b/python/examples/sazed/sazed_stream_context_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_stream_structured.py
+++ b/python/examples/sazed/sazed_stream_structured.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_context_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_structured.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_structured.py
+++ b/python/examples/sazed/sazed_structured.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_tools_context_structured.py
+++ b/python/examples/sazed/sazed_tools_context_structured.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/examples/sazed/sazed_tools_structured.py
+++ b/python/examples/sazed/sazed_tools_structured.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from mirascope import llm
 
 
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str

--- a/python/scripts/example_generator.ts
+++ b/python/scripts/example_generator.ts
@@ -90,7 +90,7 @@ ${this.main_function}${this.invoke_main}
   private get format_def(): string {
     if (!this.structured) return "";
     return `
-@llm.format(mode="strict-or-tool")
+@llm.format
 class KeeperEntry(BaseModel):
     topic: str
     summary: str


### PR DESCRIPTION
Prelude to getting rid of strict-or-tool; standard practice will be do
let the provider choose which mode to use