### PR TITLE
refactor: clients use cached singletons

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -24,7 +24,7 @@ from . import (
     types,
 )
 from .calls import call
-from .clients import AnthropicClient, GoogleClient, OpenAIClient, get_client
+from .clients import client, get_client
 from .content import (
     AssistantContentChunk,
     AssistantContentPart,
@@ -95,7 +95,6 @@ from .tools import (
 
 __all__ = [
     "APIError",
-    "AnthropicClient",
     "AssistantContentChunk",
     "AssistantContentPart",
     "AssistantMessage",
@@ -125,14 +124,12 @@ __all__ = [
     "Format",
     "FormattingMode",
     "FormattingModeNotSupportedError",
-    "GoogleClient",
     "Image",
     "ImageUrl",
     "Message",
     "MirascopeError",
     "Model",
     "NotFoundError",
-    "OpenAIClient",
     "Partial",
     "PermissionError",
     "RateLimitError",
@@ -163,6 +160,7 @@ __all__ = [
     "UserMessage",
     "call",
     "calls",
+    "client",
     "clients",
     "content",
     "exceptions",

--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -13,7 +13,7 @@ from .base import (
 )
 from .google import GoogleClient, GoogleModelId, GoogleParams
 from .openai import OpenAIClient, OpenAIModelId, OpenAIParams
-from .providers import ModelId, Provider, get_client
+from .providers import ModelId, Provider, client, get_client
 
 __all__ = [
     "AnthropicClient",
@@ -31,5 +31,6 @@ __all__ = [
     "OpenAIParams",
     "ParamsT",
     "Provider",
+    "client",
     "get_client",
 ]

--- a/python/mirascope/llm/clients/anthropic/__init__.py
+++ b/python/mirascope/llm/clients/anthropic/__init__.py
@@ -1,6 +1,6 @@
 """Anthropic client implementation."""
 
-from .client import AnthropicClient, get_anthropic_client
+from .clients import AnthropicClient, client, get_client
 from .model_ids import AnthropicModelId
 from .params import AnthropicParams
 
@@ -8,5 +8,6 @@ __all__ = [
     "AnthropicClient",
     "AnthropicModelId",
     "AnthropicParams",
-    "get_anthropic_client",
+    "client",
+    "get_client",
 ]

--- a/python/mirascope/llm/clients/google/__init__.py
+++ b/python/mirascope/llm/clients/google/__init__.py
@@ -1,7 +1,7 @@
 """Google client implementation."""
 
-from .client import GoogleClient, get_google_client
+from .clients import GoogleClient, client, get_client
 from .model_ids import GoogleModelId
 from .params import GoogleParams
 
-__all__ = ["GoogleClient", "GoogleModelId", "GoogleParams", "get_google_client"]
+__all__ = ["GoogleClient", "GoogleModelId", "GoogleParams", "client", "get_client"]

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -1,12 +1,13 @@
-"""Anthropic client implementation."""
+"""Google client implementation."""
 
 import os
 from collections.abc import Sequence
 from contextvars import ContextVar
+from functools import lru_cache
 from typing import overload
 
-import httpx
-from anthropic import Anthropic, AsyncAnthropic
+from google.genai import Client
+from google.genai.types import HttpOptions
 
 from ...context import Context, DepsT
 from ...formatting import Format, FormattableT
@@ -29,108 +30,126 @@ from ...tools import (
 )
 from ..base import BaseClient
 from . import _utils
-from .model_ids import AnthropicModelId
-from .params import AnthropicParams
+from .model_ids import GoogleModelId
+from .params import GoogleParams
 
-_global_client: "AnthropicClient | None" = None
-
-ANTHROPIC_CLIENT_CONTEXT: ContextVar["AnthropicClient | None"] = ContextVar(
-    "ANTHROPIC_CLIENT_CONTEXT", default=None
+GOOGLE_CLIENT_CONTEXT: ContextVar["GoogleClient | None"] = ContextVar(
+    "GOOGLE_CLIENT_CONTEXT", default=None
 )
 
 
-def get_anthropic_client() -> "AnthropicClient":
-    """Get a global Anthropic client instance.
+@lru_cache(maxsize=256)
+def _google_singleton(api_key: str | None, base_url: str | None) -> "GoogleClient":
+    """Return a cached Google client instance for the given parameters."""
+    return GoogleClient(api_key=api_key, base_url=base_url)
+
+
+def client(
+    *, api_key: str | None = None, base_url: str | None = None
+) -> "GoogleClient":
+    """Create or retrieve a Google client with the given parameters.
+
+    If a client has already been created with these parameters, it will be
+    retrieved from cache and returned.
+
+    Args:
+        api_key: API key for authentication. If None, uses GOOGLE_API_KEY env var.
+        base_url: Base URL for the API. If None, uses GOOGLE_BASE_URL env var.
 
     Returns:
-        An Anthropic client instance. Multiple calls return the same instance.
+        A Google client instance.
     """
-    ctx_client = ANTHROPIC_CLIENT_CONTEXT.get()
-    if ctx_client is not None:
-        return ctx_client
-
-    global _global_client
-    if _global_client is None:
-        api_key = os.getenv("ANTHROPIC_API_KEY")
-        _global_client = AnthropicClient(api_key=api_key)
-    return _global_client
+    api_key = api_key or os.getenv("GOOGLE_API_KEY")
+    base_url = base_url or os.getenv("GOOGLE_BASE_URL")
+    return _google_singleton(api_key, base_url)
 
 
-class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
-    """The client for the Anthropic LLM model."""
+def get_client() -> "GoogleClient":
+    """Retrieve the current Google client from context, or a global default.
+
+    Returns:
+        The current Google client from context if available, otherwise
+        a global default client based on environment variables.
+    """
+    ctx_client = GOOGLE_CLIENT_CONTEXT.get()
+    return ctx_client or client()
+
+
+class GoogleClient(BaseClient[GoogleParams, GoogleModelId, Client]):
+    """The client for the Google LLM model."""
 
     @property
-    def _context_var(self) -> ContextVar["AnthropicClient | None"]:
-        return ANTHROPIC_CLIENT_CONTEXT
+    def _context_var(self) -> ContextVar["GoogleClient | None"]:
+        return GOOGLE_CLIENT_CONTEXT
 
     def __init__(
-        self, *, api_key: str | None = None, base_url: str | httpx.URL | None = None
+        self, *, api_key: str | None = None, base_url: str | None = None
     ) -> None:
-        """Initialize the AnthropicClient with optional API key.
+        """Initialize the Google client."""
+        http_options = None
+        if base_url:
+            http_options = HttpOptions(base_url=base_url)
 
-        If api_key is not set, Anthropic will look for it in env as "ANTHROPIC_API_KEY".
-        """
-        self.client = Anthropic(api_key=api_key, base_url=base_url)
-        self.async_client = AsyncAnthropic(api_key=api_key, base_url=base_url)
+        self.client = Client(api_key=api_key, http_options=http_options)
 
     @overload
     def call(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> Response: ...
 
     @overload
     def call(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> Response[FormattableT]: ...
 
     @overload
     def call(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> Response | Response[FormattableT]: ...
 
     def call(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> Response | Response[FormattableT]:
-        """Make a call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make a call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_response = self.client.messages.create(**kwargs)
+        google_response = self.client.models.generate_content(
+            model=model_id,
+            contents=contents,
+            config=config,
+        )
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(google_response)
 
         return Response(
-            raw=anthropic_response,
-            provider="anthropic",
+            raw=google_response,
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,
@@ -145,11 +164,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextResponse[DepsT, None]: ...
 
     @overload
@@ -157,11 +176,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextResponse[DepsT, FormattableT]: ...
 
     @overload
@@ -169,39 +188,39 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
 
     def context_call(
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
-        """Make a call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make a call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_response = self.client.messages.create(**kwargs)
+        google_response = self.client.models.generate_content(
+            model=model_id,
+            contents=contents,
+            config=config,
+        )
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(google_response)
 
         return ContextResponse(
-            raw=anthropic_response,
-            provider="anthropic",
+            raw=google_response,
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,
@@ -215,60 +234,60 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
     async def call_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncResponse: ...
 
     @overload
     async def call_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncResponse[FormattableT]: ...
 
     @overload
     async def call_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
 
     async def call_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
-        """Make an async call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make an async call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_response = await self.async_client.messages.create(**kwargs)
+        google_response = await self.client.aio.models.generate_content(
+            model=model_id,
+            contents=contents,
+            config=config,
+        )
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(google_response)
 
         return AsyncResponse(
-            raw=anthropic_response,
-            provider="anthropic",
+            raw=google_response,
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,
@@ -283,11 +302,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncContextResponse[DepsT, None]: ...
 
     @overload
@@ -295,11 +314,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncContextResponse[DepsT, FormattableT]: ...
 
     @overload
@@ -307,11 +326,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> (
         AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]
     ): ...
@@ -320,28 +339,28 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
-        """Make an async call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make an async call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_response = await self.async_client.messages.create(**kwargs)
+        google_response = await self.client.aio.models.generate_content(
+            model=model_id,
+            contents=contents,
+            config=config,
+        )
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(google_response)
 
         return AsyncContextResponse(
-            raw=anthropic_response,
-            provider="anthropic",
+            raw=google_response,
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,
@@ -355,61 +374,59 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
     def stream(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> StreamResponse: ...
 
     @overload
     def stream(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> StreamResponse[FormattableT]: ...
 
     @overload
     def stream(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> StreamResponse | StreamResponse[FormattableT]: ...
 
     def stream(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> StreamResponse | StreamResponse[FormattableT]:
-        """Make a streaming call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make a streaming call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_stream = self.client.messages.stream(**kwargs)
-
-        chunk_iterator = _utils.convert_anthropic_stream_to_chunk_iterator(
-            anthropic_stream
+        google_stream = self.client.models.generate_content_stream(
+            model=model_id,
+            contents=contents,
+            config=config,
         )
+
+        chunk_iterator = _utils.convert_google_stream_to_chunk_iterator(google_stream)
 
         return StreamResponse(
-            provider="anthropic",
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,
@@ -423,11 +440,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextStreamResponse[DepsT]: ...
 
     @overload
@@ -435,11 +452,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextStreamResponse[DepsT, FormattableT]: ...
 
     @overload
@@ -447,40 +464,38 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]: ...
 
     def context_stream(
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
-        """Make a streaming call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make a streaming call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_stream = self.client.messages.stream(**kwargs)
-
-        chunk_iterator = _utils.convert_anthropic_stream_to_chunk_iterator(
-            anthropic_stream
+        google_stream = self.client.models.generate_content_stream(
+            model=model_id,
+            contents=contents,
+            config=config,
         )
+
+        chunk_iterator = _utils.convert_google_stream_to_chunk_iterator(google_stream)
 
         return ContextStreamResponse(
-            provider="anthropic",
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,
@@ -493,61 +508,61 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
     async def stream_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncStreamResponse: ...
 
     @overload
     async def stream_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncStreamResponse[FormattableT]: ...
 
     @overload
     async def stream_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
 
     async def stream_async(
         self,
         *,
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
-        """Make an async streaming call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make an async streaming call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_stream = self.async_client.messages.stream(**kwargs)
+        google_stream = await self.client.aio.models.generate_content_stream(
+            model=model_id,
+            contents=contents,
+            config=config,
+        )
 
-        chunk_iterator = _utils.convert_anthropic_stream_to_async_chunk_iterator(
-            anthropic_stream
+        chunk_iterator = _utils.convert_google_stream_to_async_chunk_iterator(
+            google_stream
         )
 
         return AsyncStreamResponse(
-            provider="anthropic",
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,
@@ -561,11 +576,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncContextStreamResponse[DepsT]: ...
 
     @overload
@@ -573,11 +588,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT],
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
 
     @overload
@@ -585,11 +600,11 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> (
         AsyncContextStreamResponse | AsyncContextStreamResponse[DepsT, FormattableT]
     ): ...
@@ -598,29 +613,29 @@ class AnthropicClient(BaseClient[AnthropicParams, AnthropicModelId, Anthropic]):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: AnthropicModelId,
+        model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
-        params: AnthropicParams | None = None,
+        params: GoogleParams | None = None,
     ) -> AsyncContextStreamResponse | AsyncContextStreamResponse[DepsT, FormattableT]:
-        """Make an async streaming call to the Anthropic API."""
-        input_messages, format, kwargs = _utils.prepare_anthropic_request(
-            model_id=model_id,
-            messages=messages,
-            tools=tools,
-            format=format,
-            params=params,
+        """Make an async streaming call to the Google GenAI API."""
+        input_messages, format, contents, config = _utils.prepare_google_request(
+            model_id, messages, tools, format, params=params
         )
 
-        anthropic_stream = self.async_client.messages.stream(**kwargs)
+        google_stream = await self.client.aio.models.generate_content_stream(
+            model=model_id,
+            contents=contents,
+            config=config,
+        )
 
-        chunk_iterator = _utils.convert_anthropic_stream_to_async_chunk_iterator(
-            anthropic_stream
+        chunk_iterator = _utils.convert_google_stream_to_async_chunk_iterator(
+            google_stream
         )
 
         return AsyncContextStreamResponse(
-            provider="anthropic",
+            provider="google",
             model_id=model_id,
             params=params,
             tools=tools,

--- a/python/mirascope/llm/clients/openai/__init__.py
+++ b/python/mirascope/llm/clients/openai/__init__.py
@@ -1,7 +1,7 @@
 """OpenAI client implementation."""
 
-from .client import OpenAIClient, get_openai_client
+from .clients import OpenAIClient, client, get_client
 from .model_ids import OpenAIModelId
 from .params import OpenAIParams
 
-__all__ = ["OpenAIClient", "OpenAIModelId", "OpenAIParams", "get_openai_client"]
+__all__ = ["OpenAIClient", "OpenAIModelId", "OpenAIParams", "client", "get_client"]

--- a/python/mirascope/llm/clients/providers.py
+++ b/python/mirascope/llm/clients/providers.py
@@ -3,10 +3,21 @@ from typing import Literal, TypeAlias, overload
 from .anthropic import (
     AnthropicClient,
     AnthropicModelId,
-    get_anthropic_client,
+    client as anthropic_client,
+    get_client as get_anthropic_client,
 )
-from .google import GoogleClient, GoogleModelId, get_google_client
-from .openai import OpenAIClient, OpenAIModelId, get_openai_client
+from .google import (
+    GoogleClient,
+    GoogleModelId,
+    client as google_client,
+    get_client as get_google_client,
+)
+from .openai import (
+    OpenAIClient,
+    OpenAIModelId,
+    client as openai_client,
+    get_client as get_openai_client,
+)
 
 Provider: TypeAlias = Literal["openai", "anthropic", "google"]
 ModelId: TypeAlias = OpenAIModelId | AnthropicModelId | GoogleModelId | str
@@ -57,4 +68,64 @@ def get_client(provider: Provider) -> AnthropicClient | GoogleClient | OpenAICli
         case "google":
             return get_google_client()
         case _:
+            raise ValueError(f"Unknown provider: {provider}")
+
+
+@overload
+def client(
+    provider: Literal["openai"],
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> OpenAIClient:
+    """Create a cached OpenAI client with the given parameters."""
+    ...
+
+
+@overload
+def client(
+    provider: Literal["anthropic"],
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> AnthropicClient:
+    """Create a cached Anthropic client with the given parameters."""
+    ...
+
+
+@overload
+def client(
+    provider: Literal["google"],
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> GoogleClient:
+    """Create a cached Google client with the given parameters."""
+    ...
+
+
+def client(
+    provider: Provider, *, api_key: str | None = None, base_url: str | None = None
+) -> AnthropicClient | GoogleClient | OpenAIClient:
+    """Create a cached client instance for the specified provider.
+
+    Args:
+        provider: The provider name ("openai", "anthropic", or "google").
+        api_key: API key for authentication. If None, uses provider-specific env var.
+        base_url: Base URL for the API. If None, uses provider-specific env var.
+
+    Returns:
+        A cached client instance for the specified provider with the given parameters.
+
+    Raises:
+        ValueError: If the provider is not supported.
+    """
+    match provider:
+        case "openai":
+            return openai_client(api_key=api_key, base_url=base_url)
+        case "anthropic":
+            return anthropic_client(api_key=api_key, base_url=base_url)
+        case "google":
+            return google_client(api_key=api_key, base_url=base_url)
+        case _:  # pragma: no cover
             raise ValueError(f"Unknown provider: {provider}")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -106,19 +106,18 @@ def openai_api_key() -> str:
 
 
 @pytest.fixture(scope="session")
-def anthropic_client(anthropic_api_key: str) -> llm.AnthropicClient:
+def anthropic_client(anthropic_api_key: str) -> llm.clients.AnthropicClient:
     """Create an AnthropicClient instance with appropriate API key."""
-    return llm.clients.AnthropicClient(api_key=anthropic_api_key)
-
-
-# Use function scope to work around Google async "event loop closed" issues
-@pytest.fixture(scope="function")
-def google_client(google_api_key: str) -> llm.GoogleClient:
-    """Create a GoogleClient instance with appropriate API key."""
-    return llm.clients.GoogleClient(api_key=google_api_key)
+    return llm.client("anthropic", api_key=anthropic_api_key)
 
 
 @pytest.fixture(scope="session")
-def openai_client(openai_api_key: str) -> llm.OpenAIClient:
+def google_client(google_api_key: str) -> llm.clients.GoogleClient:
+    """Create a GoogleClient instance with appropriate API key."""
+    return llm.client("google", api_key=google_api_key)
+
+
+@pytest.fixture(scope="session")
+def openai_client(openai_api_key: str) -> llm.clients.OpenAIClient:
     """Create an OpenAIClient instance with appropriate API key."""
-    return llm.clients.OpenAIClient(api_key=openai_api_key)
+    return llm.client("openai", api_key=openai_api_key)

--- a/python/tests/llm/clients/anthropic/test_client.py
+++ b/python/tests/llm/clients/anthropic/test_client.py
@@ -8,8 +8,8 @@ def test_context_manager() -> None:
 
     global_client = llm.get_client("anthropic")
 
-    client1 = llm.AnthropicClient(api_key="key1")
-    client2 = llm.AnthropicClient(api_key="key2")
+    client1 = llm.client("anthropic", api_key="key1")
+    client2 = llm.client("anthropic", api_key="key2")
 
     assert llm.get_client("anthropic") is global_client
 
@@ -24,3 +24,28 @@ def test_context_manager() -> None:
         assert llm.get_client("anthropic") is client1
 
     assert llm.get_client("anthropic") is global_client
+
+
+def test_client_caching() -> None:
+    """Test that client() returns cached instances for identical parameters."""
+    client1 = llm.client(
+        "anthropic", api_key="test-key", base_url="https://api.example.com"
+    )
+    client2 = llm.client(
+        "anthropic", api_key="test-key", base_url="https://api.example.com"
+    )
+    assert client1 is client2
+
+    client3 = llm.client(
+        "anthropic", api_key="different-key", base_url="https://api.example.com"
+    )
+    assert client1 is not client3
+
+    client4 = llm.client(
+        "anthropic", api_key="test-key", base_url="https://different.example.com"
+    )
+    assert client1 is not client4
+
+    client5 = llm.client("anthropic", api_key=None, base_url=None)
+    client6 = llm.get_client("anthropic")
+    assert client5 is client6

--- a/python/tests/llm/clients/openai/test_client.py
+++ b/python/tests/llm/clients/openai/test_client.py
@@ -70,8 +70,8 @@ def test_context_manager() -> None:
 
     global_client = llm.get_client("openai")
 
-    client1 = llm.OpenAIClient(api_key="key1")
-    client2 = llm.OpenAIClient(api_key="key2")
+    client1 = llm.client("openai", api_key="key1")
+    client2 = llm.client("openai", api_key="key2")
 
     assert llm.get_client("openai") is global_client
 
@@ -86,3 +86,28 @@ def test_context_manager() -> None:
         assert llm.get_client("openai") is client1
 
     assert llm.get_client("openai") is global_client
+
+
+def test_client_caching() -> None:
+    """Test that client() returns cached instances for identical parameters."""
+    client1 = llm.client(
+        "openai", api_key="test-key", base_url="https://api.example.com"
+    )
+    client2 = llm.client(
+        "openai", api_key="test-key", base_url="https://api.example.com"
+    )
+    assert client1 is client2
+
+    client3 = llm.client(
+        "openai", api_key="different-key", base_url="https://api.example.com"
+    )
+    assert client1 is not client3
+
+    client4 = llm.client(
+        "openai", api_key="test-key", base_url="https://different.example.com"
+    )
+    assert client1 is not client4
+
+    client5 = llm.client("openai", api_key=None, base_url=None)
+    client6 = llm.get_client("openai")
+    assert client5 is client6

--- a/python/tests/llm/models/test_model.py
+++ b/python/tests/llm/models/test_model.py
@@ -17,7 +17,7 @@ def test_client_pulled_from_context_at_call_time() -> None:
     """Test that models get client at call time, not construction time."""
     model = llm.model(provider="openai", model_id="gpt-4o")
 
-    custom_client = llm.OpenAIClient(api_key="test-key")
+    custom_client = llm.client("openai", api_key="test-key")
 
     mock_call = MagicMock(return_value=MagicMock())
     custom_client.call = mock_call

--- a/python/tests/llm/responses/test_response_resume.py
+++ b/python/tests/llm/responses/test_response_resume.py
@@ -8,7 +8,7 @@ from mirascope import llm
 
 
 @pytest.mark.vcr()
-def test_response_resume_basic(openai_client: llm.OpenAIClient) -> None:
+def test_response_resume_basic(openai_client: llm.clients.OpenAIClient) -> None:
     """Test basic resume functionality with text content."""
     messages = [
         llm.messages.system("You are concise."),
@@ -41,7 +41,7 @@ Because he was outstanding in his field!\
 
 
 @pytest.mark.vcr()
-def test_response_resume_with_tools(openai_client: llm.OpenAIClient) -> None:
+def test_response_resume_with_tools(openai_client: llm.clients.OpenAIClient) -> None:
     """Test resume functionality after tool usage."""
 
     @llm.tool
@@ -68,7 +68,7 @@ def test_response_resume_with_tools(openai_client: llm.OpenAIClient) -> None:
 
 
 @pytest.mark.vcr()
-def test_response_resume_with_format(openai_client: llm.OpenAIClient) -> None:
+def test_response_resume_with_format(openai_client: llm.clients.OpenAIClient) -> None:
     """Test resume functionality with structured output formats."""
 
     class Book(BaseModel):
@@ -106,7 +106,7 @@ def test_response_resume_with_format(openai_client: llm.OpenAIClient) -> None:
 
 @pytest.mark.vcr()
 def test_response_resume_model_override(
-    openai_client: llm.OpenAIClient, anthropic_client: llm.AnthropicClient
+    openai_client: llm.clients.OpenAIClient,
 ) -> None:
     """Test resume functionality with model override using context manager."""
 

--- a/python/tests/llm/responses/test_stream_response_resume.py
+++ b/python/tests/llm/responses/test_stream_response_resume.py
@@ -8,7 +8,7 @@ from mirascope import llm
 
 
 @pytest.mark.vcr()
-def test_stream_response_resume_basic(openai_client: llm.OpenAIClient) -> None:
+def test_stream_response_resume_basic(openai_client: llm.clients.OpenAIClient) -> None:
     """Test basic resume functionality with text content."""
     messages = [
         llm.messages.system("You are concise."),
@@ -43,7 +43,9 @@ Because he was outstanding in his field!\
 
 
 @pytest.mark.vcr()
-def test_stream_response_resume_with_tools(openai_client: llm.OpenAIClient) -> None:
+def test_stream_response_resume_with_tools(
+    openai_client: llm.clients.OpenAIClient,
+) -> None:
     """Test resume functionality after tool usage."""
 
     @llm.tool
@@ -75,7 +77,9 @@ def test_stream_response_resume_with_tools(openai_client: llm.OpenAIClient) -> N
 
 
 @pytest.mark.vcr()
-def test_stream_response_resume_with_format(openai_client: llm.OpenAIClient) -> None:
+def test_stream_response_resume_with_format(
+    openai_client: llm.clients.OpenAIClient,
+) -> None:
     """Test resume functionality with structured output formats."""
 
     class Book(BaseModel):
@@ -116,7 +120,7 @@ def test_stream_response_resume_with_format(openai_client: llm.OpenAIClient) -> 
 
 @pytest.mark.vcr()
 def test_stream_response_resume_model_override(
-    openai_client: llm.OpenAIClient, anthropic_client: llm.AnthropicClient
+    openai_client: llm.clients.OpenAIClient,
 ) -> None:
     """Test resume functionality with model override using context manager."""
 
@@ -146,7 +150,7 @@ def test_stream_response_resume_model_override(
 
 @pytest.mark.vcr()
 def test_stream_response_partial_consumption_resume(
-    openai_client: llm.OpenAIClient,
+    openai_client: llm.clients.OpenAIClient,
 ) -> None:
     """Test resume functionality when stream is only partially consumed."""
 


### PR DESCRIPTION
`llm.get_client(provider)` gets the client for that provider from the context manager, or constructs/retrieves the default client for that provider if there's nothing in context.

`llm.client(provider, api_key? base_url?)` retrieves the client matching those details from cache (if present), or constructs a new client and adds it to cache otherwise.

We now can retrieve both API key and base url from environment variables for consistency.

Client files renamed from `client.py` to `clients.py` to disambiguate from the `client` method for each provider.

As with `llm.Model` not allowing bare usage of `Model()`, you can't directly instantiate the clients, it's a type error to do so.

Removed `llm.OpenAIClient` etc from the top level namespace now that `llm.client()` or `llm.get_client()` are the right entry points. This will avoid future pollution esp. with multiple "virtual providers" like `OpenAIResponsesClient` and `OpenAIChatCompletionsClient` or however we name things.