### PR TITLE
refactor: unify format tool creation logic

### DIFF
--- a/python/mirascope/llm/formatting/_utils.py
+++ b/python/mirascope/llm/formatting/_utils.py
@@ -3,8 +3,8 @@
 import inspect
 import json
 
-from ..tools import FORMAT_TOOL_NAME
-from .types import FormattingMode
+from ..tools import FORMAT_TOOL_NAME, ToolParameterSchema, ToolSchema
+from .types import Format, FormattableT, FormattingMode
 
 TOOL_MODE_INSTRUCTIONS = f"""Always respond to the user's query using the {FORMAT_TOOL_NAME} tool for structured output."""
 
@@ -25,3 +25,50 @@ def default_formatting_instructions(
         json_schema = json.dumps(schema, indent=2)
         instructions = JSON_MODE_INSTRUCTIONS.format(json_schema=json_schema)
         return inspect.cleandoc(instructions)
+
+
+def create_tool_schema(format: Format[FormattableT]) -> ToolSchema:
+    """Convert a `Format` to a `ToolSchema` for format parsing.
+
+    Args:
+        format: The `Format` instance containing schema and metadata
+
+    Returns:
+        `ToolSchema` for the format tool
+    """
+
+    schema_dict = format.schema.copy()
+    schema_dict["type"] = "object"
+
+    properties = schema_dict.get("properties")
+    if not properties or not isinstance(properties, dict):
+        properties = {}  # pragma: no cover
+    required = list(properties.keys())
+
+    description = (
+        f"Use this tool to extract data in {format.name} format for a final response."
+    )
+    if format.description:
+        description += "\n" + format.description
+
+    parameters = ToolParameterSchema(
+        properties=properties,
+        required=required,
+        additionalProperties=False,
+    )
+    if "$defs" in schema_dict and isinstance(schema_dict["$defs"], dict):
+        parameters.defs = schema_dict["$defs"]
+
+    def _unused_format_fn() -> None:
+        raise TypeError(
+            "Format tool function should not be called."
+        )  # pragma: no cover
+
+    tool_schema = ToolSchema.__new__(ToolSchema)
+    tool_schema.fn = _unused_format_fn
+    tool_schema.name = FORMAT_TOOL_NAME
+    tool_schema.description = description
+    tool_schema.parameters = parameters
+    tool_schema.strict = True
+
+    return tool_schema

--- a/python/tests/e2e/cassettes/structured_output/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/async.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '936'
+      - '1117'
       content-type:
       - application/json
       host:
@@ -50,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFFdSwMxEPwrZZ9TuCttxbyJVmrh/AYpIiHm1rvQu+Sa3Si23H+XnFRR
-        8W2zMzs7md2DLUFCS5XK8qJy07uq2LXHp6u37W7h77fFYgUC+L3DxEIiXSEICL5JDU1kibVjEND6
-        EhuQYBodSxyTdw55PB1Pssksm+VTEGC8Y3QM8nF/kGTvGxUpaQ5G0juqLF/Pz3avgZ/r+fVtTuv1
-        zfJ8OSlAgNNtmlOqtUGT8R2qFx9azYyl8pG7yGoQVUnSdZFB7oEtD4bvl4vR5UmxGF2dj1L9cHF5
-        BgJ05NoHkHCtOVizGd16rl8iUfqqZusqkEd9/ySA2HcqoCbvfrofAMJtRGcQpItNIyAOccn9pxHF
-        foOOQE6P5wKMNjUqE1Cz9U79ZGQHPKAu/8MOs2kBdjW2GHSjZu1f/jea17/RXsBXbJ+t+ZEAwvBq
-        DSq2mHJJRy51KKHvPwAAAP//AwBABrf1MgIAAA==
+        H4sIAAAAAAAAAwAAAP//dFJdb9swDPwrAZ8VwE6bNdVbt2YfwJp9oGuBDoPAyUysxRY9kdpQBP7v
+        g9xlRTfsjbo7Hk8EDxAasNDLzlX1pw/f9s3mJty8+Lrl1e7t+fN89+oUDOj9QEVFIrgjMJC4KwCK
+        BFGMCgZ6bqgDC77D3NBcOEbS+el8US2W1bIuNp6jUlSwnw9HS2XuXJbiOQUp7+yqenG5qs+u+OJ+
+        8bNuJefzNa3aWzAQsS99zvUhoXgeyG059ahKjeOsQ1Y3mbpiGYesYA+gQafA16/Xs83F1Xr27uWs
+        1LdvNpdgALO2nIpwG5Ko+z3kPWoKfg8GOnxEP7K22ywCo4GEGuIO7Nk4fjEgyoNLhMLx6dcmQuh7
+        pugJbMxdZyBPu7SHh5ROeU9RwC6fnRjw6FtyPhFq4OieKqojnwib/3HH3jKAhpZ6Sti5Zf+v/pGt
+        27/Z0cCfnT5Aq9qAUPoRPDkNlMBCuYAGUwPj+AsAAP//AwDsdM08TwIAAA==
     headers:
       CF-RAY:
-      - 983c40e97d5bdee2-SEA
+      - 9845539d4c22c366-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -67,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:59 GMT
+      - Wed, 24 Sep 2025 21:20:37 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -81,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:54:58Z'
+      - '2025-09-24T21:20:36Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:54:59Z'
+      - '2025-09-24T21:20:37Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:54:57Z'
+      - '2025-09-24T21:20:35Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:54:58Z'
+      - '2025-09-24T21:20:36Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqiLrQGnogUgLftCY8z
+      - req_011CTTvdNBU8gbPo7qmjm8Fu
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1769'
+      - '2185'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/async_stream.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '1131'
       content-type:
       - application/json
       host:
@@ -53,17 +54,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01TinjGuTCCwQdTVfsGibFkk","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}    }
+        data: {"type":"message_start","message":{"id":"msg_01PXfMr2Twge6VvPbgGSkyZD","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}   }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01KvxumT4jhSPPUyXPmmuxMJ","name":"__mirascope_formatted_output_tool__","input":{}}      }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01QSUzkFAeLWvXkgexxzXs5a","name":"__mirascope_formatted_output_tool__","input":{}}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}          }
 
 
         event: ping
@@ -73,8 +74,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        \"T"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}     }
 
 
         event: ping
@@ -84,8 +84,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"HE
-        NAME OF T"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        \"TH"}}
 
 
         event: ping
@@ -95,8 +95,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"HE
-        WI"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
+        N"}         }
 
 
         event: ping
@@ -106,69 +106,115 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ND\""}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"AME
+        "}    }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
+        THE"}          }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        WIND\""}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \""} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"au"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
-        \"Pat"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rick
-        Rothfu"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ss\""}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rating\""}             }
+        \"author\""}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        7}"}   }
+        {\"fir"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"st_name"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":\"Patri"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ck\",\"last"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_name\":\"Roth"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fus"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"ra"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ting"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        7}"}          }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0    }
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}            }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}               }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"               }
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
       CF-RAY:
-      - 983c41dc798c27de-SEA
+      - 984554721d9b1846-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -176,7 +222,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:37 GMT
+      - Wed, 24 Sep 2025 21:21:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -190,35 +236,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:36Z'
+      - '2025-09-24T21:21:09Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:36Z'
+      - '2025-09-24T21:21:09Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:36Z'
+      - '2025-09-24T21:21:09Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:36Z'
+      - '2025-09-24T21:21:09Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqmD897yDDjvekWxcBf
+      - req_011CTTvfsnFsZhs7QDHgQfU8
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '984'
+      - '1361'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_async.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
-      only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"}'
     headers:
       accept:
@@ -19,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '781'
+      - '1247'
       content-type:
       - application/json
       host:
@@ -51,15 +57,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRbUvDQAzHv0r5v77Bph3Te6fMqfiICIJW2qON67kuN+9ysjH63aXO+YivEvL7
-        JYFkDVtBYx6meX+Q7tmJO5z49NhY78/HZ6vd/fslFGS1oM6iEMyUoOBd0xVMCDaIYYHC3FXUQKNs
-        TKyoFxwzSS/t7fR3hv3hIIVC6ViIBfphvR0ptOya34NGURTPwXHG64yTJINYaSiDTjLcnhwllwcX
-        R8nVJOnyu9PLcQa18UyU2vmNeG3E23KW3Dipn2IIn5I3YnnaSaOM24yLokD7qBDELXJPJjiGBnGV
-        S/SMDxDoJRKXBM2xaRTi+wX0GpYXUXJxM+IAPdgfKZSmrCkvPRmxjvOfRn/LPZnqP7bt7RbQoqY5
-        edPkw/lf/4sO6t+0VXBRvpfSXYVA/tWWlIslD43ub5XxFdr2DQAA//8DAAWGs7YFAgAA
+        H4sIAAAAAAAAA3SRXWsUMRSG/8rwXmdhP7XmrtqWWugqKig0kgkzpztpZ07W5ESqy/x3yXYXbYtX
+        Ce/zvOdAsoNvoTGkjZ3O3r47+/Z5OVtf3l2dLPh3+/DGDS5DQX5tqViUktsQFGLoS+BS8kkcCxSG
+        0FIPjaZ3uaVJCswkk+VkPp2vpqvZEgpNYCEW6JvdcaTQQynvD426ru9SYMM7w1VlIF56MtCVwZfL
+        82p9en1efbioyv3r+/WZgXr0XJYuxCLuiyW69TGJZTcc+h+dRN/cHyrF6N0T4VOQ7janZFCE8TA5
+        OvG8KcZrw6Phuq4xfldIErY2kkuBoUHcWsmRcQCJfmTihqA5971C3j+b3sHzNouVcE+coBfzE4XG
+        NR3ZJpITH9g+NaZHHsm1/2PHbllA244Giq63q+Gl/5fOuud0VAhZ/o1eLRQSxZ++ISueIjTKZ7cu
+        thjHPwAAAP//AwANpajYOgIAAA==
     headers:
       CF-RAY:
-      - 983c40aa8dbe30c5-SEA
+      - 98455366feb376d6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -67,7 +74,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:48 GMT
+      - Wed, 24 Sep 2025 21:20:28 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -81,35 +88,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:54:48Z'
+      - '2025-09-24T21:20:27Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:54:48Z'
+      - '2025-09-24T21:20:28Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:54:47Z'
+      - '2025-09-24T21:20:26Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:54:48Z'
+      - '2025-09-24T21:20:27Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqhbuEwD5YkfUpcFo6v
+      - req_011CTTvcj5nkeyVRFfcA959c
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1311'
+      - '1999'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_async_stream.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
-      only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}","stream":true}'
     headers:
       accept:
@@ -19,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '795'
+      - '1261'
       content-type:
       - application/json
       host:
@@ -54,24 +60,23 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01DZGHau2agyWmLzpi4uAP4k","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":197,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"id":"msg_01P5i1qu2XkShjHbGynhJuqx","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}           }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```json\n{\n  \"title"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\":
-        \"THE NAME OF THE WIND\",\n  \""}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
+        \"THE"}          }
 
 
         event: ping
@@ -81,35 +86,58 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
-        \"Patrick Rothfuss\",\n  \"rating\": 7"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        NAME OF THE WIND\",\n  \""}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n}\n```"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
+        {\n    \"first_"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":
+        \"Patrick\",\n    \""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"last_name\":
+        \"Rothf"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":
+        7\n}"}}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0   }
+        data: {"type":"content_block_stop","index":0     }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":197,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":43}       }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":58}      }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"              }
 
 
         '
     headers:
       CF-RAY:
-      - 983c419c1d72d446-SEA
+      - 9845543bcc617de4-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -117,7 +145,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:27 GMT
+      - Wed, 24 Sep 2025 21:21:01 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -131,35 +159,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:26Z'
+      - '2025-09-24T21:21:00Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:26Z'
+      - '2025-09-24T21:21:00Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:26Z'
+      - '2025-09-24T21:21:00Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:26Z'
+      - '2025-09-24T21:21:00Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqkT6zVVnLpR2XawA3S
+      - req_011CTTvfEaNjMVgsCTQri9Dv
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1027'
+      - '1097'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_stream.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
-      only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}","stream":true}'
     headers:
       accept:
@@ -19,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '795'
+      - '1261'
       content-type:
       - application/json
       host:
@@ -54,7 +60,7 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_014BSnDYGsgq3XjNhvA1BpGa","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":197,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}    }
+        data: {"type":"message_start","message":{"id":"msg_01MLd36GZdH6R45oGLi8cnbn","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}}
 
 
         event: content_block_start
@@ -64,13 +70,13 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":
-        \"THE NAME OF THE WIND\",\n  \""}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
+        \"THE"}    }
 
 
         event: ping
@@ -80,34 +86,53 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
-        \"Patrick Rothfuss\",\n  \"rating\": 7"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        NAME OF THE WIND\",\n  \""}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n}\n```"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
+        {\n    \"first_"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":
+        \"Patrick\",\n    \""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"last_name\":
+        \"Rothfuss\"\n  },\n  \""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":
+        7\n}"}            }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0      }
+        data: {"type":"content_block_stop","index":0            }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":197,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":43}       }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":58}             }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 983c412fce5edef6-SEA
+      - 984553d3ec25f979-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -115,7 +140,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:10 GMT
+      - Wed, 24 Sep 2025 21:20:45 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -129,35 +154,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:08Z'
+      - '2025-09-24T21:20:44Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:08Z'
+      - '2025-09-24T21:20:44Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:08Z'
+      - '2025-09-24T21:20:44Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:08Z'
+      - '2025-09-24T21:20:44Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqjAxrt5PUmtoUT8nxs
+      - req_011CTTve1aFuigvymLEudkiQ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1810'
+      - '1035'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_sync.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
-      only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"}'
     headers:
       accept:
@@ -19,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '781'
+      - '1247'
       content-type:
       - application/json
       host:
@@ -51,15 +57,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJHbSgNBDIZfZfmvp9DaltK5U2ytF1YRQcWV3WE3dsfuZupMxgNl311W
-        rUe8Ssj3JYFkC1tCowmrrD+YNnJQxufhfHRxZBfXw/mVP3BPUJCXDXUWhWBWBAXv6q5gQrBBDAsU
-        GldSDY2iNrGkXnDMJL1Rb6+/N+6PByMoFI6FWKBvtruRQs9d81vQyPP8PjhOeZtykqQQKzWl0EmK
-        i8UsWe6fzJLTedLll8fLwxTq3TNRKuffxTMj3hbr5NxJdRdD+JS8EcurTpqk3Kac5znaW4UgbpN5
-        MsExNIjLTKJnfIBAD5G4IGiOda0Q3y6gt7C8iZKJWxMH6MF0olCYoqKs8GTEOs5+Gv0d92TK/9iu
-        t1tAm4oa8qbOxs1f/4sOqt+0VXBRvpdGQ4VA/tEWlIklD43ub6XxJdr2FQAA//8DAELE4XsFAgAA
+        H4sIAAAAAAAAA3SRW0sDMRCF/8pynlNoa6uSN7WKIl4QwQdXQtiddqO7k5pMRC373yW1xRs+JZzv
+        OzOQrOBqaHRxYYajXXd0OFrMDsOke/fP7jzdzvn1EQrytqRsUYx2QVAIvs2BjdFFsSxQ6HxNLTSq
+        1qaaBtEzkwwmg/FwPB1ORxMoVJ6FWKDvV9uRQq+5vD40ViUXRQlx0lIJXZS4PT0uLg8ujourkyLf
+        784uZyXUp2eTND5kcV3M0dyFKIZtt+lfWwmuetpUstHaH8KNl2aeYiyRhX4zOVhxvMjGXsk9+geF
+        KH5pAtnoGRrEtZEUGBsQ6TkRVwTNqW0V0vqh9AqOl0mM+CfiCL0z3leobNWQqQJZcZ7NT2O45YFs
+        /R/bdvMCWjbUUbCtmXZ//S86an7TXsEn+R5N9xUihRdXkRFHARr5e2sbavT9BwAAAP//AwBg21eC
+        LAIAAA==
     headers:
       CF-RAY:
-      - 983c403799f376c1-SEA
+      - 984552fb2ebb767c-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -67,7 +74,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:31 GMT
+      - Wed, 24 Sep 2025 21:20:11 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -81,35 +88,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:54:31Z'
+      - '2025-09-24T21:20:10Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:54:31Z'
+      - '2025-09-24T21:20:11Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:54:29Z'
+      - '2025-09-24T21:20:09Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:54:31Z'
+      - '2025-09-24T21:20:10Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqgFAYE4QAdvLPQ4iPx
+      - req_011CTTvbTH11cMFpAPPjHpV1
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2608'
+      - '1973'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/stream.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '1131'
       content-type:
       - application/json
       host:
@@ -53,17 +54,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01Tmv7hBrSdrGJEd9ANL2BwR","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":28,"service_tier":"standard"}}}
+        data: {"type":"message_start","message":{"id":"msg_01LFsa1a8FpW7dbRBL2i525s","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}            }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01BirGvoB2bEAjN6nmoj4AuF","name":"__mirascope_formatted_output_tool__","input":{}}    }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01NPWZZavRFsMVcmDtS3ofMp","name":"__mirascope_formatted_output_tool__","input":{}}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}       }
 
 
         event: ping
@@ -73,7 +74,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
+        \""}         }
 
 
         event: ping
@@ -83,8 +85,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"TH"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
+        NAME OF "}     }
 
 
         event: ping
@@ -94,8 +96,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
-        NAM"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
+        WIND"}   }
 
 
         event: ping
@@ -105,99 +107,93 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
-        "}       }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
-        THE W"}              }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"IND\""}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \""}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"au"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor"}  }
+        \"author"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"P"}            }
+        {\"first_n"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"atrick
-        Rothf"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame\":\""}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uss"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Patrick\",\"l"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"as"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"t_name\":\""}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Rothfuss\""}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rating\": "}              }
+        \"r"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7}"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"atin"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"g\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        7}"}              }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0        }
+        data: {"type":"content_block_stop","index":0             }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}               }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}  }
 
 
         event: message_stop
 
-        data: {"type":"message_stop" }
+        data: {"type":"message_stop"             }
 
 
         '
     headers:
       CF-RAY:
-      - 983c416bdd84def6-SEA
+      - 98455405def9f979-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -205,7 +201,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:19 GMT
+      - Wed, 24 Sep 2025 21:20:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -219,35 +215,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:18Z'
+      - '2025-09-24T21:20:52Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:18Z'
+      - '2025-09-24T21:20:52Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:18Z'
+      - '2025-09-24T21:20:52Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:18Z'
+      - '2025-09-24T21:20:52Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqjt3u9pkQ9R1833FPE
+      - req_011CTTvebkpNH2XYjgYFQ5ah
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1077'
+      - '1261'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/sync.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '936'
+      - '1117'
       content-type:
       - application/json
       host:
@@ -50,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFFdTwIxEPwrZJ9LciCH0jdB/ErAj2DEGNM0vYWr3LW13ZIQcv/d9Aga
-        Nb5td2Znp7N70AVwqMNaZL35y0nczabLxcOTyUd+ZdTSTxwwoJ3DxMIQ5BqBgbdVasgQdCBpCBjU
-        tsAKOKhKxgK7wRqD1B10+1k/z/LeABgoawgNAX/dHyXJ2krEkDRbI+kdRda7GkZX63ftb7dqmK/G
-        k/HOnRXAwMg6zQlRay+Dsg7FyvpaEmEhbCQXSbSiIkkaFwn4HkhTa3hxPe3Mz2fTzt1lJ9XPN/ML
-        YCAjldYDh3tJXqtN59FSuYohpK9K0mYN/LRp3hgEsk54lMGan+5bIOBHRKMQuIlVxSC2cfH9wYgg
-        u0ETgA9GQwZKqhKF8ihJWyN+MrIj7lEW/2HH2bQAXYk1elmJvP7L/0Z75W+0YfAV26E1PGUQ0G+1
-        QkEaUy7pyIX0BTTNJwAAAP//AwDobqI+MgIAAA==
+        H4sIAAAAAAAAAwAAAP//dFJda9wwEPwrxzzrwE7jXKK3QhPa0rsmIdAviljkvbM4W3KlVdvk8H8v
+        cnoNaenbamZ2drTsAa6FxpB2pqrXOVzT2/FmzQ/vVruHeHOxpk8rKMj9yEXFKdGOoRBDXwBKySUh
+        L1AYQss9NGxPueVlCt6zLE+XJ9VJUzX1KRRs8MJeoL8cjpYSQm9yKp5zkPLOpqqbn+2mPr+yF/u7
+        H7f3n/3HM97IAAVPQ+kzZnCRkg0jm22IA4lwa0KWMYuZTU2x9GMW6APEyRz47vXlYvNyfbl4f7Uo
+        9Yc3m1dQoCxdiEW4dTGJ+T3kmiQ6u4dCT0/obZBum1PCpBBJnN9Br6bpq0KSMJrIlIJ//rWZSPwt
+        s7cM7XPfK+R5l/rwmNJI2LNP0M3ZCwVLtmNjI5O44M1zRXXkI1P7P+7YWwbw2PHAkXrTDP/qn9i6
+        +5udFP7s9BE6rxUSx+/OshHHERrlAlqKLabpFwAAAP//AwAe0+6tTwIAAA==
     headers:
       CF-RAY:
-      - 983c407d483076c1-SEA
+      - 98455334896d767c-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -67,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:41 GMT
+      - Wed, 24 Sep 2025 21:20:20 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -81,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:54:41Z'
+      - '2025-09-24T21:20:20Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:54:41Z'
+      - '2025-09-24T21:20:20Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:54:40Z'
+      - '2025-09-24T21:20:18Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:54:41Z'
+      - '2025-09-24T21:20:20Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqh4qhtuUPJAyZjWqEa
+      - req_011CTTvc8YQA7P6G6ApNx8G7
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1575'
+      - '2184'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_async.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '936'
+      - '1117'
       content-type:
       - application/json
       host:
@@ -50,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFFdSwMxEPwrZZ9TuNZ+aN4qKrVitSpoEQkh2fZiL8mZbAq23H+XnFRR
-        8W2zMzs7md2D0cDBxrUoeo/j19EIp9ulu+/PVvbibXmLiyNgQO81ZhbGKNcIDIKvckPGaCJJR8DA
-        eo0VcFCVTBq70TuH1B10+0V/WAx7A2CgvCN0BPx5f5Ak7yuRYtZsjeR3EkXvabPTVp8eb8a7q8l2
-        EWZ0vF0NgYGTNs8JYU2QUfkaxcoHK4lQC5+oTiRaUZElXZ0I+B7IUGv4YXremU+uzzs3F51cP17O
-        z4CBTFT6ABxuJQWjNp07T+UqxZi/Ksm4NfBx07wwiORrEVBG7366b4GIbwmdQuAuVRWD1MbF959G
-        BPkNugh8cDJioKQqUaiAkox34iejOOABpf4PO8zmBViXaDHISgztX/432it/ow2Dr9g+W6Mxg4hh
-        axQKMphzyUfWMmhomg8AAAD//wMAuZx2dDICAAA=
+        H4sIAAAAAAAAAwAAAP//dFJdT+MwEPwr1T67UgLkQH47CY6eUDmEaE/odLK2zrYxTezgXXMfVf47
+        cqAgQLytZ2Znx6vdgatBQ8cbU5TXp34ZZlu6ndcV3zfzZnG3wCNQIP96yipixg2BghjaDCCzY0Ev
+        oKALNbWgwbaYappy8J5kejQ9KA6qoiqzjQ1eyAvoX7u9pYTQmsTZcwyS38kU5XKFs+OT28VqdV4+
+        XCz/0P+/524DCjx2uc+YzkVkG3oy6xA7FKHahCR9EjOammzp+ySgdyBOxsA3s7PJ5df52eTHt0mu
+        f36/PAUFmKQJMQvXLrKY5yFXKNHZLSho8RW9DtKsEzMMCiKK8xvQx8PwWwFL6E0k5ODffm0kmO4T
+        eUugfWpbBWncpd49pTQStuQZdPXlUIFF25CxkVBc8OatotjzkbD+jNv35gHUN9RRxNZU3Uf9K1s2
+        79lBwctOn6CTUgFTfHCWjDiKoCFfQI2xhmF4BAAA//8DAAAZ3OVPAgAA
     headers:
       CF-RAY:
-      - 983c40bedd59838c-SEA
+      - 984553850ad6908e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -67,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:53 GMT
+      - Wed, 24 Sep 2025 21:20:33 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -81,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:54:52Z'
+      - '2025-09-24T21:20:32Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:54:53Z'
+      - '2025-09-24T21:20:33Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:54:50Z'
+      - '2025-09-24T21:20:31Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:54:52Z'
+      - '2025-09-24T21:20:32Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqhqjhGKXDiuUNUViED
+      - req_011CTTvd5dKB1EzNWXAXTNQ7
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2533'
+      - '1780'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_async_stream.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '1131'
       content-type:
       - application/json
       host:
@@ -53,17 +54,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01GhiHugUTD9ChTDgNHpR4CM","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}               }
+        data: {"type":"message_start","message":{"id":"msg_01M8ToPE5dSzB7t3GDHTL3R1","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}       }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01LaKX3ctDEinRnHzApkBLoP","name":"__mirascope_formatted_output_tool__","input":{}}     }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01FLNEpFehXHcnWXFUQoFnaF","name":"__mirascope_formatted_output_tool__","input":{}}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}         }
 
 
         event: ping
@@ -74,7 +75,29 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        \""}              }
+        "}}
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"THE
+        NAME "}          }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
+        "} }
 
 
         event: ping
@@ -85,7 +108,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        NAM"}      }
+        WIN"} }
 
 
         event: ping
@@ -95,84 +118,83 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
-        OF THE WI"}  }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ND\""}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"au"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
+        {\"fir"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"st_na"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"me\""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"Patrick\",\""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"last_name\":"}
         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"a"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uthor\""}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \""}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Pat"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rick
-        Ro"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thfuss\""}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Rothfuss\"}"}        }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rating\": "} }
+        \""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7}"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ra"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ting\":
+        7}"}              }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0               }
+        data: {"type":"content_block_stop","index":0  }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}               }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}      }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 983c41b39dc2a348-SEA
+      - 98455456a8ffd7ae-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -180,7 +202,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:31 GMT
+      - Wed, 24 Sep 2025 21:21:06 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -194,35 +216,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:29Z'
+      - '2025-09-24T21:21:05Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:29Z'
+      - '2025-09-24T21:21:05Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:29Z'
+      - '2025-09-24T21:21:05Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:29Z'
+      - '2025-09-24T21:21:05Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqkj7uiiCLPCzW48SH3
+      - req_011CTTvfZ2eDW4M4HEckEEWC
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1826'
+      - '1719'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_stream.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '1131'
       content-type:
       - application/json
       host:
@@ -53,17 +54,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01XAqmwNsP7keEaL74JRMpy7","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"id":"msg_01Nx9bifmoFsxv6kAgwntrU2","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,"service_tier":"standard"}}             }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_016aDNJ4xJ7thCf1pjQFJFP9","name":"__mirascope_formatted_output_tool__","input":{}}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Pq33wSjK9EHPkxCxZtdeQZ","name":"__mirascope_formatted_output_tool__","input":{}}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}        }
 
 
         event: ping
@@ -73,7 +74,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"titl"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
+        \""}          }
 
 
         event: ping
@@ -83,8 +85,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":
-        \"THE "}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
+        NAME "}             }
 
 
         event: ping
@@ -94,80 +96,94 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"NAME
-        O"}  }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"F
-        THE W"}         }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"IND\""}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
+        THE WIND\""}  }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\":"}             }
+        "}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        \"Patri"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"author\""}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ck
-        Rothfuss\""}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        {\"first_n"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame\":"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Patrick\",\"l"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ast_n"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":\"Rothfuss\""}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rating\":"}        }
+        \"r"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        7}"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ating\":
+        "}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7}"}   }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0               }
+        data: {"type":"content_block_stop","index":0   }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":496,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}         }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}   }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"         }
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 983c4151ec4fdef6-SEA
+      - 984553eebfbff979-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -175,7 +191,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:15 GMT
+      - Wed, 24 Sep 2025 21:20:50 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -189,35 +205,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:14Z'
+      - '2025-09-24T21:20:48Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:14Z'
+      - '2025-09-24T21:20:48Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:14Z'
+      - '2025-09-24T21:20:48Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:14Z'
+      - '2025-09-24T21:20:48Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqjaM33YUGLVULaaiF7
+      - req_011CTTveKsqXgULEyX8VNLnu
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1258'
+      - '1765'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_sync.yaml
@@ -5,9 +5,10 @@ interactions:
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","input_schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -18,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '936'
+      - '1117'
       content-type:
       - application/json
       host:
@@ -50,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFHRSgMxEPyVss8p3JVei3kTrFS0WqUgKhLW3LYXepecycYi5f5dcqVK
-        Fd82O7Ozk9k9mBIkNGGjsnza3iw8rorV2e5zot/idr72JoIA/mwpsSgE3BAI8K5ODQzBBEbLIKBx
-        JdUgQdcYSxoGZy3xcDwcZaMiK/IxCNDOMlkG+bI/SrJztYohafZG0juqLL9eL+ZF/rRbzot4Ub7d
-        V48fG3oGARabNKdUYzwG7VpSa+cbZKZSuchtZNWLqiRp28gg98CGe8Or+Wxwe76YDe4uB6l+vLq9
-        AAEYuXIeJCyRvdHbwYPjah1DSF9FNnYDctp1rwICu1Z5wuDsqfseCPQeyWoCaWNdC4h9XHJ/MKLY
-        bckGkOOziQCNuiKlPSEbZ9UpIzvinrD8DzvOpgXUVtSQx1oVzV/+D5pXv9FOwHdsh9ZkKiCQ/zCa
-        FBtKuaQjl+hL6LovAAAA//8DABUtLgIyAgAA
+        H4sIAAAAAAAAAwAAAP//dFJdi9swEPwrYZ4VsJ3LpfXbQdOmHL1+cDT9oIg9eWOL2JIrrQpt8H8/
+        5Gt6XEvfVjOzs6NlT7ANagyx1UW537XXl5848XWoPq++XNm7Y7XdQEF+jpxVHCO1DIXg+wxQjDYK
+        OYHC4BvuUcP0lBpeRu8cy/JiWRXVuliXF1Aw3gk7Qf31dLYU73udYvacg+R30kV56/371Wa3f0XP
+        q8EEe9f8+phaKDgacp/Wgw0UjR9ZH3wYSIQb7ZOMSfRsqrOlG5OgPkGszIFvd9vFzdWb7eLty0Wu
+        969vXkCBknQ+ZOHBhij695B3JMGaIxR6ekQ/eOkOKUZMCoHEuhb1Zpq+KUTxow5M0bunX5uJyN8T
+        O8OoXep7hTTvsj49pNTij+wi6vXlSsGQ6VibwCTWO/1UUZz5wNT8jzv35gE8djxwoF6vh3/1j2zZ
+        /c1OCn92+gA9KxUihx/WsBbLATXyBTQUGkzTPQAAAP//AwDfGbd5TwIAAA==
     headers:
       CF-RAY:
-      - 983c4058bbac76c1-SEA
+      - 984553218ea9767c-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -67,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:35 GMT
+      - Wed, 24 Sep 2025 21:20:17 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -81,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:54:35Z'
+      - '2025-09-24T21:20:16Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:54:35Z'
+      - '2025-09-24T21:20:17Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:54:34Z'
+      - '2025-09-24T21:20:15Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:54:35Z'
+      - '2025-09-24T21:20:16Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqgdrYL1y83WZWYDS1i
+      - req_011CTTvbuWpgqffB6RNmptes
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1502'
+      - '1829'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/google/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/async.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -30,13 +33,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WR3WrCQBCF7/MUy1xrUcFKvZNqUepfNbSFpsjUrMli3I27k2IJefduEqOxzcUy
-        zDmZM/tt6jAGW5S+8JG4gT77sB3G0uLMNSWJS7JC1bLNGDVdveWX1mprIX7Kf4LUAxIUcQ/6Hrjj
-        EZsPZiO2eGJ5/TaZDz1oeIAJhUoXniWSFts9WykKd4kxha6RhAys3suglpNd6s/GdTutIp5HH5TP
-        o8qeVQbYCSlMuOJolMxta3exhIsqpM9Ptt1yqoBiNCQGAz7jhJYTXmhArNUhJlftuXxUScGp3S6H
-        1bDe6g9nnRRhdCt1e41/c83Qpoqozrv2FPaSGAn6yW/ijt5dqIGg27UqEk4NGFjuSRDSnxU7PeeM
-        rKT4yrURJa6AHyzAZueu29xFaMIiEDQ3sZKGT/wC6Wa8xunzcfp1/30ks0xw00oGL+Bkzi/sMMXO
-        cQIAAA==
+        H4sIAAAAAAAC/2WRTW+CQBCG7/yKzZy1qdrG1ltTaeSgoqW2SWnMRhbYCrtkd0hsCf+9C4hCyoFs
+        5n3n65nCIgQOVAQ8oMg0zMiniRBS1P9KkwKZQCO0IRPMqMKrt/mKzttYkJ2qJCh8QI4J82Hmg7ew
+        yeppaZP1C6ne785q7sPAB5pjLJXxGHvIlca9oGmT41JU/HCsbQntKluJcZhr7UNpNEWRi8gI0xI6
+        o5SX99fguoCSCaumS2XAktZetgYzguA63jKqpahsr97ahYvKRcBOJnxrtQ3q0pBrGrElQ2pQ0gsw
+        yJRMM/TkkYlnmdcoR6OmWId8Tx8/nnWUSJN+6sNk8K+unpuuPOmepHMtsyRNOP5Um3j2hwcdENgf
+        qyVhdYCBOU0exdgfcXQ3sc7IGoo7pjRvcEUsNQCH45v7YWhOFtcNQTGdSaGZE1SebDx/o06obNfb
+        /U4dV+6/F3KzAau0/gBsW5gPlAIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +48,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:13:15 GMT
+      - Wed, 24 Sep 2025 21:20:39 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1764
+      - gfet4t7; dur=1572
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/async_stream.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -30,11 +33,11 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":\\\"THE
-        NAME OF THE WIND\\\",\\\"author\\\":\\\"Patrick Rothfuss\\\",\\\"rating\\\":7}\"}],\"role\":
+        NAME OF THE WIND\\\",\\\"author\\\":{\\\"first_name\\\":\\\"Patrick\\\",\\\"last_name\\\":\\\"Rothfuss\\\"},\\\"rating\\\":7}\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        11,\"candidatesTokenCount\": 19,\"totalTokenCount\": 165,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 11}],\"thoughtsTokenCount\": 135},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"TPHSaPy7MoqnmtkPo4_d4AQ\"}\r\n\r\n"
+        11,\"candidatesTokenCount\": 29,\"totalTokenCount\": 230,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 11}],\"thoughtsTokenCount\": 190},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"x2DUaOC6N4asz7IP3-2AkQY\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -43,11 +46,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:13:17 GMT
+      - Wed, 24 Sep 2025 21:21:13 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1332
+      - gfet4t7; dur=1785
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/json_async.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "Please recommend the most popular book
       by Patrick Rothfuss"}], "role": "user"}], "systemInstruction": {"parts": [{"text":
-      "Respond only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      "Respond only with valid JSON that matches this exact schema:\n{\n  \"$defs\":
+      {\n    \"Author\": {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"}], "role": "user"}, "generationConfig":
       {"responseMimeType": "application/json"}}'
     headers:
@@ -18,7 +24,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '863'
+      - '1329'
       content-type:
       - application/json
       host:
@@ -32,13 +38,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/12RUW+CMBCA3/kVTZ91mZplZm9O3cYSlShuS8YeGjmgEVvWHokL4b+vhYF1PJDm
-        7uvd9bvKI4QemIh5zBA0fSCfJkJI1fxtTgoEgSbRhUywYAovbPtVztkgCGd7iVaRICSiyDGHyAQi
-        Gr4syXq2WpLNE7Hnd3+9iOig5ViJmVQtGDBU/HAkW4lZUmrdQ4ohF6mF7iNRU6dx3Z+/BpdxlczB
-        znKSMeQdXncATbjgOtsC01JYbBduAtpnuYjhbMK3XtegKU1LzVJYATIjjvV6aKHkqcBQHkHMZdmI
-        G02nbTVH9BUwGf/lUSLLr1OT7q5TWC9MW567G3CWY17Jco4/9inh8iOkjgn8N1fnwnOUUbOBMs3w
-        esbRyMKNtNbjGyjNW2EpnIzC4fjmbpjkTGdNR6pAF1Jo8GPLPA4nOxbwuZ/skm/UQfb67E9ne+rV
-        3i81yH4QhAIAAA==
+        H4sIAAAAAAAC/12RW2+CMBTH3/kUTZ91ES8x2ZuZLvjgJY5tJmNZqhRohBbbQ+JC+O5ruWgZD6T5
+        n9+5/U/pIITPhIcsJEAVfkZfWkGorP8mJjhQDjrQSVrMiYQH23yl9dYI0JtJwmXAEQowMEhpoIUA
+        +94KbRebFdq9IvP+XG+XAR40HCkgEdKAdaKRIiYV/HCStfl7ApKdL22KIVLSAw4CkqhQKsAGqNrK
+        kgDjsSHmAa+wNW11f38PHjtKkVKzQCZCmnZ41QF6Ks5UcqBECW6wN3+3x/co4yG9aXnkdA3q0rhQ
+        JKYbCkS7Te6e4lyKLAdfXCh/EUXt9sSdN9Ws6/SA2biNgwCS9kNuF7MKq6Vuy1L7bNZF9ZYkZfBr
+        VvFXRx9bTsC/uTovHMsyrM9WxAn0Z3SnE6c1rfHxg0rFGsNimmkLh+On2TDSB0zqjlhSlQuu6Do0
+        DBt772TngXc9Xa6g9qNT5KrFFDuV8wdoKYp+uQIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -47,11 +53,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:55:03 GMT
+      - Wed, 24 Sep 2025 21:24:27 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2431
+      - gfet4t7; dur=1490
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/json_async_stream.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "Please recommend the most popular book
       by Patrick Rothfuss"}], "role": "user"}], "systemInstruction": {"parts": [{"text":
-      "Respond only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      "Respond only with valid JSON that matches this exact schema:\n{\n  \"$defs\":
+      {\n    \"Author\": {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"}], "role": "user"}, "generationConfig":
       {"responseMimeType": "application/json"}}'
     headers:
@@ -18,7 +24,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '863'
+      - '1329'
       content-type:
       - application/json
       host:
@@ -32,12 +38,12 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\n
-        \ \\\"title\\\": \\\"THE NAME OF THE WIND\\\",\\n  \\\"author\\\": \\\"Patrick
-        Rothfuss\\\",\\n  \\\"rating\\\": 7\\n}\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 188,\"candidatesTokenCount\":
-        32,\"totalTokenCount\": 312,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        188}],\"thoughtsTokenCount\": 92},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"LO3SaPetCoCsqtsPuJuTgAQ\"}\r\n\r\n"
+        \ \\\"title\\\": \\\"THE NAME OF THE WIND\\\",\\n  \\\"author\\\": {\\n    \\\"first_name\\\":
+        \\\"Patrick\\\",\\n    \\\"last_name\\\": \\\"Rothfuss\\\"\\n  },\\n  \\\"rating\\\":
+        7\\n}\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 317,\"candidatesTokenCount\": 52,\"totalTokenCount\":
+        523,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 317}],\"thoughtsTokenCount\":
+        154},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"jGHUaKzILIXNqtsP2LWQ4AQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -46,11 +52,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:55:41 GMT
+      - Wed, 24 Sep 2025 21:24:29 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1482
+      - gfet4t7; dur=1518
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/json_stream.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "Please recommend the most popular book
       by Patrick Rothfuss"}], "role": "user"}], "systemInstruction": {"parts": [{"text":
-      "Respond only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      "Respond only with valid JSON that matches this exact schema:\n{\n  \"$defs\":
+      {\n    \"Author\": {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"}], "role": "user"}, "generationConfig":
       {"responseMimeType": "application/json"}}'
     headers:
@@ -18,7 +24,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '863'
+      - '1329'
       content-type:
       - application/json
       host:
@@ -32,12 +38,17 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\n
-        \ \\\"title\\\": \\\"THE NAME OF THE WIND\\\",\\n  \\\"author\\\": \\\"Patrick
-        Rothfuss\\\",\\n  \\\"rating\\\": 7\\n}\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 188,\"candidatesTokenCount\":
-        32,\"totalTokenCount\": 312,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        188}],\"thoughtsTokenCount\": 92},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"EO3SaOz2DPaDmtkPiem2uA8\"}\r\n\r\n"
+        \ \\\"title\\\": \\\"THE NAME OF THE WIND\\\",\\n  \\\"author\\\": {\\n    \\\"first_name\\\":
+        \\\"Patrick\\\",\\n    \\\"last_name\\\": \\\"Roth\"}],\"role\": \"model\"},\"index\":
+        0}],\"usageMetadata\": {\"promptTokenCount\": 317,\"candidatesTokenCount\":
+        38,\"totalTokenCount\": 527,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        317}],\"thoughtsTokenCount\": 172},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"rmDUaIXgEsKfz7IPtd3n8Ao\"}\r\n\r\ndata: {\"candidates\": [{\"content\":
+        {\"parts\": [{\"text\": \"fuss\\\"\\n  },\\n  \\\"rating\\\": 7\\n}\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        317,\"candidatesTokenCount\": 52,\"totalTokenCount\": 541,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 317}],\"thoughtsTokenCount\": 172},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"rmDUaIXgEsKfz7IPtd3n8Ao\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -46,11 +57,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:55:13 GMT
+      - Wed, 24 Sep 2025 21:20:47 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1304
+      - gfet4t7; dur=1648
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/json_sync.yaml
@@ -2,12 +2,18 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "Please recommend the most popular book
       by Patrick Rothfuss"}], "role": "user"}], "systemInstruction": {"parts": [{"text":
-      "Respond only with valid JSON that matches this exact schema:\n{\n  \"description\":
-      \"A book with a rating. The title should be in all caps!\",\n  \"properties\":
-      {\n    \"title\": {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
-      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\":
-      {\n      \"description\": \"For testing purposes, the rating should be 7\",\n      \"title\":
-      \"Rating\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      "Respond only with valid JSON that matches this exact schema:\n{\n  \"$defs\":
+      {\n    \"Author\": {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"}], "role": "user"}, "generationConfig":
       {"responseMimeType": "application/json"}}'
     headers:
@@ -18,7 +24,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '863'
+      - '1329'
       content-type:
       - application/json
       host:
@@ -32,13 +38,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WR32+CMBCA3/krmj7rMjWbZm+LsugSf0zJXDKWpZETGqHF9ljcCP/7WhDEjYem
-        ufu4u36XO4TQHRMBDxiCpg/k3UQIycvT5qRAEGgSdcgEU6bwwlZf3robBOFkf6K5LwjxKXKMwTcB
-        n3pTlywe5y5ZPhF7384WE592Ko5lGElVgSuGiu8OZC0x2mdaN5BiyEVooaEvCtpqXDT3j85lXCVj
-        sLMkMoC4xosaoHsuuI7WwLQUFtt4yxVtslwEcDLhW6duUJammWYhzAGZEccaPTRVMknRkwcQY5mV
-        4nqjUVWtJfoKGPTPeZTI4uvUYNj5V1hPTFsetzfQWo55JYs5ftuneO6bR1sm8M9ctQunpYyaDWRh
-        hNcz9npD5yyt8vgKSvNKWAiJUdjt39x19zHTUdmRKtCpFBpmgWXu4WfDnqdj93OaHFGvvo4DvX2h
-        TuH8AqTWP0qDAgAA
+        H4sIAAAAAAAC/2WRW0+DMBTH3/kUTZ8342bm1LdFMGKySyZeEjHmZBSog5a0h2S68N1tuUxQHkjz
+        P79z+5+jQwjdgYh4BMg0vSFvRiHkWP9tTApkAk2gk4xYgMJftvmOvbdBkB1sEj2GgpCQIseMhUYI
+        aXDvkdVi6ZH1HbHvF3/lhnTUcFBiKpUF60QrxVxp/BCQt/kbQMV3+zbFEhkMgK3ENC61DqkFqray
+        AuQiscQ8FBXtTVud3u+j3x2VzJhdIJcRyzq86gAzleA63TLQUljsMVhv6CnKRcQORj53ugZ1aVpq
+        SNiSIRi34eQpLZTMCwzknolbWdZuX0zmTbXedQbAbNrGUSJkg9Dl5Hr0r7B2TVue9c/Wu6jZEjKO
+        X3aVwHsNaM8J/DNX54XTs4yas5VJisMZpzNrQG1a4+MzU5o3hiUsNxaOp2ezcWwOmNYdqWK6kEIz
+        P7LMZ+4+wcM49nx3+z33NxOMd1cLSZ3K+QFJbKVEuQIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -47,11 +53,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:54:33 GMT
+      - Wed, 24 Sep 2025 21:20:14 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1446
+      - gfet4t7; dur=2676
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/stream.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -29,12 +32,13 @@ interactions:
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":\\\"THE
-        NAME OF THE WIND\\\",\\\"author\\\":\\\"Patrick Rothfuss\\\",\\\"rating\\\":7}\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        11,\"candidatesTokenCount\": 19,\"totalTokenCount\": 167,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 11}],\"thoughtsTokenCount\": 137},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"GO3SaIe6GfHmqtsPvq3sWQ\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":
+        \\\"THE NAME OF THE WIND\\\", \\\"author\\\": {\\\"first_name\\\": \\\"Patrick\\\",
+        \\\"last_name\\\": \\\"Rothfuss\\\"}, \\\"rating\\\": 7}\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 11,\"candidatesTokenCount\":
+        36,\"totalTokenCount\": 185,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        11}],\"thoughtsTokenCount\": 138},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"tmDUaODeIY3Vz7IPk4udwQQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -43,11 +47,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:55:21 GMT
+      - Wed, 24 Sep 2025 21:20:55 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1596
+      - gfet4t7; dur=1936
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/strict_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/strict_async.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -30,13 +33,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRQW+CQBCF7/yKzZy1qQ2N0ZutNvWgopK2SelhIyNsxF26OzS2hP/eBQSx5bCZ
-        zHvMm/02dxiDHZehCDmhgTF7tx3G8uosNSUJJVmhadlmyjVdvPWXd2prITyVP0EeAAlKMIBxAP7z
-        jC0nixlbPbGyfp0vpwH0AuAZxUpXHo+TFrsD2yiK95kxla45CRlZfVhAJ6do64/eZTutEiyjjyrE
-        pLEXjQH2QgoTb5AbJUvb1l950KpChniy7VunCahGQ2Z4hAskbjnxlgakWh1T8tUB5aPKKk6DQT2s
-        g/VaH511UsSTa2no9v7NNVObKpIu785T2EvyRNB3eRN/9uZDBwRdr9WQcDrAwHLPopj+rOi6zhlZ
-        TfEFtRE1rgiPFmD/7ua+v0+4iatA0GhSJQ3Ow9Izyn623JNfE96Xn2Q8cqcPh/UanML5BYhgfPJx
-        AgAA
+        H4sIAAAAAAAC/1WR206DQBCG73kKMtetsUSt9s7YmpLYgxVbEzFmU7awKeyS3cG0Nry7A0i7cEE2
+        8/9z+ubkuC5smYxExJAbGLmfFHHdU/2vNCWRSyShDVEwZxov3uY7WW+yID9USXAKAQWmPIRRCMF0
+        4s4fZxN38exW740/H4fQC4EVmChNHrLvhDb4LVnW5CwZarHd17aU2cpKYbIrjAmhJE0zFDImYViC
+        NUp5fn/1LgtolfJqukxFPG3tZWugEaQwyYozo2RlewsWSzirQkb8QOFrp21Ql4bCsJjPODJCyc7A
+        INcqyzFQey6fVFGjHAyaYhb5ju49/OuokKXd1Ps216prxtRVpPZJrGvRkiwVeKw2CSYfAVggsDtW
+        S8KxgAGdpogT7I44uKnMNbKG4pprIxpcMc8IYN+7uu3v6GRJ3RA0N7mShvtRTX4zfmf+0Zvevax+
+        h/7Sw591/GrAKZ0/MpZLsJQCAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +48,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:54:46 GMT
+      - Wed, 24 Sep 2025 21:20:25 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1715
+      - gfet4t7; dur=1799
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/strict_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/strict_async_stream.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -29,12 +32,12 @@ interactions:
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":
-        \\\"THE NAME OF THE WIND\\\", \\\"author\\\": \\\"Patrick Rothfuss\\\", \\\"rating\\\":
-        7}\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
-        {\"promptTokenCount\": 11,\"candidatesTokenCount\": 24,\"totalTokenCount\":
-        159,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 11}],\"thoughtsTokenCount\":
-        124},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"G-3SaO36CJatqtsPuebOsAQ\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":\\\"THE
+        NAME OF THE WIND\\\",\\\"author\\\":{\\\"first_name\\\":\\\"Patrick\\\",\\\"last_name\\\":\\\"Rothfuss\\\"},\\\"rating\\\":7}\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        11,\"candidatesTokenCount\": 29,\"totalTokenCount\": 192,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 11}],\"thoughtsTokenCount\": 152},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"uWDUaM_TLeHOz7IPt7_D0Aw\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -43,11 +46,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:55:24 GMT
+      - Wed, 24 Sep 2025 21:20:58 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1482
+      - gfet4t7; dur=1552
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/strict_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/strict_stream.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -30,11 +33,11 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":\\\"THE
-        NAME OF THE WIND\\\",\\\"author\\\":\\\"Patrick Rothfuss\\\",\\\"rating\\\":7}\"}],\"role\":
+        NAME OF THE WIND\\\",\\\"author\\\":{\\\"first_name\\\":\\\"Patrick\\\",\\\"last_name\\\":\\\"Rothfuss\\\"},\\\"rating\\\":7}\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        11,\"candidatesTokenCount\": 19,\"totalTokenCount\": 171,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 11}],\"thoughtsTokenCount\": 141},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"CO3SaIHEHKy9qtsPs6WugQQ\"}\r\n\r\n"
+        11,\"candidatesTokenCount\": 29,\"totalTokenCount\": 171,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 11}],\"thoughtsTokenCount\": 131},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"qmDUaMy6BqOJz7IP3em76QQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -43,11 +46,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:55:05 GMT
+      - Wed, 24 Sep 2025 21:20:42 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1604
+      - gfet4t7; dur=1542
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/strict_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/strict_sync.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -30,13 +33,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/12RzW7CMBCE73kKa89QFSpalRsqoHLgPyqVmh4ssiQWwU7tjUQb5d1rJw2Y5mCt
-        dsY76y9lwBjsuYxFzAkNDNmH7TBW1qfTlCSUZIW2ZZs513T1Nl/p1dZCeHaXoIyABGUYwTCC8HXC
-        FqP5hC2nzNW72WIcQScCXlCqdO1ZcdJif2QbRemhMKbWNSchE6s/VeDlVJf6s3PdTqsMXfRJxZi1
-        9qo1wEFIYdINcqOks23D5QouqpAxnm37PmgD6tFQGJ7gHIlbTvxCA3KtTjmF6ojyRRU1p16vGeZh
-        vdWf/3RSxLNb6bG96801Y5sqMp+39yvsI3km6Nu9JJy8h+CBoNu1WhKBBwws9yJJ6d+KD85cI2so
-        vqE2osGV4MkC7PbvBt1Dxk1aB4JGkytpcBY7z2D5s+WLcX+E4fSLzMrwbS7Wawiq4BdFVxydcQIA
-        AA==
+        H4sIAAAAAAAC/2VRXU+DMBR951c0fd7MxuJIfFtk6qL7cOJHIsY0o4NmpcX2opuE/24LY4PIA7m9
+        59x7zz23cBDCGyIiFhGgGl+hd5NBqKj+FpMCqAADNCmTzIiCM7f+ilZsKED3tggXIQYGnIbmEeLg
+        booWk/kULW+QjV9nCz/EPYOQHBKpLMtUbJnS8ClIeixbEVBss6uZnHSwtYRkm2sd4tKiigATsYW8
+        Ercklaf4o3deRElOrcpURpQ39LIhGB2C6WRNiZbC0p6C5QqfUCYiujfpgdMMqFrjXJOYzikQYyk5
+        GYczJdMMArmj4lrmlaXDYd2sdYEOPhofcZBAeBdyB71/fbVvpjLePk3ramZJwhkc7CbB9C3ALSOg
+        K6txwmkZhs2B8jiBrkTXGzlHy2oXX6jSrLYrpqkxsO9eXPa35mpJNRArqjMpNJ1FlsNu/Wdy/+X6
+        3w+Pv95sBWNvcpj8YKd0/gAbEEAFnAIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +48,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:54:28 GMT
+      - Wed, 24 Sep 2025 21:20:08 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1374
+      - gfet4t7; dur=2188
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/sync.yaml
@@ -4,10 +4,13 @@ interactions:
       by Patrick Rothfuss"}], "role": "user"}], "generationConfig": {"responseMimeType":
       "application/json", "responseSchema": {"description": "A book with a rating.
       The title should be in all caps!", "properties": {"title": {"title": "Title",
-      "type": "STRING"}, "author": {"title": "Author", "type": "STRING"}, "rating":
-      {"description": "For testing purposes, the rating should be 7", "title": "Rating",
-      "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"], "required":
-      ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
+      "type": "STRING"}, "author": {"description": "The author of a book.", "properties":
+      {"first_name": {"title": "First Name", "type": "STRING"}, "last_name": {"title":
+      "Last Name", "type": "STRING"}}, "property_ordering": ["first_name", "last_name"],
+      "required": ["first_name", "last_name"], "title": "Author", "type": "OBJECT"},
+      "rating": {"description": "For testing purposes, the rating should be 7", "title":
+      "Rating", "type": "INTEGER"}}, "propertyOrdering": ["title", "author", "rating"],
+      "required": ["title", "author", "rating"], "title": "Book", "type": "OBJECT"}}}'
     headers:
       accept:
       - '*/*'
@@ -16,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '624'
+      - '883'
       content-type:
       - application/json
       host:
@@ -30,13 +33,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRT2+CQBDF73yKzZy1qSam1ptRGm3inyipTUoPGxlhI+7i7pDYEr57d6EothzI
-        ZN5j3syPwmMM9lxGIuKEBkbsw3YYK6q305QklGSFpmWbGdd089ZP0aqthfDiPoIiBBKUYgijEIKZ
-        z5bjhc9WL8zVu/lyGkInBJ5TonTlWXPSYn9kG0XJITem0jUnIWOrP5XQyimv9Wfntp1WKbrok4ow
-        bexlY4CDkMIkG+RGSWfbBqs1XFUhI7zY9qPXBFSjITc8xgUSt5z4lQZkWp0yCtQR5UTlFaderx7W
-        wnqvP//qpIin99LgsfNvrpnaVJG2ebd+hT2Sp4K+3CWB/x5ACwTdr9WQ8FrAwHLP44T+rNh351fI
-        aopvqI2occV4sgC7/YdB95Byk1SBoNFkShqcR84z7H5v+WqH/n73eiazpvNschwPwSu9H6TfEv5x
-        AgAA
+        H4sIAAAAAAAC/2VRy26DMBC88xWWz0mVpA+k3tpC1Rzypm+qygobsAI2shcpLeLfa0NIQOWA1juz
+        u7OzpUMI3TIR8YghaHpLPk2GkLL+W0wKBIEGaFMmmTOFZ27zlZ3YUBAOtoiWIUWOKYTmEdLgySfz
+        u5lPFo/Exq/TuRfSgUFYgYlUlmUqdlxp/BYsO5YtGSq+3TfMlPWwtcRkV2gd0sqiiiEXsYXcinYk
+        Vaf4a3BeRMkUrMpMRpC29KolGB2C62QNTEthaZtgsaQnlIsIDiY9ctoBdWtaaBbDDJAZS9nJOJor
+        meUYyD2IB1nUlo7HTbPOBXr45c0RR4ks7Ze6V4N/fbVnpvK0e5rO1cySLOX4YzcJ/LeAdozAvqzW
+        CadjGDUHKuIE+xLHE9c5Wta4+AJK88auGDJj4HBycT3cmasl9UCqQOdSaJhGlpNm3jNbiHsfxOrX
+        nS7Fh7cZrd6pUzl/MD/pRpwCAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +48,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:54:43 GMT
+      - Wed, 24 Sep 2025 21:20:22 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1292
+      - gfet4t7; dur=1287
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/tool_async.yaml
@@ -6,13 +6,15 @@ interactions:
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.\nA
       book with a rating. The title should be in all caps!", "name": "__mirascope_formatted_output_tool__",
-      "parametersJsonSchema": {"description": "A book with a rating. The title should
-      be in all caps!", "properties": {"title": {"title": "Title", "type": "string"},
-      "author": {"title": "Author", "type": "string"}, "rating": {"description": "For
-      testing purposes, the rating should be 7", "title": "Rating", "type": "integer"}},
-      "required": ["title", "author", "rating"], "title": "Book", "type": "object"}}]}],
-      "toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames":
-      ["__mirascope_formatted_output_tool__"]}}, "generationConfig": {}}'
+      "parameters": {"properties": {"title": {"title": "Title", "type": "STRING"},
+      "author": {"description": "The author of a book.", "properties": {"first_name":
+      {"title": "First Name", "type": "STRING"}, "last_name": {"title": "Last Name",
+      "type": "STRING"}}, "required": ["first_name", "last_name"], "title": "Author",
+      "type": "OBJECT"}, "rating": {"description": "For testing purposes, the rating
+      should be 7", "title": "Rating", "type": "INTEGER"}}, "required": ["title",
+      "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -21,7 +23,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1065'
+      - '1174'
       content-type:
       - application/json
       host:
@@ -35,25 +37,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21U25KiSBR8768weHV65SK3fUPA9gZ4QRA2NgyEAlGoQqoQpGP+fWh7eqadaR4I
-        OJknT5HBydenXo8KAxilUUAApv7t/ddVer3X+/0NQ5AASDrgo9QVi6Akv7nv1+un544SVzAkKYJq
-        kGUPzT9xGOSgq1P7fZ6WAQ5RAfYxKvOAEBDtUUWKiuwJQtl+T337szkoE/yFaIeQlGR3XXui90zF
-        0HvWuPf27E5N7S+hN6mKHFH51rEMSJmG594akWNcYfwVuwxICpOOLf6BfX94//7YSnUjquRINmkC
-        A1KV9wOqZKsr0YSk+WCYzBr6+BJca9JoRE084NpjOt85Uj6X45EQxtvVaKpuVDLc5VLspxlsjP7p
-        DMW1q6mT+KoLPNn5W1uNQhoHXriUxcaHNl1HCXfK8pf6yoJ1Y1v0bKuduHGf4VEMl8AhriaWw+VR
-        dq6DmWEOPNtmgIYUZqWcBZ6tDcko0BSh7Qle7VMuLXw6vplLe5KxLqMk7Vh21Uia8TXfJzpUT2HV
-        iL55u9HeRTcEXHMe69RmrcvioA0VOt0ehaHpcO6VGcv1rC/T7NRs5JfK5yRFssSZMnHCdlSD1p0z
-        7LbR4wu2oKPEUyvITTEwKlXu242zJLAVhFvNulpyjCSOIRWkQ/kMF2qjsySSqinsL5T1AE6jyWph
-        WRP+yo1Mb6gfnR0+5ddWNfKiEc71KosK3GfNuRKnUTOUw1EobRVQ+VPn5Xg9wdxajdTtyZLcKRB0
-        hlVSbXlbKZe+7rAu2XF20zJCmEgFw823Nh4LwvrW/SDnXHQOJjdwktLSDkKa05Un1LorsUXBTK7x
-        QFPdYbu+Lk2W89IX/XJeMYfSPfRJvzbFASNl89VGyM6Z77qLK2Nxtie6k7mhTHh6ORGtSctkELpt
-        nKODOKpw5hkz4tTGStMiK5ZOujUulyM5o5MNuJmqIJ6RWUE+ulhtqqJi6PF2w7R5MVaZHYeGKzqI
-        wo3BMMOzkc7Wfc3m1/IiapwSBOaY5w4pOJRjm654PQVFhAuXj3l2AFp/jmHEAlohsM/I5MJBq/S3
-        uRYnQFg4MruuXuTtyCNregewfZr5uyw9SJiThiN545nIVhyO9cqzn7vRSZ9bl0hCxSY0Fm2tUU9f
-        bdf/vzeLKtH7qucoAtkH/dfqUXEKU3xcgwAj+Ebb2Nby105TKYxA05Xpp48Bd2mqwkECDECCLg+D
-        XxlDFSXKC2KjM4Aqqu55yHDSu9qn/HwgcOJPnCASZI8Qy3/7Sxhr3dg0+xysnzK3+8ogS8ntHm76
-        zv4UT92Ax3N9ePH0ybKPEHo8I8O/GXA37d1HB5Q4fTcsAXln4TP7D/8cZwE+3idSJcAFghhMo3t8
-        P7ebYLZoZnO2vBC8lP2bX69W1NP3px9WF4yEWwYAAA==
+        H4sIAAAAAAAC/21V25KiSBB9768wfHVmbe6yEfuAIAqKKCC3jQ2jhAJKrkLhhY7596Xt7hl7engg
+        qvKcPFmVEXnq5WkwGAagCFEIMGyGfw/+7SODwcv9/4qVBYYF7oGPUB+sQI1/cd++l4d1T4naIsCo
+        LESQZZ+S3/EC5LCPD/f7HNWgCcoK7qOyzgHGMNyXLa5avMdlme33w2+/J4M6bv4g+oq0OCnrP2Kv
+        h0J1g/cfpTcA1yhIv8jfqRl4YBolTqK2aYZfmD++Jg9rgFER93ncH0CMcHbXtBazwVrQZgNdHryu
+        HWUt/a7/49P+t1rD/qZtnGATxQXAbX1XFatUFsIFRvkkULR0VSjnw4WfX6AfqgkgZSvhtMPl6pl5
+        alkBSamX2OGOhKmTx5rnlMo0ti6rHLEYzvmYk3L1qvGI9lt2lAbJNFdXhPq8ZI60h/nUrHAOJRpk
+        R51VNfFSRCls+QtqlXIkaKojbkdj7ybF1k4QJdlGzjnhZLaY2xkVO16ZrLxUEbf+enPGRNBh+joO
+        SX5LXXNyYUXmjMNbppwY9grEqj7Jn0NNvU6vhyzrRMMlp+FBcluCbW/z1ZgWKb44IrkBuhFVrk0j
+        K0/DEgpye+LJym8EdJ1lx2AcdwdKj50KZVzdSQTJtd2hXS+oWaKeVesijA/8RGOnQCmMSSOdOCab
+        WzF7WuFskXqbKxHU4q3gGFIYwYXARAHnPLuErjrzBupekPs4BBL/LK43G0T5x3oH2clWZMtcQc7U
+        jXen1hLsxj8Y4/RGahqplcW0GPEqhguZWVfJJDjvNH0jLZDszCtpaQF/dG5OIh34xdY5e77qpRZH
+        UbUCOzc3Jrrne8qlyCjJPE6cehxPmalayYAgp0aX8+dNXepXseAVhVjVkeyfEh6SsQr1A6POuNgf
+        LS8EQZsRVAlCF9xwK+lmC4G225yqMBDbvFrR3OJ2mwfHAG+pNHJFIkzzFUdtsmhdO0vBNpjpNSdu
+        LmiLVAjCZWISbKfOTXRWRkRNU7slC+hK8e248oupddHH4XJJB1M+JmnM0d7V6CiG5ZpksbOX+alj
+        cHYOMjcZz8NVDGeMF12rlJzTSHTmxyKIG9psGDe1c7M2iMst5W+HDZlO5Jh0QgWeLoDlnEBoA13G
+        rJuLbRLbq900SWh0shsMXB8eTpv183JJwaaRFqY8Ap6tSMFaQ2v9Mga8Nb5JdCjr27Qbu8s16lbb
+        eN4tgitF2GfhVp85PL3w2jpbMtHO606HZ1Lb2Tti98/j9P6a3P9+Te2wLt9mPy9DmH3Qf451b08F
+        ahIDgqYsXmmmpW9+utMQFSG89uHnp48Cd+lh24AYahCD3sHBT+cbVnWZV9gqU1iIZXt3cJJ4d6QH
+        x/9EoPl3HJcYZJ8hiv72RbiR+rIoe3wKHl6J/pYgQ/h2d7uZaz0YbV/g87k+evH00LIPg/t8RoKd
+        PL037a2PNqwb9NawGOZ9C7+TfzHfo97Ak3vFYQ2bqiwaqISvnO/5ZgeUbjFnV0bHKRsSn+1421v7
+        j6f/AetMUpQNBwAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -62,11 +66,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:54:55 GMT
+      - Wed, 24 Sep 2025 21:34:50 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2262
+      - gfet4t7; dur=1401
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/tool_async_stream.yaml
@@ -6,13 +6,15 @@ interactions:
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.\nA
       book with a rating. The title should be in all caps!", "name": "__mirascope_formatted_output_tool__",
-      "parametersJsonSchema": {"description": "A book with a rating. The title should
-      be in all caps!", "properties": {"title": {"title": "Title", "type": "string"},
-      "author": {"title": "Author", "type": "string"}, "rating": {"description": "For
-      testing purposes, the rating should be 7", "title": "Rating", "type": "integer"}},
-      "required": ["title", "author", "rating"], "title": "Book", "type": "object"}}]}],
-      "toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames":
-      ["__mirascope_formatted_output_tool__"]}}, "generationConfig": {}}'
+      "parameters": {"properties": {"title": {"title": "Title", "type": "STRING"},
+      "author": {"description": "The author of a book.", "properties": {"first_name":
+      {"title": "First Name", "type": "STRING"}, "last_name": {"title": "Last Name",
+      "type": "STRING"}}, "required": ["first_name", "last_name"], "title": "Author",
+      "type": "OBJECT"}, "rating": {"description": "For testing purposes, the rating
+      should be 7", "title": "Rating", "type": "INTEGER"}}, "required": ["title",
+      "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -21,7 +23,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1065'
+      - '1174'
       content-type:
       - application/json
       host:
@@ -36,12 +38,12 @@ interactions:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
         {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"author\":
-        \"Patrick Rothfuss\",\"title\": \"THE NAME OF THE WIND\",\"rating\": 7}},\"thoughtSignature\":
-        \"CiQB0e2Kb1a1JRzI9pMMwkdxkP/zmlI6cIrwvfK0H+jUPY8OlAEKbAHR7YpvRuoSFxjQHnfW9hLZbXZuQHjRk+7qqgCwDA15kESkJR0ewAIlq289w+kZ0ID8NiE0MQicEDherAar/CvZ6oZEsl/EOZz2Nj1pCTCBf3+TEyPM6WlXpu6mQhPOy1M0ojPeM6qTxoT7dwrqAQHR7Ypvdnec//+sxcteuC9I/4LJ9L+jooXECCxikrix1yyq8qsl0OQdXA6/7/yB/6P8o+ymmz4fujW/l8e3zP+w47J1kFDtuMDfZvjveU1/J8dRoeC9nvL0XboGZ3xDUeuySyN5mikENh+uHVufE+scCV5pYvwrdfwzizGjDAoA3nUbZWxBfSIDqOV0ibLGS3UbZVHyIX+QJO/w3EjpqaEZ/jmj34WqqWm7CPJsI4IQTQ6Eq+4HNbGtR1guxiSDSD4/+vdbCiBHwB4Zmpb9OAu/OdXPFd0qH8pikjxMsvvcJreUJdHEWqfCZwqAAgHR7Ypv4fSdwqIttD3TKVpgS16iitwUbRga1kXnDHQjuyoOGH7EVNeISl2rYaKpiMR8+TGep3hVKy9ZqL7b7iBrigP4LkgKrc7UV72iOZAbx1Lzu7et866buGt385QCZFH4TwqP826k8/7oEXVgUxTOt0QMI319DAtetvzngK+iX+Jpsmct1qbS+z1J582X/DKj4lJBIXHtHOwDipl7mk07XDuEc/1XrN4qQTd4vmlTLx4JxevJBQ5DGBcaxseFS7OhSLKJSNAzJQ/gWAdx4nLgnjCF2hXcxGtyLBRKjuueYteiiEp7sH3aOdDOCViyaAOs3ah24Ayh+AKOJot86CkK3AEB0e2Kb/UDah5oC53VNkSDhBgCxUNGg+cVfHQaNU31ZxBPM33tZe4jqwY7TArunkw/IdwaIzUZ7+hjqXy9xkJotUrrH3m84Byt8uWVBWadr87nhr/h5wnRi2YEKbh0rN6t9QWwAH7mk+w+aCZ86TDLzxXxi+E9G5ZsFXlhmmyoSc8ZZ2FVFIIHL/WGOd0twipEaqim3smR7vV15srR+WDa4lxY7yfvq4dFaWPE25HiXmazfA9ej2MyFL+9K6835t9r0jwBMSC7+p/cESXJ7KqcThS2aY33sF8oDQg/CkMB0e2Kb1MWSZCKVe8B5MJItjrHuTg0/TKpklsmaGOYKlzUsRKsBQGOYNULfWCopFKYD4J7GB9FmRCyj9ja/nbhJetx\"}],\"role\":
+        {\"last_name\": \"Rothfuss\",\"first_name\": \"Patrick\"},\"rating\": 7,\"title\":
+        \"THE NAME OF THE WIND\"}},\"thoughtSignature\": \"CiQB0e2Kb/6nhq89IPYXPJpTjStnREpBcdCwkNx37n0ILs+POy0KeQHR7YpvEHmW7XNAIOwzNpK9t3elL0AzeLl9+IeQvhZI1USDxsRjwYmg8TVmUa8bV7ow3YA5DAflaOQHBklpInkagWT6UEHxQVQpaCHgjW/UMSbycrd5j+hJ3vXzszOeaXYltNN+GnuhTVdTBRCcIqRigJJNkjiRQ7kKyQEB0e2Kb541OF6Ojzrim2yHyzKl+rhFrJzpDjIW3CJz+zwKKOYntdGbDhWwxP3Tstk/9cLrcB7N38xKwiAxdP9Jv1bIfnkFSxwRbMSfvPaxBS2XB8Pkm2Q8OLYxTIBkyu3XtMgYhsli2+HID94mvudyErnXnlRv3T52y9z1NJk675ytoBtXbLW7H3zTjwrd5cQ7tyWIi+06f4ue9KlKqOiRWHfgJkYWnUwKza3RcU+7BesSBtkV8LKei0+3nuwUlKgH6EO5zZx9dNwK5QEB0e2Kb5e8D0tfc98sUXuQpRl48KzbATUHrBGd2pVAxJLHn+kNG54EdYLd9g8IB+tN/i3ZvhVw4RwEwYqXCPT5FSRskLF4k+Xw92hDwTQp8GjLyXuOXCLDbZczBY1FXZLyBxd2PaREFondWUaFvxjbXp2lj+Eiwp0Oou74/pp3PpsNF8LeRsxKjs5mivnHZvm25GRCazR7m8xbtRVm9vucGlm6LdyNNSFISOEPJA8fViT01VR2z/aTKg/JK98tKJn9lBgwVH1NJrYib2BYr2O99NtB80Nwpvo9o2qjETnt/dAKqE53CsMBAdHtim/vbdVZUdMgJ0KJpUHeSzzj0r5UilamFIDhzix1/rcleGOtXhrz//K5sbwx2HcBw+/ZisLC2W7KsA5apZffC7RlmwLa2ni59qDP3NapUmH4oulwNOHh4PbOQvfQJvr33reh2YodLOqePl5cTC/IWE9C5jp5QHli6iqWietXceohmHQ4rtn1CJ/7xLTxr+ItPP/lvBzeKiCnpQwA1leVq8JoIWJANSkw+j6VSDaTIOfPvbkNblGax1nVKQtG5T7lCn4B0e2KbwF4Fn3VfdXEtep/dzrMWiEFgTSA6ppySraRNrd79+H1RwkWLIrbYnZbE8J3/Blzut/or0FJ8y0VVjbz59mZpmhQpsVejvQoba7aOTiPdFSTSpUSO65/A5DtyfaM7hNWgM5Xz9BLg74mmWJFHUGq6P+BKfg/EDJIUXI=\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        138,\"candidatesTokenCount\": 37,\"totalTokenCount\": 355,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 138}],\"thoughtsTokenCount\": 180},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"JO3SaKLIMLyJqtsPs42WkQQ\"}\r\n\r\n"
+        217,\"candidatesTokenCount\": 49,\"totalTokenCount\": 461,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 217}],\"thoughtsTokenCount\": 195},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"_mPUaNmbHOfRz7IPp6Lx-Qw\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -50,11 +52,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:55:34 GMT
+      - Wed, 24 Sep 2025 21:34:55 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2134
+      - gfet4t7; dur=2053
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/tool_stream.yaml
@@ -6,13 +6,15 @@ interactions:
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.\nA
       book with a rating. The title should be in all caps!", "name": "__mirascope_formatted_output_tool__",
-      "parametersJsonSchema": {"description": "A book with a rating. The title should
-      be in all caps!", "properties": {"title": {"title": "Title", "type": "string"},
-      "author": {"title": "Author", "type": "string"}, "rating": {"description": "For
-      testing purposes, the rating should be 7", "title": "Rating", "type": "integer"}},
-      "required": ["title", "author", "rating"], "title": "Book", "type": "object"}}]}],
-      "toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames":
-      ["__mirascope_formatted_output_tool__"]}}, "generationConfig": {}}'
+      "parameters": {"properties": {"title": {"title": "Title", "type": "STRING"},
+      "author": {"description": "The author of a book.", "properties": {"first_name":
+      {"title": "First Name", "type": "STRING"}, "last_name": {"title": "Last Name",
+      "type": "STRING"}}, "required": ["first_name", "last_name"], "title": "Author",
+      "type": "OBJECT"}, "rating": {"description": "For testing purposes, the rating
+      should be 7", "title": "Rating", "type": "INTEGER"}}, "required": ["title",
+      "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -21,7 +23,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1065'
+      - '1174'
       content-type:
       - application/json
       host:
@@ -35,13 +37,13 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"title\": \"THE
-        NAME OF THE WIND\",\"author\": \"Patrick Rothfuss\",\"rating\": 7}},\"thoughtSignature\":
-        \"CiQB0e2Kb8DhGRimWBaxTYlCE1/Ro4NZBuSmIaGI1FFgGW1TavoKdwHR7YpvCJK6ViyNXSXOkU2CEEkc22Xd+tPdjkXstOxhkHc4WNy47ui8I8mqnhmI+9kRoewhCK4OTMp9hrWBlfsREDvS47C9SIi5nUQ+7XlMuvAJMPC7/8oBemR4sYpih27m/qw+Cf29hElpKQBE+rFDn49ANFomCv0BAdHtim/WdkpzgvCmpYM4u2E8Xi9yaM6utZcr9RgDRWiO7qpF4WVONR7qHZ5R7WI7FHMCQ2D0AOjOBjqXQOF34lD4T7kn8DUtSxwHqmHXUfCE8ggGCO8aCYPwmgE664QblDyKgXPctY0tocqIdaUmqFgxbaM4oegqMSW8j3U1quFW0msIjHFFZAWYxo0HFBxyEQruBYefV2hh3Z7gtdSVNMD/EBkCcgVjQQqNXdnbY2DK7chmakSuqbQbOhV7j2YFALqDrzrCq7M0IYZUKEaHgtp4uGZes63daI25I9WvNwXbayxTxoyyU39X9zYmufZQgfzBhj7QnwZJvP0XUQr+AQHR7YpvJxu+Y+d0Ck1Xk9RjSvkcE4ANBbRuIcsQyvH87x7YLimF5X5sL4RGMEIsKBDQkV/z+cwqq/YN45/Opzt3+E1pR13j9lpRuVfG+Ivr8GmFWBcGF4m9bqIp2eak5wiXEzFq+SuOEzIVIX3gyw6aZXjf7y5RYwlUoj91ltpJy0RQaFtr+V6dkAQ3huyosyeMaAdFRjfwGEMCEcJpFn6GclOCgEwubWfJ4UVyJfg6lZcuKoruHXPH1kTjskvXsdIwu5I0ozARfP425i+j7pTx6AeDukmNyjCt6Uq/Xb9mt9IjakK5hz/aLa25LoTobs2CG+lPNPyUOkRc7M2/CnQB0e2Kb/ZcZuBW27nB6KI2uyqaJcKu4iK1bekSEzKCxxpr4gL2fk2RpYIC54aRLxn8OfTE1wET77HdIWUb8Phh6Y0R1rKnlFR77c7JHlHZC0AJT9uW0Ac+hW8J1zyuXOZ5opiJwuMgKmtuTK53GxMp/3p7wg==\"}],\"role\":
+        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"author\":
+        {\"last_name\": \"Rothfuss\",\"first_name\": \"Patrick\"},\"rating\": 7,\"title\":
+        \"THE NAME OF THE WIND\"}},\"thoughtSignature\": \"CiQB0e2Kb1OpapOwotnClNAHfzlnk0tA+iJ34wR3FsTgW+pKGLwKbAHR7YpvV+6gh8X20tg0MJQEaV67xvTrMGpcftbmVHk9a9jusIqkYVZC3RgPhH6euEgZqUALsH5bmCGnmJFZIv1Phq38pGRwHZfbrUELd9E/MfGfaXp9Fo/uozup8qrhNxESNtgMtUESCLv30grqAQHR7YpvrGpvsmCxBjp87g/XhaVLnpnodyfCZ9Xk1eiQvHIBuv1hr2l9Yl5fJyvclngqDsvvgS/LmiduAUwub30ZAKeD9wjfCpkxIFe4kkk8ypIrxkzmP0BwzNmTZeDomwa6d9GM4jzPPoJ9wN80scq9urOAtn2pXhkSjIx4Qq7vRTIHheyMX1OlpUJ0fvdQsATVxQk7lh7jFJA/k94gsP6kePPf2Fj4OlHitm/9DF3kVE2RuesntajHgxTCwHV35RB7xKUX7aBfKVq+4qrNrptPkU5xjla7LPjEIyH+MYrmzAKSrw6i+UlJkAruAQHR7Ypvy7kQ7MBy8/s5h8CLBy/F0dHD2z7UDuRY1djUE1ZH/CXAst/M5GhUsSVmN7H7QQgoK7bqXWqvkCzih216xR2Hv1I/27xczTUWHDg6BtAF7YZ/bPVCAnvuZeL/bZ4wUjQve2E6ZqN/thL5XWCGKbCjtkf9ehZs8FqT4Oiv9Cs3ip9xxgy3gn+LRgqvlllJQezgoZOjphH7h7yFaaTYliKltRKVI7qtgs5BhXuQ17yWugJZz20Kuim6E8BiMLeckitKLH7zJL4dnBcHW5HDsh5qEI5et4xx7VUyoGvrvpZUX8RuX9BzC90LMcsKjQIB0e2Kb01Cg3S1yTbtkXBCVAw1EAjefL1rSFM117R3kANRRvemJRNBoS/JOvlz8VoAeOUxYeEt4AsexJhtoZIcle1He9ZUgDCWXgX4eTyj1c9qDtG6qhkUVHTY8JSSWPA5ywEOhFLuZXRw78sqAmzd5l+qPzCXKe0vId9VV4UimoYubPnlpm2hsZBemDwe0UdZhQgvAch5eYq5tk6pf0vpFmlUpw52LJoF/0BHWRuUwXvLvbKjtPLcHIhjZPJsHg2Gqer8I8rMiQCvrKq3sMHEMRhA+hwiAZhiU8NcmFDmcy0Q1TX4BDeen72AurNMmuYluYYDrPy+mbr9WuptEzei194LnpbNMq7Lu92c+griAQHR7YpvjaVT7dfn60ViqLz6ZnjxGGqwfqYkWk7L/enH2y8/PCm7dsJ7D/BbNDkto/TnbArYvlpeafF5C16FM4be9z4jAdswUdXLdPwBsZfFqk+icDjqvmQ//u+fLcQZ+5y/1wW7vz8xvjY9AdJlaUJc10dUMLARguGqbFNmmwuv4gf7wbX24TWzFXtzVrB5IDZMS3xNohzWXL/AIsmWUeEzbUBMS+QRfji1hFw6w9/PDPx0F6WvY4OPJ9mgvlyJMSOiq09rYx7oO9IUZfalljs7JE9ZomumKRU2zi9slk5730gKzwEB0e2Kb6cT/3Q5UoYbF7/bTqJRdgUBk7X4oVjP8ncmgrjubLYXaqrCC35OG6jGgkSDFlzob0lj1fGpp74JMsf5PKk/mrU/zgxHgxjyp5pxxCFMzXyrdR/5oPf4J4uayyE2lIJJWxyITuUfU8LPh6Pku6VbyClLM5uu55AirldJxQPvCbDJ1v98AHE6LViOJagQkorz4mHHAqDu/wqKYSFmBHY/ri++d588XKzWSoPo1Z4s8CdypEd+YuP+E9ai48eTJFbQt+eVtO3T5gJc1mkKVgHR7YpvXU909N/aJyQSPTzOLkeqGAI53fDEsQUrROe092kP/q5XqG0I9u7Ta1ne9vOoIGOkyl0InSlw2yszSJTQ4FVd/9ys83szuhXaIU8iDGhgjcsa\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        138,\"candidatesTokenCount\": 37,\"totalTokenCount\": 326,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 138}],\"thoughtsTokenCount\": 151},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"FO3SaN_BGNXYqtsPx-TGoA8\"}\r\n\r\n"
+        217,\"candidatesTokenCount\": 49,\"totalTokenCount\": 550,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 217}],\"thoughtsTokenCount\": 284},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"-2PUaKCsBfjVz7IP8JqOwQQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -50,11 +52,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:55:17 GMT
+      - Wed, 24 Sep 2025 21:34:53 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1369
+      - gfet4t7; dur=2358
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/google/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/google/tool_sync.yaml
@@ -6,13 +6,15 @@ interactions:
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.\nA
       book with a rating. The title should be in all caps!", "name": "__mirascope_formatted_output_tool__",
-      "parametersJsonSchema": {"description": "A book with a rating. The title should
-      be in all caps!", "properties": {"title": {"title": "Title", "type": "string"},
-      "author": {"title": "Author", "type": "string"}, "rating": {"description": "For
-      testing purposes, the rating should be 7", "title": "Rating", "type": "integer"}},
-      "required": ["title", "author", "rating"], "title": "Book", "type": "object"}}]}],
-      "toolConfig": {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames":
-      ["__mirascope_formatted_output_tool__"]}}, "generationConfig": {}}'
+      "parameters": {"properties": {"title": {"title": "Title", "type": "STRING"},
+      "author": {"description": "The author of a book.", "properties": {"first_name":
+      {"title": "First Name", "type": "STRING"}, "last_name": {"title": "Last Name",
+      "type": "STRING"}}, "required": ["first_name", "last_name"], "title": "Author",
+      "type": "OBJECT"}, "rating": {"description": "For testing purposes, the rating
+      should be 7", "title": "Rating", "type": "INTEGER"}}, "required": ["title",
+      "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -21,7 +23,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1065'
+      - '1174'
       content-type:
       - application/json
       host:
@@ -35,24 +37,28 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21U25KiSBB9768weHV2ERHRjdgHQBQQQbm2bmwY1VBCCVQJFF6YmH9f2p6e0Znl
-        gSgyT56TZFSery+9HhMBHKMYUFgzf/X+6SK93tf7+z1HMIWYdonPUBc8gYr+xH48Xx/OHeTQ4Igi
-        ghWQ50/F3/MYFLCLM/t9gSpQR+QE9wdSFYBSGO9JQ08N3VNC8v2e+fJrMaiS+n9Iu0wFKMJJlxN/
-        LXova2hKqnfVNaAVirKeQ2h6aOr6N4kOTRHN7y16mtqzpJXas+e993OoWzPmF/y3p+9vz3RMJ9sk
-        KXVRggFtqjurciYzKdYoKqbWEeaWOzTUvjHL2LFd9i9om1jxEinsdlH6if52QTw7i1NzovHz4GCv
-        YMjtFORcNfaym6CtOXbzTbsMs90mVpN47FyUoA1mGoga01qfUTWr09JvV0rWWGfrqhtjA8twcPKs
-        VbYoRo2TzljPkyHloJHfcKathsnQXu4QeJMpPh7D6LrN9STF5Woc18GpZHNxwdppK8mpT44ja5Wy
-        ueTZtIXzU5zajeCwjfbm7UaVLcPp4UgzRz8ODmqg83EZG4MrmlJaZqRUr7UcXIR+IO8O3itxsu1p
-        0m6xn5kCDSWAIbq5N95WaTg2vZDbbA9NcVnWs8Cv1sVKMt5e+627Pl1ujuJffN2rOYEEcylr1WO/
-        AmIxkUBhsGXt7QwjXQpBM94tLEdvz8drnNsbV1ls/aNIppIQyTPBdM+VwicyPg69qfEqi4m2HBcX
-        3lA8zdUEtNhmangQY3fsBFPOeZtf+DwY1YJp1k7ZBDfTkkaz2gA+PDbNbaAW3CWWHVqJgwTb2W2J
-        50CpWIntV+VqyPmm1WAi2tTHy1Nj9MFSxKzHK6LOD9WUP1ZlMB7ZN280PI9GtRnSTdCGeRbK6oQX
-        tdIwERknRQE4bhNF10XqJr4IFjCs5m4hxkPVPmwyjV6Wc5j7a3mtn31pvEvaNoq4UbiMBIQnWvE6
-        m5sgpec1bYY68sOdrrKJ4OZXp3S4kvz9eNN/3vJ/f95wpiIfe1KQGOaf8B8rwBwQRnXqQFAT/A5z
-        PXv9Y98YhGN47cKDl0+BOzXT1CCBK0hB50vgx64zp4oUJ+qRDGKFNHdf4vjJB9uDjz0B+O9ewFBC
-        Qf6UGk4HX34jrmedLMofDe7B+7q/BDmit7szqK/eg3V0As99fc7i5WFkn2bw3CPHCS/fh/YxxwBW
-        NfoYWAKLboR/DP8U/jjkoE7vikwF6xPBNdTjd4zYtC5Y7V2TLlcFzdZVVKhEUpmXby//AQI4Oy3j
-        BQAA
+        H4sIAAAAAAAC/21V2bKaWBR9v19h+WrSTILaVf2gyCSXSUTBri7rMCOjnAMCqfx7c6fEm4QHCvZa
+        ezyw9renyWTqgcJPfIACOP178u9omUy+vd5fsLJAQYFG4MM0GitQo5/ct+vbw/NICZvCQ0lZsCDL
+        Pjm/4wXIg9E+vVzypAbQK6vgEpZ1DhAK/EvZoKpBF1SW2eUy/fKrM6gj+IegI1IDlBTRiC1+dXpx
+        a1Bc1n90HNEMQHT5KGtfojhsIPwt91tzSf3A1QGqEy+d/sb8/ocaUIKyV6+DyE3UtcJNNH7y8nyS
+        1O2vIb5/ev8l3HRspoliZCZRAVBTv0ZlW4df+yJKcgyvHLpbqVibSJzl53ttzedUinOn7ujKpnDn
+        d5Zhb9syYMjtgiwcXVhQm2AP+/igxjVGH+lDSd701dpnImrLWkZtZGU2OxPkgkhrP+/Fe9w+O1a0
+        mQ+cejQEOQgru2h1yj3PdK7wq9hvtPDZuwpd0Uq+vT/PRaURroObaAcq9w0jrLATjoKGS/ZtA1XY
+        paZNhbmrgKEeXJqfLTEjra/CtdfYHe4k5pVSt4QUahDUPYvCeeOa+X0lcSmXeYN/XLr7G6NpdLhb
+        ns9HF8kcQ0j9SlOKXPfKW+JubVrl6Ph+rOPZ6cA0WHFatNQ2S91Ux2u+CPusZlxVvO4djUdzHrYO
+        4XCzzdVdiQxan3hK99JTF6JUxklrxe7u801lKkwpQJyhWIG9U4fBbqTjM59d3VQxA4J2d4i04p2x
+        oI4+fSfMda/Hp/DOmyg/AEzfZCtrK0J0DpSBmvE3jg50KRhYE+4LZTDppR013LKQNINrlm2nPqfs
+        nU75fo6d/JDbLBY2dm/rtl2f2kLECwjWxZoPr7OkjbXNDKZyKYb0AuBay/O5IZni/BCf8hspOGOz
+        JbZNqjXcKgMeElSke3JfF/qcwFQenekrefNq7XBytE6GjAfEQ2dbQwI7zTMVf74MqHgGrCHfNp2R
+        dxxN5lZwgMaajc47nU/EeDyERDidbqPf+KEiKKX6xqxkRz3fCWvfYWQkVDKr7Eo7PovwWEpQmSuB
+        Glqhtmu9bXoj91dF7PQb3R95t/A5ig1pMUs0qVs9BzsTWG7icNH2mqM1v7nqkXdkwmVtS+2OrO8o
+        H09crxZYv6sDOYfG0R6IgMlaz8l2ve2YWKHEqiwHx6xuVWFuSRustrgdI2DCMVoNh9XVQWW7wI1y
+        n+5p0c7LZ/zGCnXk6j4jhAjkGC/gNhOQXsXJ5tjC2grm5zOt9gnADTUGmoKFzk3BwPkZLlmCu/Fz
+        dVfHS9kTm6WtFGWjg9kNx1qZbaJIkm+dmkWbIb5iQKvICDtbqk+YHnsPRbY/7AkBkndx8BRqF9Fq
+        gkX45iT3Z1H651E5fqrGfz8VY1qXb7qTl36QfdB/SMooaUUC430AYFm80MyDpv8Qv2lS+EE3mvGn
+        jwSvoacNBFGgBAiM2wP8ENZpVZd5hQ5lGhRs2bxuD5J4V+SHbfOJMF+946hEIPsMMeSX3wLD7Zg2
+        yR7X0MOGGrsEWYL6V6Xl7MODjo8JPtf1MYunh5F9iOvnGokV8/Q+tLc5HoMaJm8Di4J8HOFX8i/6
+        aziukvg147QOYFUWMJD8F85XQbeAPv7femgMC0kvLxTXG8b06fvT/wcJelCJBwAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -61,11 +67,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:54:38 GMT
+      - Wed, 24 Sep 2025 21:34:48 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2644
+      - gfet4t7; dur=1803
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output/openai/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/async.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}}}'
     headers:
@@ -13,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '662'
+      - '929'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +48,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrK4g924Xt2parW+GkryAPuAUKJAoEmlpJbCiSIFdBC8P/
-        HpB2LLkPoBeC4OwMd2Z3lzAGsoSMgWg4idaq8frL7Ov6+g4391XavbtQa7Ghj8o+X13ZWwujwDDb
-        HyjolfVGmNYqJGn0ARYOOWFQnaaL1XLxNp1MItCaElWg1ZbGczOeTWbz8WQ1niyPxMZIgR4y9pAw
-        xtgunqFFXeJPyFiUiS8tes9rhOxUxBg4o8ILcO+lJ64JRj0ojCbUsetdDiRJYQ5ZDt8+XbKb99eX
-        7PYDC/fvn28uchjlwDtqjIs1d5ycFE9sY6ipOu8j7jhJXeeQpfvhPw6rzvNgU3dKDQCutSEeYooO
-        H4/I/uRJmdo6s/W/UaGSWvqmcMi90aF/T8ZCRPcJY48xu+4sDrDOtJYKMk8Yv5vOpgc96KfVo7Nj
-        sECGuBqw5q+sM72iROJS+UH6ILhosOyp/ah4V0ozAJKB6z+7+Zv2wbnU9f/I94AQaAnLwjospTh3
-        3Jc5DMv8r7JTyrFh8OiepcCCJLowiRIr3qnDnoH/5QnbopK6RmedPCxbZQuxrabparFYppDskxcA
-        AAD//wMA/zj0THUDAAA=
+        H4sIAAAAAAAAA4xSYW/TMBD9nl9h3ecWpVXblHyDbQiQKDCBNolMketcEjPHtuzLtKnKf0d2S5PB
+        kPgSRffuPb97d4eEMZAV5AxEy0l0Vs0vPl5fSKPePqWG39zefl099tWl1A+b3XetYRYYZv8TBf1m
+        vRKmswpJmhMsHHLCoLrI1ttstd2u0gh0pkIVaI2l+crMl+lyNU+383RzIrZGCvSQsx8JY4wd4jdY
+        1BU+Qs6iTKx06D1vEPJzE2PgjAoV4N5LT1wTzEZQGE2oo+tDASRJYQF5Ad/eX7Hdm09X7PM7Fv5v
+        PuwuC5gVwHtqjSsgPxRQS+ep1Lw7cr5wclLcxzbFp8i1obbuvS9gmBXgOEndFJBnw9SKw7r3PCSh
+        e6UmANfaEA9JxhDuTshwHluZxjqz939QoZZa+rZ0yL3RYURPxkJEh4Sxuxhv/ywxsM50lkoy9xif
+        W2TLox6MCx3R5esTSIa4mtTTxewFvbJC4lL5yYJAcNFiNVLHbfK+kmYCJJOp/3bzkvZxcqmb/5Ef
+        ASHQElaldVhJ8Xzisc1huPd/tZ1TjobBo3uQAkuS6MImKqx5r46nCP7JE3ZlLXWDzjp5vMfalmJf
+        L7Lter3JIBmSXwAAAP//AwCUU/LXmAMAAA==
     headers:
       CF-RAY:
-      - 983c40fb4f25767c-SEA
+      - 984553b9bd62f16e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +67,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:01 GMT
+      - Wed, 24 Sep 2025 21:20:40 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +85,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '582'
+      - '718'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '594'
+      - '789'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,7 +107,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_bdac0dfd44e8407887b6a3c878303516
+      - req_23c42882987e4c52b9ba647e80d43d24
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/async_stream.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}},"stream":true}'
     headers:
@@ -13,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '676'
+      - '943'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -36,7 +38,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -45,75 +47,101 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"18BvzTSd4mB"}
+      string: 'data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"2lXlGGaYFw2"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"K8QC9ZWuQ0"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"S72PRqCsFv"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"dVuJWTMO"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"MK6YQOoR"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"prgPrvoT"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"kne7nsLX"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"WVEtN7TlFf"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"4CyG2bEa8a"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"tbzeZNIn"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"BQfp54L7"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"dMPd6ThFyp"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"M2c9YhrrBz"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"wf1jQym3V"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"Jf2nPsV0F"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"mytTog6n"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"H6Kht9V1"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"EwaIlbbA"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"6tTQXbFD"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"htu1GiP"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"FDEMNzt"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"LlLyFD86"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"vTRjknA"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"HVVGwV"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"first"},"logprobs":null,"finish_reason":null}],"obfuscation":"aS6rnZXf"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"a4hNqeDe"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"Kciwy2lm"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"6jENgjzxmvZk"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"l1KSPeh6"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"7tT4YCL18T"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"wzo8a4"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"5YD0xwD9"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"syIWmjdv"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"AQouPcR"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"last"},"logprobs":null,"finish_reason":null}],"obfuscation":"1gBWVIR5L"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"6MRT0fw3zv"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"7vnKVSlC"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"4ap7rktfaRyO"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"kySC0bHb"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"evMWdyVlIQn9"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"R"},"logprobs":null,"finish_reason":null}],"obfuscation":"CXkG3Q6TWAVp"}
 
 
-        data: {"id":"chatcmpl-CJ2SoFwadb55ZFcomtVZY5W2BTSSt","object":"chat.completion.chunk","created":1758653738,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"gj11lrn"}
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"oth"},"logprobs":null,"finish_reason":null}],"obfuscation":"LuOKfntamm"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"iT9HlpjNcFmc"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"lkDaek60tu"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"kXl14Udi7t"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"DVuVsXxmPV"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"3XyT4eo"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"9EntDjpAd2"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"i4cUPzRNODHJ"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"1NNwzbNvOcZ9"}
+
+
+        data: {"id":"chatcmpl-CJRSXOjggRllpwCKbc9SYL5f2tDMJ","object":"chat.completion.chunk","created":1758749821,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"QrL072j"}
 
 
         data: [DONE]
@@ -122,15 +150,19 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c41eacfa7308c-SEA
+      - 98456bb11b98ec84-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:39 GMT
+      - Wed, 24 Sep 2025 21:37:02 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=JH_6PAvw.0UCr3VZR88v3s1N9f9SQ5oqN49kdGIKio8-1758749822-1.0.1.1-vQcSJ9L_ECX90y7Wf0W23yEq4qUrgURFbXHLOdILIxAt5tOMMHWAovI6zjEog4iIhwjk5vOozo12v23CEEU5xhJ0j8bWMvtHll_7u45a5rY;
+        path=/; expires=Wed, 24-Sep-25 22:07:02 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -146,13 +178,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '369'
+      - '424'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '390'
+      - '554'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +200,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_01c46cd2c4584f5d835dbee64302f52c
+      - req_115401ec93de4c43b9552c6cfdd85980
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/json_async.yaml
@@ -1,10 +1,15 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"system","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"description\": \"A book with a rating. The
-      title should be in all caps!\",\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\": {\n      \"description\":
+      matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\": {\n      \"description\":
+      \"The author of a book.\",\n      \"properties\": {\n        \"first_name\":
+      {\n          \"title\": \"First Name\",\n          \"type\": \"string\"\n        },\n        \"last_name\":
+      {\n          \"title\": \"Last Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
@@ -17,12 +22,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '812'
+      - '1278'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -50,18 +55,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFJNj9MwEL3nV1hzblGafiT0trBFgGBBBYkDWUWuM0m869iWPUFFVf87
-        ctI2LR8Slyia99543ps5RIyBLGHNQDScRGvV9PX75MssXmwX6f3TRu+z/fxu+6rrZqWTyQeYBIXZ
-        PaGgs+qFMK1VSNLoARYOOWHoOkuX2Wo5X2Uve6A1Jaogqy1NF2aaxMliGmfTeHUSNkYK9LBm3yPG
-        GDv03zCiLnEPaxZPzpUWvec1wvpCYgycUaEC3HvpiWuCyQgKowl1P/Uh14zlQJIU5rBmOXx9u2EP
-        dx837NMbFv6/vXu4z2Ey8HhHjXED8TMnJ8Uz2xpqqs77C8lxkroOpDTXx+uHHVad58G37pS6ArjW
-        hnjIrbf8eEKOF5PK1NaZnf9NCpXU0jeFQ+6NDoY8GQs9eowYe+zD7G7yAetMa6kg84z9c7N0PvSD
-        cX0jOj8lDWSIq7GexGfVTb+iROJS+at1gOCiwXKUjrvjXSnNFRBduf5zmr/1HpxLXf9P+xEQAi1h
-        WViHpRS3jkeaw3Dd/6JdUu4HBo/uhxRYkEQXNlFixTs1HB74n56wLSqpa3TWyeH6KluIXTVLs+Vy
-        lUJ0jH4BAAD//wMAXRkLsIYDAAA=
+        H4sIAAAAAAAAAwAAAP//jFNtb9MwEP6eX2Hd5xZ1oV1Dv6FuCNgobJoYEpkiz74k3hzbsi+8Vf3v
+        yEnWtDAkvljRPS+5e87eJoyBkrBiIGpOonF6un5/vf5yU+nsobzafL78deauFuvby+8X4cI7mESF
+        vX9AQU+qF8I2TiMpa3pYeOSE0fVkuciW8yxLX3VAYyXqKKscTed2ms7S+XSWTWeng7C2SmCAFfua
+        MMbYtjtji0biD1ix2eSp0mAIvEJY7UmMgbc6VoCHoAJxQzAZQWENoem63uaGsRxIkcYcViyHm7fn
+        bPP6wzn7+IbF79t3m7McJj2Pt1RbH4mdMJZK5QMVhjeD/hMnr8TjIIkMzY8I15bqsg0hh0jYDc6e
+        kzJVZCxzszvs1mPZBh7DMq3WBwA3xhKPYXc53Q3Ibp+MtpXz9j78IYVSGRXqwiMP1sQUAlkHHbpL
+        GLvrNtAehQrO28ZRQfYRu9+ly6z3g3HnIzo/HUCyxPVYf5nOJ8/4FRKJKx0OdgiCixrlKB0Xzlup
+        7AGQHEz9dzfPefeTK1P9j/0ICIGOUBbOo1TieOKR5jE+iX/R9il3DUNA/00JLEihj5uQWPJW97cV
+        ws9A2BSlMhV651V/ZUtXnGTpUsqZWCwg2SW/AQAA//8DAH7mjI67AwAA
     headers:
       CF-RAY:
-      - 983c40b8bee8b89e-SEA
+      - 984553795bd7a38d-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -69,7 +74,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:50 GMT
+      - Wed, 24 Sep 2025 21:20:30 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -87,13 +92,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '434'
+      - '1217'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '450'
+      - '1238'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -103,13 +108,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799847'
+      - '799745'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 11ms
+      - 19ms
       x-request-id:
-      - req_03b8be1d86774396a390d51b93376641
+      - req_2a31c0e2c0bb4caa839dbfadc4fcd265
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/json_async_stream.yaml
@@ -1,10 +1,15 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"system","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"description\": \"A book with a rating. The
-      title should be in all caps!\",\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\": {\n      \"description\":
+      matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\": {\n      \"description\":
+      \"The author of a book.\",\n      \"properties\": {\n        \"first_name\":
+      {\n          \"title\": \"First Name\",\n          \"type\": \"string\"\n        },\n        \"last_name\":
+      {\n          \"title\": \"Last Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
@@ -17,12 +22,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '826'
+      - '1292'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,114 +54,167 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"wWm5ybiCaTP"}
+      string: 'data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"sA1v168MWPU"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"Lv1ra3nWHS"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"IkGguXnxnX"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"GqcSOWl7rBgI"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"CTKCDUuSlVBb"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"DjycCdipOd"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"nYZFtxWsvd"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"7QKlEocA"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"swW1XNeB"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"4oCE2HCnuQ"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"vfcPOcvIWp"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"W75HNRuXRS"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"2YecZpIyyf"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"zTWy143xPi"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"vlCkB9ZFOU"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"8GkvX3QM"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"BWw48ENy"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"nom8yajThJ"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"yOAXzVp4Fr"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"s6PvSMRpZ"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"esY8UGETF"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"oIfrOgwP"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"wJNGK2m6"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"YjajtUDY"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"JnGzfpDL"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"tzUWKXZrguuV"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"zKsc2uUFmJe4"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"c4eYT0tsuS"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"PxIpfq8uzs"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"VxAfIzG"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"CWG1qpb"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"pegr06Xsf0"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"VI8uY5UN97"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"xvrpWugMP3"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        {\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"b9RbjhbAE"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"WNhCcA"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"   "},"logprobs":null,"finish_reason":null}],"obfuscation":"GpCFhHJY3c"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"DlixfpF7"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"z7wpR99mAh"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"yZB6Fyn8Yafz"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"first"},"logprobs":null,"finish_reason":null}],"obfuscation":"OooFaLx6"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"zE0DLBXJFy"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"prmzjidm"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"DtsYA9FH"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"ToQXVB6Inq"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"cOHZ9sezupa8"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"ltGXvJu1uA"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"rEWw22qH9q"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"Z1aXIt"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"Q0HsHUz"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"OTj3eR1S"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"l5qu1CRcIV"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"   "},"logprobs":null,"finish_reason":null}],"obfuscation":"Wau5u9kq3b"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"VOY6i5XRvry3"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"sICg7NTwS3"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"VW3MDXHEThqr"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"last"},"logprobs":null,"finish_reason":null}],"obfuscation":"L0HJVb23c"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"YMnPzt2g01u"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"lL5CEFjX"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"ikgJe32HiWmL"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"jOjKAp08Mm"}
 
 
-        data: {"id":"chatcmpl-CJ2SebBpUldue10XdBdeqi7KujT4X","object":"chat.completion.chunk","created":1758653728,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"4yd3J7n"}
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"cSJdaFHhQi"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"R"},"logprobs":null,"finish_reason":null}],"obfuscation":"OjdCA1ReJSFm"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"oth"},"logprobs":null,"finish_reason":null}],"obfuscation":"PRixeEzXQD"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"GOo4hUrhFvfM"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"eYKxdHAHze"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"EZLBOXO4U"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"tl4PAyoc6zLM"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        },\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"yzPykJFt"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"5Pfvg6b2wPl2"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"XfGxjGVfYL"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"g32JEDC"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"FYA9EBQO0t"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"HeWAUpyikSX4"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"OYaiN785zcuN"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"vxvGTI3GfSG"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"Cxv9YzrKkOzF"}
+
+
+        data: {"id":"chatcmpl-CJRD5LZuH9s6uc4au42uvapREkFeY","object":"chat.completion.chunk","created":1758748863,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"Eet7h9W"}
 
 
         data: [DONE]
@@ -165,13 +223,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c41acba4827b3-SEA
+      - 9845544d4f09def6-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:29 GMT
+      - Wed, 24 Sep 2025 21:21:03 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -189,13 +247,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '259'
+      - '218'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '278'
+      - '241'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -205,13 +263,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799847'
+      - '799745'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 11ms
+      - 19ms
       x-request-id:
-      - req_e1604f73d08f4c37ba8fe8c8ca9f70c1
+      - req_1b845301d567457d8b5acb07bf1c6ac3
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/json_stream.yaml
@@ -1,10 +1,15 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"system","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"description\": \"A book with a rating. The
-      title should be in all caps!\",\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\": {\n      \"description\":
+      matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\": {\n      \"description\":
+      \"The author of a book.\",\n      \"properties\": {\n        \"first_name\":
+      {\n          \"title\": \"First Name\",\n          \"type\": \"string\"\n        },\n        \"last_name\":
+      {\n          \"title\": \"Last Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
@@ -17,12 +22,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '826'
+      - '1292'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,114 +54,167 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"cpfwwNOafzA"}
+      string: 'data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"MVy4CsCrkvS"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"PCnVxBQL13"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"QuCoJAeUwu"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"HdyxqrB7agJF"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"3pesQYjBzsz3"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"na3PuaxCQX"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"TbvK1fQIlN"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"6pcUEGkx"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"iLzIBUcg"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"T4GuHj7NKh"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"D5KkvzeDps"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"do3uvCshpS"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"xzCUmbf2Bk"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"hplckSZXmq"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"CVfn7T5drK"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"MATwImrs"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"TZvc8rEA"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"3a3DCJh9Ig"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"2kcemc4FWv"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"Hb6GLnncK"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"n1cqZEfPk"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"WmLMlSv4"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"JjT6pTgI"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"C8uPawIw"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"BjkZnHdk"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"NaBU56OCq7gR"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"H3dZgiqRhKRz"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"WT5VikjbZu"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"0jVAjUpn2h"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"rsIgGUF"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"86nAzed"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"Seh9NpUSQo"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"P7NMr5sUQh"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"877eZgysdj"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        {\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"wdWJ8lbxX"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"zLNsm2"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"   "},"logprobs":null,"finish_reason":null}],"obfuscation":"6OnWGDxRTq"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"vYXzKSx5"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"JdLZqov0OH"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"i7RPcAFmdlyu"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"first"},"logprobs":null,"finish_reason":null}],"obfuscation":"Qj371gls"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"i2Xtpfd0th"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"ngWjvxyn"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"mDhSeihy"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"2ngr65iVyk"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"q5wuMN6KG6iF"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"tSsGvIc7DO"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"qbVZjgDNSz"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"jSEuoF"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"mQoSwD0"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"H7rL7Kgm"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"EaOCus6FTr"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"   "},"logprobs":null,"finish_reason":null}],"obfuscation":"8XywBGIhG2"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"lt9t8bQC0Svo"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"mcetLFsVBZ"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"if0VuUpgGTNi"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"last"},"logprobs":null,"finish_reason":null}],"obfuscation":"xDMiwbYhZ"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"sYf3ZJ4qFW0"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"H0mVbqfO"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"ImED1bPNZqDT"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"tZrcb0C2V4"}
 
 
-        data: {"id":"chatcmpl-CJ2SP1H2dScTm5JeYtTe0RxJwtab1","object":"chat.completion.chunk","created":1758653713,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"h4KICru"}
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"PACXrbOH2l"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"R"},"logprobs":null,"finish_reason":null}],"obfuscation":"a1TpDFea99N7"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"oth"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZVX2W10LQL"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"SnVcDbXvUCQi"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"pMgMmLJiFh"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"GMyNVOrCj"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"TVVFzyYooCId"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        },\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"0CPiH2Ck"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"6HnTPbqoBuoU"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"2MwVdSdZ6v"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"fh664bk"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"BVIdYzRkLb"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"NVZWByT0grmQ"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"4OjzNVcoa5BZ"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"5QTcmhk97Ep"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"eI8Dx8jZDKLc"}
+
+
+        data: {"id":"chatcmpl-CJRCpR84BdB1cmLETAAeipE1pU7jx","object":"chat.completion.chunk","created":1758748847,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"SmB0cbq"}
 
 
         data: [DONE]
@@ -165,13 +223,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c414b7b4f709c-SEA
+      - 984553e9dbf8ba33-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:13 GMT
+      - Wed, 24 Sep 2025 21:20:47 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -189,13 +247,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '371'
+      - '156'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '418'
+      - '169'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -205,13 +263,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799847'
+      - '799745'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 11ms
+      - 19ms
       x-request-id:
-      - req_77fcbdf017ce4a67b93760b70946c32f
+      - req_16bd88dda95b9640862f52af1124d416
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/json_sync.yaml
@@ -1,10 +1,15 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"system","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"description\": \"A book with a rating. The
-      title should be in all caps!\",\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"rating\": {\n      \"description\":
+      matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\": {\n      \"description\":
+      \"The author of a book.\",\n      \"properties\": {\n        \"first_name\":
+      {\n          \"title\": \"First Name\",\n          \"type\": \"string\"\n        },\n        \"last_name\":
+      {\n          \"title\": \"Last Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
       \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
@@ -17,12 +22,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '812'
+      - '1278'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -50,18 +55,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFJdi9swEHz3rxD7HJfEucQhb+Waci307jju2of6MIq8ttWTJSGtQ0rI
-        fy+yk9jpB/TFmJ2Z1c7sHiLGQBawZiBqTqKxKr79nDwp9ZjePj98Te6axqe7l5ed2dB+3zYwCQqz
-        /YGCzqp3wjRWIUmje1g45ISh6yxdrJaL+TKdd0BjClRBVlmKb0ycTJObeLqKp8uTsDZSoIc1+x4x
-        xtih+4YRdYF7WLPp5Fxp0HteIawvJMbAGRUqwL2XnrgmmAygMJpQd1MfMs1YBiRJYQZrlsHz3Ybd
-        v/+yYQ8fWfj/9un+QwaTnsdbqo3riY+cnBRv7MlQXbbeX0iOk9RVIKWZPo4fdli2ngffulVqBHCt
-        DfGQW2f59YQcLyaVqawzW/+bFEqppa9zh9wbHQx5MhY69Bgx9tqF2V7lA9aZxlJO5g2752b9Trpg
-        zusb0PkpaSBDXA31ZHpWXfXLCyQulR+tAwQXNRaDdNgdbwtpRkA0cv3nNH/r3TuXuvqf9gMgBFrC
-        IrcOCymuHQ80h+G6/0W7pNwNDB7dTgrMSaILmyiw5K3qDw/8T0/Y5KXUFTrrZH99pc3Ftpylq8Vi
-        mUJ0jH4BAAD//wMAM1A0nIYDAAA=
+        H4sIAAAAAAAAAwAAAP//jFPfb5swEH7nr7DuOZlIShqUtyrNtLZqN3XRNmlUyDEHuDU2s4+qU5T/
+        vTLQQLZO2ouF7vvB3Xf2PmAMZAYrBqLkJKpaTdfX9+urTbl9ed59+3rzePnj7PpCrX/dhuHW3cDE
+        K8zuEQW9qT4IU9UKSRrdwcIiJ/Sus+UiXkZxPItaoDIZKi8rappGZjoP59E0jKfheS8sjRToYMV+
+        Bowxtm9P36LO8AVWLJy8VSp0jhcIqyOJMbBG+Qpw56QjrgkmAyiMJtRt1/tEM5YASVKYwIolsP20
+        YXcXtxv2+SPz39+v7i4TmHQ83lBprCe2Ql/KpXWUal71+i+crBRPvcQzFD8h3Bsq88a5BDzh0Dtb
+        TlIXnrFM9GHcrcW8cdyHpRulRgDX2hD3Ybc5PfTI4ZiMMkVtzc79IYVcaunK1CJ3RvsUHJkaWvQQ
+        MPbQbqA5CRVqa6qaUjJP2P5uvow7Pxh2PqDReQ+SIa6G+tk8mrzjl2ZIXCo32iEILkrMBumwcN5k
+        0oyAYDT13928591NLnXxP/YDIATWhFlaW8ykOJ14oFn0T+JftGPKbcPg0D5LgSlJtH4TGea8Ud1t
+        BffbEVZpLnWBtrayu7J5nc7i+TLLQrFYQHAIXgEAAP//AwBsL2bquwMAAA==
     headers:
       CF-RAY:
-      - 983c40534bb3ba0f-SEA
+      - 9845531a7fdc6cc2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -69,7 +74,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:34 GMT
+      - Wed, 24 Sep 2025 21:20:15 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -87,13 +92,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '490'
+      - '684'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '552'
+      - '896'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -103,13 +108,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799847'
+      - '799745'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 11ms
+      - 19ms
       x-request-id:
-      - req_3f66220d06234853be28f323eb803c4c
+      - req_ea38f4c60da04944872bd6b17ece7553
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/stream.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}},"stream":true}'
     headers:
@@ -13,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '676'
+      - '943'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,75 +47,101 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"aVNNHEZOzFL"}
+      string: 'data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"xQL6mw96iNc"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"CHHKrJyqI8"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"KnD6TrhhKf"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"EZBGtsRA"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"p5q4MTG8"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"DnA6TSfq"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"iFrY1cJe"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"QgQfRYRaWq"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"R1Saqja6Cm"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"A23WYDlb"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"106DHCF4"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"F3KizD8U61"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"NG7zOTVAje"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"kJbLz2iKs"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"IUCN3xdZr"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"hjMZqzr2"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"Nol9Avuc"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"52oZiDwk"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"G0nQiYzY"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"XfakkCM"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"Q9x2qdk"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"59RLze3z"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"1anCnlJ"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"fnExa1"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"first"},"logprobs":null,"finish_reason":null}],"obfuscation":"H05JwJQj"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"NzbL4IbL"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"fmz2exAO"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"nu5jg0e9wS53"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"AEzu0MeI"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"6xKIKG3wQy"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"VVE10a"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"9y6x4INg"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"4Cfn2uMV"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"EHIk0e5"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"last"},"logprobs":null,"finish_reason":null}],"obfuscation":"DnLeXo1MS"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"8SGTWs7ZKX"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"6STdeij5"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"h6eycHW1R8X8"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"iU56Q8PI"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"4YjlqPVTiSLh"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"R"},"logprobs":null,"finish_reason":null}],"obfuscation":"g8TlBtSItJAg"}
 
 
-        data: {"id":"chatcmpl-CJ2SXP1Y7XBWyGMxueF5hSSXpwRUR","object":"chat.completion.chunk","created":1758653721,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"ImAQlDD"}
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"oth"},"logprobs":null,"finish_reason":null}],"obfuscation":"SKIZpakJJe"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"69hJK1fgneMP"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"qTp7mj6Bub"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"WVUEZaByi7"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"p6ee1n1SpQ"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"G0bMXlx"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"hCIIh7of7n"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"TPs11UxV6DCY"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"jevZJdFaPfAM"}
+
+
+        data: {"id":"chatcmpl-CJRSJUKeAL2LGOvJdOM1qOBRErc07","object":"chat.completion.chunk","created":1758749807,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"iuNc3NT"}
 
 
         data: [DONE]
@@ -122,15 +150,19 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c417ffb61709c-SEA
+      - 98456b5548d2df86-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:22 GMT
+      - Wed, 24 Sep 2025 21:36:47 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=xiCXI2fxGSMvh8M5gCBH25lApGOF7uJ1Al0wFqrKInA-1758749807-1.0.1.1-6XQKPDvaw6txnOwmRwJStJIe2msFJ2MoOgprAqcQYsRpH_q7GeVqnVYUQN1CIwVCuLNPSAwrMxjz1TU.Rdjhc3ZO91km9fuRULMS8L_zIbI;
+        path=/; expires=Wed, 24-Sep-25 22:06:47 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -146,13 +178,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '329'
+      - '390'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '351'
+      - '414'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +200,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_e3480e63d3c44a1082bbb89fc37de7f6
+      - req_eeb8197d5f9d403ba91d76f8dff3a690
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/strict_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/strict_async.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}}}'
     headers:
@@ -13,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '662'
+      - '929'
       content-type:
       - application/json
       cookie:
@@ -45,18 +47,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrK4g924Xl+gXdHCdFW7RpEaQoiigQaHIlMaFIglwVTQ3/
-        e0H5IbkPoBeC4OwsZ2Z3lzAGSkLGQNScROP0ePN+evdC/j79EuT8+ttPqteb1dV603xI5ROMIsNu
-        n1DQifVK2MZpJGXNARYeOWHsmi7nq8X89WK16IDGStSRVjkaz+x4OpnOxpPVeLI4EmurBAbI2EPC
-        GGO77owSjcQfkLHJ6PTSYAi8QsjORYyBtzq+AA9BBeKGYNSDwhpC06ne5UCKNOaQ5XD/9obdrj/e
-        sE9vWLx/fXd7ncMoB95SbX1X85mTV+KZ3VmqyzaEDveclKlyyJb74T8eyzbwaNO0Wg8AbowlHmPq
-        HD4ekf3Zk7aV83YbfqNCqYwKdeGRB2ui/kDWQYfuE8Yeu+zaizjAeds4Ksg+Y/ddOk0P/aCfVo9O
-        j8ECWeJ6wJqdWBf9ConElQ6D9EFwUaPsqf2oeCuVHQDJwPWfav7W++Bcmep/2veAEOgIZeE8SiUu
-        HfdlHuMy/6vsnHInGAL670pgQQp9nITEkrf6sGcQXgJhU5TKVOidV4dlK10htmW6XM3niyUk++QX
-        AAAA//8DAEUamCZ1AwAA
+        H4sIAAAAAAAAAwAAAP//jJJRb9MwEMff8ymse05RG9ql5G0ahQFioDE2JDJFrnNJzBzbsi8VqOp3
+        R066JoMh8RJF97v/+e5/t48YA1lCxkA0nERr1ezi/fXFjdD0hT5cbram3X1tz7e33beX7a58C3FQ
+        mO0PFPSoeiFMaxWSNHrAwiEnDFUX6WqdLtfrZNWD1pSogqy2NFuaWTJPlrP5ejY/OwobIwV6yNj3
+        iDHG9v03tKhL/AkZm8ePkRa95zVCdkpiDJxRIQLce+mJa4J4hMJoQt13vc+BJCnMIcvh5nLDrs4/
+        btinNyz83727ep1DnAPvqDEuh2yfQyWdp0LzdtB85uSkeOjTFJ+Sa0NN1XmfwyHOwXGSus4hSw/T
+        VhxWnefBCd0pNQFca0M8ONmbcH8kh9PYytTWma3/QwqV1NI3hUPujQ4jejIWenqIGLvv7e2eOAbW
+        mdZSQeYB++cWaTLUg3GhI01eHSEZ4moSny/iZ+oVJRKXyk8WBIKLBstROm6Td6U0ExBNpv67m+dq
+        D5NLXf9P+REIgZawLKzDUoqnE49pDsO9/yvt5HLfMHh0OymwIIkubKLEindqOEXwvzxhW1RS1+is
+        k8M9VrYQ22qRrlersxSiQ/QbAAD//wMA6vrX25gDAAA=
     headers:
       CF-RAY:
-      - 983c40a2d8557687-SEA
+      - 984553600d2730a6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -64,14 +66,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:47 GMT
+      - Wed, 24 Sep 2025 21:20:26 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        path=/; expires=Tue, 23-Sep-25 19:24:47 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        path=/; expires=Wed, 24-Sep-25 21:50:26 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000;
+      - _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -88,13 +90,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '846'
+      - '950'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '984'
+      - '972'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -110,7 +112,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_d6efe1a75b74435a95ea823e9ddf403e
+      - req_18a3ab99d9b548bca40ab4e666c9a76b
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/strict_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/strict_async_stream.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}},"stream":true}'
     headers:
@@ -13,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '676'
+      - '943'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,75 +47,101 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"iDT9bX9FSCo"}
+      string: 'data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"qpIrh7QAEoX"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"eKrpmoK6Uo"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"UmH43wtxUZ"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"XfyEQW0R"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"EWxapoco"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"MDz8MYvQ"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"D1pltVF4"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"bLKiovRzQ6"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"Yh5DdDzZXz"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"ppg0Hev6"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"RWE8ATrv"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"Cbu6C9Jx7B"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"lemRPJjNJ1"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"1AqzEXBla"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"yc16YtHmD"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"6UoAhHC9"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"F8hGOjcR"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"VBT7693m"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"okmiEWru"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"VjaSiDA"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"iqVQkFR"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"kgtji64c"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"GUKyQuU"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"0bEpMS"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"first"},"logprobs":null,"finish_reason":null}],"obfuscation":"mQMD4wCN"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"1bGWx8Iw"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"oEuMy8rW"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"CIY6ZHOb9en0"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"OkSkdvdh"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"dEKg7X0kPd"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"RNBF3m"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"9oMi70ME"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"BGcPys0t"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"flt6v5C"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"last"},"logprobs":null,"finish_reason":null}],"obfuscation":"GVGcrGiQZ"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"8XzCtEQ8hG"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"UsLcOVvh"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"Sg2pjrVaps8P"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"HHvusE4W"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"kGSIMlBi56fw"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"R"},"logprobs":null,"finish_reason":null}],"obfuscation":"AMZEYczFOlvk"}
 
 
-        data: {"id":"chatcmpl-CJ2Sa7mSbwgCVX4INYcJuwhy1m8gT","object":"chat.completion.chunk","created":1758653724,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"1s6E3Fi"}
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"oth"},"logprobs":null,"finish_reason":null}],"obfuscation":"H5oYZkH9Pk"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"QFdK3gmll8ho"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"RS7y2nwjW4"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"cJLrBeUewL"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"OWR2MGB6p6"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"yvWRbxB"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"F1dyLIo0aM"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"nkP05ToAr3xz"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"a86aLdLXTXNU"}
+
+
+        data: {"id":"chatcmpl-CJRD1q2V1RHIpUSwDAEyfjxH1BUhh","object":"chat.completion.chunk","created":1758748859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"uJwzaRC"}
 
 
         data: [DONE]
@@ -122,13 +150,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c41941d1aa371-SEA
+      - 984554329d431e0b-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:25 GMT
+      - Wed, 24 Sep 2025 21:20:59 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -146,13 +174,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '272'
+      - '426'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '287'
+      - '461'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +196,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_be07d82140ad45dabd0c61f0dc8376bc
+      - req_aa335413c06f42449b8eb1df43c3f132
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/strict_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/strict_stream.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}},"stream":true}'
     headers:
@@ -13,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '676'
+      - '943'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,75 +47,101 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"wLvpja5UhKq"}
+      string: 'data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"i3Bi25pDhND"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"kMjMkEjSWG"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"pEjcvVdEwY"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"VhJ1jq0F"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"LCBb7gzv"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"45ZefVA9"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"wor2MXzb"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"uOn29MkTwt"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"eArLKLbeka"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"364k8Hv3"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"mc3OYTug"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"1OcH1oJbsE"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"S89jj8M4DC"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"T1iTpNBaP"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"6C9ZF3RRS"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"sdW1vSNn"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"ycikh7pb"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"TH6A04Y5"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"fpE7nbeO"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZMFujpv"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"SbhSI9V"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"UOckzt4v"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"X2Ar7q0"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"l3kKjR"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"first"},"logprobs":null,"finish_reason":null}],"obfuscation":"w9rFhDwh"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"DzSAEsSK"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"Afm6x1D8"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"8FiyO7YHoZUI"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"PMmPutxg"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"dfrnldyR45"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"HFLddg"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"kFvRtuNA"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"gx2BKE8v"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"iPvRtVI"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"last"},"logprobs":null,"finish_reason":null}],"obfuscation":"nOwoCAUV8"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"O8O9KFtCBl"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_name"},"logprobs":null,"finish_reason":null}],"obfuscation":"Nz4DJ1Pf"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"5Ixpoii9YI7q"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"IT2xjJLT"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"thTszWloEpvo"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"R"},"logprobs":null,"finish_reason":null}],"obfuscation":"R7Cfv2krFOnS"}
 
 
-        data: {"id":"chatcmpl-CJ2SHDli7k5HXVnuX96C9HpBr3vCA","object":"chat.completion.chunk","created":1758653705,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"BkDBaS8"}
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"oth"},"logprobs":null,"finish_reason":null}],"obfuscation":"jXdDFZoRyp"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"XHpHJ4oPBjPD"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"KNogF4tY1h"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"4Y2GztXaNZ"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"2CMgYGfIDM"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"s5NEqMR"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"k0eAAurHWF"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"3NgCPgrgHwr3"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"2G09lMelpfzq"}
+
+
+        data: {"id":"chatcmpl-CJRClscIsvW9pNOsN13UoLA7xFLdt","object":"chat.completion.chunk","created":1758748843,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"V06JowS"}
 
 
         data: [DONE]
@@ -122,13 +150,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c411bf9ba76b2-SEA
+      - 984553cd197eba33-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:06 GMT
+      - Wed, 24 Sep 2025 21:20:43 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -146,13 +174,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '358'
+      - '595'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '399'
+      - '623'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +196,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_d15f9fea0cbf48a7bf9910613b4cb946
+      - req_a6a4ea97310742d08e1772539f94e6fe
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/strict_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/strict_sync.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}}}'
     headers:
@@ -13,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '662'
+      - '929'
       content-type:
       - application/json
       cookie:
@@ -45,18 +47,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFJdi9swEHz3rxD7nJTYTZzUb+XuyrXQXDkKhasPo0hrWz1ZEtK6tIT8
-        9yLnw04/oC9CaHZWM7O7TxgDJaFgIFpOonN6fvMhe2yM2abyZtf10t0++Xsu06eHZZu+gVlk2N03
-        FHRmvRK2cxpJWXOEhUdOGLum69UmX73O880AdFaijrTG0Xxp59kiW84Xm/kiPxFbqwQGKNjXhDHG
-        9sMZJRqJP6Bgi9n5pcMQeINQXIoYA291fAEeggrEDcFsBIU1hGZQvS+BFGksoSjh8/0d2779eMce
-        3rF4//J+e1vCrATeU2v9UPOJk1fihT1aaus+hAH3nJRpSijWh+k/Hus+8GjT9FpPAG6MJR5jGhw+
-        n5DDxZO2jfN2F36jQq2MCm3lkQdrov5A1sGAHhLGnofs+qs4wHnbOarIvuDwXZqlx34wTmtEs1Ow
-        QJa4nrCWZ9ZVv0oicaXDJH0QXLQoR+o4Kt5LZSdAMnH9p5q/9T46V6b5n/YjIAQ6Qlk5j1KJa8dj
-        mce4zP8qu6Q8CIaA/rsSWJFCHychsea9Pu4ZhJ+BsKtqZRr0zqvjstWuErs6XW9Wq3wNySH5BQAA
-        //8DABsOzFV1AwAA
+        H4sIAAAAAAAAAwAAAP//jFLBbptAEL3zFas54wpbtqHcKidV49RJFUXqoURovQyw8bKLdofKleV/
+        rxacQNpU6gWhefPevnkzp4AxkAWkDETNSTStmm22D5vNcXt1f7Ood7tjdLhVt/VXuV2X1fMaQs8w
+        +2cU9ML6IEzTKiRp9AALi5zQq87jVRIvkyRKeqAxBSpPq1qaLc1sES2WsyiZRRddURsp0EHKfgSM
+        MXbqv96iLvAIKYvCl0qDzvEKIX1tYgysUb4C3DnpiGuCcASF0YS6d33KgCQpzCDN4PHLNbv7tLtm
+        95+Z//9+c3eVQZgB76g2NoP0lEEpraNc82bgfONkpTj0bYpPkQdDddk5l8E5zMBykrrKII3PUysW
+        y85xn4TulJoAXGtD3CfZh/B0Qc6vYytTtdbs3R9UKKWWrs4tcme0H9GRaaFHzwFjT3283ZvEoLWm
+        aSknc8D+uXm8GPRgXOiILj5eQDLE1aQezcN39PICiUvlJgsCwUWNxUgdt8m7QpoJEEym/tvNe9rD
+        5FJX/yM/AkJgS1jkrcVCircTj20W/b3/q+015d4wOLQ/pcCcJFq/iQJL3qnhFMH9coRNXkpdoW2t
+        HO6xbHOxL+dxslqtYwjOwW8AAAD//wMAEZMdd5gDAAA=
     headers:
       CF-RAY:
-      - 983c4031ef53ba0f-SEA
+      - 984552f45f2e9917-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -64,14 +66,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:28 GMT
+      - Wed, 24 Sep 2025 21:20:09 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        path=/; expires=Tue, 23-Sep-25 19:24:28 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        path=/; expires=Wed, 24-Sep-25 21:50:09 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000;
+      - _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -88,13 +90,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '710'
+      - '733'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '723'
+      - '823'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -110,7 +112,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_44aff175c3d84ee185e88fbe75919b1b
+      - req_90cd7db007c049ba87864205068c8a18
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/sync.yaml
@@ -1,8 +1,10 @@
 interactions:
 - request:
     body: '{"messages":[{"role":"user","content":"Please recommend the most popular
-      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"description":"A
-      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
+      book by Patrick Rothfuss"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"Book","schema":{"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
+      book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true,"description":"A
       book with a rating. The title should be in all caps!"}}}'
     headers:
@@ -13,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '662'
+      - '929'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +48,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFLbitswEH33V4h5TkruMX7bbbc3SHYJW7pQL0aRx7aysiSk8dIS8u9F
-        zsXOtoW+CKEzZ3TOmdlHjIHMIWEgKk6itmr4/utk8/p0v/q2/XTzsFtsb+VT/BivN7P5dLWDQWCY
-        7Q4FnVnvhKmtQpJGH2HhkBOGruPlPF7Mp4t42gK1yVEFWmlpODPDyWgyG47i4WhxIlZGCvSQsB8R
-        Y4zt2zNI1Dn+hISNBueXGr3nJUJyKWIMnFHhBbj30hPXBIMOFEYT6lb1PgWSpDCFJIXHz3dsfbO6
-        Y/cfWbh//7L+kMIgBd5QZVxb88DJSfHCNoaqovG+xR0nqcsUkuWh/4/DovE82NSNUj2Aa22Ih5ha
-        h88n5HDxpExpndn6N1QopJa+yhxyb3TQ78lYaNFDxNhzm11zFQdYZ2pLGZkXbL8bT8bHftBNq0Mn
-        p2CBDHHVY83OrKt+WY7EpfK99EFwUWHeUbtR8SaXpgdEPdd/qvlb76Nzqcv/ad8BQqAlzDPrMJfi
-        2nFX5jAs87/KLim3gsGje5UCM5LowiRyLHijjnsG/pcnrLNC6hKddfK4bIXNxLYYL+P5fLGE6BD9
-        BgAA//8DAEYEo4V1AwAA
+        H4sIAAAAAAAAAwAAAP//jJLBbtswDIbvfgqBZ2dIvKROfWu7DOuAdVs3tIe5MBSZtrXKkibRRYsg
+        7z7ITmN364BdDIMff4r8yV3EGMgSMgai4SRaq2YXH68vvvLNr7PL0xN706zOH7/d8OTtNrkV5w8Q
+        B4XZ/kRBz6o3wrRWIUmjBywccsJQdZGu1ulyvU6SHrSmRBVktaXZ0sySebKczdez+clB2Bgp0EPG
+        fkSMMbbrv6FFXeIjZGweP0da9J7XCNkxiTFwRoUIcO+lJ64J4hEKowl13/UuB5KkMIcsh+8fNuzq
+        7NOGfX7Pwv/t5dW7HOIceEeNcTlkuxwq6TwVmreD5gsnJ8V9n6b4lFwbaqrO+xz2cQ6Ok9R1Dlm6
+        n7bisOo8D07oTqkJ4Fob4sHJ3oS7A9kfx1amts5s/R9SqKSWvikccm90GNGTsdDTfcTYXW9v98Ix
+        sM60lgoy99g/t0iToR6MCx1pcnqAZIirSXy+iF+pV5RIXCo/WRAILhosR+m4Td6V0kxANJn6725e
+        qz1MLnX9P+VHIARawrKwDkspXk48pjkM9/6vtKPLfcPg0T1IgQVJdGETJVa8U8Mpgn/yhG1RSV2j
+        s04O91jZQmyrRbperU5SiPbRbwAAAP//AwB4Mh/amAMAAA==
     headers:
       CF-RAY:
-      - 983c40919883ba0f-SEA
+      - 9845534bfbe96cc2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +67,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:44 GMT
+      - Wed, 24 Sep 2025 21:20:23 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +85,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '637'
+      - '1000'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '674'
+      - '1063'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,7 +107,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_50f1b962da094abbb403b27936999340
+      - req_70d7275e0c1b45e48011aa7604bf80ea
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/tool_async.yaml
@@ -4,9 +4,10 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","parallel_tool_calls":false,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","parameters":{"description":"A book
-      with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +16,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1010'
+      - '1191'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,20 +49,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFPbTtwwEH3fr7DmebcKewlL3iqgQKtu70VqF0XGmSQGx7bsCS1d7b9X
-        dmCTBSo1D5E1Z87MmePxZsQYyAIyBqLmJBqrJsdvp1+WC6U+HfLL81X15/u7s0Vx9Ese39QXDYwD
-        w1zfoKBH1ithGquQpNEdLBxywlD14HCxTBez9CiNQGMKVIFWWZrMzWSaTOeTZDlJ0gdibaRADxn7
-        OWKMsU38B4m6wN+QsWT8GGnQe14hZLskxsAZFSLAvZeeuCYY96AwmlAH1bpVagCQMSoXXKm+cfdt
-        BufeJ65Ufrr4oauTs9p/ODKzk2931yssjqupHPTrSt/bKKhstdj5M8B38exJM8ZA8yZy87yRjnth
-        LOalcQ0nwiI3LdmW8qg9f1KWMeCuahvUFEaCzRpIksI1ZGv4en7KVq/fn7IPb1g4X16sTtYwXgNv
-        qTYu5nzk5KS4ZZ8N1WXrfcQdJ6mrNWSHW9hrtx29dL4aOOywbD1Xz63nWhviwYHo/dUDst1dszKV
-        debaP6FCKbX0de6Q++geeDK2kxUkxObQ7m0IWGcaGyy7xdjuIE27etAvcI9OH3YNyBBXA9bykbVX
-        Ly+QuIwrtNtawUWNRU/tt5e3hTQDYDSY+rmal2p3k0td/U/5HhACbVgf67CQYn/iPs1heN//Stu5
-        HAWDR3cnBeYk0YWbKLDkreqeHvh7T9jkpdQVOutkfH9Q2ryczdJ5wudJAqPt6C8AAAD//wMAo7r8
-        q4gEAAA=
+        H4sIAAAAAAAAAwAAAP//jFTJbtswEL37K4g524W8NHZ1i9O0TYGmTVIgXRQQNDWSmFAkQY7SBIb/
+        vaCUWMpSoDoIxLx5M28WcjtiDFQOKQNZCZK105Ojz+dHm+UPOjurrxd3zeY6vzysL07XxeJCrWEc
+        GXZzjZIeWW+krZ1GUtZ0sPQoCGPU6fLtarlYrebzFqhtjjrSSkeThZ3MktlikqwmycEDsbJKYoCU
+        /R4xxti2/UeJJsc7SFkyfrTUGIIoEdK9E2PgrY4WECGoQMIQjHtQWkNoomrTaD0AyFrNpdC6T9x9
+        28G575PQmufFdP3nZH34sXK62mwaLES5/vVzNsjXhb53raCiMXLfnwG+t6fPkjEGRtQtl/NaeRGk
+        dcgL62tBhDm3DbmGeKudPwvLGAhfNjUaiiXBNgNSpDGDNIPvn47Z6eGXY/b1A4vny5PT9xmMMxAN
+        VdZnkG4zKJQPxKOClvNNkFfypnXTYoicW6qKJoQMduMMvCBlygzS5Q6eKNqNXjtfDYbgsWiC0C+n
+        I4yxJGKT2vFcPSC7/SZoWzpvN+EZFQplVKi4RxHaBkMg6zpZUUKbHJonSwTO29rFrt5gm266nHXx
+        oN/xHp29ewDJktADezIdvxKP50hCtVu2X2wpZIV5T+0XXDS5sgNgNKj6pZrXYneVK1P+T/gekBJd
+        3DDnMVfyacW9m8f4BPzLbd/lVjAE9LdKIieFPk4ix0I0urudEO4DYc0LZUr0zqv2ikLheDGfHywS
+        sUgSGO1GfwEAAP//AwAPnWwVqwQAAA==
     headers:
       CF-RAY:
-      - 983c40e07c73765e-SEA
+      - 984553938967b9be-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -69,7 +70,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:57 GMT
+      - Wed, 24 Sep 2025 21:20:34 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -87,13 +88,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '868'
+      - '992'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '885'
+      - '1006'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -109,7 +110,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_b811868d059147f3af99682b30201715
+      - req_4036dd3a9990434184440f504139a79c
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/tool_async_stream.yaml
@@ -4,9 +4,10 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","parallel_tool_calls":false,"stream":true,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","parameters":{"description":"A book
-      with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +16,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1024'
+      - '1205'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -47,75 +48,101 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_v4rsxgcJyZWXBaKb6Y29Adgw","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"FQ4IVTC3z6IZBg"}
+      string: 'data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_gNtQtKXG8KuV6sRLi9WrHmwu","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"TEUU0o4r3KcUjX"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"QPHlBLrYAWz5vc"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"D6vzHg3CFcOoRA"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"JNY9FvKt5j4ZLm"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Hye7wJ1VlvytD5"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"VQ1hFVrIrbsyhB"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"54uVPKH5xokPNb"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         OF"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"xs6dkd08AkSazrL"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"p7xAH4XvxSgPn5C"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"tKnKN9raamdVCL"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"7VVbyh74oWB0qP"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"WaQljFvW1kaibH"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"M02N7BLlIw473L"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"zX84CiR5im8E1"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"clplMYn2uVh3L"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"K3bcPOFFyxpGML"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"eisP7dUruJLyG"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"oy9mJ0DPoCVT"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"first"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"hhrMplvabSxeon"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Roth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"z02plvn8nNDzrK"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_name"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"K0kv44cTbHmDgG"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"66"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"HrYI7ZZAGmjE4D"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"TUVPv5IKK1Bb"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"bcxEU7aMyPuPqa"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"UF1mM1O1u5pYzE"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"6a6LzBkiaR73N"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"last"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"XY0IRp09BYpqmvk"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_name"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"53l17sBvc0z8sl"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Ud"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"GVvCHVvgIl76Si"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"v5"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"R"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"v8"}
 
 
-        data: {"id":"chatcmpl-CJ2Sl1AczM2suzJxykdyK65WsJlUH","object":"chat.completion.chunk","created":1758653735,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"5Ibz6Vz"}
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"oth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Uk"}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"qboNXh17VygiW"}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Mz"}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"hE"}
+
+
+        data: {"id":"chatcmpl-CJRDACKRfLwFqd8AGfou5XYCGYc8j","object":"chat.completion.chunk","created":1758748868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"bdVT7bz"}
 
 
         data: [DONE]
@@ -124,13 +151,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c41d3dab0b12c-SEA
+      - 984554697bf7ebdf-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:35 GMT
+      - Wed, 24 Sep 2025 21:21:08 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -148,13 +175,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '376'
+      - '400'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '390'
+      - '419'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -170,7 +197,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_614f56b590a14ffcb4782ccf5bdc10bc
+      - req_afc4098038e3412fa6c9a4eebb7cde18
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/tool_stream.yaml
@@ -4,9 +4,10 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","parallel_tool_calls":false,"stream":true,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","parameters":{"description":"A book
-      with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +16,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1024'
+      - '1205'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -47,75 +48,101 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_ohTBLuOrkdUqwBGQDocE4uxV","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"aJFHRC319u3VgL"}
+      string: 'data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_rEwjRaE5JflLjgK8E04ZbkVZ","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"0HkZ6roTWAKoLk"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"OITGR6ggFkYz03"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"JHhkXfLZQK2LoD"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"yUkgKhx3UbPOU8"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"eFs9z5zJ7J2wxj"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"er0q5qILVDO5Ep"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"sQqwYADtdCf9Do"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         OF"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"3x1KUqC09XjoLq2"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"kSY48aWKTRztoBw"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"1kWUdQbgOAMKtN"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Q60xFPx1lNWPuF"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"wLqZPYwX2Dgj60"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"JQ1LcJllPA5pPM"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"jBi9cOKFcjZVs"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"em0hD4cvTExTN"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"7W59qcgjWNqVSA"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"YURLLdg7dk39X"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ErOh6QVIkTCj"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"first"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"XrCCN6DjguIjT4"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Roth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"jos7CxWz74zHsG"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_name"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"5Nk0QFhKShlkjW"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"U3"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ICAwbE2vkOVd5d"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"zbl6YQvxdHQw"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"dzdAq8cYWmmeSO"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"48LQykVdlpKIfB"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"uk4q8FlQlTtif"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"last"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"nolsGMRcAKja1wv"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_name"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"cZDY8hfXk8QGkK"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"k3"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"KSHJcfgiplNXvx"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"n5"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"R"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Z5"}
 
 
-        data: {"id":"chatcmpl-CJ2STmQn60cKSLCPksx7QsbbgySve","object":"chat.completion.chunk","created":1758653717,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"ixAIeSI"}
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"oth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"6w"}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"dmmoXH8YpHGpf"}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"D2"}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"FI"}
+
+
+        data: {"id":"chatcmpl-CJRCtJZNOWEdSv9jmJJniGgqQfKET","object":"chat.completion.chunk","created":1758748851,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"dKHQFwb"}
 
 
         data: [DONE]
@@ -124,13 +151,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c4165eaf2709c-SEA
+      - 984553fe5d4fba33-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:55:17 GMT
+      - Wed, 24 Sep 2025 21:20:51 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -148,13 +175,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '438'
+      - '397'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '491'
+      - '424'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -170,7 +197,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_6c65c7a244ca444eab379e3c862617cc
+      - req_23d1094d9981431697a080c4297370bf
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/openai/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/openai/tool_sync.yaml
@@ -4,9 +4,10 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","parallel_tool_calls":false,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
-      a rating. The title should be in all caps!","parameters":{"description":"A book
-      with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"description":"For
-      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +16,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1010'
+      - '1191'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,20 +49,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFPvT9swEP3ev8K6z+0U+rv5hoANJmAMgdi0osh1LqmHY3v2BY1V/d8n
-        O9CkwKTlQ2Tdu3f37vm86TEGMoeUgVhzEpVVg6PPw2tnq4vR6eP3m8PbR3m8OlwcT24Xfz5NTqAf
-        GGb1EwW9sD4IU1mFJI1uYOGQE4aqB7PJfDoZTWeLCFQmRxVopaXB2AyGyXA8SOaDZPpMXBsp0EPK
-        fvQYY2wT/0GizvE3pCzpv0Qq9J6XCOkuiTFwRoUIcO+lJ64J+i0ojCbUQbWuleoAZIzKBFeqbdx8
-        m8659Ykrlf26E4vzb1difKZWF9V5jfnsaP718qjTryn9ZKOgotZi508H38XTV80YA82ryM2ySjru
-        hbGYFcZVnAjzzNRka8qi9uxVWcaAu7KuUFMYCTZLIEkKl5Au4eb0hF0eXpywLx9ZON+dXR4vob8E
-        XtPauJhzxclJ8cCuDa2L2vuIO05Sl0tIZ1vYa7ftvXe+7zjssKg9V2+t51ob4sGB6P39M7LdXbMy
-        pXVm5V9RoZBa+nXmkPvoHngytpEVJMTmUO9tCFhnKhsse8DY7mA6bepBu8AtOnzeNSBDXHVY8xfW
-        Xr0sR+IyrtBuawUXa8xbaru9vM6l6QC9ztRv1bxXu5lc6vJ/yreAEGjD+liHuRT7E7dpDsP7/lfa
-        zuUoGDy6RykwI4ku3ESOBa9V8/TAP3nCKiukLtFZJ+P7g8JmxWg0HSd8nCTQ2/b+AgAA//8DANp6
-        sumIBAAA
+        H4sIAAAAAAAAAwAAAP//jFRtT9swEP7eX2Hd53ZKS0dLviFgGtNgE6AxtqDIOJfEq2N79oUOVf3v
+        kx1owsuk5UNk3XPP3XMv9mbEGMgCUgai5iQaqyZHny6OPpv1zbpW16d7X3xzUR3685WZ3azdFMaB
+        Ye5+oaAn1jthGquQpNEdLBxywhB1uni/XMyXy+kiAo0pUAVaZWkyN5NZMptPkuUk2X8k1kYK9JCy
+        nyPGGNvEf5CoC/wDKUvGT5YGvecVQrpzYgycUcEC3HvpiWuCcQ8Kowl1UK1bpQYAGaNywZXqE3ff
+        ZnDu+8SVyu/JrOXxZbX6LuzvH6f26u6yOTtYfxvk60I/2CiobLXY9WeA7+zpi2SMgeZN5OZ5Ix33
+        wljMS+MaToRFblqyLeVRe/4iLGPAXdU2qCmUBJsMSJLCDNIMrj6esPPDsxP25QML5+vT8+MMxhnw
+        lmrjMkg3GZTSecqDgsj5yslJsYpuig+RC0N12XqfwXacgeMkdZVButjCM0Xb0Vvn28EQHJat5+r1
+        dLjWhnhoUhzP7SOy3W2CMpV15s6/oEIptfR17pD72GDwZGwnK0iIyaF9tkRgnWls6OoKY7rpYtbF
+        g37He3R28AiSIa4G9mQ6fiNeXiBxGbdst9iCixqLntovOG8LaQbAaFD1azVvxe4ql7r6n/A9IATa
+        sGHWYSHF84p7N4fhCfiX267LUTB4dPdSYE4SXZhEgSVvVXc7wT94wiYvpa7QWSfjFYXS5uXe3v48
+        4fMkgdF29BcAAP//AwClwRAbqwQAAA==
     headers:
       CF-RAY:
-      - 983c40752b2dba0f-SEA
+      - 9845532e798a6cc2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -69,7 +70,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:54:40 GMT
+      - Wed, 24 Sep 2025 21:20:18 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -87,13 +88,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1056'
+      - '716'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1077'
+      - '738'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -109,7 +110,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_c443d08580984c78aeaa68b36e9f7f15
+      - req_25aa668a1bf245b4ab0addbc22c78b32
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '825'
+      - '839'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RRXW/bMAz8KwGfFcDu8gW9FWiCDWm6os3aDcMgsDIbq7ElR6Q2dIH/eyEX2dAO
-        e6N4x+PpeARXgYaWd6YoF5u1zLYfFg/ru3CxWt4+fb3+hitQIM8dZRYx445AQQxNbiCzY0EvoKAN
-        FTWgwTaYKhpz8J5kPBmfFWfTYlpOQIENXsgL6O/Hk6SE0JjEWXMwkt/JFOUXoodpOau4qxfrp8Wv
-        y8Pv2l+CAo9tnjOmdRHZho7MY4gtilBlQpIuiRlETZb0XRLQRxAng+Htx+Xo6nyzHH1ejXJ9/+nq
-        AhRgkjpE0HCNEp3dj26C1I+JOX8Vxfkd6Hnf/1DAEjoTCTn4t+4HgOmQyFsC7VPTKEhDXPr4asRI
-        2JNn0JN5qcCircnYSCguePOWUZzwSFj9DzvN5gXU1dRSxMZM23/5f9Gyfo/2Cv7E9tqazRUwxZ/O
-        khFHOZd85ApjBX3/AgAA//8DAI+2i0kyAgAA
+        H4sIAAAAAAAAA3RRXUsDMRD8K2WfU7h+Wc1bUUsttUoRlYqEkNv2Qu+SM7upSLn/LjmpUsW3zc7s
+        7GT2ADYHCRVtVdYbx8nzxfmyz48b2rzPHlaz3WA/AwH8UWNiIZHeIggIvkwNTWSJtWMQUPkcS5Bg
+        Sh1z7JJ3Drk77Paz/igb9YYgwHjH6Bjky+Eoyd6XKlLSbI2kd1RZb07LS6L1YjrgxWK7nrp5jRMD
+        Apyu0pxSlQ2ajK9RbXyoNDPmykeuI6tWVCVJV0cGeQC23Bp+mF13lpPb687dtJPqp5vlFQjQkQsf
+        QMK95mDNrrPyXGwiUfqqZuu2IMdN8yqA2NcqoCbvTt23AOFbRGcQpItlKSC2ccnDlxHFfoeOQA7H
+        fQFGmwKVCajZeqdOGdkRD6jz/7DjbFqAdYEVBl2qUfWX/4P2it9oI+A7tq/W2VgAYdhbg4otplzS
+        kXMdcmiaTwAAAP//AwCItqzWMgIAAA==
     headers:
       CF-RAY:
-      - 983c42a8b9a70933-SEA
+      - 98455546ca0175f2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:10 GMT
+      - Wed, 24 Sep 2025 21:21:45 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:10Z'
+      - '2025-09-24T21:21:44Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:10Z'
+      - '2025-09-24T21:21:45Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:09Z'
+      - '2025-09-24T21:21:43Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:10Z'
+      - '2025-09-24T21:21:44Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqocqDc2TCbAnwJTP8h
+      - req_011CTTviPErhimjLt29MPY6Q
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1439'
+      - '1901'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async_stream.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '853'
       content-type:
       - application/json
       host:
@@ -51,18 +51,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_011vX6qktbSGr1sY42w89Gyt","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}         }
+        data: {"type":"message_start","message":{"id":"msg_01HJePd5XnZLCHmSwkPGX9tS","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01AhmjhvKWASdK3Fo4NrgGit","name":"__mirascope_formatted_output_tool__","input":{}}
-        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Ku1W1jZFjo3Rbga17Avqfq","name":"__mirascope_formatted_output_tool__","input":{}}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}         }
 
 
         event: ping
@@ -72,7 +71,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"titl"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"t"}     }
 
 
         event: ping
@@ -82,102 +81,111 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":
-        \"THE NA"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"itle\""}       }
 
 
         event: ping
 
         data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ME
-        O"}             }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"F
-        "}             }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        WIND\""}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        "}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"author\""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \"P"}    }
+        \"THE NAME "}          }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"atrick
-        "}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
+        TH"}  }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Rothfuss\""}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
+        WIND\""}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rating\":"}      }
+        \"a"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        7}"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uth"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or\":
+        \"Pa"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"trick
+        R"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"othfu"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ss"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \""} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rating\":
+        7}"}           }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0}
+        data: {"type":"content_block_stop","index":0               }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}            }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}  }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"               }
+        data: {"type":"message_stop"            }
 
 
         '
     headers:
       CF-RAY:
-      - 983c437e0decba2a-SEA
+      - 98455607ef9bdf13-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -185,7 +193,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:44 GMT
+      - Wed, 24 Sep 2025 21:22:15 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -199,35 +207,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:43Z'
+      - '2025-09-24T21:22:14Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:43Z'
+      - '2025-09-24T21:22:14Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:43Z'
+      - '2025-09-24T21:22:14Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:43Z'
+      - '2025-09-24T21:22:14Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqr8i864WmZA37DHPzk
+      - req_011CTTvkfQ1qxvDbau5yDacz
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '945'
+      - '1367'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async.yaml
@@ -47,15 +47,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJHbSsNAEIZfJfzXW0hrY3XvBBVFPFCKFY2EJRmb1XQ27s56oOTdJdZ6
-        xKsZ5vv+gWFWsBU0lmFRpMPhyfX8de+ZZ+b+0k/b3dPsavYSoCCvLfUWhWAWBAXvmn5gQrBBDAsU
-        lq6iBhplY2JFg+CYSQbjwSgdZWk2HEOhdCzEAn2z2qwUeunD70VjlXOS5BArDeXQSY7Z0UFytnd6
-        kJwfJn0/Pz7bz6HWnolSO78WL4x4Wz4kUyf1XQzhU/JGLC96aZJzh+5WIYhrC08mOIYGcVVI9IwP
-        EOgxEpcEzbFpFOL7zXoFy22UQtwDcYDeniiUpqypKD0ZsY6Ln0K64Z5M9R/bZPv91Na0JG+aIlv+
-        9b/osP5NOwUX5ftoa0chkH+yJRViyUOjf1RlfIWuewMAAP//AwDopw6y9gEAAA==
+        H4sIAAAAAAAAAwAAAP//dJFdS8NAEEX/SrjPW+in1X0TWqugVURUMBKWZEyWJrN1d1YqJf9dYq2f
+        +DTDnHMHhtnCFtBoQpn1B4tytbDnM7+a3pejCQ9vm2ITjqAgr2vqLArBlAQF7+puYEKwQQwLFBpX
+        UA2NvDaxoF5wzCS9cW/YH076k8EYCrljIRboh+1+pdCmC78XjW3KSZJCrNSUQicpbk7nyfL4Yp5c
+        niRdf3e2nKVQO89EqZzfiVdGvM1XybWT6imG8Cl5I5bLTpqm3KJ9VAji1pknExxDg7jIJHrGBwj0
+        HIlzguZY1wrx/Wa9heV1lEzcijhAH0wVcpNXlOWejFjH2U+hv+eeTPEf22e7/bSuqCFv6mzS/PW/
+        6KD6TVsFF+X7aHSoEMi/2JwyseSh0T2qML5A274BAAD//wMAPuzQt/YBAAA=
     headers:
       CF-RAY:
-      - 983c42721b7c8399-SEA
+      - 98455509bfcf76b0-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:01 GMT
+      - Wed, 24 Sep 2025 21:21:35 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -77,35 +77,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:01Z'
+      - '2025-09-24T21:21:34Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:01Z'
+      - '2025-09-24T21:21:35Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:00Z'
+      - '2025-09-24T21:21:33Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:01Z'
+      - '2025-09-24T21:21:34Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqnyRh3sdWG8eQxDmXv
+      - req_011CTTvhfV8ea71oQsgQGRWw
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1463'
+      - '1446'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async_stream.yaml
@@ -50,24 +50,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_014ujHfMQ8V1MiHtuuYuqZiG","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}              }
+        data: {"type":"message_start","message":{"id":"msg_01Fvj4DGu5rzWyZ1NsFb4opK","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here''s
-        a fantastic"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        book recommendation for you:\n\n```json\n{\n  \"title\":"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
+        \"THE NAME OF THE WIND\",\n  "}            }
 
 
         event: ping
@@ -77,50 +77,13 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        \"THE NAME OF THE WIND\",\n  \"author\": \"Patrick Rothf"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
+        \"Patrick Rothfuss\",\n  \"rating\": "} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\",\n  \"rating\":
-        7\n}\n```\n\nThis is"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        the first book in The Kingkiller Chronicle series and follows"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Kvothe, a legendary figure telling his own story. It"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s
-        a beautifully written fantasy novel with"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        incredible world-building, magic systems, and storyt"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"elling
-        within storytelling. Perfect for anyone who loves epic"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        fantasy with rich prose and compelling characters!"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7\n}"}         }
 
 
         event: content_block_stop
@@ -130,18 +93,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":121}        }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}          }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"           }
+        data: {"type":"message_stop"      }
 
 
         '
     headers:
       CF-RAY:
-      - 983c433adbed76eb-SEA
+      - 984555cfd94fb9f4-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -149,7 +112,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:33 GMT
+      - Wed, 24 Sep 2025 21:22:06 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -163,35 +126,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:32Z'
+      - '2025-09-24T21:22:05Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:32Z'
+      - '2025-09-24T21:22:05Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:32Z'
+      - '2025-09-24T21:22:05Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:32Z'
+      - '2025-09-24T21:22:05Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqqLtKxvRoATDw4iD7U
+      - req_011CTTvk18988rXiAsBfW2Ld
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '868'
+      - '864'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_stream.yaml
@@ -50,7 +50,7 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01Bec7N6VQNVUUhxiBiZ6jNS","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"id":"msg_01TyAhy3F1KDv7vcjQig4KJn","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
 
 
         event: content_block_start
@@ -60,13 +60,12 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
-        \"THE NAME OF THE WIND\",\n  "}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}        }
 
 
         event: ping
@@ -76,35 +75,41 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
-        \"Patrick Rothfuss\",\n  \"rating\": "}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \"THE NAME OF THE WIND\",\n  "}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7\n}"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
+        \"Patrick Rothfuss\",\n  \"rating\": "}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7\n}\n```"}
         }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0       }
+        data: {"type":"content_block_stop","index":0         }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}      }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":43}         }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"             }
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 983c42ddf9bea3aa-SEA
+      - 9845556f4a0fb9e0-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -112,7 +117,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:18 GMT
+      - Wed, 24 Sep 2025 21:21:51 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -126,35 +131,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:17Z'
+      - '2025-09-24T21:21:50Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:17Z'
+      - '2025-09-24T21:21:50Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:17Z'
+      - '2025-09-24T21:21:50Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:17Z'
+      - '2025-09-24T21:21:50Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqpFEjBxZ3zP7uXrzEw
+      - req_011CTTviryUZ29nw1Fx7hSTG
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '758'
+      - '1046'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_sync.yaml
@@ -47,15 +47,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SR20rDQBCGXyX811tIerCyd4r1cGGV0uqFkbAm02Zpsht3Z6Wl5N0lrfWIVzPM
-        9/0Dw+ygC0jUfpXFyfnsIZksaTGb2jDaXC3mK/sy2EKAtw11FnmvVgQBZ6tuoLzXnpVhCNS2oAoS
-        eaVCQT1vjSHuDXv9uD+KR8kQArk1TIYhn3bHlUybLrwvErvURFEK1lxRChmlmF9PounZ7SS6u4y6
-        /vFmepFCHDwVuLTuIN4rdjpfRzPL5TJ4/yk5xdqsOmmcmhbts4Bn22SOlLcGEmSKjIMz+ACeXgOZ
-        nCBNqCqBsL9Z7qBNEzhjuybjIU/GArnKS8pyR4q1NdlPIT5yR6r4jx2z3X5qSqrJqSob1X/9L5qU
-        v2krYAN/Hw1OBTy5N51TxpocJLpHFcoVaNt3AAAA//8DAJzaq+L2AQAA
+        H4sIAAAAAAAAAwAAAP//dJHbSsNAEIZfJcz1FpLaWN27ovUAWqsoRYyEJZk2S5PZuDsrlZB3l22t
+        R7yaYb5vfhimA12ChMat8jh5mJzYRbpMrvjxuKH5SG9u2/MRCOC3FoOFzqkVggBr6jBQzmnHihgE
+        NKbEGiQUtfIlDpwhQh6MBsN4mMZpEmIKQ4zEIJ+6fSTjJixvi4QuoyjKgDXXmIGMMri/mEazyfU0
+        ujmLQr+4nJ1mIHae8lwZuxPniq0u1tGd4WrpnfuUrGJNqyCNM+qhfxbg2LS5ReUMgQSkMmdvCT6A
+        wxePVCBI8nUtwG9vlh1oaj3nbNZIDuThWEChigrzwqJibSj/KcR7blGV/7H9bsjHtsIGrarztPnr
+        f9Gk+k17Acbz99HBkQCH9lUXmLNGCxLCo0plS+j7dwAAAP//AwARL1yY9gEAAA==
     headers:
       CF-RAY:
-      - 983c420a88e37b4d-SEA
+      - 984554a689fedee2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:45 GMT
+      - Wed, 24 Sep 2025 21:21:19 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -77,35 +77,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:44Z'
+      - '2025-09-24T21:21:19Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:45Z'
+      - '2025-09-24T21:21:19Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:43Z'
+      - '2025-09-24T21:21:17Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:44Z'
+      - '2025-09-24T21:21:19Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqmkYWTUX5U3hBzSZHR
+      - req_011CTTvgVijfXTurmS5xT1hJ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1360'
+      - '1640'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/stream.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '853'
       content-type:
       - application/json
       host:
@@ -51,17 +51,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01GaqWnFDVqmRKuacWTVdAom","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}      }
+        data: {"type":"message_start","message":{"id":"msg_01BvHsitJFgsXUFPdWKhLxF1","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Uvo6ATGVac7zRAxmXT7erZ","name":"__mirascope_formatted_output_tool__","input":{}}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01M9nVtDQVem5FtU51yauSNA","name":"__mirascope_formatted_output_tool__","input":{}}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
 
 
         event: ping
@@ -71,7 +71,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ti"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ti"}             }
 
 
         event: ping
@@ -81,7 +81,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tl"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tle"}}
 
 
         event: ping
@@ -91,8 +91,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":
-        \"THE NAM"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        \"THE "}   }
 
 
         event: ping
@@ -102,8 +102,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
-        "}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"NAME
+        OF "}             }
 
 
         event: ping
@@ -113,8 +113,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
-        THE WIND"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE"}  }
 
 
         event: ping
@@ -124,63 +123,74 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        WIN"}        }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"a"}           }
+        \"author\""}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uthor\":
-        \""} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"Patr"} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Patrick
-        Roth"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ick
+        Rot"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fuss\""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hfuss\""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        "}            }
+        \"rati"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"rating\":
-        7}"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng\":
+        7}"}             }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0        }
+        data: {"type":"content_block_stop","index":0         }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}   }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}           }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"     }
+        data: {"type":"message_stop"            }
 
 
         '
     headers:
       CF-RAY:
-      - 983c430dcc61a3aa-SEA
+      - 984555a43d5ab9e0-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -188,7 +198,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:26 GMT
+      - Wed, 24 Sep 2025 21:22:00 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -202,35 +212,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:25Z'
+      - '2025-09-24T21:21:58Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:25Z'
+      - '2025-09-24T21:21:58Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:25Z'
+      - '2025-09-24T21:21:58Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:25Z'
+      - '2025-09-24T21:21:58Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqpovjtDQhbWMXnRoms
+      - req_011CTTvjVCZjgBxrzaeYTDyu
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1173'
+      - '1651'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/sync.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '825'
+      - '839'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RRXUsDMRD8K2WfU7iTO1vzJlip1NZPUBAJMbfthd4lZ3Yjarn/LjmpouLbZmd2
-        djK7A1uBhJY2Ksvn1TuuwtTa6clTcXd+fTi1V4sSBPBbh4mFRHqDICD4JjU0kSXWjkFA6ytsQIJp
-        dKxwTN455HExPsgOyqzMCxBgvGN0DPJht5dk7xsVKWkORtI7qiy/YaL1donz44Ux9zevxaw8mnQg
-        wOk2zSnV2qDJ+A7V2odWM2OlfOQushpEVZJ0XWSQO2DLg+Hb+Wy0Ol7ORheno1Tfna1OQICOXPsA
-        Ei41B2u2o2vP9ToSpa9qtm4DctL3jwKIfacCavLup/sBIHyO6AyCdLFpBMQhLrn7NKLYb9ERyGKS
-        CzDa1KhMQM3WO/WTke3xgLr6D9vPpgXY1dhi0I0q27/8bzSvf6O9gK/YPluHEwGE4cUaVGwx5ZKO
-        XOlQQd9/AAAA//8DAIyD2p8yAgAA
+        H4sIAAAAAAAAA3RR70vDMBD9V8Z9zqCd6yr5pqgozDl/QBWRENPbGtYmXXIZltH/XdIxRcVvl3vv
+        3r2824MugUPj1yJJ788/5rPV42m3XYYtPr/PiuKp+AAG1LUYWei9XCMwcLaODem99iQNAYPGllgD
+        B1XLUOLYW2OQxtPxJJlkSZZOgYGyhtAQ8Nf9UZKsrUXwUXMwEt9BJOl8d9udLU5OVBmKl8xcdHka
+        XGQZ2cQ5IRrtpFe2RbGyrpFEWAobqA0kBlERJU0bCPgeSNNg+On6crQ4u70c3V2NYl3cLC6AgQxU
+        WQcclpKcVpvRg6VqFbyPX5WkzRp43vdvDDzZVjiU3pqf7gfA4zagUQjchLpmEIa4+P5gRJDdoPHA
+        p/mEgZKqQqEcStLWiJ+M5Ig7lOV/2HE2LsC2wgadrEXW/OV/o2n1G+0ZfMV2aM1yBh7dTisUpDHm
+        Eo9cSldC338CAAD//wMAonM0CzICAAA=
     headers:
       CF-RAY:
-      - 983c4241bf497b4d-SEA
+      - 984554df3e2ddee2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:54 GMT
+      - Wed, 24 Sep 2025 21:21:29 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:53Z'
+      - '2025-09-24T21:21:28Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:54Z'
+      - '2025-09-24T21:21:29Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:52Z'
+      - '2025-09-24T21:21:26Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:53Z'
+      - '2025-09-24T21:21:28Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqnQJdQoLpurEe8NYeV
+      - req_011CTTvhAPv8k9BvvJ4UEFrm
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1542'
+      - '2192'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '825'
+      - '839'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFHbSgMxEP2VMs8p7Govkje1ihe8oJZ6QUJIpt3obmZNJoqU/XfJShUV
-        3yZzzpw5ObMGZ0FCE1eqKGfz+cnJ/uUynN6Z0ozPdl5ocr8LAvi9xczCGPUKQUCgOjd0jC6y9gwC
-        GrJYgwRT62RxGMl75OFouFVsjYtxOQIBhjyjZ5AP640kE9UqxazZG8nvpIpyfrXAiZ0fza63bxdv
-        T/d7E0LbggCvmzynVOOCjoZaVEsKjWZGqyhxm1j1oipL+jYxyDWw497wzdHB4Hz37GBwcTjI9eL4
-        fAYCdOKKAki41ByceR5cEVfLFGP+qmbnVyCnXfcoIDK1KqCO5H+674GILwm9QZA+1bWA1Mcl159G
-        FNMz+ghyNC0FGG0qVCagZkde/WQUGzygtv9hm9m8ANsKGwy6VuPmL/8bLavfaCfgK7bP1mQqIGJ4
-        dQYVO8y55CNbHSx03QcAAAD//wMAMXcRLDICAAA=
+        H4sIAAAAAAAAAwAAAP//dFFdb9swDPwrAZ8VwDaSptDbPrp1X1nRFQjQYRAImY3V2qInUkPbwP+9
+        kIts6Ia9Ubzj8XQ8QGjBwiB7V9Wnt5/f7D5dN3hRD7f1Y3jkKzl9AAP6MFJhkQjuCQwk7ksDRYIo
+        RgUDA7fUgwXfY25pKRwj6XK1bKpmXa3rFRjwHJWigv1+OEoqc++yFM3ZSHlnV9UNX76+l28573cn
+        1+dptf3Ybd/fg4GIQ5lzbggJxfNI7obTgKrUOs46ZnWzqCuSccwK9gAadDZ8dX622L76crb4+m5R
+        6t2H7VswgFk7TmDhAjUFf7e4ZO1uskj5KmqIe7CbafphQJRHlwiF40v3MyD0M1P0BDbmvjeQ57js
+        4dmIU76jKGBXm8aAR9+R84lQA0f3klEd8UTY/g87zpYFNHY0UMLerYd/+X/QuvsbnQz8ju25dbIx
+        IJR+BU9OA5VcypFbTC1M0xMAAAD//wMAQnleDjICAAA=
     headers:
       CF-RAY:
-      - 983c4288bdcec366-SEA
+      - 9845551f2d6eba06-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:05 GMT
+      - Wed, 24 Sep 2025 21:21:39 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:05Z'
+      - '2025-09-24T21:21:39Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:05Z'
+      - '2025-09-24T21:21:39Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:04Z'
+      - '2025-09-24T21:21:37Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:05Z'
+      - '2025-09-24T21:21:39Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqoEtNLMMVd6FzMoK9x
+      - req_011CTTvhvBg6J9A9fnGPB8Gf
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1466'
+      - '2356'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async_stream.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '853'
       content-type:
       - application/json
       host:
@@ -51,17 +51,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01EnW8GxRCCXjzwBM5kyyBwt","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":27,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"id":"msg_01GCtfXVq8ua1P4cbJNffVNM","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01TVfNeJiS1eYYpoCPujLpun","name":"__mirascope_formatted_output_tool__","input":{}}     }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01F3RagbU7i3CgidjBj6mxLE","name":"__mirascope_formatted_output_tool__","input":{}}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}             }
 
 
         event: ping
@@ -71,113 +71,122 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}    }
 
 
         event: ping
 
         data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"title\":
-        \"THE"}}
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        NAME OF T"}    }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"HE
-        W"}    }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"IND\""}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"au"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        \"Patrick "}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Rothfus"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\""}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rating"}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        7}"}              }
+        "}            }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"THE
+        NAME O"} }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"F
+        "} }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
+        WIND"}               }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"au"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
+        \""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Patr"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ick"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        Rothfuss\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"r"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ating\":
+        7}"}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0    }
+        data: {"type":"content_block_stop","index":0 }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}
-        }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}               }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
       CF-RAY:
-      - 983c435d3ef7c371-SEA
+      - 984555e66ce8eb93-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -185,7 +194,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:39 GMT
+      - Wed, 24 Sep 2025 21:22:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -199,35 +208,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:38Z'
+      - '2025-09-24T21:22:09Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:38Z'
+      - '2025-09-24T21:22:09Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:38Z'
+      - '2025-09-24T21:22:09Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:38Z'
+      - '2025-09-24T21:22:09Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqqkJyrMcYD1dcbA9Tg
+      - req_011CTTvkGU8BtVfqfbMZKxeU
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1250'
+      - '1512'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_stream.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '853'
       content-type:
       - application/json
       host:
@@ -51,17 +51,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01PeMvBYNW5UEa9wmYPfKVHQ","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}     }
+        data: {"type":"message_start","message":{"id":"msg_01NGaTzFgBXW64UGSSQfd9F9","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_015FTjaagqaH4Lufu3UkKAVR","name":"__mirascope_formatted_output_tool__","input":{}}           }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01YJnSNF4LitTUBUBWZSffnA","name":"__mirascope_formatted_output_tool__","input":{}}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
 
 
         event: ping
@@ -71,96 +71,112 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}           }
 
 
         event: ping
 
         data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"title\":
-        \""}              }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        NAME OF "}         }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        WIND\""}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author"}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"Patrick"}   }
+        \"THE"}  }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Roth"}  }
+        NAME"}         }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fuss\""}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        OF THE WIN"}       }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rating"}         }
+        \"author"}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        7}"}             }
+        \"Patrick"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        R"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"othfuss"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"ratin"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"g\":
+        7}"} }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0      }
+        data: {"type":"content_block_stop","index":0            }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":471,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}              }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"              }
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 983c42f61b10a3aa-SEA
+      - 98455587c96db9e0-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -168,7 +184,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:22 GMT
+      - Wed, 24 Sep 2025 21:21:55 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -182,35 +198,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:21Z'
+      - '2025-09-24T21:21:53Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:21Z'
+      - '2025-09-24T21:21:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:21Z'
+      - '2025-09-24T21:21:53Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:21Z'
+      - '2025-09-24T21:21:53Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqpXjuvonDRhSMm3Rr7
+      - req_011CTTvj9iYCzkR7mYE8WMdH
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1020'
+      - '1062'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_sync.yaml
@@ -5,7 +5,7 @@ interactions:
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
       should always be the\nlucky number 7.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object"}}]}'
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '825'
+      - '839'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFFdb9swDPwrAZ8VwG6TBtNbsHQfGJJmRYc+DINAyGys1hY9kdpaBP7v
-        g1xkRVfsjeIdj6fjEUIDFno5uKre/5b1Yfv49V7X+/Ntnb6sv+Xb92BAnwYqLBLBA4GBxF1poEgQ
-        xahgoOeGOrDgO8wNzYVjJJ0v5mfV2bJa1gsw4DkqRQX7/XiSVObOZSmak5Hyzq6qF5uLYcWb9DS8
-        uxb2/eYed8uPYCBiX+ac60NC8TyQu+PUoyo1jrMOWd0k6opkHLKCPYIGnQzffLqc7dbby9nVh1mp
-        bz/vNmAAs7acwMIeNQX/MLtmbe+ySPkqaogHsKtx/GFAlAeXCIXja/cTIPQzU/QENuauM5CnuOzx
-        2YhTfqAoYBer2oBH35LziVADR/eaUZ3wRNj8DzvNlgU0tNRTws4t+7f8F7Ru/0VHA39je25drAwI
-        pV/Bk9NAJZdy5AZTA+P4BwAA//8DAFSb5gcyAgAA
+        H4sIAAAAAAAAA3RRXWsbMRD8K2afZTgbfxS9hdZtmuIkJDahLUWspT2f4pN0kVaG1Nx/L7rgliT0
+        bbUzOzuaPYE1IMGlvaomm9oc1o/bh+3xcvH4ZefW9fHq3oEAfu6osCgl3BMIiKEtDUzJJkbPIMAF
+        Qy1I0C1mQ+MUvCcez8bTajqv5pMZCNDBM3kG+fN0luQQWpVT0RyMlHdW1WS7+/HbrBbf5vrDd32V
+        N/XuNuFHEODRlTmlnI2YdOhI1SE6ZCajQuYusxpEVZH0XWaQJ2DLg+HN5Wp0fbFejW4+j0r98PX6
+        EwjAzE2IIOEWOVp9GN0FbuqcUvkqsvV7kMu+/yUgcehUJEzBv3Y/AImeMnlNIH1uWwF5iEueXowo
+        DgfyCeRsORWgUTekdCRkG7x6zajOeCQ0/8POs2UBdQ05itiquXvP/4dOmrdoL+BvbC+txVJAoni0
+        mhRbKrmUIxuMBvr+DwAAAP//AwCrzY89MgIAAA==
     headers:
       CF-RAY:
-      - 983c422438a87b4d-SEA
+      - 984554beb8b5dee2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:49 GMT
+      - Wed, 24 Sep 2025 21:21:24 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:55:49Z'
+      - '2025-09-24T21:21:23Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:55:49Z'
+      - '2025-09-24T21:21:24Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:55:47Z'
+      - '2025-09-24T21:21:21Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:55:49Z'
+      - '2025-09-24T21:21:23Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqn47wHHFvHXuKCzEvu
+      - req_011CTTvgnAgzN5LMtt4LHqhA
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1586'
+      - '2366'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/async.yaml
@@ -32,13 +32,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRX2+CMBTF3/kUzX3WRc3czN7MZNElKlP2L2NZGqnQCC1rL5mG8N3XwlDIeCCX
-        e07vuf1ROITAjoqQhxSZhjvyYTqEFNXbalIgE2iEpmWaGVV48dZP0aqNBdnRHoIiAOSYsMB8BODP
-        XbKaLl2yfiC2fl2sZgH0jEJzjKWqXR5FxXcHspEY73Ota4eiyEVkHbcltMLKc/3Zu6yoZMJsfipD
-        ljT2sjHAnguu4w2jWgpr2/prD84qFyE7mvbAaQKq0ZBrGrElQ2pg0TMSyJRMM/TlgYl7mVewbkb1
-        sBbbjj66/tNRIk060nAy6f2bq2cmlSdt6K3/YS5JE44nexPfffOhBQK7azUknBYwMOjzKMbuisOB
-        NVfIaoovTGle44pYagD2R1fj/j6hOq4CQTGdSaHZIrSeZ2++pYtT6r6vH79Re6fx14+cPoFTOr8v
-        fTkkdgIAAA==
+        H4sIAAAAAAAC/12Ry26DMBBF93yFNeukSpD63EUNbUibh1L6UEtVucEBC7CRPUiJIv69BkLilIU1
+        mns9d3zYO4TAmoqIRxSZhjvyZTqE7Juz1qRAJtAIXcs0C6rw5G2/vVUbC7JtfQn2ISDHjIVwF0Iw
+        8ch8NPPI4oHU9bs/H4fQC4GWmEjVeJYUFV+nZCUx2ZRaN7qiyEVs9OsKrJzqWH/3TtspmbE6OpcR
+        yzp71RlgwwXXyYpRLUVtewkWSziqXERsa9oDpwtoRkOpacxmDKnhRI80oFAyLzCQKRP3smw4Xbnt
+        MAvrmT68PegokWZnkjvo7lpz9dik8szmbf0K80iacdzVLwm8jwAsEHi+VkfCsYCB4V7GCf5b0R06
+        B2QtxTemNG9xxSw3APvuxWV/k1GdNIGgmC6k0MyPak/6OHmlz7tf//NpmmO65NMf72bkg1M5f6PU
+        a8hxAgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -47,11 +47,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:13:20 GMT
+      - Wed, 24 Sep 2025 21:24:32 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1649
+      - gfet4t7; dur=1591
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/async_stream.yaml
@@ -35,8 +35,8 @@ interactions:
         \\\"THE NAME OF THE WIND\\\", \\\"author\\\": \\\"Patrick Rothfuss\\\", \\\"rating\\\":
         7}\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
         {\"promptTokenCount\": 62,\"candidatesTokenCount\": 24,\"totalTokenCount\":
-        200,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\":
-        114},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"UfHSaMDFF7XYqtsP076uqQ8\"}\r\n\r\n"
+        153,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\":
+        67},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"kWHUaO7BNJCUmtkPu7a8-AI\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +45,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:13:22 GMT
+      - Wed, 24 Sep 2025 21:24:34 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1268
+      - gfet4t7; dur=1028
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_async.yaml
@@ -28,13 +28,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRW0/CQBCF3/srNvMMRkHA+GYEIioXoV4S68OGDu1K2W12pwnS9L+7bW1pYx82
-        k3NOZ2a/TR3GYMulL3xOaOCWfVqFsbQ4c09JQknWqCQrxlzTOVt+aaO2EcJj/hOknmTMAxIUoWcF
-        D9yHCVvczSdsOWV5/T5bjD3olDmeUKh0GVxx0mK7Z2tF4S4xpg5pTkIGeWjkyQwag7O6/uqc19Uq
-        wnyXg/IxquJZFYCdkMKEa+RGyTy2cZcrqF0hfTxa+dKpBhStITE8wDkSt+B4jQdirQ4xuWqP8l4l
-        Bbhhr2zW4Nzy+5VPinjUsq4GN51/fc3YThVR8wEab2MvySNBP/lN3MmHCw0Q1F6rIuE0gIHlnwQh
-        tVccXjt/xEqIb6iNKGkFeLD8ur2LQXcXcRMW80CjiZU0OPOLPZL+hj8+PU9Hp81pNFuJ1XeQvLyC
-        kzm/wuK3aIECAAA=
+        H4sIAAAAAAAC/2WRXU+DMBSG7/kVzblmRjc3F++MzLi4Lyd+Rbyoo0Az1mJ7SGYI/90WhEHkojl5
+        35dzTp8WDiGwoyLkIUWm4Zp8GIWQojqtJwUygcZoJCNmVOEpW39FpzYRZEf7ExSBICQA5JiywAgB
+        +PczsrpZzsj6jtj6db7yAnDrHM0xkaoObigqvtuTrcQkyrVuQ4oiF7ENXQWihM7gsq0/3dO6SqbM
+        7nKQIUubeNkEIOKC62TLqJbCxp789QZal4uQHY187jQDqtaQaxqzJUNqwNEWD2RKHjL05Z6JW5lX
+        4CbDulmHc88fNT5KpGnPuhhP3X99tWem8rT7AJ23MZekKccfexN/9uZDBwT212pIOB1gYPjncYL9
+        FSeXzh+xGuILU5rXtGJ2MPwGw7PxIEqpTqp5oJjOpNBsHtrMZOg904X3tcaH6Bv1Rs1Hi+njOzil
+        8wuACZ8OgQIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -43,11 +43,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:56:14 GMT
+      - Wed, 24 Sep 2025 21:21:47 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1119
+      - gfet4t7; dur=906
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_async_stream.yaml
@@ -31,9 +31,9 @@ interactions:
         \ \\\"title\\\": \\\"THE NAME OF THE WIND\\\",\\n  \\\"author\\\": \\\"Patrick
         Rothfuss\\\",\\n  \\\"rating\\\": 7\\n}\"}],\"role\": \"model\"},\"finishReason\":
         \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 62,\"candidatesTokenCount\":
-        32,\"totalTokenCount\": 228,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        62}],\"thoughtsTokenCount\": 134},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"bu3SaMeQJ5yCmtkP4_jUuA8\"}\r\n\r\n"
+        32,\"totalTokenCount\": 155,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        62}],\"thoughtsTokenCount\": 61},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"CmHUaJmjA9KhqtsPwbHL8AI\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -42,11 +42,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:56:48 GMT
+      - Wed, 24 Sep 2025 21:22:18 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2227
+      - gfet4t7; dur=879
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_stream.yaml
@@ -31,9 +31,9 @@ interactions:
         \ \\\"title\\\": \\\"THE NAME OF THE WIND\\\",\\n  \\\"author\\\": \\\"Patrick
         Rothfuss\\\",\\n  \\\"rating\\\": 7\\n}\"}],\"role\": \"model\"},\"finishReason\":
         \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 62,\"candidatesTokenCount\":
-        32,\"totalTokenCount\": 205,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        62}],\"thoughtsTokenCount\": 111},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"U-3SaIXhJ6OJz7IPuKW8wAU\"}\r\n\r\n"
+        32,\"totalTokenCount\": 198,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        62}],\"thoughtsTokenCount\": 104},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"72DUaJDQNvj4qtsP2ZysyQE\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -42,11 +42,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:56:20 GMT
+      - Wed, 24 Sep 2025 21:21:53 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1170
+      - gfet4t7; dur=1452
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/json_sync.yaml
@@ -28,13 +28,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRUU+DMBSF3/kVTZ83s43o1DezoZtxG25ETcSHZtxBM9Zie0lmCP/dFoRB5KG5
-        Oedw7+3XwiGE7pmIeMQQNL0nn0YhpKhO60mBINAYjWTEjCm8ZOuv6NQmgnC2P9EiFISEFDmmEBoh
-        pMHCI+uHlUc2j8TW78v1PKSDOsdyTKSqgz5DxfdHspWYHHKt25BiyEVsQ9NQlLQzuGzrr8FlXSVT
-        sLucZARpEy+bAD1wwXWyBaalsLFdsPFp63IRwdnII6cZULWmuWYxrACZAcdaPDRT8pRhII8gZjKv
-        wN1M6mYdzj3fbXyUyNKeNb6bDv711XMzlafdB+i8jbkkSzn+2JsE3kdAOyCwv1ZDwukAo4Z/HifY
-        X3E8cp0/ZDXFN1Ca17hiOBmAw8nV9fCQMp1UA6kCnUmhYRnZzCp3d8x/el4gvHyj9uXtbBi/etQp
-        nV/vJp6hggIAAA==
+        H4sIAAAAAAAC/2WRy07DMBBF9/kKa9YtKuVRxA7RAln0nQISYWE108Rqagd7ggpV/h07UdJEeGGN
+        5l7P4/jkMQZbLiMRcUID9+zDZhg7lbfTlCSUZIU6ZZMZ13T2VufUiq2F8OgewSmUjIVAglIMbSKE
+        4GXCZg/TCZs/MRe/+bNxCL3Kx3NKlK6MC05abPdspSjZ5cY0Js1JyNiZRqEsoNW4aOLP3nlcrVJ0
+        sxxUhGltL2oD7IQUJlkhN0o62zqYL6BRhYzwaNMDr25Qlobc8BinSNyC4w0eyLQ6ZBSoPcpHlZfg
+        bodVsRbnjn5V66SIpx3pcnTd+1fXjG1XkbY/oPU3dkmeCvpxmwST9wBaIKg7Vk3CawEDyz+PE+qO
+        eOe2L4lVEF9RG1HRivFg+fWHFzf9XcpNUvYDjSZT0qAfOc/gebzhPurp1/fyd+QvFF8vB8sNeIX3
+        B/o8OvKBAgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -43,11 +43,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:55:46 GMT
+      - Wed, 24 Sep 2025 21:21:20 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1254
+      - gfet4t7; dur=1081
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/stream.yaml
@@ -35,8 +35,8 @@ interactions:
         \\\"THE NAME OF THE WIND\\\", \\\"author\\\": \\\"Patrick Rothfuss\\\", \\\"rating\\\":
         7}\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
         {\"promptTokenCount\": 62,\"candidatesTokenCount\": 24,\"totalTokenCount\":
-        213,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\":
-        127},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"W-3SaPGqG_ODz7IPm-7kuQo\"}\r\n\r\n"
+        165,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\":
+        79},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"-WDUaPyVCJuJmtkPopr32AY\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +45,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:56:28 GMT
+      - Wed, 24 Sep 2025 21:22:01 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1841
+      - gfet4t7; dur=1144
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_async.yaml
@@ -32,13 +32,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/1WRQW+CQBCF7/yKzZy1qbbW1putNuWgUKWtSelhIyNsxF2yOyS2hv/eBUSBw2Yy
-        7+282Y+TwxhsuYxExAkNTNi37TB2qs5SU5JQkhWalm1mXNPVW3+nVm0thMfyEpxCIEEphjAJIXib
-        s+V0MWfeKyvrL3c5C6EXAs8pUbry+Jy02O7ZSlGyy42pdM1JyNjq4wJaOcWl/uldt9MqxTL6oCJM
-        G3vRGGAnpDDJCrlRsrStA8+HiypkhEfbvnWagGo05IbHuEDilhO/0IBMq0NGgdqjfFF5xelhWA9r
-        Ye3og6ezTop42pVGzd3WXDOzqSJt8279CvtIngr6LV8SzDcBtEBQd62GhNMCBpZ7HifUXXE8cM7E
-        aoifqI2oacV4sPz6w5tRf5dyk1R5oNFkShp0o9Lj53drvvQS19u8/41d//4Rn9X0A5zC+QfT9ozU
-        cAIAAA==
+        H4sIAAAAAAAC/2WRy26DMBBF93yFNeukSmmTSN1VJVVRlWfpQypdWGECVoiN7EFKi/LvtaEkoHqB
+        hrnX8ziuPMZgy2UiEk5o4I592gxjVf11mpKEkqzQpmyy4Jou3uZUndhaCI/uElQxkKAcY/sTQ/Q0
+        Y4v7+YwtH5mL38NFEMPAKrykTOnGteKkxXbPNoqyXWlM49CchEydY3qCTrPTOf4aXEbUKkfX/6AS
+        zFv7qTXATkhhsg1yo6SzvUTLFZxVIRM82vTIaxvUpaE0PMU5Erew+BkJFFodCorUHuWDKmtYE78p
+        1mHb0/3bP50U8bwnXY8ng391TWC7irwLvfMedkmeC/p2m0Szjwg6IKg/VkvC6wADi75MM+qPOHXb
+        18QaiG+ojWhopXiw/Ib+1Xi4y7nJ6n6g0RRKGgwT5/H94JU/36hFKDc/03A1Cr+D0XoN3sn7Bb2D
+        YW51AgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -47,11 +47,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:55:58 GMT
+      - Wed, 24 Sep 2025 21:21:31 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1166
+      - gfet4t7; dur=897
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_async_stream.yaml
@@ -35,8 +35,8 @@ interactions:
         \\\"THE NAME OF THE WIND\\\", \\\"author\\\": \\\"Patrick Rothfuss\\\", \\\"rating\\\":
         7}\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
         {\"promptTokenCount\": 62,\"candidatesTokenCount\": 24,\"totalTokenCount\":
-        192,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\":
-        106},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"Xu3SaN2yCIKfqtsP_evqkQQ\"}\r\n\r\n"
+        169,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\":
+        83},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"-2DUaILKBKqhqtsPtIyVuQg\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +45,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:56:30 GMT
+      - Wed, 24 Sep 2025 21:22:03 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1178
+      - gfet4t7; dur=1091
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_stream.yaml
@@ -31,12 +31,12 @@ interactions:
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":\\\"THE
-        NAME OF THE WIND\\\",\\\"author\\\":\\\"Patrick Rothfuss\\\",\\\"rating\\\":7}\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        62,\"candidatesTokenCount\": 19,\"totalTokenCount\": 195,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\": 114},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"T-3SaOjsEJfUz7IP2cSgqAU\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"{\\\"title\\\":
+        \\\"THE NAME OF THE WIND\\\", \\\"author\\\": \\\"Patrick Rothfuss\\\", \\\"rating\\\":
+        7}\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\":
+        {\"promptTokenCount\": 62,\"candidatesTokenCount\": 24,\"totalTokenCount\":
+        160,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 62}],\"thoughtsTokenCount\":
+        74},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"7GDUaJihMP66qtsPwIHz0QY\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -45,11 +45,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:56:16 GMT
+      - Wed, 24 Sep 2025 21:21:49 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1356
+      - gfet4t7; dur=935
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/strict_sync.yaml
@@ -32,13 +32,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRX2+CMBTF3/kUzX3WRdzcv7dlssxkKlOiy8YeOqnQiC1rL4sL4buvBVHIeCCX
-        e07vuf1ROITAhoqIRxSZhnvyYTqEFNXbalIgE2iEpmWaGVV49tZP0aqNBdnBHoIiBOSYstB8hBA8
-        e2T2MPXI/InYej2ZjUPoGYXmmEhVu3yKim92ZCEx2eZa1w5FkYvYOm5KaIWVp/qzd15RyZTZ/L2M
-        WNrYy8YAWy64ThaMaimsbRnMfTipXETsYNoDpwmoRkOuacymDKmBRU9IIFNyn2Egd0w8yryCdT2s
-        h7XYdvTh1VFHiTTtSO6d2/s3V49NKk/b0Fv/w1ySphx/7U0C7y2AFgjsrtWQcFrAwKDP4wS7K7qD
-        kXNEVlNcMaV5jStmewOwP7wY9bcp1UkVCIrpTArNJpH1vOSXS+qvVzP98/6N2h99rb3d6y04pfMH
-        tlOa4XYCAAA=
+        H4sIAAAAAAAC/2WRX0/CMBTF3/cpmvsMRjGC8mYAlYR/4lCDM6Zh3dYw2qW9U2DZd7fdHGxxD83N
+        PWf33P6aOYTAhgqf+xSZhj75MB1CsuK0mhTIBBqhaplmQhWeveWX1WpjQba3P0HmAXKMmQd9D9yn
+        EZndT0dk/kBs/TaeDT1oeUBTjKQqPAuKim+2ZCkxClKtC11R5CI0ei+HWk5+qj9b5+2UjJmN3kmf
+        xZU9rwwQcMF1tGRUS2FtL+58ASeVC5/tTfvSqQKK0ZBqGrIpQ2o40RMNSJTcJejKLRMDmRacup1y
+        WA1rQ7+6+9NRIo2bUve69W+uHppUHtd5157CXJLGHA/2Ju7o3YUaCGyuVZFwasDAcE/DCJsr3lpv
+        QayE+MqU5iWtkO0Mv3bn4qYdxFRHRR4ophMpNBv71nN8HK7o5Hs9mPRWx954wddfgXz+ASd3fgHA
+        3yVAcAIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -47,11 +47,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:55:42 GMT
+      - Wed, 24 Sep 2025 21:21:16 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1219
+      - gfet4t7; dur=918
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/sync.yaml
@@ -32,13 +32,13 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRT2+CQBDF73yKzZy1qVZr0ltTbTSN/4ltUnrYyAgbcZfuDokt4bt3F0Qh5UCG
-        eW/nzf7IPcZgz2UoQk5o4Il92g5jefl2mpKEkqxQt2wz5Zpu3urJG7W1EJ7dIcgDIEEJBvYjAH86
-        YYvn+YQtX5mr32eLcQAdq/CMYqUr14qTFvsj2yiKD5kxlUNzEjJyjlEBjbDiWn91bitqlaDLP6kQ
-        k9pe1AY4CClMvEFulHS2rb9cwVUVMsSzbd97dUA5GjLDI5wjcQuLX5FAqtUpJV8dUb6orIT12K+G
-        Ndi29P7gopMinrSk3nDU+TfXjG2qSJrQG//DXpIngn7cTfzJhw8NENReqybhNYCBRZ9FMbVXHPW8
-        C7EK4g61ERWtCE+WX7d/N+weEm7iMg80mlRJg7PQeZbdhy2fTedvyKNvMqvfAW6O6zV4hfcHro/Y
-        RXUCAAA=
+        H4sIAAAAAAAC/1WRy26DMBBF93yFNeukSlGbRN21SapGVR5N6ZsurOCAFbCpPUhpEf9eG0JiWKBh
+        7vXc8aH0CIEtFRGPKDINN+TLdAgp67fVpEAm0AhtyzRzqvDsbZ7SqY0F2cEegjIE5Jiy0HyEEDzM
+        yPJ2MSOre2Lrt/lyGkLPKLTARKrGtaao+HZPNhKTXaF141AUuYitY1SBE1ad6u/eeUUlU2bzMxmx
+        tLVXrQF2XHCdbBjVUljbc7Baw0nlImIH0x54bUA9GgpNY7ZgSA0sekICuZJZjoHcMzGRRQ1r6DfD
+        HLYd3b866iiRph3pcthqzlw9Nak8daE7/8NckqYcf+1Ngtl7AA4I7K7VkvAcYGDQF3GC3RVHY+9I
+        rIH4ypTmDa2YZYZf37+47u9SqpM6DxTTuRSazSPr8bPpC30cftx9BvnfaL7+6fPJ4GkMXuX9A7La
+        +dR1AgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -47,11 +47,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:55:55 GMT
+      - Wed, 24 Sep 2025 21:21:30 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1388
+      - gfet4t7; dur=861
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_async.yaml
@@ -6,11 +6,11 @@ interactions:
       str, rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.",
-      "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema": {"properties":
-      {"title": {"title": "Title", "type": "string"}, "author": {"title": "Author",
-      "type": "string"}, "rating": {"title": "Rating", "type": "integer"}}, "required":
-      ["title", "author", "rating"], "title": "Book", "type": "object"}}]}], "toolConfig":
-      {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "name": "__mirascope_formatted_output_tool__", "parameters": {"properties":
+      {"title": {"title": "Title", "type": "STRING"}, "author": {"title": "Author",
+      "type": "STRING"}, "rating": {"title": "Rating", "type": "INTEGER"}}, "required":
+      ["title", "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
       "generationConfig": {}}'
     headers:
       accept:
@@ -20,7 +20,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '923'
       content-type:
       - application/json
       host:
@@ -34,24 +34,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21Uy5KqSBDd91cYbLk9PETU2SmgoAgoiODEhFG8qwWKhgLFjv73Qftxte+wILLy
-        nMxTlRF53p56PcIHeQADgMOK+Lv3T5fp9d5u/yuGchzmuAO+Ul2yACX+zf343u7ijhLVuY8hygWQ
-        pg/Fn3gOsrDLE4dDBktQ+agIDxEqM4BxGBxQjYsaHzBC6eFA/PpZDMq4+p+mHVICDPO4w4Y/izoQ
-        Q5zeRC1Z6mmTldTTZ71rvFM08Q+Vq06NE1ReKwyAS+gfexuEk6iuKuIH+f3h/P7Yi+i61HGCTRjn
-        ANfl7Q5C4UqTQMYwGzNkS+uDjVW0JRjQjsNPR2uLHsevohoqEh8YSDbB+kjyMB0mhUSdXXPLuHVR
-        nlLgtKYd2FSFSB7DBTLTqHVIa+JMpRlto5GWTvZlsj2J7pqWQH+050+lOoqDbW5sRI8aUNTOXHqT
-        sV/7OilwjDRKGDVf7RaNuNjL+4V94jeBPDjhMx+Py3691W1Kd+eyAZZn2tuyDXUSUpY/t1Y7mTOe
-        W9dJ6DUTRVjYkA7IxavnC7puzF5q2m0M+cVRM0U3JaRsRXI3vjQBq2vZQjRsj18LttKQ/gtEvKi6
-        G05t8vO+L+jO1PXLZkZ7jeNEQVE3AtrNudqyAceD2FPcIGL63DBS7KWk5Y2lC32V4ZZMeqbMLBIy
-        H0/3rtdgf7yg23aDpGO+kSsUO9DWR1N9xiRwxA+XoxOXeKaaTYEutJxiavsRsx5WAnakJbumLmi8
-        MhJ0PlrAEltmvSBJFihnSK5PsunixEyNvdbWMTN11KXiNk2yLZq8kvXLtp8FoxltrfaOBuS2aQZG
-        9CrhBh9ZT6xJbeEUEJAvmUIiQFV7JhiLjjvPyxl6RUPZb6RYM/uSzGJ2fATbAeKm58lg6UpiZm60
-        OpWzYy6RfrmY84Zp1xoTUUskqzZUJie48VamQjmpcImKbcExumYgWlPdrTnJkLsZBl5kz2aSUzXj
-        l5d2xeY0lmbVgit00m/0150cFloXDk5zdiLVQnP03aPZKqPEcvq0kMW6fNE4jrvfht+b8O/vLSBK
-        9LF5GQrC9Iv+vSZEBHNYJZsQVCi/0kxLN74XkoB5EJ67NP30JXBrTdQViMNViEHnXeDbD4iiRFmB
-        LXQMcwHVN+9i+p9+cOd1D4RvHCMM0keI5n/90bgSO1mY3pvgnT92rwQpxO3NayTHuvOWTuDxXl+z
-        eLob2ZdhVD8ewT59Du1jjnZYVvBjYHGYdSN8Zv8aPEcpqJKbIlGGVYHyKlSCK2fz3DeBCp+nnowu
-        Q8XgdY9h152VvT/9B3kEcjMHBgAA
+        H4sIAAAAAAAC/21UXZOiOBR9719h8erstoCIbtU8IKCCIgjKh1tbVpTwoZBACCo9Nf990Z7u0Znh
+        gQr3nJzcXOqcby+dDnMAKExDQGHF/NP5t610Ot/u7xuGEYWItsBHqS0WgNCf3Pfn28O6pUQ1OtAU
+        Ixlk2dPmHzgCOWzrzG6XpwRUB1zAXYRJDiiF4Q7XtKjpjmKc7XbMl183AxJXfxC9ITVNMLkJW4CS
+        9HDq2JgmUV1Vv6m0bAJoiuKWLf4BpCnN7i2uZ2pnKRlqx5x0bmtPWyrML/zvT9/fn+WYtqc6TqiT
+        xgjQmtxV5dJQpXBG03xE5ONQXozEwsZownrq6NXho6o82BdvnZ8VxE9wuN1uoquLjt1hbJEL3xeW
+        a3o55/ogaE6sNE+G0+pi+FtQ9yZTKEiH+LKCrvPKG/VooNISyXgziMLGkOfZcRVkPLANYb4aduvD
+        1JGKyD7F8piX9fjqBRWZicpAmZxHJb8vY9Y3VeBPx6bnVOxmHXZdn/pJ30GiexL3fUPnxnsuRU7f
+        nCD12E8irWwctRttjgJ/nuO1tAw1/eI4RXeQrTleVuSjsdI2tJG2jj4bKo1T6qvgaBDsaqWwsMDk
+        bayT3Ey6gwUp64EaeovTuPLGixzZsRJ608uwrgxrP6BH//wm71lu0UycczDYrsTNrN/eo6k5fllO
+        BxkNXkOhjhrdeeup0KfdTS+V4iw9hRGaXbqcODfG6GzTsXS1Kt7GoRqIbZcH9rpZZk7j17muwV4M
+        o6T2hWsRKnSgzcxgsm/AukldyXWTcePLnBCN7cYVb3/OblTCqUGFUd7NOXZZcAszkM1cyZ1ucBW5
+        LWvOXnXIB/wksC4LecrRKMVj03gbcmef7c2Vto25ZCGEZrXusWmGwv3RGZ4bVWWlelOkgoh8q/AM
+        vphCWYstwfMMSJKLUo5fo4lD1qA713HXEsh12redYEqvpYvtAPrE24wO2+YEVptmnR6CvjaILFaT
+        te0lkHqzOZK0sy68EolVoItsyrojQdT01VIJQt5Q6qzAM3GZvpnLkbR/62n9WtrymZEcQzGRTsmE
+        DzxyguZKv3z9+uiQn+7476czGILf/ZXjEGYf9E/rMFGK0iqxIWhHeaM5a9P6NDGTohBe23Lv5eOA
+        uzRTVyCGBqSgzTPwmRFMQXBe0DU+wdYJ9T3PWP6H6x/y74nwiVNMQfYMscKX34QrpT02zR6D8SEz
+        21uCLKXNPVFUf/2QR+0Bz319zOLlYWQfIfLcI9tnX34M7X2OLiRV+j6wGObtCP/i/hb+ijJQJfcT
+        GQKrAqMKauGNI3jKBhiiKNNFUtLK2i2he1oZzMv3l/8BwMGvDhsGAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -60,11 +60,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:56:07 GMT
+      - Wed, 24 Sep 2025 21:21:41 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1541
+      - gfet4t7; dur=1537
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_async_stream.yaml
@@ -6,11 +6,11 @@ interactions:
       str, rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.",
-      "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema": {"properties":
-      {"title": {"title": "Title", "type": "string"}, "author": {"title": "Author",
-      "type": "string"}, "rating": {"title": "Rating", "type": "integer"}}, "required":
-      ["title", "author", "rating"], "title": "Book", "type": "object"}}]}], "toolConfig":
-      {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "name": "__mirascope_formatted_output_tool__", "parameters": {"properties":
+      {"title": {"title": "Title", "type": "STRING"}, "author": {"title": "Author",
+      "type": "STRING"}, "rating": {"title": "Rating", "type": "INTEGER"}}, "required":
+      ["title", "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
       "generationConfig": {}}'
     headers:
       accept:
@@ -20,7 +20,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '923'
       content-type:
       - application/json
       host:
@@ -35,12 +35,12 @@ interactions:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
         {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"rating\":
-        7,\"title\": \"THE NAME OF THE WIND\",\"author\": \"Patrick Rothfuss\"}},\"thoughtSignature\":
-        \"CiQB0e2Kbzws0iorFgVkzCACmXFf+PAkFzzsppnW+bQcxGNGUEIKiAEB0e2Kb3DK5yJFs8FuuPxeNA4uuC3IogFO5kNcfBNXsulOn/KZl3eBin9k4kH1byOowrLEFUkob81T3dt3zThC4Ps/m3P2QTo5BxN2rXpIKc7P+6z3zfgomViAyRJf8EVYrpKVhqA/UfSSRJW1jcC+xjD38OSxeVDz1cHVLXx97WulYuYTz4QTCtEBAdHtim/Ep/95asyV3u1HTXzt+xRuFkY6fLK6F6TzcmXDnxjS6/K5I0oEWo8Du8lVGw/DbqJ7ReR4Om3pyx8j3NgqrKlFUspLC/xN9jtIAY955M/KP2zM0iGmk+H6lUViW7SrnX7BTM1bZf5FArM9d+GBtUiURD3sLd3Yf1bf5noqZzux+q0jttZQSOyEHeLgndJJ/VWU2hgiieAZ/UX9VUbYuG3lTP0lLK48yUZOr+KPsdyhaF/OOB6JMobKJU+XVrvDqnkMw1RCuXdenPYmVCoKtgEB0e2Kb+FMjytiVNjQCn9/DcpG1PzIiBAlOTJ1Dp+67RLVuCGcP00lHEy1k7qEQ/N40kVrgBxzRQop/G9g0e2yY65p00oV7NkMeJiokJpXOFn2CsJiegT9eW9X7MM25nnhxBvFnWmlUIIl32IheVQQHEEyjTcpPOO5XFudnIjC+1Jt2uT4lNBOdRIQYB2YoHnfCgDzJzZd8EqGoeKOoyIoawmQl96YKrUbVAvlwzp/4q4K+BvPmgo4AdHtim+zwwMnn8c2Et1kTI3nMT6IBYQIUFhGV9btwlPxxDFSoTxKOFYav5DoXjruw6ciZVIcz0M=\"}],\"role\":
+        7,\"author\": \"Patrick Rothfuss\",\"title\": \"THE NAME OF THE WIND\"}},\"thoughtSignature\":
+        \"CiQB0e2Kb2B3+JaCNyLriNMbSHmxoGSyFw7rouJRPfL8lst8cLYKiwEB0e2Kb9TwJ7zXDHGM6QECeHV9nc5gFaBGyNAjb7qNlg7MiK0805e1IoVBgFNReWDVWT7u1jPRbNUwis5ioZn4IaDC9Dgvvsizv/QH/BPRGOUMwHmNFm1npZuoaVNTMGBg9UFj9rMz9mfK+xv2ySimUnrghtu9gOOj4ldwhG3eBKr5GIHAyDZn2KGkCsYBAdHtim/Szb6BAotICXjJOaa/1ami9jTYd6jYA38dun856uid3/dsLM4Sya5Ux/8Wfa5u/pAJO0JrOAW7mP0LpZ0XCOoZknwO9fm6oeYe+kTy/axudnI+VFSCiLaIvIm5o4yZ936ORSfPES8qLsX3LXA+OUf0NrRdwOHbcsCJkKANBgnzKOi+o3JvV10151x4V5nLUeHcjZgGYZbZqYTFSi1n71UASAulQXCFkspJOPV83XygcfIzxCWR7KJaKG6KeVX7VN45CtYBAdHtim+2jICJk3Rurb510HiCJ3OVIg2NGLQR6gj0R0UfQ0iK5ckBhFnnpdsEAhGAybffADhzfojg+mlSiDJZn5gWIam4Ihncwk41ElbfQ8gQBN9u/5HHaVG3NcQIvKLgvu4ESCmH1ey8rj8IUR5qP+Tz22KSfIqjb9vHqA9+S5yvD2d9IrvInSawwwTMwm5yub9mWllLhLAyfuGDl8ryoEUwLoyb59wuKNnQs611+DZD04nbtPCXKBlPwMpofJpQx6irxl11DLumS5tuMff7S13U3n3MoQqFAQHR7YpvK2J//xeeqRjS3dlQhQ4MwFk69mN+hyxfWOpiN8Ir7wq0n94iBwqMoDhbb3VDb9JzTI2TAKHysYGdU7ixELflHu9AXQkGQAnS45OtSc6/PZFUw2gmZYycykKw2KTP/B7HMjoZujp/2VJzXv4ceE5uF3Zg09SO0LZrYUav+JWPz0g=\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        137,\"candidatesTokenCount\": 37,\"totalTokenCount\": 301,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 137}],\"thoughtsTokenCount\": 127},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"aO3SaJGiDuarqtsPs9iUuA4\"}\r\n\r\n"
+        137,\"candidatesTokenCount\": 37,\"totalTokenCount\": 321,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 137}],\"thoughtsTokenCount\": 147},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"A2HUaJuDJqqhqtsPtIyVuQg\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -49,11 +49,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:56:41 GMT
+      - Wed, 24 Sep 2025 21:22:12 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1305
+      - gfet4t7; dur=1445
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_stream.yaml
@@ -6,11 +6,11 @@ interactions:
       str, rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.",
-      "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema": {"properties":
-      {"title": {"title": "Title", "type": "string"}, "author": {"title": "Author",
-      "type": "string"}, "rating": {"title": "Rating", "type": "integer"}}, "required":
-      ["title", "author", "rating"], "title": "Book", "type": "object"}}]}], "toolConfig":
-      {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "name": "__mirascope_formatted_output_tool__", "parameters": {"properties":
+      {"title": {"title": "Title", "type": "STRING"}, "author": {"title": "Author",
+      "type": "STRING"}, "rating": {"title": "Rating", "type": "INTEGER"}}, "required":
+      ["title", "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
       "generationConfig": {}}'
     headers:
       accept:
@@ -20,7 +20,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '923'
       content-type:
       - application/json
       host:
@@ -34,13 +34,13 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"title\": \"THE
-        NAME OF THE WIND\",\"author\": \"Patrick Rothfuss\",\"rating\": 7}},\"thoughtSignature\":
-        \"CiQB0e2Kb3IGtEgjVZFG6CuW++UuZLtv0Riu1F1BnL6vIp42FAoKfAHR7YpvsqXYeyDeS8X1M64IYDGqsNONtoYxnYQhkFzZBBWavLqK7qr07bS2UVwk7BB18yLFCjF4LYKXGRSXzHBMPAhE7/jOHeJRP9OKMFcZ2JK/wvJjn2AtULzazijNgQDcftco3ybyk9x83I4hyUbzXRgsPLkVkDjtekgK4AEB0e2KbyV0rW5Q5E4eLvC+aoAEQuj4xNGRVTiPNgEgnnbIPz/wYSJI363/Zp/8I5cIHUzdhhb0uNG+nsjAHFYyEx/NAnFnfI1Kt0iXUcnX9BVfteUhIh/js63MzRTNbss558bhx8HP6Gql9B/iFZgmY3FHIfXytrahX730LWA8vwfUJy5e+8li3lLAo8Qg/086dYhdeeBVHV4qcNX1hD8mmay+jITJsygTGRGD50r6LK3POBl9U7P9qaO4mxPFPkJytNTudqh63goa34NyOBrsCC3ExfpYUKlV2TsTlf9OEQq4AQHR7Ypv4+CMSDr7BHcL+OQ4FmFT33FaXqMz4siNKVta0OVBoDq+8LQGhIJh2GsaKqXE3RbCm4QS9606128AbhkRUEs+5gLUcmg43UKhHt/ry+LyHQ/33cvfXAHEMbrcZDLja0jvtg4+b/63I3SLghlz5Y0dnzX+AHwjXDIxQSNXjpTGjeDnaK0cZnA7iQbTO1Xqhmo03L3tI6hWfXOXUBw4X1GQ4XvdU/Q4sHMbCnNFfUZlHdzxEt0KdAHR7YpvLwZTE8RKBtt+jslCDYJe3AE8BhYn5Dzp/aUggIrV6zPXqYH0Kz7YGu8H/iAI2EUcKp8AEHshEshvxHo9cEHIaus8vQPuDdnjHGzAz6x9Ilhy+ZIuiGMond2Xijbc9oMSHbjgu/voK65DI8xKYcCT\"}],\"role\":
+        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"author\":
+        \"Patrick Rothfuss\",\"title\": \"THE NAME OF THE WIND\",\"rating\": 7}},\"thoughtSignature\":
+        \"CiQB0e2Kbxjf/ErzVoDz8m2pd4BAO9DszU/Hkum5WuVH+P2i3qgKiAEB0e2Kb28K9AwLadzxVV+Ni2MVUVGZ4NkVJdx/2fD8GZDUS04D7V7nu0Pdkir2mi1b3GQohP1LMgcIQ0ckrTegHwTWiwuVIJwj+Lno5rnRRRd2oUWj6d0p7OOYXQDCOycqse+cXY5VVukNzhWBwSwHfK79JuezNONmWUQCxXJkaXfoNf6LregSCuQBAdHtim/q0dMDcCnL5Gly87DCrJKwQsSw6XaJ/jpgJRq4ka0NI6ypIDHwANXVr9RWH6V0XPmxFlw0C70rNcA6kbD22N6VN9Di2Z/ylSs5/yV4AcrKT1HSEJcXeACjXDjQcbA2bdjUjB3BJb45tR/SyVxCgNWWdp07oKuxLmVsNLALXkfDnAo28smQFNUUg9/6U8zNqg/c1aLKTUMlDsUV/xG1QGOfzD7GjqJcGmpsgCDKXhEOM281EZ66ThHVLRgLEgtDMbi84rULxvUKucXiZoNL6a9+kK3nKCaxGco8xWic2KvBCswBAdHtim+OZSZjL1WDa+0mB47H6DCJuyXtSpQ4Gggoj5uYruMKhPEQ8uCJ6hutULcbuU0qxOrUuOw/bpSVEEMr5AXO4aiEqIlLNxlNx7OGBSlf4dJG5FgqeZJnW6724bV6GmTLqs5bzs7DzYHhBSEdP36Olq+zIL2viClRktgOPwCoQvUeMVh5f0d7CFOaONbxj5hOSdwOmKKoQ1WX988O/dcAcFQImtund9bVJpdEQ61oTaN2Sub+rXUgbDlPbnBLkYeKOk18QomdPkogCs4BAdHtim8ySnx0+JAieDTEWzAiQ6iY6F3lLxgRF4qwYd38ooexGVg6HJnQ2TNT2OdPpx86V8iZUN7S5TI+vt1ZqwNkQDuFRugjX69HANkywkuInnbkoUWo3VbGn/lioWro1iqXshYefySW0R9jp4nl1V7amq1DCzEYkRf/ZWjSbnySOwRpT6GsxfwuI/4A3XJ9WyRG9YzVjdoul9VWsnNCEnQCVnKBcHS8tdU1ZvzJi5BE8OeP8siuMUmTLrkgfknPd/FWBbH9tbd+orshEHEKPwHR7YpvE2Olgz4YqEbiclTXj5Fxz0GH9kLRkYZy87Q4IbiD8kTR7ZXnnMQnZIeiJ2ThGaFyyjVJMrah6ZCxoA==\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        137,\"candidatesTokenCount\": 37,\"totalTokenCount\": 318,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 137}],\"thoughtsTokenCount\": 144},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"V-3SaP3rGffqz7IPoPzasAo\"}\r\n\r\n"
+        137,\"candidatesTokenCount\": 37,\"totalTokenCount\": 353,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 137}],\"thoughtsTokenCount\": 179},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"82DUaJ-dL4WdqtsPtfe8uQg\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -49,11 +49,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 18:56:24 GMT
+      - Wed, 24 Sep 2025 21:21:57 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1382
+      - gfet4t7; dur=1881
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/google/tool_sync.yaml
@@ -6,11 +6,11 @@ interactions:
       str, rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in Book format for a final response.",
-      "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema": {"properties":
-      {"title": {"title": "Title", "type": "string"}, "author": {"title": "Author",
-      "type": "string"}, "rating": {"title": "Rating", "type": "integer"}}, "required":
-      ["title", "author", "rating"], "title": "Book", "type": "object"}}]}], "toolConfig":
-      {"functionCallingConfig": {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
+      "name": "__mirascope_formatted_output_tool__", "parameters": {"properties":
+      {"title": {"title": "Title", "type": "STRING"}, "author": {"title": "Author",
+      "type": "STRING"}, "rating": {"title": "Rating", "type": "INTEGER"}}, "required":
+      ["title", "author", "rating"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
+      {"mode": "ANY", "allowedFunctionNames": ["__mirascope_formatted_output_tool__"]}},
       "generationConfig": {}}'
     headers:
       accept:
@@ -20,7 +20,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '950'
+      - '923'
       content-type:
       - application/json
       host:
@@ -34,24 +34,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21UXXOiSBR991dYvDqzKqjgVu0DnyKCoCBGtrasFhskAo3dDQqp/PclZpJJMuGB
-        6r7n3HO7b/U9T51ulwlBfkyOgELC/N39t410u0/3/wuGcgpz2gJvoTZYAEx/c1+/pw/rlhKVeUgT
-        lMsgTT8l/8JzkME2zuz3WYIBCVEB9xHCGaAUHveopEVJ9xShdL9nfnxNBjgm34i+ICU9Ifwi7ACK
-        k/DcXSN6ikpC/lBp2TSh6f0Unq52l6Kldm2t+7LezpfKdwkY0CSP2wz+C/b8af/8OZVpz1TGJ+om
-        cQ5oie8lZbRTxaNOk0wI2FmQRuNB5W/MB5NVBd0+a2a1uejh5XG2Mwk47k4hIoqxbqTFjLsO9enj
-        JOxzvneWYnmoygHrL67N1eFdibPjbT+zxuEkjYbKANuNrbKP+jqQgftAzKt4ctSL4sORU+9MKkTQ
-        Alq/LwQH118sBfY8SvViJJfqdBlYpX8aEN4IgDs9BhLme/3T1VrYdLTNkCbXY9t3tVxeVV4+ulja
-        AZqgvPUyNWcLXhev7nKjNJ7rK6x2M0e6f6vUauLzY3vVj7bJ2ptJ7myFnMnWjOatJDhZ250iF9zZ
-        T22zFCvRZeU1Gx6Wg8mgb81hNalOYMOemokrePl0i8PaekhD48FdpfZqrE3ddTbwq8jI8uHUzkm/
-        t5EuZ4nT9EHkhw239VhPjKXBxt9y0QHXZqo4m0uosfOlHpucIV489ViLaYFBcBamIDFrGhAX1Dan
-        XKur2cBilxZxPZcdNQNKv+J8ogYjuyeZuj7xprfEwWpoYvgYz1lxfHig650z49fzrB7cdHgwmw3J
-        hN1jLeUzd+XsUrfIrePIuhiBlonXLfAUoUkNtbetsKym13BAzapiBfmgqHI9WmjO7aAZm4ZvRpni
-        055RQjxRj44HUb6szje0OpBG5/HGHWNDT11joVxyapnGzgP8bifFEqKyVGuD3E4SZ5ia82Z8ELfy
-        +AycyqsXgeWvVZ8XTb7E10duJjQsSkdnrydosLA8YqRTaP3DdL579f/9fvEMRq9DlaEjTN/o7yPB
-        REmekNMaAoLyF5rr2c77rDFJfoS3NjzovBW4SzMlATG0IAWtT4H32WcKjLKCeugMcxmVd58acvyr
-        2gdf+0R4xymiIP0MDdkffwgTpS2bpB8N74MXtrcEaULru42oD94H22gLfD7XWy86H1r2Zg7kyyWE
-        zq+mvfbRh5gkrw2LYda28Cf71/hnlAJyuldkMCQFygmcH184y5+cCwxuoxl4dKHEmY5lrRRVpvPc
-        +R/tSXYa8wUAAA==
+        H4sIAAAAAAAC/21U25KiSBB9768wfGVm5drY+yaIYnvjDrqxYZRQIAoUVBWCTsy/D23f7JnhgajK
+        c/JkVkbk+fHQ6/VDUERpBCgk/X97/3WRXu/H7f+CoYLCgnbAe6gLlgDTT+7r9+Pu3FHiughpigoV
+        ZNmX5De8ADns4v3dLk8xICEq4S5GOAeUwmiHalrWdEcRyna7/rffkwFOyF9EX5CaHhB+ETYAxWl4
+        6lmIHuKakD9UOjYGNC2Sji3/BaQpzW4tOrrWW42WWm896b2c/dlq3P+N//PL/edXuX7XU50cqJ0m
+        BaA1vqmqlaiNIp2m+aC+1qJg+dPtkWFWls7MBhYvg5w5W+uZMcz2J70p3Jo9No1MPSk8bUeywT/L
+        Q8mcFOJwwTqV6op4ngiUV/cCJz2vZ6Kp6OKjRQ8kyQTMBGaptHkUJk9DU2vH0AvsqFwJIwvprqyF
+        S6IXdjtoNFLoM/aAfOMSm8YmwJY9ZUenwD5hpORaK6dPErYuOTStDQi2rcilsizMOKVpYcR5vPAM
+        8mdzTqZKa4ZtVVuO78j8chpitksJsmlu2dx8v3H9hpbnI79nsiGQvXplzX3NApGUngF83oLMcil7
+        GGuXDAQFmiimmkpObeWjKWIuFUX6cDI5zzVZsZcEaKfDUiMTe1nuM1Qe5xgtGihmlbNmq2N7Ua72
+        ALp4Lo3YdN8wJtXdlbg5kMsUWGJQtbOxwQ/DxXFwYbQpkzwS3adBo8lZhmN2EEPPqwThETpHQRhG
+        Es8k83Q/0sH5UoGqZXF3P1pOBCvfXatblwTwEc3mbrac+yxYVZeTYCiLVkL7Stu0y1ZbVcvFyMsK
+        NaqqS3t+nBgps/XheskqOT9Mcr71iAUDZKnQsFgOMunCVTfCxV1MjcFgLVe6ZURnkBvP8OzjJ3+v
+        Smp67OYmyilL9EUgOYuryuVNOCnSeECSJ75xDSfkAqJ1nRlltcHNVorNdhKqk81RlhktXycTUcvn
+        DDEaZ4skzr2yDWrTgabHEdgr1/qJ8cZZ2W5KWZcxvzhNM4UxPbSgQyHXZlhvea64NhslAFOPe9xK
+        hraJh2ac24zomQP/fls+N+X/zy3pY/S6azmKYPZO/1ijfpwWKTlYEBBUvNBsZ218LHQ/LSLYdmH2
+        4b3ATbpfE5DAJaSg8zbw4Rf9EqO8pA46wUJF9c3bOOHNAe688AvhA6eIguwrxHHf/hAm465smt2b
+        5J1/dq8EWUovN3fRAufOm7oCX/t6n8XD3cjeDYX8/oiHt6G9ztGDmKSvA0tg3o3wO/+P9D3OADnc
+        KvYxJCUqCJxFLxzOH7tg7uAlWNhXeWYUZztqTLf/8PPhF+XfGqAnBgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -60,11 +60,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 18:55:51 GMT
+      - Wed, 24 Sep 2025 21:21:25 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1758
+      - gfet4t7; dur=1540
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/async.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +46,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xSy27bMBC86yuIPVuFrdiWoVvRJG3dJmnaFD1UgUBTK4kNRRLkKkhh+N8Lyg/J
-        fQC9EARnZzkzu9uIMZAlZAxEw0m0VsVv1snDxw936666VpcXb5/vu/r+Zm2+2u7LSw2TwDCbHyjo
-        yHolTGsVkjR6DwuHnDB0naWL1XJxkaazHmhNiSrQakvx3MTJNJnH01U8XR6IjZECPWTse8QYY9v+
-        DBJ1iS+Qsenk+NKi97xGyE5FjIEzKrwA91564ppgMoDCaELdq97mQJIU5pDl8PDuit2+vrlid9cs
-        3L+9v73MYZID76gxrq/5xMlJ8cQ+G2qqzvsed5ykrnPI0t34H4dV53mwqTulRgDX2hAPMfUOHw/I
-        7uRJmdo6s/G/UaGSWvqmcMi90UG/J2OhR3cRY499dt1ZHGCdaS0VZJ6w/26WzPf9YJjWgCaHYIEM
-        cTVizY+ss35FicSl8qP0QXDRYDlQh1HxrpRmBEQj13+q+VvvvXOp6/9pPwBCoCUsC+uwlOLc8VDm
-        MCzzv8pOKfeCwaN7lgILkujCJEqseKf2ewb+pydsi0rqGp11cr9slS3Eppqlq8VimUK0i34BAAD/
-        /wMAGyZgY3UDAAA=
+        H4sIAAAAAAAAA4xSXWvbMBR9968Q9zkZTkjizG+jbWgHzbYSKOtcjCJf21plSUjXY1vIfx9yPuy0
+        G+xFCJ17rs459+4ixkAWkDIQNSfRWDW++vhw3fAN3j991ckmXtPV6nGxXN0+/f5yt4FRYJjtdxR0
+        Yr0TprEKSRp9gIVDThi6TpL5Mpkt38eLDmhMgSrQKkvjmRlP4+lsHC/H8eJIrI0U6CFl3yLGGNt1
+        Z5CoC/wJKYtHp5cGvecVQnouYgycUeEFuPfSE9cEox4URhPqTvUuA5KkMIM0g83tDVt/uL9hn1Ys
+        3B/v1tcZjDLgLdXGdTWfOTkpXtiDobpsve9wx0nqKoM02Q//cVi2ngebulVqAHCtDfEQU+fw+Yjs
+        z56UqawzW/+KCqXU0te5Q+6NDvo9GQsduo8Ye+6yay/iAOtMYykn84Ldd5Pp7NAP+mn16PQYLJAh
+        rgas2Yl10S8vkLhUfpA+CC5qLHpqPyreFtIMgGjg+q2av/U+OJe6+p/2PSAEWsIitw4LKS4d92UO
+        wzL/q+yccicYPLofUmBOEl2YRIElb9Vhz8D/8oRNXkpdobNOHpattLnYlpNkOZ8vEoj20R8AAAD/
+        /wMAqSqmonUDAAA=
     headers:
       CF-RAY:
-      - 983c42b749b8a5e6-SEA
+      - 984555583d44a379-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:13 GMT
+      - Wed, 24 Sep 2025 21:21:46 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1264'
+      - '584'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1289'
+      - '629'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -99,13 +99,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799937'
+      - '799936'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_407a24c32b8845638ad4feb998de3b69
+      - req_6b804cab71f24dc7b5cf55b50ec1b747
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/async_stream.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,75 +45,75 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"cdPGerAsq1L"}
+      string: 'data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"6LSO1gfHkO4"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"RRqJTgAQpb"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"ZzkFE9qkzX"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"UOdsOImG"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"z4nHDSce"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"LMaoug83"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"EXjKZNbP"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"zpITaGEuhw"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"TyY23ajLch"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"NRKSAGU3"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"ERYzqYa2"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"YeF2gn0BJb"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"AIeUckCR51"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"FgPqIrXYd"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"4tUFEmTgl"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"FKX0M2Do"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"3UxGjTMD"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"smE58O4K"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"KNopWqxS"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"qAnvH3v"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"w9WqWPF"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"r9EE0GNj"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"u5Iviy85"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"u7rHbT"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"fPWrlt"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"NcLcnLHu"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZkrtKBVC"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"PjProzXmxGLN"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"6YfmaOdF4f8P"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"MELY8fFyIT"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"hovKTsFVo3"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Y2CEEFXk"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"iMrKCgoH"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"qzrgl2f"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"1tsisze"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"1IVae23MAC"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"6rdc1ExWjC"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"qannBlsqgjz8"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"VhOuMn6VaoJx"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"BqrGYBsi77J7"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"jdwnv3wnT4gt"}
 
 
-        data: {"id":"chatcmpl-CJ2TtwzOnAlVf3OhHUu7ukOO7a1z1","object":"chat.completion.chunk","created":1758653805,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"nk5UnzL"}
+        data: {"id":"chatcmpl-CJREHaVCs4MFTmOlmrY3KYorKKBrs","object":"chat.completion.chunk","created":1758748937,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"tx2fymg"}
 
 
         data: [DONE]
@@ -122,13 +122,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c438c1fe176c1-SEA
+      - 984556185f962b03-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:45 GMT
+      - Wed, 24 Sep 2025 21:22:17 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -146,13 +146,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '232'
+      - '277'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '246'
+      - '291'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +168,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_58675576b54040ed87fbc766b739b24d
+      - req_0261e5f37ae84a64b3798f41a2ff5980
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_async.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +46,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFLBbtswDL37KwSekyFJ4zjIre2yrRuWFkWHHebCUGTa1ipLmkR3K4L8
-        +yA7iZ1uA3YxDL73KL5H7iLGQOawYiAqTqK2anz9cfZwvd2o/CXG57sv6/jHz5v55fZTfPW+vIVR
-        UJjtdxR0VL0RprYKSRrdwcIhJwxdp0m8XMQXyWLWArXJUQVZaWk8N+PZZDYfT5bjyeIgrIwU6GHF
-        vkWMMbZrv2FEneMvWLHJ6Fip0XteIqxOJMbAGRUqwL2XnrgmGPWgMJpQt1PvUs1YCiRJYQorlsLD
-        hzXbXH5es9t3LPx/vdm8TWHU8XhDlXEd8Y6Tk+KJ3Ruqisb7E8lxkroMpCTV++HDDovG8+BbN0oN
-        AK61IR5yay0/HpD9yaQypXVm619JoZBa+ipzyL3RwZAnY6FF9xFjj22YzVk+YJ2pLWVknrB9Ljlk
-        Cf32evDiCJIhrvr6dHIEztplORKXyg+2AYKLCvNe2q+ON7k0AyAamP5zmr/17oxLXf5P+x4QAi1h
-        nlmHuRTnjnuaw3Dc/6KdQm4HBo/uWQrMSKILi8ix4I3q7g78iyess0LqEp11sju+wmZiW0yTZRwv
-        Eoj20W8AAAD//wMAmx1Dc4UDAAA=
+        H4sIAAAAAAAAA4xSXY/aMBB8z6+w9hkqoEBo3k7lqn4e1fV07ak5RcbZJOYc27U3JyrEf6+cAIF+
+        SH2Jop2Z9c7s7iLGQOaQMBAVJ1FbNXz9/nYpJj+2cvXwgONi+UXcf/u4uVp9WE82WxgEhVlvUNBR
+        9UKY2iokaXQHC4ecMHQdx7NFPF0sXs1boDY5qiArLQ2nZjgZTabD0WI4mh+ElZECPSTse8QYY7v2
+        G0bUOW4hYaPBsVKj97xESE4kxsAZFSrAvZeeuCYY9KAwmlC3U+9SzVgKJElhCglL4e7tNbu5+nTN
+        Vm9Y+P/67maZwqDj8YYq4zriZ05Oiid2a6gqGu9PJMdJ6jKQ4lTvzx92WDSeB9+6UeoM4Fob4iG3
+        1vLjAdmfTCpTWmfW/jcpFFJLX2UOuTc6GPJkLLToPmLssQ2zucgHrDO1pYzME7bPxYcsod9eD748
+        gmSIq74+Hh2Bi3ZZjsSl8mfbAMFFhXkv7VfHm1yaMyA6M/3nNH/r3RmXuvyf9j0gBFrCPLMOcyku
+        Hfc0h+G4/0U7hdwODB7dsxSYkUQXFpFjwRvV3R34n56wzgqpS3TWye74CpuJdTGOF7PZPIZoH/0C
+        AAD//wMAw7hMk4UDAAA=
     headers:
       CF-RAY:
-      - 983c42818d73df19-SEA
+      - 98455518dac3b9ac-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:03 GMT
+      - Wed, 24 Sep 2025 21:21:36 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '546'
+      - '373'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '594'
+      - '414'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,7 +105,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_c144e8ed9b82472fb8981e3e9b71933c
+      - req_17e93bbd090b4d59ac48f507cb7f5a19
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_async_stream.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,114 +45,114 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"N1viFWAyBjS"}
+      string: 'data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"VvDAYoWkCsv"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"fTqzozMnCu"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"k7kZt7KwTv"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"XrLvxKLGQsGU"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"sBj2CSJJng8S"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"EHTPh7QCCQ"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"jylXlrf0io"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"5PPwmWy3"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"vfvVI8mZ"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"xbVOnlk2lw"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"mfgbQOl1tr"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"IayEt782rq"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"CdyXv2t7fh"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"VcDaNnHYlT"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"f8doJSves8"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"BJDq83IM"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"rf8GBFVr"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"nt7U2oeJ2L"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"eRmY6kIYx3"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"KyRuEtNkv"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"DoNeWDmOB"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"EMt2STrP"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"xbR4QMs4"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"pIaDGJIR"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"schojGhZ"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"c2Aw413eHsGT"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"LiNCuJqRtgjw"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"vCTtHWIHuH"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"oV25aoXPT3"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"6QnqUiQ"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"S4CZzmc"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"vAF8qWvdsT"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"pS6wf51Yyu"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"ik0ufyOZvz"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"hhtdzpF31A"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"kDwV0H"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"KvmAIj"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"EMbWYuJi"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"9tnF2OGM"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"KMNYk7QfGPRO"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"qrf6J1rs41JR"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"EcxTDjUZiG"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"59Nr7EN70Y"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"mGx549h6"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"isCESmFA"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"M92OK9Xvk0xY"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"9ylRouQcJWUL"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"RalemTJ3eD"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"E9aRSWkTNR"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"YcdvqyT"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"RtkHIlV"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"0YtBZiO28j"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"O9LolP2XE3"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"yT15vbRMV9ZJ"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"xY9lRgWdth6d"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"yFGzrswdAjiz"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"kEmPC3nRMMh3"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"XyBAfw3y8lS"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"ewS8shD4xfo"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"QOFOo6q8FcYs"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"3U3f0QJTPf39"}
 
 
-        data: {"id":"chatcmpl-CJ2TkTQ2JStF4BYVChBJuDZkp0sLJ","object":"chat.completion.chunk","created":1758653796,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"hD3O1RZ"}
+        data: {"id":"chatcmpl-CJRE8CsfHd0nnCkW7KtUaeSi4Cf8m","object":"chat.completion.chunk","created":1758748928,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"3H7fXUk"}
 
 
         data: [DONE]
@@ -161,13 +161,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c4353986ddf2d-SEA
+      - 984555deff872841-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:36 GMT
+      - Wed, 24 Sep 2025 21:22:08 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -185,13 +185,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '410'
+      - '271'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '433'
+      - '364'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -207,7 +207,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_491e93800f8a4ea39b9caff0c0c822f1
+      - req_91a6c2eaa88945db8d993e56642aaaad
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_stream.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,114 +45,114 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"edsqBeYBXiQ"}
+      string: 'data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"vyUwPMtscw4"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"oohOMGy5QD"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"0QMNTLP1HY"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"bNo92F509bZZ"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"0n4Z3D3g6yOR"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"x8B0um5al7"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"QG8039Jl4n"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"201oKndQ"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"ihxwkMpd"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"H21DSJNuhY"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"FR4GjRNTXq"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"UpGS2CmQg1"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"05SfrYquR0"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"4NFpt7sPj4"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"u1uSzaseCo"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"VSperlgI"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"n8ZH0Z27"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"Ent1Gstbwh"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"55kyTNBVpv"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"cuzeWC9gx"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"wuG2zNrwc"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"t4sLVzS6"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"alGyYQpk"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"PIgQB500"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"w2J8SLde"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"ioE6LAeoM0m2"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"t76hf84yCzVi"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"DufIvNwZzD"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"3u5hISvyUs"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"rbzz1lA"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"x766EA6"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"LpioxGelep"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"gQdIBcv6Ew"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"RewN9HKZFh"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"WMoihSUXsE"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"W66yv7"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"k3Vt1i"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"9YCryn3V"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"Q7oTzaLw"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"6ysTNqVYBS8C"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"YqwjpDnCXAxA"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"K4QDhKYuyW"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"5SGPO81Lyg"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"mYb92G9V"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"gbqdHQVe"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"jeYooQdjNm23"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"ZrcJcpVq1pLQ"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"dEQmZGqJOm"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"o3ZBeVeD35"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"ly28wb2"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"z9UrPSX"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"eBfVi1CUvl"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"ODI0IikJ9L"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        "},"logprobs":null,"finish_reason":null}],"obfuscation":"53894GKkd4ol"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"CUDBNOAmyCiz"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"r0sSNn2z77rw"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"3yYuL7gdwZDP"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"G07aydgSHCO"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"srpdRP6KBSW"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"cXBxsgIHxb4a"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"mBX4Q06a880m"}
 
 
-        data: {"id":"chatcmpl-CJ2TU8OBOe5dc5DAHIVCaZjyFIgND","object":"chat.completion.chunk","created":1758653780,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"qiDydF2"}
+        data: {"id":"chatcmpl-CJRDtu5BFSmPZePzf67gv1W7ofOSu","object":"chat.completion.chunk","created":1758748913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"RoiHaYP"}
 
 
         data: [DONE]
@@ -161,13 +161,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c42f02d922b03-SEA
+      - 98455582e9d3c62f-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:20 GMT
+      - Wed, 24 Sep 2025 21:21:53 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -185,13 +185,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '352'
+      - '274'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '371'
+      - '449'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -207,7 +207,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_74885065984444c5b92929c14892aca5
+      - req_6f9e398035fe460b9bed06f8463c2246
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/json_sync.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +46,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFLBbtswDL37KwSek8FJkzjIbd06dB3WFkuxHubCUGTaViNLmkRvK4L8
-        +yA7iZ1uA3YxDL73KL5H7iLGQOawYiAqTqK2avzuZrr+ud7i98tP9+Lu0Vxv1/j1Acv85lnHMAoK
-        s3lGQUfVG2Fqq5Ck0R0sHHLC0HWSzJeL+UUyW7RAbXJUQVZaGs/MeBpPZ+N4OY4XB2FlpEAPK/Yt
-        YoyxXfsNI+ocf8GKxaNjpUbveYmwOpEYA2dUqAD3XnrimmDUg8JoQt1OvUs1YymQJIUprFgKD9dX
-        7Pbt5yt294GF/8ePt+9TGHU83lBlXEe85+Sk2LIvhqqi8f5EcpykLgMpSfV++LDDovE8+NaNUgOA
-        a22Ih9xay08HZH8yqUxpndn4V1IopJa+yhxyb3Qw5MlYaNF9xNhTG2Zzlg9YZ2pLGZktts8lhyyh
-        314PXhxBMsRVX5/ER+CsXZYjcan8YBsguKgw76X96niTSzMAooHpP6f5W+/OuNTl/7TvASHQEuaZ
-        dZhLce64pzkMx/0v2inkdmDw6H5IgRlJdGERORa8Ud3dgX/xhHVWSF2is052x1fYTGyKSbKczxcJ
-        RPvoNwAAAP//AwDKQyOohQMAAA==
+        H4sIAAAAAAAAA4xSXW/bMAx8968Q+JwMTpvUXt6GtsPaoVkQFFvRuTAUmba1yJIg0cPWIP99kJ3E
+        yT6AvRgG747iHbmNGANZwJyBqDmJxqrx9f3qZrF4rh6X1yQe7OXn+OPm6XV1d2+X6i2MgsKsv6Gg
+        g+qNMI1VSNLoHhYOOWHoOklmaTJN03TSAY0pUAVZZWk8NeOL+GI6jtNxfLUX1kYK9DBnXyPGGNt2
+        3zCiLvAHzFk8OlQa9J5XCPMjiTFwRoUKcO+lJ64JRgMojCbU3dTbTDOWAUlSmMGcZfD44ZYt3j3c
+        sk/vWfj/cre4yWDU83hLtXE9ccnJSbFhK0N12Xp/JDlOUleBlGR6d/qww7L1PPjWrVInANfaEA+5
+        dZZf9sjuaFKZyjqz9r9JoZRa+jp3yL3RwZAnY6FDdxFjL12Y7Vk+YJ1pLOVkNtg9l+yzhGF7A3h5
+        AMkQV0N9Eh+As3Z5gcSl8ifbAMFFjcUgHVbH20KaEyA6Mf3nNH/r3RuXuvqf9gMgBFrCIrcOCynO
+        HQ80h+G4/0U7htwNDB7ddykwJ4kuLKLAkreqvzvwPz1hk5dSV+isk/3xlTYX63KSpLPZVQLRLvoF
+        AAD//wMAu44JZIUDAAA=
     headers:
       CF-RAY:
-      - 983c421cbfa8769c-SEA
+      - 984554b9dcf3df10-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:47 GMT
+      - Wed, 24 Sep 2025 21:21:21 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '936'
+      - '527'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '965'
+      - '545'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,7 +105,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_a77407b8b5b041d6ae4ec43a83571c28
+      - req_297a7342211344c1a2e349ecdcc442b5
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/stream.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,75 +45,75 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"q81BRGDcGOL"}
+      string: 'data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"zHEtcFW79be"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"3tQJpYPkmh"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"AdUVOSNfIy"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"kSNjDH3F"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"vYZhxiVD"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"lRdALB1N"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"pkAGjepB"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"AoZcDeNem2"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"WPwhqhr3nD"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"UqOgVF6s"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"lQYYUePh"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"bDnvfCeVyW"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"XWRWDElMSa"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"Kr7q8qDig"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"uz89ehsci"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"OSavmsBj"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"IvoTd8e3"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Pl1pBsvq"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"NLbM1qwK"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"UAogcih"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"Ur0FnSf"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Met6c6J1"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"BVecAGXW"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"RtLBlp"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"7q3uiJ"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"PsM3xLcV"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"2j38vu2V"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"27ZaqyNG1LM9"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"tvKbv3nrhy5J"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"bBbOF0SRTl"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"bPodJ9Dyxb"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"XaQzL3FB"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"5KdCnfM7"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"TicJB0h"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"pbSS7F0"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"iuB0H3gIRj"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"gDWAnnZtbJ"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"FLaEs5MzNraM"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"ROvxDrXHfRfR"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"lrS4l8sfiDxw"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"WX5TXbaOGCbJ"}
 
 
-        data: {"id":"chatcmpl-CJ2Tcd7aBHiuH0N2hkQPGOGr94Hi2","object":"chat.completion.chunk","created":1758653788,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"pRyoE3z"}
+        data: {"id":"chatcmpl-CJRE2BvoZ3s4cX3NiIS3F5BvYlZNM","object":"chat.completion.chunk","created":1758748922,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"Cc4VziX"}
 
 
         data: [DONE]
@@ -122,13 +122,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c4323dada2b03-SEA
+      - 984555b9eb65c62f-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:29 GMT
+      - Wed, 24 Sep 2025 21:22:02 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -146,13 +146,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '302'
+      - '292'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '322'
+      - '434'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +168,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_76e2a8e596774a93b78a10cbb182c460
+      - req_55488c35192549cdb62d5bd9b9fe6576
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_async.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +46,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFJdi9swEHz3rxD7nJTEl8Q5v5X2jvbg0rQESqkPo8hrW3eyJKR16RHy
-        34vsJHb6AX0RQrOzmpndQ8QYyAJSBqLmJBqrpu8e4t3t/bfPIt48bOubePW6fUyq3b5YPc9KmASG
-        2T+joDPrjTCNVUjS6B4WDjlh6DpPluvV8iZZ3nZAYwpUgVZZmi7MNJ7Fi+lsPZ2tTsTaSIEeUvY9
-        YoyxQ3cGibrAn5Cy2eT80qD3vEJIL0WMgTMqvAD3XnrimmAygMJoQt2pPmRAkhRmkGaw+3DHNm8f
-        79inexbuXz9u3mcwyYC3VBvX1Ww5OSle2BdDddl63+GOk9RVBmlyHP/jsGw9DzZ1q9QI4Fob4iGm
-        zuHTCTlePClTWWf2/jcqlFJLX+cOuTc66PdkLHToMWLsqcuuvYoDrDONpZzMC3bfzeNF3w+GaQ1o
-        fAoWyBBXI9bizLrqlxdIXCo/Sh8EFzUWA3UYFW8LaUZANHL9p5q/9e6dS139T/sBEAItYZFbh4UU
-        146HModhmf9Vdkm5Ewwe3Q8pMCeJLkyiwJK3qt8z8K+esMlLqSt01sl+2Uqbi305T9bL5SqB6Bj9
-        AgAA//8DAEP1Bg11AwAA
+        H4sIAAAAAAAAA4xSXWvbMBR9968Q9zkZSebEnt/C2tKOtStlMMZcjCJf22pkSUjXoyPkvxc5H3b2
+        AXsRQueeq3POvbuIMZAlZAxEw0m0Vk0/fnq6+q5v3m/Xj5/TcrZyL2u9ed3emrt7rGASGGbzgoJO
+        rHfCtFYhSaMPsHDICUPXebJMkzhNPyx6oDUlqkCrLU1jM13MFvF0lk5nqyOxMVKgh4z9iBhjbNef
+        QaIu8RUyNpucXlr0ntcI2bmIMXBGhRfg3ktPXBNMBlAYTah71bscSJLCHLIcvt5es4f1/TX7csPC
+        /dvdw1UOkxx4R41xfc0jJyfFlj0ZaqrO+x53nKSuc8iS/fgfh1XnebCpO6VGANfaEA8x9Q6fj8j+
+        7EmZ2jqz8b9RoZJa+qZwyL3RQb8nY6FH9xFjz3123UUcYJ1pLRVktth/N1/Eh34wTGtAF8dggQxx
+        NWLFJ9ZFv6JE4lL5UfoguGiwHKjDqHhXSjMCopHrP9X8rffBudT1/7QfACHQEpaFdVhKcel4KHMY
+        lvlfZeeUe8Hg0f2UAguS6MIkSqx4pw57Bv6XJ2yLSuoanXXysGyVLcSmmifpcrlKINpHbwAAAP//
+        AwA9PV9RdQMAAA==
     headers:
       CF-RAY:
-      - 983c426a0b7d764b-SEA
+      - 984555016ab8ebc3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:59 GMT
+      - Wed, 24 Sep 2025 21:21:33 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '565'
+      - '625'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '648'
+      - '723'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,7 +105,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_3302770061de44dfa0976a1de27286cc
+      - req_89930c457f364103bae2077775a0704a
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_async_stream.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,75 +45,75 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"T61kkhvhWGe"}
+      string: 'data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"e0UPiqn2Wrt"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"16ml0xpfHD"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"tRh4qHW0lZ"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"DB0A3U3u"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"29laUAX8"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"dp0J0Yly"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"mwv5fpJd"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"dy7ewOMMpH"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"zyERGy7lhl"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"rIDhiln7"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"KFQCZgtS"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"FGYZmu9IIy"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"F1TSgOmObe"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"cmWbpopbe"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"7nV1KogaO"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZVXLCetQ"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"v7lp0ysX"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"JhTy7U9Q"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"MpYtkGBr"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"wBYb6DS"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"hKNpanB"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"XD4SXxeW"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"EikD2aPH"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"XABDYC"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"qTHZy8"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"Q3NZXN7w"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"CEcFv7Eq"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"T9XbhXCSYsOq"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"32E4YKpdK76y"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"dGNkJDv79V"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"PmtB253eTp"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"YC7lGn8l"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"ZYtR0l4I"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"z0ImvGt"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"BME4JUw"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"cVt0lxO2A4"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"pSnAZXG0kX"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"eFEcj7vkLnBO"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"fTjdwrl67pbD"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"etFuGjXMDGwU"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"v1vUVXePGE6O"}
 
 
-        data: {"id":"chatcmpl-CJ2TfXqRN4qtxHNK4wpgFfxFHdhxt","object":"chat.completion.chunk","created":1758653791,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"GS602b9"}
+        data: {"id":"chatcmpl-CJRE4OrGgIGI0zISFxiAGAsYWAJ1X","object":"chat.completion.chunk","created":1758748924,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"AcJIHgB"}
 
 
         data: [DONE]
@@ -122,13 +122,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c433409b3ba46-SEA
+      - 984555c9bf9b2760-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:31 GMT
+      - Wed, 24 Sep 2025 21:22:04 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -146,13 +146,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '327'
+      - '210'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '350'
+      - '232'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +168,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_a166745202ec47319d4e04a897f6d10d
+      - req_07f982efc63e47b494f909625156e647
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_stream.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,75 +45,75 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"IKVItKmA8mq"}
+      string: 'data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"kOzOM8FYgN7"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"zHKOvAUUEY"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"TafoZMSz51"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"pxL97kYR"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"j3QdI6kn"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"tR4qX1xm"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"y36wLNhm"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"MK4sS1YorU"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"U3KLQXfa2w"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"nlxbQzT6"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        NAME"},"logprobs":null,"finish_reason":null}],"obfuscation":"NGAtcwKO"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"ishWt2ZptN"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        OF"},"logprobs":null,"finish_reason":null}],"obfuscation":"nJat4lzy0I"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"W9jE3shKk"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        THE"},"logprobs":null,"finish_reason":null}],"obfuscation":"usZIsEVVg"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"Ch5nS4lH"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        WIND"},"logprobs":null,"finish_reason":null}],"obfuscation":"jo1k2pQ5"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"kXF0phNJ"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"ICTJHfR0"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"lLnM9G2"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"ULXwtDp"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"3JSxRe6l"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"SPf2iAeu"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"sszZXk"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Patrick"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZruhRL"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZJRb5i39"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Roth"},"logprobs":null,"finish_reason":null}],"obfuscation":"9E2vHKZx"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"uFsqp6v0JO9o"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"f"},"logprobs":null,"finish_reason":null}],"obfuscation":"EE513dH9D6xN"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"J1tmemR7pF"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"uss"},"logprobs":null,"finish_reason":null}],"obfuscation":"hEIaW6tQJY"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"zUUSfLer"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"WwPfD5M1"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"dIsF4qn"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"rating"},"logprobs":null,"finish_reason":null}],"obfuscation":"59St7NF"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"xQNgmBOy0L"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"1Tzgeodnt9"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"YJ95nBHYfGre"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"7"},"logprobs":null,"finish_reason":null}],"obfuscation":"UBEjMSik6tMW"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"i17SNZUoyDiq"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"6HmHznwTpAAY"}
 
 
-        data: {"id":"chatcmpl-CJ2TQ5Fk9suF0jQigpmLlup0rWcEU","object":"chat.completion.chunk","created":1758653776,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"JcLrxTC"}
+        data: {"id":"chatcmpl-CJRDpzpsdI0pYk4asiT5qHcl4JmGw","object":"chat.completion.chunk","created":1758748909,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"RfhedZw"}
 
 
         data: [DONE]
@@ -122,13 +122,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c42d579862b03-SEA
+      - 9845556bbc13c62f-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:16 GMT
+      - Wed, 24 Sep 2025 21:21:49 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -146,13 +146,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '365'
+      - '262'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '418'
+      - '285'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -168,7 +168,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_d99494ddca6b409cbee0bb9a1872e1ae
+      - req_8591ac4bf6c14a3398adb75c1cc23522
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/strict_sync.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +46,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xSXY/TMBB8z6+w9rlFaa5pq7whKIIT3J3gBEjkFLnOJvGdY1v2BnFU/e/ISduk
-        fEi8WJZnZz0zu/uIMZAlZAxEw0m0Vs1fXSef6DZ9327S5g6v059dFX82989uS49fYRYYZveIgk6s
-        F8K0ViFJowdYOOSEoetinW5W6dV6edUDrSlRBVptab408yROlvN4M49XR2JjpEAPGfsWMcbYvj+D
-        RF3iD8hYPDu9tOg9rxGycxFj4IwKL8C9l564JpiNoDCaUPeq9zmQJIU5ZDncv92ym5cftuz2DQv3
-        L+9uXucwy4F31BjX19xxclI8sY+GmqrzvscdJ6nrHLL1YfqPw6rzPNjUnVITgGttiIeYeocPR+Rw
-        9qRMbZ3Z+d+oUEktfVM45N7ooN+TsdCjh4ixhz677iIOsM60lgoyT9h/t0iWQz8YpzWiyTFYIENc
-        TVjLE+uiX1Eican8JH0QXDRYjtRxVLwrpZkA0cT1n2r+1ntwLnX9P+1HQAi0hGVhHZZSXDoeyxyG
-        Zf5X2TnlXjB4dN+lwIIkujCJEiveqWHPwD97wraopK7RWSeHZatsIXbVYr1J09UaokP0CwAA//8D
-        AE1igFN1AwAA
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrK4g924XtypajW9CkTQrULYwAQRsFAk2tJDYUSZCr1oXh
+        fw8oPyT3AfRCEJyd5czs7iLGQBaQMhA1J9FYNX73cX1zf7VYf/uwjav5lr+9qn8+rOkufoxXX2EU
+        GGbzHQWdWG+EaaxCkkYfYOGQE4au02S+TOLlMll0QGMKVIFWWRrHZjybzOLxZDmeLI7E2kiBHlL2
+        FDHG2K47g0Rd4BZSNhmdXhr0nlcI6bmIMXBGhRfg3ktPXBOMelAYTag71bsMSJLCDNIMHu5u2er6
+        0y37/J6F++P96iaDUQa8pdq4ruYLJyfFC1sbqsvW+w53nKSuMkiT/fAfh2XrebCpW6UGANfaEA8x
+        dQ6fj8j+7EmZyjqz8b9RoZRa+jp3yL3RQb8nY6FD9xFjz1127UUcYJ1pLOVkXrD7bjqLD/2gn1aP
+        zo7BAhniasCKT6yLfnmBxKXyg/RBcFFj0VP7UfG2kGYARAPXf6r5W++Dc6mr/2nfA0KgJSxy67CQ
+        4tJxX+YwLPO/ys4pd4LBo/shBeYk0YVJFFjyVh32DPwvT9jkpdQVOuvkYdlKm4tNOU2W8/kigWgf
+        vQIAAP//AwBMn50QdQMAAA==
     headers:
       CF-RAY:
-      - 983c4205bfae769c-SEA
+      - 9845549cac7ddf10-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:43 GMT
+      - Wed, 24 Sep 2025 21:21:17 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '360'
+      - '1209'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '568'
+      - '1337'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,7 +105,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_ae6c5972cffe488e84ddd903367fe9b8
+      - req_4e5f021d40d7426784664f2cc9178e73
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/sync.yaml
@@ -17,8 +17,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,18 +46,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFJdj9MwEHzPr7D2uUVtaZuStwoOFSR6CCqBIKfItTeJOce27A0CVf3v
-        yOlH0uOQeLEsz856ZnYPCWOgJGQMRM1JNE6PX7+f7ZZrv95U8uu2KeWr6WT/ebcR31bpvYZRZNj9
-        DxR0Yb0QtnEaSVlzgoVHThi7TtPFarl4mS6WHdBYiTrSKkfjuR3PJrP5eLIaT5ZnYm2VwAAZ+54w
-        xtihO6NEI/EXZGwyurw0GAKvELJrEWPgrY4vwENQgbghGPWgsIbQdKoPOZAijTlkOew2d2y7/nDH
-        7t+yeP/ybvsmh1EOvKXa+q7mIyevxCP7ZKku2xA63HNSpsohS4/DfzyWbeDRpmm1HgDcGEs8xtQ5
-        fDgjx6snbSvn7T48oUKpjAp14ZEHa6L+QNZBhx4Txh667NqbOMB52zgqyD5i9910Nj/1g35aPTo7
-        BwtkiesBa35h3fQrJBJXOgzSB8FFjbKn9qPirVR2ACQD13+rea73ybky1f+07wEh0BHKwnmUStw6
-        7ss8xmX+V9k15U4wBPQ/lcCCFPo4CYklb/VpzyD8DoRNUSpToXdenZatdIXYl9N0tVgsU0iOyR8A
-        AAD//wMAIbdBpnUDAAA=
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrK4g924Xt+hXdgipNW7RuERQNiigQaGolsaFIllwFCQz/
+        e0HaseQ+gF4IgrMz3JndXcIYyBJSBqLhJFqrxm8+3GS3m1YtX/98Fo/Ztcy+X2TfPrbXT1vdwSgw
+        zPYHCnphvRKmtQpJGn2AhUNOGFSnq8V6NV+vLyYRaE2JKtBqS+O5Gc8ms/l4sh5PlkdiY6RADym7
+        SxhjbBfP0KIu8QlSFmXiS4ve8xohPRUxBs6o8ALce+mJa4JRDwqjCXXsepcDSVKYQ5rD13dXbHP5
+        6Yp9fsvC/fb9JsthlAPvqDEu1nzh5KR4YDeGmqrzPuKOk9R1DulqP/zHYdV5HmzqTqkBwLU2xENM
+        0eH9EdmfPClTW2e2/jcqVFJL3xQOuTc69O/JWIjoPmHsPmbXncUB1pnWUkHmAeN309n8oAf9tHp0
+        dgwWyBBXA9b8hXWmV5RIXCo/SB8EFw2WPbUfFe9KaQZAMnD9Zzd/0z44l7r+H/keEAItYVlYh6UU
+        5477Modhmf9Vdko5Ngwe3aMUWJBEFyZRYsU7ddgz8M+esC0qqWt01snDslW2ENtqulovFssVJPvk
+        FwAAAP//AwDzg6EMdQMAAA==
     headers:
       CF-RAY:
-      - 983c42563839769c-SEA
+      - 984554f39d2cdf10-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:57 GMT
+      - Wed, 24 Sep 2025 21:21:30 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1274'
+      - '484'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1298'
+      - '507'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -99,13 +99,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799937'
+      - '799936'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_bc62de9c541343f7a433788a696c9ff4
+      - req_4f0b1055b13e4488821145c0298a4e2a
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_async.yaml
@@ -5,7 +5,7 @@ interactions:
       rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
       to me!"}],"model":"gpt-4o","parallel_tool_calls":false,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -14,12 +14,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '899'
+      - '884'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -47,20 +47,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFPfT9swEH7vX2HdczulpT9Y3mDAAA2Ypoo9rCgyziVxcWzLvqB1Vf/3
-        yQ40KTBpeYis++67++7zeTtgDGQOKQNRcRK1VaMv15PlZXV+fV/RJr9dbNazs+eL9Xq6bCqUMAwM
-        87hGQa+sT8LUViFJo1tYOOSEoep4MTuez44W80UEapOjCrTS0mhqRpNkMh0lx6Nk/kKsjBToIWW/
-        Bowxto3/IFHn+BtSlgxfIzV6z0uEdJ/EGDijQgS499IT1wTDDhRGE+qgWjdK9QAyRmWCK9U1br9t
-        79z5xJXK8vv6szitljf3N1//1Hfmm7zaqLPTk16/tvTGRkFFo8Xenx6+j6dvmjEGmteRm2W1dNwL
-        YzErjKs5EeaZacg2lEXt2ZuyjAF3ZVOjpjASbFdAkhSuIF3B8vKc3Z7cnLO7CxbOP69uz1YwXAFv
-        qDIu5nzn5KR4Yj8MVUXjfcQdJ6nLFaSLHRy02w0+Oj/0HHZYNJ6r99ZzrQ3x4ED0/uEF2e2vWZnS
-        OvPo31ChkFr6KnPIfXQPPBnbygoSYnNoDjYErDO1DZY9YWw3no3betAtcIdOXnYNyBBXPdbilXVQ
-        L8uRuIwrtN9awUWFeUfttpc3uTQ9YNCb+r2aj2q3k0td/k/5DhACbVgf6zCX4nDiLs1heN//Stu7
-        HAWDR/csBWYk0YWbyLHgjWqfHviNJ6yzQuoSnXUyvj8obFYcHc2nCZ8mCQx2g78AAAD//wMAWMy5
-        E4gEAAA=
+        H4sIAAAAAAAAA4xT227bMAx9z1cIfE4Gp8ttflsvW1Og2VBkG7ClMBSZtrXKkiDRW9sg/z5IbmOn
+        3YD5wRB4eMjDI2o3YAxkDikDUXEStVWjs6ub86oZ0zLZlu58dra8kvXKfz1dfa+W1zAMDLP9iYKe
+        WW+Eqa1Ckka3sHDICUPV8Xy6mE8W75JxBGqTowq00tJoYkYnyclklCxGyeyJWBkp0EPKfgwYY2wX
+        /0GizvEeUpYMnyM1es9LhPSQxBg4o0IEuPfSE9cEww4URhPqoFo3SvUAMkZlgivVNW6/Xe/c+cSV
+        ytaL1eP6en1Z3Nf3q6n4+Pb3aY7J45dev7b0g42CikaLgz89/BBPXzRjDDSvIzfLaum4F8ZiVhhX
+        cyLMM9OQbSiL2rMXZRkD7sqmRk1hJNhtgCQp3EC6gfXlBVu9v75gnz6wcP62XJ1vYLgB3lBlXMz5
+        zMlJccduDFVF433EHSepyw2k8z0ctdsP/na+7TnssGg8V6+t51ob4sGB6P3tE7I/XLMypXVm619Q
+        oZBa+ipzyH10DzwZ28oKEmJzaI42BKwztQ2W3WFsN54s2nrQLXCHnjztGpAhrnqs2TPrqF6WI3EZ
+        V+iwtYKLCvOO2m0vb3JpesCgN/VrNX+r3U4udfk/5TtACLRhfazDXIrjibs0h+F9/yvt4HIUDB7d
+        LykwI4ku3ESOBW9U+/TAP3jCOiukLtFZJ+P7g8JmYluM54vpdDaHwX7wBwAA//8DANRl7FKIBAAA
     headers:
       CF-RAY:
-      - 983c42a01e48fd8a-SEA
+      - 9845553bfbb4b89e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +67,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:08 GMT
+      - Wed, 24 Sep 2025 21:21:43 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -86,13 +85,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '731'
+      - '600'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '767'
+      - '1194'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -108,7 +107,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_0390850017ca42f5bbcde55bcc548d62
+      - req_9d2f6fa7052443c7b493e4170254bebe
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_async_stream.yaml
@@ -5,7 +5,7 @@ interactions:
       rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
       to me!"}],"model":"gpt-4o","parallel_tool_calls":false,"stream":true,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -14,12 +14,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '913'
+      - '898'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,75 +46,75 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_bLThZTCP4HPqATL2lAcIKgSx","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"IxB0PrCrwWDGVL"}
+      string: 'data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_WUJjETd2qGdXpqNxdyCwiE9s","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"eoYJlq5ZrwcMKT"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"IdIbKcI7V0bcwI"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"K9mgBDzYNR43Qt"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"MMYDoYQzznBB0m"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"0pTb2TCkZa9Imw"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"sfwIDE7g4bFvq1"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"K19V7I0WBboA2Q"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         OF"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Ug8OpfXdFHo3oQQ"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"FsoKlYPk5jGqmw7"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"GUqcYTwEo6Eagi"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"xHbdzydfHReEWG"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"oXxhctLIzBMO6I"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"DC3gZyzb2cTJIS"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"DsNB2z4rjhscc"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"09dT5weRruowW"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"vRv3dOyVdyKdvO"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Hr4ztVuDNL1tWj"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"wIh8Tad9hcvY"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Ay3hlb6owzUe"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Roth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"3uvIzJ6NrT5ziB"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Roth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"W07LhxK7QMdOkj"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ib"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"RB"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ACQTwzNbD2CrSS"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"52VosBdIw0UCHc"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"5peL55ImJCToV"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"zQH9d0JqHdZ3y"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"yA"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"of"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"mR"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"gj"}
 
 
-        data: {"id":"chatcmpl-CJ2TpJSHMhTm22RJno1Jmw6ou2Twg","object":"chat.completion.chunk","created":1758653801,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"Fr7P8U2"}
+        data: {"id":"chatcmpl-CJREDWq43xAURdinKXvPut3pMsG4o","object":"chat.completion.chunk","created":1758748933,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"B4va49x"}
 
 
         data: [DONE]
@@ -123,13 +123,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c43739e69c383-SEA
+      - 984556007be87627-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:42 GMT
+      - Wed, 24 Sep 2025 21:22:13 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -147,13 +147,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '636'
+      - '239'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '654'
+      - '257'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -169,7 +169,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_3f65821fe8d24bf5ae2a37d7f12ea234
+      - req_eebe4679424f4458971bc13e831d5e7f
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_stream.yaml
@@ -5,7 +5,7 @@ interactions:
       rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
       to me!"}],"model":"gpt-4o","parallel_tool_calls":false,"stream":true,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -14,12 +14,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '913'
+      - '898'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,75 +46,75 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_5JEbz2Tb0IIPwWYlBUWlXufA","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"o3wDHkQ0qkhLcH"}
+      string: 'data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_dDNubEyEcY8WITLZk1NZGOo5","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"QEokQS9bTCtzzW"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"946JIndbifB5D2"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"MDGUFa69GXoEcp"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"9ZbSYVrjaGqYFn"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"eEriT28Zn3UVuX"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"IKnYIUTsSoseTh"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        NAME"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"CO0uyVSvEfmVKv"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
         OF"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"gTk3vMor9Swfo3l"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        THE"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"eR28h8eXctgwjRz"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"0tfUPSaumTG9BM"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        WIND"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"lFy241atQjebeI"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"D2SoPvzXbkOpaV"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"bZDTcWNTKyZ5r8"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"HqGtsYJnxnH8C"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"CvIQ2NdPDc5Kp"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"koVnaPLyFt6Ay6"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"tu2Ps2LV2dSZhg"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2mXVvxLUYmol"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Patrick"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Nf6v8t89yegh"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Roth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"8hT403UKwzqpLV"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Roth"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"sFOyJf1iYoJDuO"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Ct"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"f"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"de"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"uss"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"x9X5hTsW1gBiTw"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Qm48CXmDIBAjYL"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"6Ffzjt3YfKAPY"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"rating"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"pfoYRqlbBLrWM"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"uo"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"7"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Y8"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"k0"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2L"}
 
 
-        data: {"id":"chatcmpl-CJ2TYZbMMSm0DhdBzXPWZE5TzIzXu","object":"chat.completion.chunk","created":1758653784,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"x4oSHRo"}
+        data: {"id":"chatcmpl-CJRDxbG7FPLrM2KKgYfx9YqA4zfXL","object":"chat.completion.chunk","created":1758748917,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"4lcSuJs"}
 
 
         data: [DONE]
@@ -123,13 +123,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c43092a692b03-SEA
+      - 9845559d9fe3c62f-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 18:56:24 GMT
+      - Wed, 24 Sep 2025 21:21:57 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -147,13 +147,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '335'
+      - '319'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '349'
+      - '403'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -169,7 +169,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_e062b7c981ad40729b771972a192f504
+      - req_e5689a1eaf8d404481b3c698ce1e5a2c
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/openai/tool_sync.yaml
@@ -5,7 +5,7 @@ interactions:
       rating: int}.\nThe title should be in all caps, and the rating should always
       be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
       to me!"}],"model":"gpt-4o","parallel_tool_calls":false,"tool_choice":{"type":"function","function":{"name":"__mirascope_formatted_output_tool__"}},"tools":[{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
-      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}]}'
+      this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -14,12 +14,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '899'
+      - '884'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -47,20 +47,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xTy27bMBC8+yuIPduF7NhxoFubB/JA3TYImiJ1IDDUSmJDkSy5auoa/veCVGzJ
-        SQpUB4HgcHZnh8P1gDGQOaQMRMVJ1FaNji8nN+OLRVPzsw/NufszO7o8Prn7+uWnm109wTAwzMMP
-        FLRlvROmtgpJGt3CwiEnDFXH89nR4exgPhtHoDY5qkArLY2mZjRJJtNRcjRKDp+JlZECPaTs+4Ax
-        xtbxHyTqHH9DypLhdqdG73mJkO4OMQbOqLAD3HvpiWuCYQcKowl1UK0bpXoAGaMywZXqGrffurfu
-        fOJKZfPV3eK4uuCX1/n8djxTyberU5pMpr1+bemVjYKKRoudPz18t5++aMYYaF5HbpbV0nEvjMWs
-        MK7mRJhnpiHbUBa1Zy/KMgbclU2NmsJIsF4CSVK4hHQJN+enbPH+4yn7dMbC+vZicbKE4RJ4Q5Vx
-        8cxnTk6KR3ZtqCoa7yPuOEldLiGdb2Cv3Wbw1vq+57DDovFcvbaea22IBwei9/fPyGZ3zcqU1pkH
-        /4IKhdTSV5lD7qN74MnYVlaQEJtDs5cQsM7UNlj2iLHduE1ljMY2wB06ec4akCGueqz5lrVXL8uR
-        uIwR2qVWcFFh3lG79PIml6YHDHpTv1bzVu12cqnL/ynfAUKgDfGxDnMp9ifujjkM7/tfx3YuR8Hg
-        0f2SAjOS6MJN5FjwRrVPD/zKE9ZZIXWJzjoZ3x8UNisODg6nCZ8mCQw2g78AAAD//wMAU3sPhYgE
-        AAA=
+        H4sIAAAAAAAAAwAAAP//jFNdb9swDHzPrxD4nAxJliau37J+bO3adMs2FMNSGKpMO1plSZPoYEWQ
+        /z5IbmOn3YD5wRB4PPJ4orY9xkDmkDIQa06ismpwcrk8/bI4uXx//L2eL0yVLG/G7vrqXL/9+O4z
+        9APD3P9EQc+sN8JUViFJoxtYOOSEoepodpTMJkmSTCNQmRxVoJWWBhMzGA/Hk8EwGQynT8S1kQI9
+        pOxHjzHGtvEfJOocf0PKhv3nSIXe8xIh3ScxBs6oEAHuvfTENUG/BYXRhDqo1rVSHYCMUZngSrWN
+        m2/bObc+caWy+ejb8a+z283lcsPFlT2/uJ6M1ny+6fRrSj/aKKiotdj708H38fRFM8ZA8ypys6yS
+        jnthLGaFcRUnwjwzNdmasqg9e1GWMeCurCvUFEaC7QpIksIVpCv4+uGMLebXZ+zmnIXz7cXidAX9
+        FfCa1sbFnE+cnBQPbGloXdTeR9xxkrpcQTrbwUG7Xe9v57uOww6L2nP12nqutSEeHIje3z0hu/01
+        K1NaZ+79CyoUUku/zhxyH90DT8Y2soKE2Bzqgw0B60xlg2UPGNuNJklTD9oFbtHx064BGeKqw5o+
+        sw7qZTkSl3GF9lsruFhj3lLb7eV1Lk0H6HWmfq3mb7WbyaUu/6d8CwiBNqyPdZhLcThxm+YwvO9/
+        pe1djoLBo9tIgRlJdOEmcix4rZqnB/7RE1ZZIXWJzjoZ3x8UNhP3xWiWHB1NZ9Db9f4AAAD//wMA
+        4jeZdogEAAA=
     headers:
       CF-RAY:
-      - 983c423a6cc3769c-SEA
+      - 984554d8ff4bdf10-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:55:52 GMT
+      - Wed, 24 Sep 2025 21:21:26 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -86,13 +86,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '844'
+      - '739'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '890'
+      - '815'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -102,13 +102,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799936'
+      - '799937'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_47ba9eafc4ba49a78537409bc8fafb3a
+      - req_ca423ecf26fd426bb0581c942faed1b1
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1018'
+      - '1025'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRS2vDMBCE/8ucZbASu0l86yM5pCS0pYdCKUKxtraILSV6FJrg/14UCG1aetz9
-        ZmZ32SO0QoXeNyLnd4ofmrlp5PJw389u2vHtaL1SYAifO0oq8l42BAZnu9SQ3msfpAlg6K2iDhXq
-        TkZFmbfGUMiKbJSPyrzkBRhqawKZgOr1eI4M1nYi+pR5WiTVUeR8tl/o6822nJeP6/VyHB8Wxer5
-        CQxG9snXUBAba7dCm3ebzGYXA6ojtN8YVMizyVU5zjifTLMXDMMbgw92JxxJb83l4BPwtI9kakJl
-        YtcxxNOlKTAli2C3ZDyqcsYZalm3JGpHMmhrxKUiP3NHUv3Hzt40gHYt9eRkJ8r+r/6b8vY3HRhs
-        DD9bxZTBk/vQNYmgyaFC+o+STmEYvgAAAP//AwDcq8Lh7QEAAA==
+        H4sIAAAAAAAAAwAAAP//dJFLa8MwEIT/y5xlsJK4cXUsOfVxKA0lUIpQ7K3txtY6eiSU4P9eFAh9
+        0ePuNzO7y57Q1VAYfKNzuZnduMbJ/Wp/7/iwel4HefQPEAgfIyUVeW8agoDjPjWM950PxgYIDFxT
+        D4WqN7GmzLO1FLJFNstnRV7IBQQqtoFsgHo5XSIDc6+jT5nnRVIddS7nszt+n4+3RxfNozSHp+1Y
+        tmsIWDMkX0NBb5l3urNvnMx2jAHqhM5vLRTybHlVzDMpl2W2wTS9CvjAo3ZkPNufg8/A0z6SrQjK
+        xr4XiOdLU2BK1oF3ZD1UUV4LVKZqSVeOTOjY6p+K/MIdmfo/dvGmATS2NJAzvS6Gv/ovKtvfdBLg
+        GL63FqWAJ3foKtKhIweF9J/auBrT9AkAAP//AwDcAUEN7QEAAA==
     headers:
       CF-RAY:
-      - 983c5cc13da3f883-SEA
+      - 9845574fccf39b68-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:14:03 GMT
+      - Wed, 24 Sep 2025 21:23:08 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,49 +79,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:02Z'
+      - '2025-09-24T21:23:08Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:03Z'
+      - '2025-09-24T21:23:08Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:13:58Z'
+      - '2025-09-24T21:23:06Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:02Z'
+      - '2025-09-24T21:23:08Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsAQjeu7M6nxtRNYM3k
+      - req_011CTTvpXdYsJVAxVHSeEFQY
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '5043'
+      - '2049'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_019qFiAbk5E5QNNJ3uPF4MTR","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_019qFiAbk5E5QNNJ3uPF4MTR","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_0132Koj3pJwruaQ1avSbp8hT","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0132Koj3pJwruaQ1avSbp8hT","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1371'
+      - '1378'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJNbxMxEP0r0ZwdaTdkW9U3UkFRlV5oUQ8IWRN7yJr4C3uMUqL978gb
-        BVQQR8/7mDdPPoE1IMGXver6u7sPx3p83v28XW3525vnT8G8fdiAAH5J1FhUCu4JBOTo2gBLsYUx
-        MAjw0ZADCdphNbQsMQTi5Xq56lZDN/RrEKBjYAoM8vPpYskxOlVL85yDtHdVXb99ut2WR2/uB9wd
-        6+bj4fpwv9mCgIC+6ZTyNmPRMZH6GrNHZjIqVk6V1WyqmmVIlUGegC3PgR9s4V3MQS6eRlq8twHd
-        4p1PNrcAWHmMGSRsMgYTw+IRg6FcYgABCfdUQA7rtYBUd85qZBuDeiHMIFdddzVNXwQUjkllwiZ6
-        dd0MFPpeKWgCGapzAupcpzydgyqOBwoF5NXNtQCNeiSlM533vGZ0FzwTmv9hF21bQGkkTxmdGvy/
-        /D9oP/6NTgJ+13oe9d2NgEL5h9Wk2FKrrP0Cg9nANP0CAAD//wMAc3ixJVMCAAA=
+        H4sIAAAAAAAAAwAAAP//dFJNbxMxEP0r0ZwdaTfKVo1vVCIcgKpt2hNC1sQedg1e27XHKSHa/468
+        UYoK4uh5H/PmySewBiSMuVdN++lpSGM8fn/QH8LtoS/39/vt9U8QwMdIlUU5Y08gIAVXB5izzYye
+        QcAYDDmQoB0WQ8scvCderperZtU1XbsGATp4Js8gv5wulhyCUyVXzzlIfRfVtHfPL4df6eOm38X8
+        8Kjb7dO7Hd2AAI9j1Sk12oRZh0jqW0gjMpNRoXAsrGZTVS19LAzyBGx5DvzZZt6H5OXicaDF1np0
+        i/djtKkGwMJDSCDhJqE3wS926A2lHDwIiNhTBtmt1wJi2TurkW3w6kiYQK6a5mqavgrIHKJKhFX0
+        5roZyPRcyGsC6YtzAspcpzydgyoOP8hnkFebToBGPZDSic573jKaC54Izf+wi7YuoDjQSAmd6sZ/
+        +X/QdvgbnQS81noetc1GQKZ0sJoUW6qV1V9gMBmYpt8AAAD//wMAguphCVMCAAA=
     headers:
       CF-RAY:
-      - 983c5ce18d3bf883-SEA
+      - 9845575d3c3b9b68-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:14:05 GMT
+      - Wed, 24 Sep 2025 21:23:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:04Z'
+      - '2025-09-24T21:23:09Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:05Z'
+      - '2025-09-24T21:23:10Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:03Z'
+      - '2025-09-24T21:23:09Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:04Z'
+      - '2025-09-24T21:23:09Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsAnpgoGz8f1RxViaCi
+      - req_011CTTvpgsgFDyznC31bTRWo
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2397'
+      - '1623'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async_stream.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1032'
+      - '1039'
       content-type:
       - application/json
       host:
@@ -52,17 +52,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01FYQrwoR1k4p2n9d3VRnqGE","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}      }
+        data: {"type":"message_start","message":{"id":"msg_014Na1MoEKpRx3paynNwXsMK","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}               }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_013uwfr6r7wwydG4x8AFsjKA","name":"get_book_info","input":{}}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01GJCbSbjrMEMRZLc8bSt3tP","name":"get_book_info","input":{}}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}               }
 
 
         event: ping
@@ -72,8 +72,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"i"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn"}           }
 
 
         event: ping
@@ -83,8 +82,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sbn\":
-        \"0-7"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        \"0-7653-1"}  }
 
 
         event: ping
@@ -94,7 +93,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"653-11"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"178-"}        }
 
 
         event: ping
@@ -104,17 +103,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"78-X"}          }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}      }
 
 
         event: ping
@@ -124,7 +113,7 @@ interactions:
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0 }
+        data: {"type":"content_block_stop","index":0      }
 
 
         event: ping
@@ -139,18 +128,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}   }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}              }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop" }
 
 
         '
     headers:
       CF-RAY:
-      - 983c614c9b46c66f-SEA
+      - 984558c05dde755b-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -158,7 +147,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:17:06 GMT
+      - Wed, 24 Sep 2025 21:24:06 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -172,49 +161,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:17:04Z'
+      - '2025-09-24T21:24:05Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:17:04Z'
+      - '2025-09-24T21:24:05Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:17:04Z'
+      - '2025-09-24T21:24:05Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:17:04Z'
+      - '2025-09-24T21:24:05Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsQ8Zhc8A9uJrKR85qG
+      - req_011CTTvtsncUfdXZYuM9VHa2
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1886'
+      - '957'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_013uwfr6r7wwydG4x8AFsjKA","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_013uwfr6r7wwydG4x8AFsjKA","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01GJCbSbjrMEMRZLc8bSt3tP","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01GJCbSbjrMEMRZLc8bSt3tP","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tools":[{"name":"get_book_info","description":"Look up book information
       by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -225,7 +214,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1385'
+      - '1392'
       content-type:
       - application/json
       host:
@@ -260,138 +249,133 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01UqCkNhJNryYUw4R1QAJwHr","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"id":"msg_013vNiNB4bU1eUvDcyAmRzq5","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}     }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01HREtXo2kkM6DaDYmHENjn2","name":"__mirascope_formatted_output_tool__","input":{}}              }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01MZjS9qEbyQKAsTp7rhAeZs","name":"__mirascope_formatted_output_tool__","input":{}}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"tit"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
+        \""}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le\":"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        \"Mistborn"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        T"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"he
-        Final Emp"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ire\""}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\""}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \"Brandon S"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"anderso"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n\""}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pa"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ges\":"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Mistborn:"}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        54"}}
+        Th"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
+        Final Emp"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ire\""}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"publica"}    }
+        \"aut"} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tion"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hor\":
+        \"Bran"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_year\""}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"don
+        Sand"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        2006}"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"erson\""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pages"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        544"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"publicati"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on_ye"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        20"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"06}"}  }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0           }
+        data: {"type":"content_block_stop","index":0      }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}        }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}}
 
 
         event: message_stop
 
-        data: {"type":"message_stop"            }
+        data: {"type":"message_stop"           }
 
 
         '
     headers:
       CF-RAY:
-      - 983c615a8968c66f-SEA
+      - 984558c95e9d755b-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -399,7 +383,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:17:07 GMT
+      - Wed, 24 Sep 2025 21:24:08 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -413,35 +397,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:17:06Z'
+      - '2025-09-24T21:24:07Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:17:06Z'
+      - '2025-09-24T21:24:07Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:17:06Z'
+      - '2025-09-24T21:24:07Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:17:06Z'
+      - '2025-09-24T21:24:07Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsQJ3xMUTfnLVhD5Pgm
+      - req_011CTTvtyuiKEZRNCchEJLFQ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1120'
+      - '1410'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async.yaml
@@ -41,7 +41,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -53,16 +53,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RRW0vDMBT+K+V78SWVdraz5nETQVFRBB2IhKw9bsU0qblsyuh/lxSGTvEpJ+e7
-        nZPs0Dbg6NxKZPnV4tHJ+W19MV3ezKqlub67p/kcDP6zp8gi5+SKwGCNig3pXOu81B4MnWlIgaNW
-        MjSUOqM1+bRIJ9mkzMq8AENttCftwZ93e0tPH1E8HhyXR0olypi3JPSJX1OyjHWrX43tpG+NTl6N
-        TS4fZrdJlp5Oy5M0z0+rdHGMgX1bGqNEcHHMcbd4DyLLK7/Nn67Ot9Pz61BMN03VNpOuAoOWXdSt
-        yIuYJ2JeFOs+ePAdWrfU4DhIxDC8MDhvemFJOqMPg0fA0XsgXRO4DkoxhPHxomF0Ft68kXbg5VnB
-        UMt6TaK2NK4pDhnZHrckm/+wvTYGUL+mjqxUouz+8r/RfP0bHRhM8D9bVcHgyG7amoRvyYIjfnkj
-        bYNh+AIAAP//AwD9m+8/QAIAAA==
+        H4sIAAAAAAAAA3RRW0vDMBT+K+V78SWVVleneazgBVSUqQgiIWvPtrA0qbmIOvrfJYWhU3zKyflu
+        5yQbqBYcnV+KojxsqVJqenFb319Ui6u6nH98LnswhI+eEou8l0sCg7M6NaT3ygdpAhg625IGR6Nl
+        bCn31hgK+SQ/KA6qoionYGisCWQC+PNmaxnoPYnHg+NyT+tMW7vOYp+FFWXzVCuzsK6TQVmTLazL
+        Lmf1TVbk06PqMC/L6XH+tI+BfVtaq0X0acxxt3SPoihn12vnz+u708+H+Djr3h/rhb07A4ORXdIt
+        KYiUJ1JeEps+BvANlJ8bcOwkYhheGHywvXAkvTW7wSPg6TWSaQjcRK0Z4vh4yTA5i2DXZDx4dTJh
+        aGSzItE4GtcUu4xiizuS7X/YVpsCqF9RR05qUXV/+d9oufqNDgw2hp+t4wmDJ/emGhJBkQNH+vJW
+        uhbD8AUAAP//AwATeKpvQAIAAA==
     headers:
       CF-RAY:
-      - 983c5c711b4eba24-SEA
+      - 984556dfbccb092f-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -70,7 +70,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:46 GMT
+      - Wed, 24 Sep 2025 21:22:51 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -84,35 +84,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:13:46Z'
+      - '2025-09-24T21:22:50Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:13:46Z'
+      - '2025-09-24T21:22:51Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:13:45Z'
+      - '2025-09-24T21:22:48Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:13:46Z'
+      - '2025-09-24T21:22:50Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRs9TuNoMXinC93rD2Bk
+      - req_011CTTvoD1qYhQ6siA5YXLGG
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1646'
+      - '2334'
     status:
       code: 200
       message: OK
@@ -120,7 +120,7 @@ interactions:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_018tw1WJDw6DLu46vd8id2m8","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_018tw1WJDw6DLu46vd8id2m8","content":"Title:
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01SMkrsGBQCzUuVSmxVBfoQF","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01SMkrsGBQCzUuVSmxVBfoQF","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -173,16 +173,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFdi9QwFIb/SnmvM9AZWpVcyup6sxfqgqCVNpscpnHSk5qc6C5D/7t0
-        xuIXXgXe5znvgZMzvIPGlI99vX/hTvNjtuZ+/v7u5vbD27vTm9ubj1CQp5lWi3I2R4JCimENTM4+
-        i2GBwhQdBWjYYIqjXY7MJLtmd6gPbd3uGyjYyEIs0J/OW6XQ4zp8eTSGYfiSI3d87riqOoiXQB10
-        1eHOZ3mIiXV1P1L12rMJ1atp9ok6qKttiowxXfWXybCLXL037CitnZs1myPlVWqbZovKQ/DWiI/c
-        P5G5VBzq+lnHS8fDMGD5rJAlzn0ikyNDg9j1UhLjJ8j0tRBbguYSgkK5HEqf4Xku0ks8EWfo54e9
-        gjV2pN4mum7806g3nsi4/7Ftdl1A80gTJRP6dvrX/0X34990UYhFfo/aRiFT+uYt9eIpQWP9XmeS
-        w7L8AAAA//8DAD4zSScsAgAA
+        H4sIAAAAAAAAA3SR0WrcMBBFf8XcZy14jTehektKkhLo04ZSqItRpGGtVB650qhNWPzvxbvZNG3I
+        08A9Z2ZgZg/voDHmXV+vb7bbr7eUbfup/Rgfc/vwxV00v6EgTxMtFuVsdgSFFMMSmJx9FsMChTE6
+        CtCwwRRHqxyZSVbtqqmbTb1Zt1CwkYVYoL/tTyOFHpfmQ9HYd1xVHcRLoA666vDZZ7mPiXV1N1B1
+        7dmE6mqcfKIO6mibIkNMR/0yGXaRq61hRylHfrEms6O8SJu2PUXlPnhrxEfun8gcRjR1fdbxjPm7
+        QpY49YlMjgwNYtdLSYxnkOlnIbYEzSUEhXI4jd7D81Skl/iDOEOfN2sFa+xAvU10XPavUZ94IuPe
+        Y6feZQFNA42UTOg341v/L10P/9NZIRZ5HbUfFDKlX95SL54SNJaHOpMc5vkPAAAA//8DAARzPZAe
+        AgAA
     headers:
       CF-RAY:
-      - 983c5c7c1d16ba24-SEA
+      - 984556eefecd092f-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:48 GMT
+      - Wed, 24 Sep 2025 21:22:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -204,35 +204,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:13:48Z'
+      - '2025-09-24T21:22:52Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:13:48Z'
+      - '2025-09-24T21:22:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:13:47Z'
+      - '2025-09-24T21:22:51Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:13:48Z'
+      - '2025-09-24T21:22:52Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRs9bTo2RgciBZNW1kYA
+      - req_011CTTvoPQfX6bmUPJSmwxXK
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1696'
+      - '2324'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async_stream.yaml
@@ -56,24 +56,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_014GQHo1ewAF1aS5BU3U7gqk","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"id":"msg_014VvVq4kjvtEQ2MQhpfyir3","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":7,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
-        look up the book information for"}       }
+        look up the book information"}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        ISBN 0-7653-1178"}               }
+        for ISBN 0-7653-1178"}    }
 
 
         event: ping
@@ -83,65 +83,65 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}
+        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0     }
+        data: {"type":"content_block_stop","index":0           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01Frb4XcLWS36HNUZy4ANF1W","name":"get_book_info","input":{}}
-        }
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01LKpFA5MpBZxWdLp5iLMwB9","name":"get_book_info","input":{}}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}            }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"isb"}  }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        \"0-"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"n\":
-        \"0"}      }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"7653-1178"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"-7653-1178-X"}         }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"-X"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}    }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":1           }
+        data: {"type":"content_block_stop","index":1               }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}      }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}   }
 
 
         event: message_stop
 
-        data: {"type":"message_stop" }
+        data: {"type":"message_stop"}
 
 
         '
     headers:
       CF-RAY:
-      - 983c5dfcd886b9d3-SEA
+      - 98455844f84a5f68-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -149,7 +149,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:51 GMT
+      - Wed, 24 Sep 2025 21:23:47 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -163,35 +163,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:48Z'
+      - '2025-09-24T21:23:46Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:48Z'
+      - '2025-09-24T21:23:46Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:48Z'
+      - '2025-09-24T21:23:46Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:48Z'
+      - '2025-09-24T21:23:46Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsE8hMiDK9TpnTNj6UX
+      - req_011CTTvsRRaAx2s14nNDHBNg
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2609'
+      - '1676'
     status:
       code: 200
       message: OK
@@ -199,7 +199,7 @@ interactions:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01Frb4XcLWS36HNUZy4ANF1W","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01Frb4XcLWS36HNUZy4ANF1W","content":"Title:
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01LKpFA5MpBZxWdLp5iLMwB9","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01LKpFA5MpBZxWdLp5iLMwB9","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -255,23 +255,23 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01NHaDgygMFCKbjxEhUVJ8tX","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}      }
+        data: {"type":"message_start","message":{"id":"msg_0177MHsNSxf9hEFHo7jPUwuC","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}              }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
-        \"Mistborn: The Final Empire\",\n  "}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}            }
 
 
         event: ping
@@ -281,35 +281,41 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
-        \"Brandon Sanderson\",\n  \"pages\": 544"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",\n  \"publication_year\":
-        2006\n}"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson\",\n  \"pages\": 544,\n  \"publication"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"_year\":
+        2006\n}\n```"}           }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0   }
+        data: {"type":"content_block_stop","index":0           }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":49}          }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":54}  }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"          }
+        data: {"type":"message_stop"               }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5e14da6ab9d3-SEA
+      - 9845585aed1d5f68-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -317,7 +323,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:53 GMT
+      - Wed, 24 Sep 2025 21:23:51 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -331,35 +337,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:52Z'
+      - '2025-09-24T21:23:49Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:52Z'
+      - '2025-09-24T21:23:49Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:52Z'
+      - '2025-09-24T21:23:49Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:52Z'
+      - '2025-09-24T21:23:49Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsER3cWj1vixXgvXMum
+      - req_011CTTvsgPjUT7pjJgam86VD
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1409'
+      - '1392'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_stream.yaml
@@ -56,64 +56,101 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01ApbRk8c1dqWDuo7sB8A4Jk","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}            }
+        data: {"type":"message_start","message":{"id":"msg_01MzMjGyvGLoQeoHhWonuq8E","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}}
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01R3Vtivons4MceJSju6zEcg","name":"get_book_info","input":{}}   }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
+        look up the book information for"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
-        \"0-"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        ISBN 0-7653-1178-X."}    }
 
 
-        event: content_block_delta
+        event: ping
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"765"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"3-11"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"78-"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}               }
+        data: {"type": "ping"}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0        }
+        data: {"type":"content_block_stop","index":0 }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_0157vdFBvDnj25jqaEUsXf8k","name":"get_book_info","input":{}}    }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"i"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"sb"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"n\":
+        \"0"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"-7653-1178-X"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}   }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1     }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}}
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}     }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"         }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5d2b5b90769c-SEA
+      - 984557a1ee582763-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -121,7 +158,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:16 GMT
+      - Wed, 24 Sep 2025 21:23:21 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -135,42 +172,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:15Z'
+      - '2025-09-24T21:23:20Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:15Z'
+      - '2025-09-24T21:23:20Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:15Z'
+      - '2025-09-24T21:23:20Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:15Z'
+      - '2025-09-24T21:23:20Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsBfM1XodjS1bbpax7L
+      - req_011CTTvqVsAgMB65NYzM2Fi9
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1006'
+      - '1048'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01R3Vtivons4MceJSju6zEcg","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01R3Vtivons4MceJSju6zEcg","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_0157vdFBvDnj25jqaEUsXf8k","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0157vdFBvDnj25jqaEUsXf8k","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -191,7 +229,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1395'
+      - '1478'
       content-type:
       - application/json
       host:
@@ -226,23 +264,23 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01QGkvn3NCxgyZ5RL3zjNaF6","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":701,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}  }
+        data: {"type":"message_start","message":{"id":"msg_016ZsWCbbzmGnw6832AhwGRY","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}       }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":
-        \"Mistborn: The Final Empire"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
+        \"Mist"}}
 
 
         event: ping
@@ -252,19 +290,20 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\",\n  \"author\":
-        \"Brandon Sanderson\",\n  \"pages"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"born:
+        The Final Empire\",\n  \"author\": \"Brandon Sanderson"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\":
-        544,\n  \"publication_year\": 2006\n}"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\",\n  \"pages\":
+        544,\n  \"publication_year\":"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n```"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        2006\n}"}          }
 
 
         event: content_block_stop
@@ -274,18 +313,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":701,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":54}              }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":49}           }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"          }
+        data: {"type":"message_stop"}
 
 
         '
     headers:
       CF-RAY:
-      - 983c5d35cf4b769c-SEA
+      - 984557ae28212763-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -293,7 +332,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:17 GMT
+      - Wed, 24 Sep 2025 21:23:22 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -307,35 +346,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:16Z'
+      - '2025-09-24T21:23:22Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:16Z'
+      - '2025-09-24T21:23:22Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:16Z'
+      - '2025-09-24T21:23:22Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:16Z'
+      - '2025-09-24T21:23:22Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsBnRfDjgTqrMSexLJH
+      - req_011CTTvqeDDAMbKN9W8o91Kc
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1080'
+      - '874'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_sync.yaml
@@ -53,16 +53,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFHJTsMwEP2V6F24OChpEyi+AScOIFBZhZBlkkkT4djBS1mq/DtypAoK
-        4uTxvG3G3qCrwdG7lcjysm7W8/N+3b3dDM1lv1xfhebqEwz+Y6DIIufkisBgjYoN6VznvNQeDL2p
-        SYGjUjLUlDqjNfm0SGfZrMzKvABDZbQn7cEfN1tLT+9RPB0cZ3tKJcqYlyQMiW8peY51pxtje+k7
-        o5PG2ORseXKRZOnhQTlP8/xwkd7vY2TflsYoEVwcc9ot3oPI8vvj28Xy8/jhLnfFrDi9W8yv29MP
-        MGjZR92KvIh5IuZFsR6CB9+gc88aHDuJGMcnBufNICxJZ/Ru8AQ4eg2kKwLXQSmGMD1eNIzOwpsX
-        0g68PCoYKlm1JCpL05pil5FtcUuy/g/bamMADS31ZKUSZf+X/43m7W90ZDDB/2wtCgZHdt1VJHxH
-        Fhzxy2tpa4zjFwAAAP//AwCYxKbCQAIAAA==
+        H4sIAAAAAAAAAwAAAP//dFFbS+wwEP4r5XvxJZV2bXU3b66geEG8e+AgIduO22qadHMRdel/lxQW
+        XQ/nKZP5bjPJGm0Njs4tRZbndXH20B1/vNycHH7erfLF9eP71QUY/EdPkUXOySWBwRoVG9K51nmp
+        PRg6U5MCR6VkqCl1RmvyaZFOskmZlXkBhspoT9qD/11vLD29R/F4cJzuKJUoY16T0Ce+oWQR61Y/
+        G9tJ3xqdPBubnN7OL5MsPdgv99I8P5imf3YxsG9LY5QILo457hbvQWT5bGLum8vJ/PNofnheL/dm
+        99P2bgUGLbuoW5IXMU/EvCjWffDga7RuocGxlYhheGJw3vTCknRGbwePgKNVIF0RuA5KMYTx8aJh
+        dBbevJJ24OWsYKhk1ZCoLI1rim1GtsEtyfp/2EYbA6hvqCMrlSi7f/nfaN78RgcGE/zP1rRgcGTf
+        2oqEb8mCI355LW2NYfgCAAD//wMA3AamdEACAAA=
     headers:
       CF-RAY:
-      - 983c43a9de45ec50-SEA
+      - 98455630af7476b6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -70,7 +70,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:52 GMT
+      - Wed, 24 Sep 2025 21:22:22 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -84,35 +84,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:51Z'
+      - '2025-09-24T21:22:22Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:52Z'
+      - '2025-09-24T21:22:22Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:50Z'
+      - '2025-09-24T21:22:21Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:51Z'
+      - '2025-09-24T21:22:22Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqregBVzfEL3cpuvEuv
+      - req_011CTTvm9E5XxrGDPFNMPPRF
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1796'
+      - '1860'
     status:
       code: 200
       message: OK
@@ -120,7 +120,7 @@ interactions:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01XAV8SzAYW1s424CW83ThCy","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01XAV8SzAYW1s424CW83ThCy","content":"Title:
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_0192oUhN2BzCBAKdg39U8iTq","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0192oUhN2BzCBAKdg39U8iTq","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -173,16 +173,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRTWvkMAyG/0p4zx5Isplu62Pp7m0P/aCwbErwxGJi6sgZWy4tQ/77khmmn/Qk
-        eJ9HEkh7OAuNMW27sjq315vbu93z44+62vH9/d+bKl8xFORlosWilMyWoBCDXwKTkktiWKAwBkse
-        Gr032dIqBWaSVbOqy3pdrqsGCn1gIRbof/vTSKHnpflQNPYtF0ULceKphS5a/HFJNiGyLu4GKn47
-        Nr74NU4uUgt1tE2WIcSjfhkN28DFrWFLMQV+tSazpbRI66Y5RXnjXW/EBe5eyBxG1GV51vKM+UEh
-        SZi6SCYFhgax7STH5RwHkGiXiXuC5uy9Qj6cRu/heMrSSXgkTtA/60qhN/1AXR/puOyjUZ54JGO/
-        Y6feZQFNA40Uje/W41f/jVbDZzorhCzvo+ZCIVF8cj114ihCY3moNdFinv8DAAD//wMAGEm+fx4C
+        H4sIAAAAAAAAA3SRTWvbQBCG/4p4z2uQHTmJ91hoCqU9NeRSFTHWDtaS1ay6O2uSGv33IrvuJz0N
+        vM8zMzBzgnewGPOhq9c3T/f743Hcpfc7T+9uHp/vv32YHmCgrxMvFudMB4ZBimEJKGeflURhMEbH
+        ARZ9oOJ4laMI66pZberNtt6uGxj0UZRFYT+friOVX5bmc7E4tVJVLdRr4Ba2avHRZ93HJLZ6HLh6
+        8EKhejtOPnELc7Gp6BDTRX+TSFyU6hOJ45Sj/LQmOnBepG3TXKOyD74n9VG6V6bziE1d37YyY/5i
+        kDVOXWLKUWDB4jotSfADZP5aWHqGlRKCQTmfxp7gZSraaXxmybB3m7VBT/3AXZ/4suxPo77yxOT+
+        x669ywKeBh45Uei247/+L7oe/qazQSz6e9TsDDKno++5U88JFstDHSWHef4OAAD//wMADqV6Vx4C
         AAA=
     headers:
       CF-RAY:
-      - 983c43b5db9aec50-SEA
+      - 9845563cea6f76b6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:54 GMT
+      - Wed, 24 Sep 2025 21:22:24 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -204,35 +204,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T18:56:53Z'
+      - '2025-09-24T21:22:23Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T18:56:54Z'
+      - '2025-09-24T21:22:24Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T18:56:52Z'
+      - '2025-09-24T21:22:22Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T18:56:53Z'
+      - '2025-09-24T21:22:23Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRqrntntB9qH7DqE1tWg
+      - req_011CTTvmHe6VorjKU1ekAhgB
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2348'
+      - '1492'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/stream.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1032'
+      - '1039'
       content-type:
       - application/json
       host:
@@ -52,17 +52,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01Y7QEgdQStozfiCUfL5RfPg","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}      }
+        data: {"type":"message_start","message":{"id":"msg_01SjgDEWd2uXT5J3fxchsSGB","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01BsqozubHv7TU8fqpY2dezk","name":"get_book_info","input":{}}   }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01EFnkkQ3MFkjB8QzjJrRdgK","name":"get_book_info","input":{}}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
 
 
         event: ping
@@ -72,7 +72,27 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}   }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"is"}             }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"bn"}    }
 
 
         event: ping
@@ -83,7 +103,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \""}     }
+        "}   }
 
 
         event: ping
@@ -93,7 +113,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"0-"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"0-7"}      }
 
 
         event: ping
@@ -103,7 +123,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7653-117"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"653-1178-"}    }
 
 
         event: ping
@@ -113,7 +133,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"8-X\"}"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}        }
 
 
         event: ping
@@ -123,7 +143,7 @@ interactions:
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0}
+        data: {"type":"content_block_stop","index":0       }
 
 
         event: ping
@@ -138,18 +158,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}               }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"       }
+        data: {"type":"message_stop"           }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5d8c4cf8ebc4-SEA
+      - 984557fca90beb40-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -157,7 +177,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:31 GMT
+      - Wed, 24 Sep 2025 21:23:35 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -171,49 +191,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:30Z'
+      - '2025-09-24T21:23:34Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:30Z'
+      - '2025-09-24T21:23:34Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:30Z'
+      - '2025-09-24T21:23:34Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:30Z'
+      - '2025-09-24T21:23:34Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsCofr6HtTTdYWtx9EK
+      - req_011CTTvrZu2xjs5e5Lpps9Fg
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1280'
+      - '1160'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01BsqozubHv7TU8fqpY2dezk","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01BsqozubHv7TU8fqpY2dezk","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01EFnkkQ3MFkjB8QzjJrRdgK","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01EFnkkQ3MFkjB8QzjJrRdgK","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tools":[{"name":"get_book_info","description":"Look up book information
       by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -224,7 +244,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1385'
+      - '1392'
       content-type:
       - application/json
       host:
@@ -259,123 +279,122 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01Rryp7DJRiCfWWDtAUx77Kx","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":26,"service_tier":"standard"}}    }
+        data: {"type":"message_start","message":{"id":"msg_014bByJmcpiZZQLR6Avjzxf8","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}          }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01VGpb4SkJVSwchmnRCvWPss","name":"__mirascope_formatted_output_tool__","input":{}}              }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01XroNsS9w6A1NV4T8KrPRxd","name":"__mirascope_formatted_output_tool__","input":{}}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"tit"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"Mistb"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le\":
+        \"Mistb"}        }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"orn:
-        The"}      }
+        The Fi"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Final Em"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nal
+        Empi"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pire\""}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"re\""}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"au"}          }
+        \"au"}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
-        \"Br"}    }
+        \"Bran"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"andon
-        Sand"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"don
+        Sander"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"erson\""}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"son"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pages\": "} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"544"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \""}      }
+        \"pages\": "}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"publicatio"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"544"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n_year\":
-        2"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"publi"}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"006}"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cation_yea"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
+        2006}"}         }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0         }
+        data: {"type":"content_block_stop","index":0            }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}            }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}               }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"     }
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5d965999ebc4-SEA
+      - 984558063f13eb40-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -383,7 +402,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:33 GMT
+      - Wed, 24 Sep 2025 21:23:38 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -397,35 +416,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:32Z'
+      - '2025-09-24T21:23:36Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:32Z'
+      - '2025-09-24T21:23:36Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:32Z'
+      - '2025-09-24T21:23:36Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:32Z'
+      - '2025-09-24T21:23:36Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsCvXM92KHFtTpeSYpf
+      - req_011CTTvrgSwB5WyqYGW6dp9C
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1473'
+      - '1892'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/sync.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1018'
+      - '1025'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJHRS8MwEMb/l3tOodnadcujiBV90ymCSMjSs83WJjW5OMbo/y4ZDJ3i
-        493v+767445gGhAwhFbm/Pn6qtZ+eVjcbrsn/7ivW7ee3QMDOoyYVBiCahEYeNenhgrBBFKWgMHg
-        GuxBgO5VbDALzlqkrMhm+azMS14AA+0soSUQr8dzJDnXyxhS5mmRVEeZ82LVzYf1zcPdVlVIfF9h
-        XZsdMLBqSL4WSW6c20lj310y2zESiCOYsLEgIM+qRTnPOK+W2QtM0xuDQG6UHlVw9nLwCQT8iGg1
-        grCx7xnE06UpMCVLcju0AUS54gy00h1K7VGRcVZeKvIz96ia/9jZmwbg2OGAXvWyHP7qvynvftOJ
-        gYv0s1UsGQT0n0ajJIMeBKT/NMo3ME1fAAAA//8DAHOduXPtAQAA
+        H4sIAAAAAAAAAwAAAP//dJFPS8NAEMW/yztvIEkbm+5NtCjiQQ+1BZFlu5m2a5PddP8UtOS7yxaK
+        VvE483vvzQxzhG7A0fmNyIsHrT67frGK1cu73t/ezZ+7qpyDIXz0lFTkvdwQGJxtU0N6r32QJoCh
+        sw214FCtjA1l3hpDIRtnZV5WeVWMwaCsCWQC+OvxHBmsbUX0KfO0SKqjyIvldFQ/lpP16Gaxv76v
+        R7OneJhdg8HILvk2FMTK2p3QZm2T2fQxgB+h/cqAI88mV9UoK4pJnS0xDG8MPtheOJLemsvBJ+Bp
+        H8koAjexbRni6dIUmJJFsDsyHryqpwxKqi0J5UgGbY24VORn7kg2/7GzNw2gfksdOdmKqvur/6bF
+        9jcdGGwMP1vjmsGTO2hFImhy4Ej/aaRrMAxfAAAA//8DAIOyI4TtAQAA
     headers:
       CF-RAY:
-      - 983c5c06397730d7-SEA
+      - 9845568e1b652edd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:29 GMT
+      - Wed, 24 Sep 2025 21:22:37 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,49 +79,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:13:29Z'
+      - '2025-09-24T21:22:36Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:13:29Z'
+      - '2025-09-24T21:22:37Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:13:28Z'
+      - '2025-09-24T21:22:35Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:13:29Z'
+      - '2025-09-24T21:22:36Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRs8Co18cGXCTrFe7MhV
+      - req_011CTTvnF9Z6ywxaRjj9Rg2f
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1585'
+      - '1216'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_0149h3mTFRJja7et1w7eGGik","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0149h3mTFRJja7et1w7eGGik","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01X938L27f3CWqAH83EPuvEA","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01X938L27f3CWqAH83EPuvEA","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1371'
+      - '1378'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFLbahsxEP0VM88y7Lq7bq1Hpy3BTSChoQ8tRcxKY6/I6lJpVAhm/71o
-        jVvS0kfNucyZg85gDUhw+aSa9qZ7/zjcPW1vd6fh4fbx63DYx+cIAvglUmVRzngiEJDCVAeYs82M
-        nkGAC4YmkKAnLIbWOXhPvO7Wm2bTN33bgQAdPJNnkN/OV0sOYVIlV88lSH0X1bR3h09Dux++HN4d
-        t+5haN/c+5v+CAI8uqpTytmEWYdI6hiSQ2YyKhSOhdViqqqlj4VBnoEtL4HvbeYhJC9XTyOtPlqP
-        0+qDizbVAFh4DAkk7BN6E/zqM3pDKQcPAiKeKIPsu05ALMNkNbINXr0QJpCbptnO83cBmUNUibCK
-        Xl23AJl+FPKaQPoyTQLKUqc8X4IqDs/kM8jt7q0AjXokpRNd9rxmNFc8EZr/YVdtXUBxJEcJJ9W7
-        f/l/0Hb8G50F/K71MmqbnYBM6afVpNhSraz+AoPJwDz/AgAA//8DAGtd1X9TAgAA
+        H4sIAAAAAAAAA3RS34sTMRD+V8o8p7AbupXmTeVUqBb17MuJhLlk7IbLJjGZHB5l/3fJliqn+Jj5
+        fsw3HzmDs6BgKifd9Z8/bl++PbI8Snmz+/Swle/6/e4AAvgpUWNRKXgiEJCjbwMsxRXGwCBgipY8
+        KDAeq6V1iSEQrzdr2cmhG/oNCDAxMAUG9fV8teQYva6leS5B2rvqrj/8fH/3WOu+vpb7g3R3t8e0
+        71+AgIBT02k9uYzFxET6e8wTMpPVsXKqrBdT3SxDqgzqDOx4CfzBFb6POajVl5FWb1xAv7qZksst
+        AFYeYwYFrzIGG8PqFoOlXGIAAQlPVEANm42AVO+9M8guBv1EmEHJrtvO8zcBhWPSmbCJnl23AIV+
+        VAqGQIXqvYC61KnOl6Ca4wOFAmq7GwQYNCNpk+my5zmju+KZ0P4Pu2rbAkojTZTR62H6l/8H7ce/
+        0VnA71ovo77bCSiUH50hzY5aZe0XWMwW5vkXAAAA//8DAIigc79TAgAA
     headers:
       CF-RAY:
-      - 983c5c10c90c30d7-SEA
+      - 984556965d682edd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:33 GMT
+      - Wed, 24 Sep 2025 21:22:40 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:13:32Z'
+      - '2025-09-24T21:22:39Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:13:33Z'
+      - '2025-09-24T21:22:40Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:13:29Z'
+      - '2025-09-24T21:22:37Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:13:32Z'
+      - '2025-09-24T21:22:39Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRs8L25VzP1NZibwvoSg
+      - req_011CTTvnLnt9c4n6GceWsoLX
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '3655'
+      - '3506'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1018'
+      - '1025'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRQUvDQBCF/8s7byBbm6buUVE8C8WCyLJNJmlsspvuzlZLyX+XLRSt4nHme+/N
-        DHNCV0NhCK3O5cqUzcwtt0d64kYu9u2DfX45QICPIyUVhWBagoB3fWqYELrAxjIEBldTD4WqN7Gm
-        LDhribN5NstnRV7IOQQqZ5ksQ72eLpHsXK9jSJnnRVIddS7L97t6dc/jZ/mxaw+PZdGEdWMgYM2Q
-        fC2x3ji3051tXDLbMTLUCV3YWCjkWbkobjIpy2W2xjS9CQR2o/ZkgrPXg88g0D6SrQjKxr4XiOdL
-        U2BK1ux2ZANUcSsFKlNtSVeeDHfO6mtFfuGeTP0fu3jTABq3NJA3vS6Gv/pvKre/6STgIv9szZcC
-        gfyhq0hzRx4K6T+18TWm6QsAAP//AwCyBicM7QEAAA==
+        H4sIAAAAAAAAAwAAAP//dJFBT8MwDIX/i8+p1G7tVnJEYnBgSFyAgVAUUm8La+MuTpjG1P+OMmmC
+        gTja33vPtnwA24CEjlcqL2a343pi9v6RP68Wi7i9W5LbPYCAsO8xqZBZrxAEeGpTQzNbDtoFENBR
+        gy1IMK2ODWZMzmHIymyUj6q8KkoQYMgFdAHky+EUGYhaFTllHhdJdVR5Mb8utb2px7vyeU7xvrvs
+        d++zCgQ43SXfCoN6I9oo65aUzK6PAeQBLL85kJBn00k1zopiWmdPMAyvAjhQrzxqJnc++AgYtxGd
+        QZAutq2AeLw0BaZkFWiDjkFW9YUAo80alfGogyWnzhX5iXvUzX/s5E0DsF9jh163qur+6r9psf5N
+        BwEUw89WWQtg9B/WoAoWPUhI/2m0b2AYvgAAAP//AwA+DoVA7QEAAA==
     headers:
       CF-RAY:
-      - 983c5c98a860dcfb-SEA
+      - 9845570ce807767e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:52 GMT
+      - Wed, 24 Sep 2025 21:22:57 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,49 +79,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:13:52Z'
+      - '2025-09-24T21:22:57Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:13:52Z'
+      - '2025-09-24T21:22:57Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:13:51Z'
+      - '2025-09-24T21:22:56Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:13:52Z'
+      - '2025-09-24T21:22:57Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRs9vy465HRBhutsWfDK
+      - req_011CTTvojwwTWRbMzPCUmTgJ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1390'
+      - '1412'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_017jBdUCtpx7wkgvF75fsXfa","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_017jBdUCtpx7wkgvF75fsXfa","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01MG4aiH83w4ZMouQmBpwjF5","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01MG4aiH83w4ZMouQmBpwjF5","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1371'
+      - '1378'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFLfa9swEP5Xwj0rYLtORvS2jvahsMI2by0bQ1ykSyxmn1zpNFqC//ch
-        h2x0Y4+678d996ETeAcaxnQ0Vf3I42d/dXeI+e3z/XPdNLtue70HBfIyUWFRSngkUBDDUAaYkk+C
-        LKBgDI4G0GAHzI7WKTCTrNt1UzWbalO3oMAGFmIB/e10sZQQBpNT8VyClHc2VX379Nhx13358O7w
-        9WN775r9Q3/zAAoYx6IzZvQRkw0TmUOII4qQMyHLlMUspqZY8pQF9AnEyxL4vU+yD5H1qutpdesZ
-        h9XNOPlYAmCWPkTQcB2RXeDVJ2RHMQUGBRMeKYHetK2CKe8Hb1F8YPNCGEE3VbWd5+8KkoTJRMIi
-        enXdAiR6ysSWQHMeBgV5qVOfzkGNhB/ECfR290aBRduTsZHOe14zqgseCd3/sIu2LKCpp5EiDmYz
-        /sv/g9b93+is4Het51Fd7RQkij+9JSOeSmXlFziMDub5FwAAAP//AwBCBUIVUwIAAA==
+        H4sIAAAAAAAAAwAAAP//dFJdixMxFP0r5T6nMFNmumweZauw4D64iroi4Ta5dqL5MrkpdMv8d8mU
+        Kqv4mHs+7rmHnMEakODLQXX9w4e76ft2Vx9Pb467T4ftu89Pz2UPAviUqLGoFDwQCMjRtQGWYgtj
+        YBDgoyEHErTDamhdYgjE62G96TZjN/YDCNAxMAUG+eV8teQYnaqleS5B2ruqrh+O9w/xJj7bj/u7
+        m41P98PITwkEBPRNp5S3GYuOidS3mD0yk1GxcqqsFlPVLEOqDPIMbHkJ/NYW3scc5Or9RKvXNqBb
+        7XyyuQXAylPMIOFVxmBiWD1iMJRLDCAg4YEKyHEYBKS6d1Yj2xjUiTCD3HTddp6/Cigck8qETfTi
+        ugUo9LNS0AQyVOcE1KVOeb4EVRx/UCggt7ejAI16IqUzXfa8ZHRXPBOa/2FXbVtAaSJPGZ0a/b/8
+        P2g//Y3OAn7Xehn13a2AQvloNSm21Cprv8BgNjDPvwAAAP//AwAPGRrLUwIAAA==
     headers:
       CF-RAY:
-      - 983c5ca238c8dcfb-SEA
+      - 98455716baa0767e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:54 GMT
+      - Wed, 24 Sep 2025 21:22:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:13:54Z'
+      - '2025-09-24T21:22:58Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:13:54Z'
+      - '2025-09-24T21:22:59Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:13:53Z'
+      - '2025-09-24T21:22:57Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:13:54Z'
+      - '2025-09-24T21:22:58Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsA3VDJMYDy64Eapvag
+      - req_011CTTvorbnXTi1ZQmgyRRTK
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1769'
+      - '2010'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async_stream.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1032'
+      - '1039'
       content-type:
       - application/json
       host:
@@ -52,17 +52,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01L52tv57cKP1jPxaufVKcVX","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"id":"msg_019Epdu96BH3NAsrPqMRfCLg","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_0123Cov1FnLM5pAaTevWyVZG","name":"get_book_info","input":{}}        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01JiDp1aGXRvpjowMAaBsGs3","name":"get_book_info","input":{}}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}           }
 
 
         event: ping
@@ -72,7 +72,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"i"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        \"0-"}             }
 
 
         event: ping
@@ -82,8 +83,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sbn\":
-        \"0-76"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7653-1178-X"}               }
 
 
         event: ping
@@ -93,7 +93,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"53-1178-X\"}"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}}
 
 
         event: ping
@@ -103,7 +103,7 @@ interactions:
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0              }
+        data: {"type":"content_block_stop","index":0  }
 
 
         event: ping
@@ -118,18 +118,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}   }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"      }
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5e3139ed758c-SEA
+      - 984558851a4bba36-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -137,7 +137,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:58 GMT
+      - Wed, 24 Sep 2025 21:23:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -151,49 +151,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:56Z'
+      - '2025-09-24T21:23:56Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:56Z'
+      - '2025-09-24T21:23:56Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:56Z'
+      - '2025-09-24T21:23:56Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:56Z'
+      - '2025-09-24T21:23:56Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsEkTfu3KFk6qE7MB22
+      - req_011CTTvtBF596geWoYpR7qWb
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1208'
+      - '3530'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_0123Cov1FnLM5pAaTevWyVZG","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0123Cov1FnLM5pAaTevWyVZG","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01JiDp1aGXRvpjowMAaBsGs3","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01JiDp1aGXRvpjowMAaBsGs3","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tools":[{"name":"get_book_info","description":"Look up book information
       by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -204,7 +204,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1385'
+      - '1392'
       content-type:
       - application/json
       host:
@@ -239,134 +239,128 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01YGcqJWrW5podJKKqKZmsth","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":18,"service_tier":"standard"}}              }
+        data: {"type":"message_start","message":{"id":"msg_01AurveUHGvHE1X9Ca5muB7p","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}              }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_014Q2m5Wg9adqwSjM4LURieT","name":"__mirascope_formatted_output_tool__","input":{}}           }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_018eAY7oxM6Avy2dcEoNDLpR","name":"__mirascope_formatted_output_tool__","input":{}}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        \""}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Mistborn:
-        Th"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"Mi"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        Final Em"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stborn:
+        The"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pire\""}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        Final E"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        "}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"auth"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or\":
-        \""}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Brando"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mp"}
         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n
-        Sanders"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on\""}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ire\""}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        "}         }
+        \"author\": "}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Brandon
+        "}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Sanderson\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        "}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"pages\":
-        544"}      }
+        54"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4"}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \""}              }
+        \"publ"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"publica"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ica"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tion_yea"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tion_ye"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
-        200"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"6}"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar\":
+        2006}"}    }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0               }
+        data: {"type":"content_block_stop","index":0         }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}     }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}}
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"         }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5e3bdc28758c-SEA
+      - 9845589fb86fba36-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -374,7 +368,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:59 GMT
+      - Wed, 24 Sep 2025 21:24:02 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -388,35 +382,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:58Z'
+      - '2025-09-24T21:24:00Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:58Z'
+      - '2025-09-24T21:24:00Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:58Z'
+      - '2025-09-24T21:24:00Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:58Z'
+      - '2025-09-24T21:24:00Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsEssfFcaXDrxFxNvU2
+      - req_011CTTvtVSCZCbxABis2iLwh
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1148'
+      - '1525'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_stream.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1032'
+      - '1039'
       content-type:
       - application/json
       host:
@@ -52,12 +52,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_0185pqVRWyCDNH2A6tXSrRft","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"id":"msg_015xgcPFkU8RyrwGcDoeBfxh","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}   }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01T78R9RhRKa6RVp3i3ULwF6","name":"get_book_info","input":{}}      }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01T9iLpCByETWMjzeAmhmnQH","name":"get_book_info","input":{}}               }
 
 
         event: content_block_delta
@@ -73,8 +73,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
-        "}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":"}              }
 
 
         event: ping
@@ -84,7 +83,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"0-7653-1178"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"0-7653-11"}   }
 
 
         event: ping
@@ -94,7 +94,17 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-X\"}"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"78-X"}}
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}           }
 
 
         event: ping
@@ -104,7 +114,7 @@ interactions:
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0}
+        data: {"type":"content_block_stop","index":0 }
 
 
         event: ping
@@ -119,18 +129,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":591,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}            }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}  }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"           }
+        data: {"type":"message_stop"    }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5d4ccfb4769c-SEA
+      - 984557c14f392763-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -138,7 +148,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:21 GMT
+      - Wed, 24 Sep 2025 21:23:26 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -152,49 +162,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:20Z'
+      - '2025-09-24T21:23:25Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:20Z'
+      - '2025-09-24T21:23:25Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:20Z'
+      - '2025-09-24T21:23:25Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:20Z'
+      - '2025-09-24T21:23:25Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsC4Bwa92siUm1hwVor
+      - req_011CTTvqsK1eJ3EyXJciVNs3
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1076'
+      - '1241'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01T78R9RhRKa6RVp3i3ULwF6","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01T78R9RhRKa6RVp3i3ULwF6","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01T9iLpCByETWMjzeAmhmnQH","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01T9iLpCByETWMjzeAmhmnQH","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tools":[{"name":"get_book_info","description":"Look up book information
       by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -205,7 +215,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1385'
+      - '1392'
       content-type:
       - application/json
       host:
@@ -240,124 +250,138 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01TBSZrE1VsNjYr9S53CsULB","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":32,"service_tier":"standard"}}            }
+        data: {"type":"message_start","message":{"id":"msg_015pK174hMcoio7sjiteLBUk","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":23,"service_tier":"standard"}}             }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_014V4JzDdNT5DGJXzamVZ64o","name":"__mirascope_formatted_output_tool__","input":{}}          }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01MZnpZEY8hEq72Faqcq9mPM","name":"__mirascope_formatted_output_tool__","input":{}}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        "}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Mi"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        \"Mis"} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stborn:
-        "}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tb"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"The
-        Final"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"orn:
+        The Fin"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
+        Empire\""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"author\""} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"Bra"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ndon
+        Sanders"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on\""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pa"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ges"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":"}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Empire\""}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"a"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uthor\":
-        \""}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Brand"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on
-        Sanderso"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n\""}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pag"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"es\":
         544"} }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"publicati"}  }
+        "}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on_y"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"public"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ear\":
-        2006}"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ation_y"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ear\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        2006}"}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0               }
+        data: {"type":"content_block_stop","index":0       }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":697,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}    }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}      }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"          }
+        data: {"type":"message_stop"     }
 
 
         '
     headers:
       CF-RAY:
-      - 983c5d562a48769c-SEA
+      - 984557cb4f2b2763-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -365,7 +389,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:23 GMT
+      - Wed, 24 Sep 2025 21:23:28 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -379,35 +403,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:14:21Z'
+      - '2025-09-24T21:23:26Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:14:21Z'
+      - '2025-09-24T21:23:26Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:14:21Z'
+      - '2025-09-24T21:23:26Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:14:21Z'
+      - '2025-09-24T21:23:26Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRsCAd9NMnHiM9Bn5B6x
+      - req_011CTTvqz7nKVUPkxKa6VdFK
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1998'
+      - '1375'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_sync.yaml
@@ -6,7 +6,7 @@ interactions:
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1018'
+      - '1025'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFLa8MwEIT/y5xlsN04cXRrD6WHFFpKHqUUIcsbx8SWHD0CIfi/FwVC
-        m5Yed7+Z2V32jLYGR+8akWb3w9vL6XW+yNfLh6ZeyaZ62mzfweBPA0UVOScbAoM1XWxI51rnpfZg
-        6E1NHThUJ0NNiTNak08mSZ7mRVpkEzAooz1pD/5xvkZ6YzoRXMy8LBLrINJs/eiXqzLk5fLhqNqp
-        PTwPalGBQcs++hryojJmL1q9NdGsh+DBz2hdpcGRJrNpcZdk2axMNhjHTwbnzSAsSWf07eALcHQI
-        pBWB69B1DOFyaQyMycKbPWkHXswzBiXVjoSyJH1rtLhVpFduSdb/sas3DqBhRz1Z2Ymi/6v/ptnu
-        Nx0ZTPA/W5OSwZE9toqEb8mCI/6nlrbGOH4BAAD//wMAhJQSSu0BAAA=
+        H4sIAAAAAAAAAwAAAP//dJFbT8JAEIX/y3neJi1SCvuGPuiDIUqC8RKzWdqhrbS7dS8lSPrfzZIQ
+        QePjzHfOmZnMAXUBjtaWIk4m+0W/S7/u5jej5Wq/kffrdt7vwOD2HQUVWStLAoPRTWhIa2vrpHJg
+        aHVBDTjyRvqCIquVIheNo1E8SuM0GYMh18qRcuBvh1Ok07oR3obM4yKh9iJOZq/XDy+PVXZbrj76
+        xcY9LbN5MQGDkm3wleTEWuutqNVGB7PqvAM/oLZrBY44yibpVZQk2TR6xjC8M1inO2FIWq0uBx+B
+        pU9PKidw5ZuGwR8vDYEhWTi9JWXB0+mMIZd5RSI3JF2tlbhUxCduSBb/sZM3DKCuopaMbETa/tX/
+        0KT6TQcG7d15azxlsGT6OifhajLgCP8ppCkwDN8AAAD//wMA+r6yqO0BAAA=
     headers:
       CF-RAY:
-      - 983c4c3f7f16ec50-SEA
+      - 984556510c5676b6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:02:43 GMT
+      - Wed, 24 Sep 2025 21:22:27 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,49 +79,49 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:02:43Z'
+      - '2025-09-24T21:22:27Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:02:43Z'
+      - '2025-09-24T21:22:27Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:02:41Z'
+      - '2025-09-24T21:22:26Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:02:43Z'
+      - '2025-09-24T21:22:27Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRrJa55mgccV4J7nMLd6
+      - req_011CTTvmXNLs7LsA7zekNcM9
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1844'
+      - '1572'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01WFtUV8u28UBvci6rqMpcLb","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01WFtUV8u28UBvci6rqMpcLb","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_019ZBPYQh7GgUjvNftVR7Ad6","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_019ZBPYQh7GgUjvNftVR7Ad6","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
       output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
       up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object"}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
     headers:
       accept:
       - application/json
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1371'
+      - '1378'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RSTWsbMRD9K2bOMuza6zXRLSlOeimEtODWJYjxauwV1UqKNDIkZv970Ro3pKVH
-        zfuYNw+dwWiQMKSjquofD8vP++Xb/vH0Fjd3/WHTLpv1DgTwa6DCopTwSCAgelsGmJJJjI5BwOA1
-        WZDQWcya5sk7Rzxv5otqsapWdQMCOu+YHIP8eb5asvdW5VQ8pyDlnVVVt9s6H27rbdrd3p+2u6eH
-        7+tPbQQBDoeiU2owEVPnA6mDjwMyk1Y+c8isJlNVLF3IDPIMbHgK/MUk3vvo5OxbT7N749DONkMw
-        sQTAzL2PIOEuotPezb6i0xSTdyAg4JESyFXTCAh5b02HbLxTr4QR5KKq2nF8FpDYBxUJi+jDdROQ
-        6CWT6wiky9YKyFOd8nwJqtj/IpdAtjdrAR12Paku0mXPR0Z1xSOh/h921ZYFFHoaKKJVq+Ff/jta
-        93+jo4A/tV5GdXUjIFE8mY4UGyqVlV+gMWoYx98AAAD//wMAc+3u21MCAAA=
+        H4sIAAAAAAAAAwAAAP//dFJta9swEP4r4T4rYCd2RvVtK+1Kx0a7hY0xirjIt1jEllTdqaME//ch
+        h2x0ox91z8s996AjuA40jLw3VX15Fz/zzbf13Ua+pvrX+w/b7feRQYE8RyosYsY9gYIUhjJAZseC
+        XkDBGDoaQIMdMHe05OA9ybJZrqpVW7V1Awps8EJeQP84ni0lhMFkLp5zkPLOpqo/XePh6m1zef9U
+        H2id3uzWGPgWFHgci86Y0SVkGyKZnyGNKEKdCVliFjObmmLpYxbQRxAnc+CPjmUXkteLbU+La+dx
+        WFyN0aUSALP0IYGGdwl9F/ziC/qOEgcPCiLuiUG3TaMg5t3gLIoL3jwTJtCrqtpM04MClhBNIiyi
+        F9fNANNjJm8JtM/DoCDPderjKaiRcCDPoDcXrQKLtidjE532vGRUZzwRdq9hZ21ZQLGnkRIOph3/
+        5/9F6/5fdFLwp9bTqK4uFDClJ2fJiKNSWfkFHaYOpuk3AAAA//8DALXB1qBTAgAA
     headers:
       CF-RAY:
-      - 983c4c4c4ac2ec50-SEA
+      - 9845565b7d9376b6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:02:46 GMT
+      - Wed, 24 Sep 2025 21:22:30 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-23T19:02:46Z'
+      - '2025-09-24T21:22:29Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-23T19:02:46Z'
+      - '2025-09-24T21:22:30Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-23T19:02:43Z'
+      - '2025-09-24T21:22:27Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-23T19:02:46Z'
+      - '2025-09-24T21:22:29Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTRrJiowoBnwK6r4QSiTs
+      - req_011CTTvmeViWp6Kwq7amKq9j
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2841'
+      - '2647'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/async.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -36,27 +36,45 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/22UWW+jWBCF3/MrIr/SGcxuRpoHzG5jjAED9mgUgdkNl+1iDFH/9yFJpzvpGR4Q
-        nDq3qjhC38vD4+Pi4oMwC30YdYs/H/+elcfHl7f7a60CMAJwLnxIs1j7Lfzlfb9ePj3PlrgHF5hV
-        gPeL4svhH3Xgl9GsL5IIPgdVdX3OQFwtvv1u89uk+5/jcyXrAvDaYPnE0BTxhGHM6slb/Ob7/uX9
-        +9f2C5hWfZJCK0uAD/v2bR/+xklcqMCsXOUxYcs3meqTAw3MjZMZA295Tn6KxtsBvzG635FKKQ0b
-        pr57rsFXoepqsoaqUryubN1yO0O2EJ/F5czJrlyJmGi9M8PjBBpiS0HYNJiXb0PRESCIEjJzkrqZ
-        5GPmRai8vo8EpCcm3rG8WC1NORX3oBPPUt+7giEEni+bynDiLxolnDSruG9onMgCxTT2djXEdya5
-        4bqRq10KCn3fo9VJJ1aTKVocp8PlFtrbNteMiEblnISynOCBoTYrmuzDWA6SlIrOSXzFwtJNHNnb
-        SWtflSfRAe7mesDPrFSuWhUcAStROBnJUXodmVhnZ/tyr6g8L/AD1ovYZBbsmZuiZeGNk9CZ7jHf
-        86Q9oTfKTciRCEs5ZRQAyaB1NPOGuPyBKBXo0/cmJ6o814dxf/VCxRAQqe4rxqJlrCvZC2rYjLuR
-        JjavCYfxb02fBaRi6IEk35qG5sxpvMQsaLxrJAKC7GGAhe1ZsfLCJJoUvaxNQBQjukOaIXSxTsaS
-        EuFKFr9Ry4kP9mRU3076RoaxHa74uyP5iTj11D6Ce/LgeoWJ5qZpzQKl60bAUlsQsrk4qmlKp0ba
-        uiCxspJHNBlL9Z1VDFrH5015PIhYcY51ArsI06VHIsFcjtbq7qREi/TVaoyUey3FcrhHgCfVDt2U
-        pXlGrtclmAzuTnrywJzuscZGzuFCDAfFlMmLWJNrnK40p4Buw19EDBjoWik8QcNrbrN0do0Wdtrq
-        GDT0kICdfOpqXLttcM6kr0et4B1BoFlQZqcanmS52uK67YZWh8CKDLGYO+pHMW+EQrt2rBeXbWj6
-        fqlwJ3NlN9x1mTF47ysKLsQdNlH9ZHjbAo5uy+9Y2ruE5RnLLjTWHetULC8FeiBwhnTgftz60k05
-        tCEa2R6XKmyPCJQz5RRJZuc4bvM1VHoVokPnDagDVsyOOTnzD0iHw+Ds2fG+OZq7g4Zn953VSwdX
-        SLG4Px3ssAcpSt7260xN/Oy4vZtB0fHoOWhwZKP4SaTmlMdUfI/EE+RpmTVa9a/PxPhFi39+kWLR
-        VsUbGcoqjIoP+0+ULOIMZF1qRn5XvfHIsvfGT44tMhBG91lePnwMeGu96Lt5n10E/Rm7/k/ALeq2
-        KmtoV9cI8FX/hl1sxb53+4TpLwb8ow4r6BdfSsQK+/afxp0wj82Kz/z+hPb5K/0ig+Prp9iiZ39C
-        8jzg614fWTx8iuwDql93xGji4Udo7zk6Udtl74ElUTlH+IT/QT3Fhd+lbxMXbdTVFegiNXz1xM+K
-        5W+ffXU3ZROjGtm5FzruuHj4/vAvf98Z98IGAAA=
+        H4sIAAAAAAAC/22WV8+kVhKG7+dXjL5bPEtOK+0Fqck592plAU1qcqax/N+3PfbYM97lAkG976mq
+        U0ic55dPnz9/ZEn/qB/Jmi8f//z873fk8+dfvt5/04Z+zfv1LXwLvYNjMq9/eX+/fvnu+W0ptj5b
+        66Hnkrb9YfEfep90+Tv+Uebrz+kwND/XfTF8/PR3WzKXy/9Z/lbqJe1/SwB9IQkc/QLDJPUl+vib
+        79cf3n/9Mf3HWg1bWa1uXfbJus1f++G22GAe0lp3QMm2+urM20ZN7p52An6QsqwbPY/dBPr5YDQ2
+        nILbxKiv2VyHRhn7gZHnMO79BGm6GfCqhG/ENLQ0Z670IKqsFh5guiaaQqc17bojtlUKK7TXMHZ1
+        CtXNRY0oEwt7tjMoGleem8ZGL8nyCT6excN3ipFxEhUPWjq1fGiwNqaBpVai403f5tPzffjlnEzj
+        6tcNd7cswQYsbxS6F7xjL+OIKjvzRieIeWidGN6gdHLTq6nmXZU2d3vOimQBlO0IopsSPX1Ghc+v
+        k61i0NwRitO4WeoYzQAZ6otIzrvuSDFxkblmvR55wrWRQkmHABUit0Yo+poKLR+cFcpylwgbLFap
+        u105rRC6iJlnXGepDCN6y4ZUQuxwUEwU4J09YMtKxoiC07Ev6pfaevwgT0PlJPZM5zt39HFNx+QL
+        mLD0rrV6fz5MUXhCq3TXE88dblt7JUiWuppvP5HsVoyN6mlbdlkYe6a2WSJqUxTEJNhc3WVq1jvQ
+        hJTGMRNUrfDkK1oLfwBdEL9r+ckeVPQSQB0WueHFkEZNY9W1GK8ZGm0/MikFzhGUlUivlYoI7SnP
+        ofXzJXab7naiR0NpAwllKVfqwNyzFg9SpXeZZiYPkBY9LTpcWZhOFrwKRNkGI3cHOkQIdQg0TcEh
+        9cKbYC4DaSztKKfH4kRNJMkLfgvR64qSUF1yh92jUDyU29J2KoDrywNPXrl1iq+RiHDuZF5yzk4z
+        d29a4BAOaV9bdcFWZETzrrMlBuIV6OkDyjBz3WH3F95zNoGVdVa4BeISwiKaa7EpW64zvgS/Dn/t
+        guERsnK5SyzERrxoMSrcEYx2q2gsNxNGNknImJUtsoZJuazpoY1AqYjWfGrurj3iLkTtVoZaiL/I
+        lpXp0+wRrhtHVsIa37TWJE3xxQQKHDG6hZbOsHntG8zfJCY947WoB5cPOpHhwgZJxnDtC55SpXvn
+        A/h9eq4jS/VismqJfHoJDPPVxETOSpKuCe6OziaXrOS50wM8cirNnroJGQiAclNyg00g42yE223v
+        b/wlSJ7XTsc99S9r4MquSLQMOlkMpU3kpNBZebx8odZeaGSqC2ejcTj5VBCZaIi+9tNbRl6toqqf
+        UxvdKyUgUogkakJGwma6aQ7DA8Hx/riW58w45WWQ3qu+0ua91hcAxh/MQKlRCRjPubCBfvGHhSzV
+        DpvHyzBmvF/9SVDhJ4XkIMridFdJ/dPQoEu6BYXOH3x29i5HyG7D6WdywQWvKLggW4uanHXgalnG
+        3jUmIfVNAufhng0kbyklDMsDeAXqKjMmI20p1xM10/YPba9tvyseERXe5Nx9t6j6/ZwVaEGQ6lod
+        jOnb6hiK0zUiCFO+mP4ekDcIWhOtTR/4bkexsrO3IkX4yIl51kCozYJDASPY23GfF7hRefCspSA3
+        a3hEIdwDyJJR28qHL7El4uiZuf4wtoPNXhf/pNjddLVEMIAZ7mce99AlQolsg1Nrk04iWk0ra1FO
+        OFq8E13ST1hsANwkCmiAA5/5Aqqe8ijis0bGQ57bIZ9LzYdBNn1KuGaIpmVP1rMwDi2N0AYlEcOF
+        SAty9TLr5xBtGOIZU+Mw7ebsvxyuXoX3v6s4UkWBqMZ92uAJo5CBYvxpSIRC1QwWkPdjI4y6RU5n
+        N/V0Mc5Ir8jckyfALuhYIWwPCMtZL/2bWrehiTymYjsiziaHE8lYhb7xm3XDkmzdQZCZbZu14MWt
+        IcxNx7q+mUGus4DJ1yig+ruinRySBSEAxncz6m3tacHomg9HwIsOuEd11ut0cmG+Dp3PmVPs03Sz
+        eWtiw74wd3XEptTUeqGyNIf0NBAPeTAnmuYneB7msIzvi5cN1oRlmQAcShGC6FbpNJK2LgTD6WaA
+        wTx7AtsdhQxCiieDDlxZR8dbPaSeLfI+H7aiF2fYM0MR833CqUTPePp5fieXIoOhAaX55EGWPk4d
+        Z/yKr+icHa1WE4dfqHkWZRllzYXnwr3mUHG/bTbDQTKqZdVNqoImUtnBW8zAHB+zkhpVj+XednG8
+        JdTACqXU7svZdIAq1upEosY2m2RXuoPWuMfb3rIDypxTc9gXUvZ3DuuUbCXfhy7ZQyJOpIsO7yCN
+        0jPUDjxMk09rpJ9MFjyjwXhtz85bsQtWK0I90rpyghjY3dMBvdeVNfFwCTwjRIHZFEZrLfHxsIVs
+        hLt0goYQXqARF08btRSEsQe6vc+6hXf7AZ95FUI1EBE8LD1lcroPSH+4WxBx4XVzmkzGQkk+3Ws9
+        sa4FlaZCELDwK8c5uowjg7wP0r4HbskFRKYWajxaAo5Abfc7JafsEwD9LKM4hsy8A4/wayB1r8oh
+        zlNhLQZRKHd3bsWCchAtQjQZBVxCNIKX8RLNJ3IW1XkQ0y1Efe6M4dz/1/fk9Rd1/ecv4vqYh/Yr
+        YXXDI2+/2f9Eso+i7uulcvJkGb5yneuZ1p88+FH3j/x8h6FP3wp8Tf2xLUmZ6/mavPE1+RMUP8Z5
+        6MbVG5q854btK77CFP17tu9w9wcD8k1fhzVpf5AIHPnpfxIv/Lts3X7Pwd8h8nuXSVuvr9+24gmR
+        9x3avgv82Ne3WXz6bmTf4PTHHjEU+/TH0H6fY5DPS/37wMq8e4/wC/IP/EvRJkv1teLHnC/j0C+5
+        /PjNYyOSn2hfRH3jlGldrFn7OSYY4ePTr5/+C34s3jEKDAAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -65,11 +83,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:14:07 GMT
+      - Wed, 24 Sep 2025 21:23:15 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1820
+      - gfet4t7; dur=2816
       Transfer-Encoding:
       - chunked
       Vary:
@@ -95,15 +113,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -112,7 +130,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -126,34 +144,36 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21WyXKj2BLd+ysc2ur1YxAgVDsGCYRAAsQkXrxwXOZ5vEhARf17Y7tcZXcXC4Y8
-        mSdvnkUevj89P698UAVpAGDYr749/2+JPD9/f7u/YnUFwwouwEdoCTagg79z36/vn96XlGiofJjW
-        FQeK4kvxT7wCZbjEVy8vZdqB3q+b8CWquxJAGAYv9QCbAb7Aui5eXlb/+Wcx6OL+D6SvyACTunsl
-        Zrtlqrp6vi6PsOvr6l80r4MMXpH64PWgL1MIXgtxFKX+lAniN3lIgvgDClNYvI2jpD306q769mwk
-        4fMhrUDxvC+btAtX/6j68eX7x1fS1TLFECfwmsYVgEP3xs115pEJRJiWO8LfgJOqkGR81loTPeqD
-        mFdnCO24aY+EdI4xE4d47h1Qn/EodSTWa50SBrKJTg4gtbV4xO5XrpyCasY24ThJ2LDDwkOkFs7G
-        LFm7UFlRsDzcVA2HjW7jfYj31tyt0aHa6TZ5aG3B47vSKbxkemwOeSqLO7RZR1iHMxt9BwDKt22w
-        PTRbBRqYZZ7up/u2y3JjLUkYMUP9ehu5idNseS3RhXe8bxpfP8VMZjSNqkDQ6AlOQBmt1wocH6yI
-        hKXEUsgiCV12XVm6KLqdLmnsLC3owvWRC/LgOlpvzVCEF/RuVaSXXi8jcPBYijaoK/RNK135x5ml
-        N3MHXStEkPNj8tZ5ouOnTgAGMCylHJxysvgpJXR3f0A0SV2YmH0epbf62ERcyVOyeJK05piFk8nS
-        UTaS2YXiB1+qTnTJRmEzieiNyTDV7suouWKYx1fOHZd6h2g2KSobmGwh1yzIlpGOFD9KTD4+7jjb
-        9Cedlm4oSQcb8fhwSPnGul10oYEZckiB1ycH7R5gCtzcgyf7elAMYyTaNF+fk8s2y1KKYMAZVZMg
-        3ckusdZulMP6Yms+4MhYknM+KkTakr7QqOiY+kSq6fzmtmsVXQINo4k74ZYZR5SWJmEOKl/LySkZ
-        +ZESdMD55wAhsjnQSN21o7VcMee9e+vVoR3XmantlD3M0foimsd7zFO9vj7Y0fFMPbyERjfJPM9S
-        XQaquI8J+9oPNCEJyJa/OYncpIcpPF/tmKZb+Ri4apjsS/xkESawDcKyOHWUUGXEb3TSqFl/uezy
-        pAKxsY9u7Sxn7F0w/ZFShOiii64xWa6xk8utJdIGuKKWMzAezt+jDTmVTOUMsITZXk7RuaFdDmuV
-        0Bfc5sLRUEmIy/ZmzxyvVGa3mzlFICREF05FBHzMFQWmO7LahvGEcohZ8ubb44wjCMvMOSrrZ02q
-        WKVvEscqzl52Jl3dzruI5beHSWeojGoy6nYtuKOWMWZqXhpo+oI5cILYqyznc2lqT3ICwy1j16Nk
-        NV4cLXK3zEPTHqXpHqCtoALX9WRbCQTvcFbHXQMU8qfH/pJucwKPcCE3ybNDVhImpLHJU9wtAbqO
-        ZXnYPoQhb2yh4LDNbhCvOHJoDuFFtGRig8VsakJ8CGebFMT7XGym0XcPaqtT7ClnKjTjuY3h4raM
-        88hD0UQZHx9mKMzxZaq0nS6jWJkgVRD3BPaoHRU5ZOoUhuROjZR1VJ7WTnKZ8yM77M3SGkUfOeDS
-        fIFKFTp5yGLkvK4l/owMjxQoJfBngLVIF11b4BJVTlY36670pGPnzcgKBRLNNrD9HMDiZhkOT0zl
-        gW1TKLNx4WU5FJG7pu0EKiN12197MW6zpaiJAceZhKASNY9qAO8I7iRl/X3ggl0MBeVWuNdlK3ZC
-        001o4Qhqxsv8IN9l6SAMSczcSy9Bb2Mhqz21v5qJh6m6l5qE/rCmgtyFg5EQCI4donxcM775ecP/
-        3u7//73ZV1397hJlHYTFR/qv1b+K0irtEz0Er261pF2Ni/rLtVbp4mPjEkafPhq8Ua+GfrEmJYRg
-        cXDwyxVXTVeXDTTqPKy4enhzcJyi39k+Of6XBGL3E4c1BMUXiNx91H4i7vmlbVp8/hX49JewTAmK
-        FE6voxh7x/hkwEuDr+f60OLpk2QfJvj1jDiNPf0U7V1Ha3H39F2wOCwXCf/C/0v+FRWgT946rrqw
-        b+qqD4/BW85dvIKjlwp3u5+3R5WuL/tW61dPP57+Bn1bqN8NCQAA
+        H4sIAAAAAAAC/21WyXKj2BLd+ysc2tL9BIhBdEQvmMQkEGIQoBcvHFfM42XUQEX9+8N2ucqubhbA
+        zTz3ZObZnPz29Py8CkET5REY42H11/N/l8jz87e392sONmPcjEviI7QEW9CPv7Dvz7dP/wskmZpw
+        zGHDg6r6cvlHvgF1vMRXLy913oMhhG38ksC+BuMYRy9wGttpfBkhrF5eVn/8fhn06fAvpK+dTZcq
+        D8Fr5ZdHDPoFhaMo9TvDK8c0ZvA1v+L6ZX7YPNvLJ+4H2Pyj4NvI6Zs8JEH8S3bMx+ptHD0fxgvs
+        m7+enSx+3uUNqJ7Fus37ePXbre9fzt+/kq6W3qY0G+08bcA49W/cfLtV2Uge8xpRm9mbuaa9IPHG
+        Mngv7PvGcAmXu1UYF5Vji7WXODUq+8xBH7SIEMjgYPBTKzzCyA1Bdr6liHEhCIA0g575uA5QM+Ks
+        k3WP6BO+fpzTVNQZbJNjVDfYZ8dPUh4TA4TKYJdOumvLpGBysjWmhucclNOce3JyE0+SKif8ejMz
+        3JFt8ZTJrFCuzVA3+I3v9fBo3SjIZjfOC3R148i2hAXN1lpb5nRTdmJ+zsAjP7EdKpThnucRRl97
+        OcK4Bnbh7Z7qsIt3NvFyiiatcsn+5rJ8Fwx2zAQicZHsQMNvzpQYuQLnXf/Yz05067kUBlBk99ih
+        STXByV1UNpehTHl2YKD3VxpcnZab7ypM136PaZmEPB5Wm4CeH4R+0z/q7UlyT9aeXtOQrbpNc6la
+        ex/sxVbfWlN555eDogv4XVepXr4zR3rryS6dAGJGo1YbOHVX2AIV+C3K5xF3uJs0V6onS4g553gu
+        YYetodQlCZuez5OVIcJadg8oGOTk3gzRWsEe2IUJOe7exYO30Wb5XO487xZtxeGIz2Vzp3YChtJh
+        Uxms2pK0g7btUijoBozWxRFALNXIEw0MeW8Rl4pz81BzgOk44vq4DgnfRi5bBb+urzM0lAd/iDS0
+        mYIBWh5prZOdvca9ud6rV7VVSk4oRpKSoIIR9AlrSOFAo1gc2DE0xiYq2igtnfNJKtuTmeqn0bac
+        AcUx6FbUlClZ5LLdiWNHT6Rp14JNq9vSMVZJpko6yqHO226WdnDCqyFr5hJX+CtIJynNDCU8trh7
+        dy6otkFGqJfFKFbGPN+UHmU02JTDrt9qyWQjUnia+JgOMoM4b4uR1go7dClvZ0R70YOiH7u0JrmR
+        V1DMKRfU4WiAZCwRW7xUlRjfBItFz+pZlh2Jdfxzy7jCLTCJZEQoesKpAj1I5uRA/sYkAwXis+pk
+        O9k3uWPyyK4bn748cJ283qXTtqWFhzsKQTrf6BI/+xePnW1Mmq6awSEyo23pTR5zrmp7JnZjMa1j
+        W67FeteyLeW6yWHCjHkqbn2E620qHuz7QSWvohxOd45BtNudmG9GZ1BYrZZrvw4Vyc4M21XhlTPm
+        xDtcDoddwIPBLjkROQhxLZSx5igC1lBEmHVHTE8cOWsi3SQVHGw3rD4VpjBjh3OhkIeet5SKNODk
+        YZueRXye30sx2hpozYmkTeKN6KheGoF7RYhGgVqhq11yEQk14z5RDULYPNYVotDyHJaJeHIq1TG6
+        Yk5AUKQy8gYiSIyK3TmM6t2+TnYTz6MDLEpbddleE/yd6N+gcOzGCl5MSyAAbrs1vKFV0+38dR8r
+        VVE9dJ0Q7cinvbNAbbSHCB0tI8o9sWHRuZp8JimGIjjIRdGjB6Ztc0+T8Za5px43kPAqpIHyMOVy
+        55Rsf3ZcOXEA5my4+UQqaOcELFFfpTvBkAe+ztvqts2mLu/XKUHMNdgjdIYHBCvMmd7zxGZ/jaVu
+        HepZ0UsXY7IvDN0T5UzkfJ0Gk2EIpo5EVkr6KSeqytzWdnpNuK14xGaexDWleqAH3wERDDyMmcm9
+        0zosyJm6qE4FhHhHEHIh1py2L3kxz+TgKhhjPR1nFD7qhyTWquITloYY4v4oMQMLHLc6/v33Z8f5
+        5Tb/++U0qx6+u1YNo7j6gP+0olWSN/mQWTF49cQFZjsH86c3rvLFLe9LGH36KPBGvZqGxSr1eATL
+        RgF+uvSq7WHdjg4s44aH09tGgVPbd7ZPG8gXAMH8yI9wBNWXFLXB/vgH8SAsZfPq82ryaWtZpgRV
+        Pj5eR3FE3/lk80uBr319aPH0SbIPU/7a4wYjnn6I9q7jadkh8nfB0rheJPwT/w/5Z1KBIXuruOrj
+        oYXNECvRK8aqZReodMHv+bEeS3MbCWbHpqun70//BzIziRSdCQAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -162,11 +182,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:14:10 GMT
+      - Wed, 24 Sep 2025 21:23:18 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2830
+      - gfet4t7; dur=2306
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/async_stream.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -37,11 +37,11 @@ interactions:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
         {\"name\": \"get_book_info\",\"args\": {\"isbn\": \"0-7653-1178-X\"}},\"thoughtSignature\":
-        \"CiIB0e2Kb+Vz1pp0qSDzS8xbLvDTC/oHiSJ5NUVYjYQfTMQRCmEB0e2Kb5Q8sdUxlZn0PTMNutB0fnsEZlmLxEPPIWviTmFIQT6YgpEMH2QHAFd8exeltA9/XqyWCClIEt9vCYLW7V/rAe/BHFz8hlZ9olRbJRSE7usZ0gM9J+IDdawMir9pCsoBAdHtim9TXwc8rKj/lSeQbwYc/0wfkYiF62gfFMYWAMvcfm0j+Oj3PivzP/lImTZE1s/3ZUQzXw+kSBRH/1dZdDPG6F2/hLN9WIBodokmYa0ThjDOguO4zzsh5VJ/oAdQs8I6xeGXhL0/DUBpTRVsNhEvdNn5HPOBOg3NP/MkGzfkfMlgzmbittTLCfeOvFvgImwACp5gpJwI/d3BU1gNDMOAkj+bLVy/PcNJx/TsvcFzZJg8VhnVRrsQzNMg7SIBsE16490udobxtQqSAQHR7YpvTQPxovRHZV6gl0IoX4Q2SKpWJsIZIj/rXwbD5bj8nYl1QrinBk8fb3GR+Llhabo68OE24dda60UXO3zrKV7+NFJIYu3YB2/E29dNn0w+aS3JGrP2cjp6vjSmlgUppw8rG3vygb7Cff7aINBe1nWDzn3pXqufL6fmo5hrOP+oy/znqCTaUAKyj/KlGGVpCuwBAdHtim8iUCz08RfdK11RLsfzgLKLS6iscQWtyWEC3JvwoGppu2oN3p0p9FD6JEN/LGBZegs9vFLY/Xjez0Cwq242c299uB0nEDHy4op2uQaQgIfEvENSfbvuOLPtawKqYmkm5nVps3ugjhCkPTOomutIvXbTqJJKwk0NKCLFNbbQCDSl0AXrqITwEPAszafN/mTDhtHkaBCAaX7wkC0ShcJb/F70UxopV3nFqVQZUqrn740IPAdraI72hn/a1kJsp8RbFO10lTXhbKG1IL4kTF4xr233T4PMrwwT8L/9YMt1rbrKcgJA1WnUFVAK4QEB0e2KbwSh2HZicsOwg8tqdNGQ5Qi63q9oSCiRtFYzw+pXBaQhGiFX/liEDkUmthjsnNqGeXz9AYVSAX3l1aeQWtb/xuiLEUDS1yVvvAneP+72P8NhahLKmAq0fdM8O/E5DE1R+wTIAO8a7w3WAGzfoPisyj2IzIAxRFmgkd9VoFBuiucQub2eH9U0ir22cjW6F0PDd69xW4bPE/BJiC2dDsKsD+iBv587S2KzTimmzf51mN1YelPOzJW4aI/IbAVn4/LuCck3CBio9U6c6HsGCLZFRRr7nIc8t3rZyAg7QWU=\"}],\"role\":
+        \"CiIB0e2KbwZWu82e34HoThignm/iK8EQ0cpJruwxh9xHlixjCl0B0e2Kb3IpnVlkk/LYrDT4rw9v9HhoyJ+ZKFn+8lp4aXCKoXqB25ZFTGiYLfz8froDk7Z9TJDtxbglZ5cvpfFP3JrZoYGy3i3B7BuoRZwk6mnIxuzpxToI8cfh4HsKtgEB0e2Kb87jln+hWl3B4Cn3ep6EFYyRvAgRNIhPrBSbJvn6JD8NZMTxeEPeNtg3vzwWpx81oHTc/cyN/G25aauCIT9z7rPdi5I+k4ZQnhfKOfHc3n+9VpYzD8ZGDuryqGRrGoJLymdpWsmta/ZEOhhq4a3ztFhGZnVfZAqayOGb2cx0GFIbHsAZrdIzf+OOQyEwo3o5D6uDZE80hCKQqHyoJE7UJu7+BYCjzOu4qPAT6dT+EgaengrVAQHR7YpvIO2/MHS1rgqQ1esVZGmq/0rTPED9lo5kcBitSL/mb5VUGApApMNwChgnIN+Uesp1Fl0PiLSk6JfkGnCVa0ONZVA3rp11UY8QY6BUMNF3hV+YY+Nyk1PBt8b1KyisgNcIxB1Hl2kb2PVhha9Z81k37dmlRFto/xvC+b/i9MpCVw3iYA5gax7+KJi0YSHoeJoUVcwFYHNQkfORzvY1ywe36O6ORq8A/VcCqC5ITU2/i/RCeBWF7DV/kjzxMX23eS26df2Fcf7e/7EbnaqSgFXbRArnAQHR7YpvLNCQtWOfPQb/pQmXp4AZxgmMjhgLTykHKhlYfeHUR7vC3HEmSNmFSq0va2WzXjC78i9IbiHT2UZhz19D041pSujMiHhbwXjxGz84obEFe+JZ0XT+ZXIq8jg9TBBCt02c+q+9BkfMwpPAhYpEC1Y5tOEK0ul/fWrhkJuyFRWp81RvBK3ktepcyT8yfHWquvWQA0Q60tz6/KyiLWKU6Y1MV6rA+e8hZbcY8dpsJYef8d0Rri7F17o5DK88mbjYOvXpxQT5LmC19Btk+lj5UaqMm7w9jI9lhzPh8K8fmzCOTfgoJwr/AQHR7Ypva0f2HssYoQ93hm+tfvbsOHbZTN0h5EGTbrxbjb2MsjxrcsJD1tBsElvALao0KOrA/qKY1xVLSBHf1yvjb9TavQK47+4fPIk2ArH/SAxZCw63WuayZ3xWXzCQcontyJNKbZPAJAG1uJdeY5ucYo8DsXT8MzwNIKcpWAJyYTUqsScWWbFGqPXHW6aHG6g7EqEhhmQNOSp0tFBW8Xyb2BCRfvbkrdVlGEjLr0rUZy6JJ5gqzyLbBs5C1nFVIDSE/mDyMrdlUew14NaA+EUamGqlFReLjyzFx2uwgcdYkk68NFfHq30t+deihtescCw88F0OY3ShwaKbKqK0Xwq6AQHR7Ypvcp0RGoNwqAEJOIRqg61YVfozwA2j8Nm+pMlEGATV7JLAFZAcD78HsnzipF+fvQhRBFXElot2I5ymWgHOhH/eN153QCXn6uIRoALKC4/bzMXHq6T5tU0JYN5q/I15PEjUAL3anW2hZ5fc+4s6bXrGRwqnHs2gRBlamVpc5a8l9a/cQnW9yYXvjL1eShJ9yqY1or6kp1v6lI8go045Ec/u5JVZNxZJJfPDcWQ8bdUkDiDByPmtAwq/AQHR7YpvlpAFW6Zo9pcTwLdudjpRWdhtk4bV1RMEEmQZQxLtxsJjUkhd1IL1Vanhq81cOioGkQg/7LXEMd3HS3cM9reCSt2ReHYc0F0Jp3gHDkob3xgvZalClZJfOywV+deshKAinV+JQiqsjPUeFsnoRWLLWwRsayJrjvnfe4jV4P/YAsZQywo9wuFYjk8+JyqVpQmi/q4J/iYRRZKUBQhQwbDvJLTgr6mofq5Gtx2ushQ9YXtovSowCwSHdsbfCqYBAdHtim+MZ1P1uV/O4VeDc77orzil+MazqZtQNZh/GK3bM2FAkWzZaUZ6we82FBMMYPokZiSvc7LAN4sLwttPUe+4YwWSX+hEfkPt/LB3zEVncb6lHx/e3N2MdAcrmoUaTrlfJSkeWNUcompiURS0q89SsW+nKb2jKJOrGribWrGoQI+vCtYBpeivMamPZM5TNjMjqoXq+9oHl6PC9Em4u+x2fmzqogr0AQHR7YpvwkAJbv4BDzLIPZ1Rch0Ce29UnFXp0J2vM2HwNEDu+yLrUowpDWurfnxoIWJwpBaVReLxbC5fd6ziXktgX8V6lu3AzyewcczZdE0472ydnHpjtNmfZJReDFx+jLcgz4GzpEc29dYR/XNatoVnwLJKWxDVcxNI16RLQGUjrwideNf8uxa3M4f4WWKRfIef2BfjveGZHrVy+3NgflBsPIZGGyQMOaxXJUTgVLHFyaJzbd2FM3cGmigTu/mIAvGUYJ14AtGm0udeZo/wWTFdtPC+WK4u13YG2m/6T23AbI9AF3rqdGsIXF1e2Nlax4BTYGYK/AEB0e2KbzlSemSUt+YS0reTB16E0b/OofPy3bKEBE0TwNnV8xYbp5P3QoShO3OmicONUiq5e0UbYTWwDxNbt/aTVL6d+wm7XFLWeqzGlbfEjctE6lPBt3I344SbLumX9UL09fuhYeylPI9wQF3etPJWU2X1c71n+5C7JK0tc8aISowl+MA/6vV3gYH7do3xl6Qy1lvFOh9+ss0PpZpIXsHEPoA20juT1H5w6rdQDOzamHjefD+o/I8U9FMtSNdt6jTTLOA57/RI2rpeHzXHdKFf64PWc+3Ip74QS+vWf0sYGCpO8EC8B3nxBecC83fYFn/p7BnGg11hXtDacMEKwAEB0e2Kb3t4jrNRdSBv8FsPTgKnEgCL6QAahIZ6Thg9EViB3+a7GixXfwYCU4hw/emgceTAdxed2GD1UiWShBV1vstS7fGnpfLyKPbwAcyTbBDhfS3TVzVtsbS3KhkXhwRfuthyPY56mI0cvu3sg/eP7BghL2/VVrI4n4a9GsI0KBnKkHymnrfxaGD9OnrePauGr3gTlMzbtvxzLgJkWun4gCvrR+BivreeykxdyqjZsB6QM8SkxFSJpU7461HhylA=\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 430,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 212},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"XPvSaNv2AtXoz7IPyc-w8Ak\"}\r\n\r\n"
+        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 711,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 493},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"emHUaKGDAabXz7IP-OaNwAQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -50,11 +50,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:56:13 GMT
+      - Wed, 24 Sep 2025 21:24:12 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2848
+      - gfet4t7; dur=2858
       Transfer-Encoding:
       - chunked
       Vary:
@@ -80,15 +80,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -97,7 +97,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -112,12 +112,12 @@ interactions:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
         {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"title\": \"Mistborn:
-        The Final Empire\",\"publication_year\": 2006,\"author\": \"Brandon Sanderson\",\"pages\":
-        544}},\"thoughtSignature\": \"CiQB0e2Kb98pxsyxPUqzMu17uLYkn8IHbbjhXfwu0bQBxBvBHikKfAHR7YpvjWaszeSo+QNUEiq4C1kAeBg4jfLu2BV2xGxsWMSmaED6O+EN4yy32/Hg/4rBbBzo/fyGk0qw0iClBxGFj99NyBBsh/BA1YV+n3r/hbTuXq0X7MP/JI4BVGcPAlJC2XqgJK7jzysufLpngvsGB/K/8N+fR7a/zVUKwQEB0e2KbwEvos1Hqiv4tDkmCoU5qhHP4xqSUMFJdiYMYkbm2GhkF0/VT74Nr9blVSI+oT86aumTHIYn6H6ky3yPxXe56Y95Q/HrF6udnI7vJSg5flKU0ylIUwxkveHR9IwedQlj/iN6/fyeAT4IJIZF963fD5FGTRWq/dR4p49Dcm/ujWk2jcB4TI93Uk0SS74nixVzf93p0yIkB+18OVO1/KezKdusLX/BDeYq1owax3ZRHADYTwJF+SQsT/QOHLVOCpkCAdHtim8zD1boaCOJGEv87jcG3fq7CQq863QLW/ZetFztrkjKp2TFO08ic3qP5d8E5Qi2KSkGB6XmODi8t3CPtnJLgkBBUP5m3h3ARzF8Jeby0P/5ccr81lIKP/1buBgvUHY490bDyZ84xCKBowWV63KQnyz6HBP/AXAdI74j2Dp5MDlbN6hnuDiynCP61kINUU8ESqdXtauL5K/7C3BXAH8MvLCvY6mNJnWMLIfWEjefApWuXIP/gQaZBGKLE5eKu1o02g8sqt2dLFgXH2zXwmk2TAeEmGZ4L5Cjmrww9ZjTJNEcVB7boUSj7VuscbOSQrpKpzGzpP8o0yqvatl7HBdATBqq94RvGa7vNW/Fa8KfWdsxEhe2BroKkAIB0e2Kb7dWlaouiz8w9oIliSVmuen/HcvdhoQcxo27QdvPvuTMDupckRWs+uz0+rj6fHnk6RdEwH1kwqahdbr5X1fhO2k9nzf4dYr5OtIsMxVQXeGn79sQFFmqQaPKOKOTobEtM2VYBTexRIndvJYzhJ03p2YODJcrhUWIsV3Jqxbwcei9UqMKjFbCRSvkbe6GYgzOUp4pAnmAI+Q8K3Jt2/lz/Wk/4ojMyqfaLcsrmhJ3Hz4yQ04wS7oHQXZ3Sor13s7vGhnQO12ZPssUHC5M5C8+v/xfPRM0D9Uj/jRFu2VEdnQNl+8bb0jjdgVg/QuZQgxrK6vgkPsXCXeM35lSh9EFhpKdaYHADaIAnmQcggrJAQHR7YpvNlhC4sPzc0dmwOonDGzRMLgGeZHHeHHplucoXxILe3tA55uSxV9F3AAxUyxGqzr1v1+gzkswBITUZHVrbYYXW6FZRXyD+e7pHumYbPYCfjLgugThavV/oHI9V3ctnifnzMRKc5FYUuPhslUrgRHkjRciXVK2yshbnzhuvfm+H6JzTSSXcv4vbGXHszyqQlbVO9OqDJEC2CfeVUko01T80lmhXjieE/Nq5E5DftNDDXLpgxoT3QrPC4Kv1Lu9yCIcC71gDAqoAQHR7Ypv+vST2+JEkv5CTjhE1XYI5VOsYDHsydMTrwnP9mfJlmRNgyOX41/MKBDlXPp6bMwgmAnQelpFcsFeH4bYslykAM4s3a1DycgcKCD72pdkBHROsnVbDuGZe3j2NlnIri0slZl/IRFwYG9n7KsAGP5FeXw3La0eWur7BGk6z6+Ct1gSlcmcdzAbet4QBoFfSpaZ6t7yV4qIVmM4DvjUcNgsqi5tiQqnAQHR7YpvCzYkrNksY4loyLzeEyZBlvwSHrwbvRsTN4efKt9CeZ0VkGjVCN1ZwnI4iYeQRjejyrnKDGxGQn63CTWVJmAHTq419mtNEFwmxozVz6GDOJKqtA3tA/r/YH5/9bm2SE3sIXrYhO6wYfHdPMRHaq6O1ZBiKGs4otnfkzDw0rUuKkr/AxPtD1aXJ3aZ4i29UxMx5MjZYOhLZRCcrDoT8AzwCWdiCiIB0e2Kb53Q0UaXUDnbzpULinb0RZfYBRBmsYIQvx4T6u9l\"}],\"role\":
+        The Final Empire\",\"pages\": 544,\"publication_year\": 2006,\"author\": \"Brandon
+        Sanderson\"}},\"thoughtSignature\": \"CiQB0e2Kb/++3qFmf1QX3NSUYCIpHRuaPjjWYyVxirBFaKllC/UKfQHR7Ypv+Y8kulKAHZm+YDmKE5nOv0tK/Tjdu1XhG8grzaQffYRBl0jY9YkaxAz8nsjjV39o8g2OfPtNc56HQYYt+u3k2Pzr5nlnXbZrZBtpsE4DRX88KdMnWQUWiVhaB0vvRJcTahrozgNoBwdpKsoEEf4+FXV6ybJktacjCsEBAdHtim8cRsp+C6ODB/K5Opf4CRlOWrrQayXxsUJEBCvLg5eNZGAZV9m/Bs/53BlPtxeMQ6nKzxGI0HSXopZd3Pe6VvTieYPqQYO7HA5iGDszUcN7jTA8HXULdwJxip7So0uUUrwJNxKcGcJi7dbZl2pMMGiT0YU/HLWPiGV7vDHDzd/OPAzEFdVgmHPWa94LFNFWDyGpven0c1hLR/D8Li05++3+HdIM+2iXbwhx8WI8fZDaMX1mLo6HI5RyOk639AqYAQHR7YpvC3o3d7jv24DRL85ekbF52Mmzd+1CV1CTqAemr/E3ZKmLRo+FjymHqQg2KHCVNy0WN8mUd58FUpdtZdZ+m4yPru1x39rbi/RwbbhOBp+FgWapKsGLxvBhyKz1R8Lm84aDpR/FEFryHmk9RrMymYhJUNfsBdPfNkLIonoX82V7PZ2JVNHZG6ZVtJqArUBx/xe2xk2gCtoBAdHtim8bj8FCRUZWaEhJOAodKoUa9L405+7sTytWTT3rJtQZWzTxd5t+1mWZMXNdEc0VyqrLA0/OZHtq4APoMlJR5zynDfeMi+YCEjfUCRtGGC8ORytqz6kewImFf0OV/2jBBZs5fU7UI5IZFJ3mNLwZP/B9OkM61/v69zTm0txKQUJ6SMgcBLwAQLBs9EC3TC7ou/z1jfm7LZLtE0xJUxUfjz/lK3U5QGAD5o/LCScxjYT6tEQgPwaSJeRRHjqYJ67v/sD426QU2ryKHMykAtaO9ZR71dnQgoAK6AEB0e2Kby+yLsGxUcjwovgHZX36DhqInYyur1h36I0Eg76KAu/RXeGyTVBwigyAR+VR9EbKomW0pIKTVOijIwtDqkHuWDxEAbOqGZY0E1ggPddVoZDNJ66L7rx48pBBJKqtxVSE7iueVfYtSMqAgjgu62Oo4UWBnsxUGCAHGtSPaHLClsSD0wlPAo3oWTg58ENTX+GUUn8LvqSKB+MSG+inTAAtGQDHyBvP+I87fSa9SzvhxPrLiRah6+sT17uB/H8A+fDrx+Nx3XoFwad5P5yHERg3lQ7xqU1Rwr8h2Iv9kFHfPkmSiZ3fCo0BAdHtim8+MfCt1OCSyHAt/HjmpAwEjGVGPEbLTqwltSrEN1Bp+K9uhX6+RB4SzhoW6/gUQ9dhHg79wQ9M2KKCoQqBq4o0dmhv0KX2UPhfDFDG2LG1y6a24K5Vz9ISPuSB7jBZ72FG5Cl45kDvOBdZwTzcuvshmmbv1P17yV2ySkuOzKJxC4q5BCBnkM8u\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 627,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 310},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"XvvSaJXKH92hz7IPgIPNmQU\"}\r\n\r\n"
+        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 554,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 237},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"fGHUaIbWOsasz7IP4vHz8Qo\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -126,11 +126,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:56:16 GMT
+      - Wed, 24 Sep 2025 21:24:14 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2284
+      - gfet4t7; dur=1831
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/stream.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -37,11 +37,11 @@ interactions:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
         {\"name\": \"get_book_info\",\"args\": {\"isbn\": \"0-7653-1178-X\"}},\"thoughtSignature\":
-        \"CiQB0e2Kb1YrROwY0F6Zcpmkj9db6TmEKXRQe+Hf0LEsKzs+x2sKfwHR7Ypv3ZnTIOt16xemGuE2fJpk8TBC3iNiZg0GnOazrX0kqGVhxXMDFXTCFv65IMDN7jDzuHSp/+wK1tmPRcJOVKYF9txRQq2bNj0pFDLG0VUOSrglPF3lLk2hfpjt1NQX/ECvG6L2h7SKDDDSAQTyo66G8DAQIStsBjE8UfcK7QEB0e2Kb84xpF12ZO5jiWQrCvHOGqB7DHjb54J66Wp1FLoNoPW8Uw9EfEDoXe8sIvQ4XO+IdpZ5eBqpxOc5mXEGsQ1LUf4g76WJjCUusb1x80N0cqk/dAO4eB30trhRn0YQfHgqh5QGS8MsJVkJpu1y0wCQVyZoU+eCN9JQNOhkcDSkIyKfv6yHUxbPRSPM6TVmdUJkFSnbw2vJCHljZV9nZO5qvf6tv1CoYDxebTEXShTen7DhAsJXzBv+ILX+tnfMhM/3fkfhGev62F3syvbzOPniG304OpXVIliFgznVlpMao3eMNAL6//sYgQkKggIB0e2Kbwv7+ruPNfmiQFuJhMMETqK62AJ0MXPaTiOPisP4vvKSoRI96Kpcp8/IBVylrl8RAnblItTMMj3Ao7CeLzKTZUjLuIMSuWO/GKNnqEmtef6JBW3MYjPkif2fpwc11RA1RojaWqB8i5dF5CfM43iGrTJTWr+WvMr3OrLOhf5VGH/zjjkC6qTc4oMaYxltVl5zABZA7UFz3RU7PjbPOoY+lVPhZ/OvPW/hQnxZCG5quZaOzTYPUbVx5dbuyETpNqB8yRCBluuG18t0jAK9y9FibZj+bnjQA8dNPuah33Kmw08kffI+S4QQB0MEDsfRqPCBPb97VbFuhVLkJKnZeS8K8gEB0e2Kb0LSpGP/TqGDSpOCjhYlRVxWRZlKUGDD5c8k+Us8tPoMB6cORHIh6WJMjVWX/zOmwVqFBCIoRH8/L2gfRQsnETX70MmXunBWaH4jTLZ5x4fIyCrzKNtWjYyMGsvKEw0TSO36wUTfWw0UzkGEWJmpveIuXgzCBrwBjq55zvjfYeLCVAQ5D4jIi193oV9E5ztv2oUucgRwB8phiFPsGB0uQc0JhE6gZw8TazsQ3f2X1rfUw6u3r2R+cRI6ZlyZy0KS++m5l2vXOIhDuyRIWfQ2Aw1hpfTh7+y0pzllxkEMvoPmBJwWyKCMGLzVC4pG1Aq0AQHR7Ypv11nW5+qdCBMABuQfv4NUBB9fASDMgVMNQovHonnqdFCFkqtNdNph5kKxcPF4cu85Q1OCTer8EOKSEkPo039Q6MYeloPs7ozzNMfiDbQ300eeKIH3BfmcQgL4n1boPQtLAnTXRxLCLuoZ3yGorLt6cUtPf76WCBSM4gNzfXjnmDeXGG44nCstQudEQZXxYYCcfy/xOivZ0ZCoXK9Hx+XjWNEOj53X3p0jhCE9u9GAVg==\"}],\"role\":
+        \"CiQB0e2Kb21oCM6zDTtneCYd+ejvNbR4dFtd85bqZGOfn+J/tCYKegHR7Ypv6ssCax0t/qZmMoXdrHYGdjzYum2nTzR4iFgG8v6UXsIifgypL+qrbSZLOzjXKRSGcnCtnYDZeWL91pxFWrej0NzL2Xjz+3SHuBLLWlGPmtcDfjXlSlfmUHx3YfIxdFeo+kJ2DQ+SCyqs0/A0q1lQw0kF7OZyCusBAdHtim+yR1tDKAxha/fHEmC6Uhnl7DRFaWF4Rge6L/hyMv0xik6xIb9trN7q3op/u2gqilNfp7eTrvWbGF2nSMU69qY4rqQyBFbXyCCnn69eys9RmBwaLcBs26zy0EThOmgR3S4Vg6l1qAXOV5I79aofIuvSqbaxirK8iOM70ArkTzO5XBGYmC+cg/Xt+Znn0BsjU6sEYkpYjHcGTGd3YGeWx7911SFcbtLxovXyrTu90PqrjY6cvZ7TSs22z4rP6oNnIn+XvIG1lipAP4v9tOTqLZK7MiD5O+tvoNyiJT6x+d5r6MoAkwLLkgr9AQHR7YpvKsDhTM6GD28EQWfOgtHJtVwdrwL1ARg9pUe/jGu21HDSDfdvB50OZ6t925IwrXtvVWz3iOzLy+JZbmi5uaxDIaTA1U0TtbM7FD2E9rQEQmJaO51gjrC0MLp0u6BWVDFDb06EPF+ncH6vusqevtWCjq3ufwSgtujj1s75RAgRUUI76TF4aICXfn9edsm2smXm0krDyjXImOGbp4WlZ94YoE4Zy/USdN8c2EhWc9JJL9gmF3QzU+PxILZRMT2PtimlksLJr8RwtJ9VgzOP2fVpuh9Sir7/tiZtNMvj496rkEWH0gB8F9mLSwqaRXhOIjY+kuY3D44Rp44=\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 421,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 203},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"m_HSaPvcCM3Rz7IP5ZS9mQU\"}\r\n\r\n"
+        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 327,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 109},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"W2HUaNeTDMbAqtsPqrnCsQg\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -50,11 +50,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:14:36 GMT
+      - Wed, 24 Sep 2025 21:23:40 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1761
+      - gfet4t7; dur=1350
       Transfer-Encoding:
       - chunked
       Vary:
@@ -80,15 +80,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -97,7 +97,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -111,13 +111,13 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"pages\": 544,\"publication_year\":
-        2006,\"title\": \"Mistborn: The Final Empire\",\"author\": \"Brandon Sanderson\"}},\"thoughtSignature\":
-        \"CiQB0e2Kb0YPwowipDKAID9cFFNweOap22CSXXXNfb4HkxentdUKewHR7YpvbYde6tGsYtqZZeWlNmj1xRdGBde+MUcJhiWYIHRCgNS5pUEHscNkIfeRhdYm8TVRuwFhWrKuY6NxtPj93IUtMQs1lWzOxu7FpJLSfJZ2vUmd727Le8RJd7v27bDTOJRAIiKuasuVo8b0ZxwYV6HHK4KUfUYysgrcAQHR7Ypvu+4snLP10iVjkpj5WGf0Pqn1i4kVciP9W38MFiMbe23TkDYAKsPYOtEsIZci2BLcA5guumU/X+j2Y2c+IvzYX9jYDBRSC3tWxmWJG6MpZKWxAJ9qpfqrLwBcpfZZtgiQLwIeV88d/6Vr5kYcA9JpFdYeGTQnQ0vBJCfdOw76HxgqAx0c7C+lhZluHvv//dg/Q8qPyR4k1nzGteGAyIJOvi2aGtobwmLU5kHtT+M1VBj/BXIEgvhQtxsNZvTrkxbOU2M36V+pxA0KhKL43zbtZMVFV59SE3IK8QEB0e2Kb9ceQNRjZzS2Ua8mR64YiKDUi2j8NhroKKFfOBJN+OBwJ1pTqREjE9ZSY9OuY/0UxIOeoQLOSzjrZJzyJPSp3vex1onTLbifmNYXxclZE6mrwScjeGxrLjsPbFSKWzAIjUBrSdk+GUsvy+mXRiMLQ41foAkMXfznZO+2d7Ta0X7S2wir1UsCenbjFE3X/MFyiqvNgDwAA+u+D5iJJR4F1YbjRGK6T6ExULwDoOp06e4c9nKtwu2mt0VS7NYoPhsFWjOiLMLnH3X/DxklIYLpIcR6oQMyHsxhrVYJqLXH9M/Xf3Ju3W2xrfp4c9WDCvkBAdHtim9pvgtaY/YQFemeEzBaRVmVU5h1iZfvPPczeS0pQKhdNyWW+Nk8qKOrDbffDpYi0C+Ybk7KcBHEQit1Q8TcwHYVWmXyaNNGQYaJ4Ya4YDEZhU4nrVcRzZZJXk2M/FFrk3IwSaVLtnXvzDA2IS5BVT3nSXjhP6ZRXeSgysxsvvmUdjm6+H2gwOK4UFdgfcHz13uoqRbwYbkHvpozL79B3+qS170rpf2+z8UmMGbxzBUWE0oxEe9/mOdAxukXBCZELUN5LxMQBU5bA8YIoU8OJmO6SnHY3F3ofWmtBc3wGmxM1VswU50+YKViGEHwQKCcowLCNqv0CsEBAdHtim8e6Y58+VOt4+T6Fs/XijjUMR705Ug24xA5CCrHE2Rvy6qX+IDKELlnOgQmX4hWNUE8yDC/nXb9LK0PSTa6LTsOd8H6Zb06r75m7ewNbRIR9jM/NuLNeAcnk34+t/ETAZ4HhM8ftNgFWV1brZr4RWxGIs7y8VAZn+ssA1wyVc/eheu+dAfQmbgvvXYDcHKU8vN5PR3eaoDIkgGKCrATDOM5x0QIKq3Y/Syolb6z/0UBtW5bAg7gFlF7XfDyfAqXAQHR7Ypv0e7J/8BBXmjwgGv0viLeLG9oqvp3+v6pZyGgEPhuG9TMRzgtM2YkkxAFN1zRMAz4I27C/kkTv+yPgXRRXks3SnOxfOSZmmhLC6EzqblEoYSIoCrEmSQoZqJu1I/TLPPrBhz5+7EAqoOVuOrJWbLlY2fQLudpetpNsglme9WaHT+6q09gQqdh7ZKCSx7ruHRPr5QK9gEB0e2Kb+JLijWGkJgpuoSVsgmX5/XRnwtWr8uEVFaOb/8YW0ai3f4+uHpse8oEOSLoFlfFXWQ4fdE1aJLxzC+uEsmb8rfp5U/Orcy7sExDxBXNO3S8YqfRatnFJmJZ/bstmFpJ5DE38rRT2O9veZJ5bKLckuUdoK6JA+ATtINoH5zE8I2Y5QCfd6se2C+uvui78iadePKz+wJrMlARFl93soLm6LrP3DRS79t1xLK3yRvxLq6ValfZrnX84LZO5tTZBEI77b9IO4b1LjSTSPjQc4yqMQ/pYuHyQnLsvnd87+ViKf/7tmudwWE3Fgk8s9lelcJMtMoKSgHR7YpvdL4imt9xwwq4Qoyx54loC7kymZ6XleDHhZW7VcxxuPTy+iHT+7F+j/d1Xs9LL3gA+ycWSuO6HHF+HbNTItbdm+GNMmBc\"}],\"role\":
+        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"publication_year\":
+        2006,\"author\": \"Brandon Sanderson\",\"pages\": 544,\"title\": \"Mistborn:
+        The Final Empire\"}},\"thoughtSignature\": \"CiQB0e2Kbwhc5WufNctTePfLw8pOKeFMbzIaZBtlcEqmWDDyaEMKewHR7YpvOLqErdmpRjepgt962uqrwdZJExrLR+u2KOjJEXYwt95ChyyxX7le+275hi2YugAgGgflkrzUVobLLyNJPK2jp/HgOwknuTPPK1fJnTZKX6UuY55p4l2/KLoDkQjMQeFmTyOfVvfZndIM3vER646MQNZOCP4GBQrMAQHR7YpvWiCycg6Hv19V78OuMcqqgECkeldlxGevj2jLSItxOU/+uKt/CgMA3nkJ292q5+iQqHbJGUqUAxUkBy+61/ce20v7DqzbGcyUnFUwxmyYcGczjL/+RIrlFGrXUhbXOHbgcfUxJ/zIDYZILUKE9UiyNY2my21yLE6Sz6y2aKexrF0Sf3D+F/yhdynedHxDO/gcNAHaZPOCEHyrVf3PL4QDuvZ0guXsesxStezefbjn29KDZlMI5gbVAQcOIwAR+LwLspkWUHP7gArqAQHR7YpvKIritbtDUbQ+yZD0T05QLVnqD4uwT3xCCmA/LFwcujaZaCml14PRcANR9zZZbWPeg5k7D3n0r66Gn6xtKF4U7eraSvHXFpGT8xoYCd/fNPIM8STpoisRsqxzV6T3Xw/zNc5ovMnAapUkelvraXpiza0jFXsc8OnU1LLIzOmlF/5HnvFVVvvKaVG55XsngB60zJ1z1AbzHn4NtcxPvcBxdkRPlrUT+KoJliMo3U5nshEVR6j4CG9TGZUzSWjVzuO+rNVS68ybsH+i4O5OYArMxHSeVdW3T32qSh+sWaloiZM1sawItArVAQHR7Ypvb+IgtgeF1uEPFev7lDIKXFOu2U8XBo2AusbAvG9eL+kmYHZjDjjp65BItbGN2UqBHjgmuy15uBGevaBaJHKTXFFwtS1hAAautbAy5VZgvPjrKySW5SDhh5yFRyswtHs39r+wLkDXEWcZAVJLbnXoptrMT8L68aU89jDgVT/mzKVP4bopRHBxDIgTlNmjFenAyadw0VH/sl3W2AEisqLLsh8SyZQSoZ4GDaEmF+dgmldl4coPuJsAjP5qXtqqIqYKLeqld+EJopERPuEk8YotegqCAgHR7Ypv4sFBMKnczgKpluaNd9OlN13jaGO0rbAe4Afx3yqwWEqOntOc0zpBTuo7FsK0sevWxgWUZgMBtxyi6BeW0OxFNHdYf1GbIG+t4vrjJ93BZ5NmteGoV9VyPOFMXyq+iDSM7j7qlORXpXTR+ytFRg0wqaBZiK1hHv2JBrGoLbpjfWU+epB1ZWK4SUiSn6jkjx5lFFAG3YXwWMbXz4J1m/jkKrJfcISVKN8C3Ixz6IuatqjARGUIhx1a4tW4LBLqKl0eLBjCVtfrPTQA20pDhaE/pgCLBEGEKOU8e3BXq6sBhWGS5ZJr9Z5/efFk//nMWCEv1J/2IIgJ8Do9xsZSUQq/AQHR7Ypv4f4s+rn4F8rpgOinudRFPs75Pms1CCX/vLCins0ekMfCGdn06ky9PMHjzmCX6qRXJxfixVE1Vcq5gnqbsauQH7c2DOz3ORMRUcWLYObTzwyDKfxZuZY7gv4c6Nh0VfHr33ygyotg+TNps+SxfaFXioquhTPT7lc47GVbC7/hCENDXIsqJZAUmTm4tlJ3j+LTVOs976gyCWnlUOIW1dHDvysEc7icWYChPM5ubVa+jfYGaaJCDSTFQCJUCiIB0e2Kb+EX4560SxF4TGZViug0SGCrVbU/sMbqbqcuEJMD\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 645,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 328},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"nfHSaIKMFLHoz7IP6Ob12Qs\"}\r\n\r\n"
+        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 582,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 265},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"XGHUaKaQH46lqtsPvt-52QY\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -126,11 +126,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:14:39 GMT
+      - Wed, 24 Sep 2025 21:23:42 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=3043
+      - gfet4t7; dur=2042
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/sync.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -36,30 +36,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21V2ZKiSBR9r6+o8NWpkUUQ5g1FFJQdRZiY6EggWQSSfe3ofx+ruqu7qmd4IMh7
-        T97lEHHO16fn54UPUJAEoIXN4q/nvx+R5+evb+/XXIFaiNpH4j30CJagbn9hvz9fP3w/IGGH/DYp
-        0A5k2afLP/II5PARX0Sw/eIVRfolQWGx+ON3GKij5n+uPzJJ46HXAtjLhqbIFxzfMC+3xW+4b5/O
-        3z6XX7Rx0UVxayYRAm1Xv82zK7kjFxzbJGdNmbnegXlaTrAl/TtKVs04SOOy7XY9Em0u9OhKW7Me
-        VhIsDQ60MHqVvx4IY+r0FVmngVr0xVg4l22RZJVU26OuC9bMAOq6M8TCNCUVzXMvC5W8DqcbNm1O
-        VSTW4ZGN1rmvyLG9DxiW7hxitmBEEJyEjjdkSBG+uoMOAGFwrxYgvcS14upCDjw8ubYtUMO5oAiB
-        3EhcU222knTJZZiT+P48DvkEbMDvKdpCGXVRg/lshpIHXO+0dzLVuWSB4aGNxaWTRgzL1FIkzNTC
-        lLgwrOTYp2t5Xc47W8cRP8LegZm3vPAHXULN1sj5Gnn6Vl85tSu2HH4idXCnhuPOcbwdFHm3aS40
-        t4ksDVwPBcDdCCoM4zi7QZburRbP3VK7UddEo/17zV+vSpPNjadbbHx0PTYeFb2tKkyjafVmrfN8
-        RfsoYM8NBbsAn8ihWzaTvt1JR3cprbXH4sTB2xphfj/h1Kic2co1sqCPDoE3T6OpFqMm7ojeLfey
-        3O1rTiy4C8wG9ihE8r3fVCs8YUg9pvcleSPKc5HJOXETNpfJ7g9BTbdgOsp9aI7MSVoaM2pGFpPE
-        rM8qBbds3EqQsVQmgOJSGaaS2Hf1WWTsxzAwwj2v0icrB2qUicS9lU4WBkfvoJ6Ps96c9nGyrrk8
-        sViqGALcPDTSCaXehLYrV0WShQsB6bEbVVnbbCSqCp4bhne5aImS+TUmXARvYtRJXgt4dlDvE17G
-        90pjkh6aBSoFbhtpQ2RO1Z7lV9bVLlgfv+Cc0lpsuksFPb3E40GIuKNeYnU23MQ8z4U1hW/DiXJD
-        SrIUt0IYU0olJ6Na5FYhzsezG9bzWaodIuia4Z6psyWkYyZGCXcSyNgltcRU5q7KNT3AmpHp5T7d
-        S4nYFO1a1Nfs9jBO1DCNWHsg00jZZ0uREwhROle0QDqEZKRk6LW+7tIY3ckEU0gYm5GSxMSFCoP7
-        udx5rsmVMKx47Cj0Uq3ZfIahlKvT5XHb4+FK1+ydyXejA4e0Eqr6shbUbiSkWlnruminqbt//ISS
-        4XLOkHyhSqSmXR1av0eaoKx7zT/FrGvCxCl9vOHtGi8pbzkybXgju5UMDcJhD+4o4Mqqo5bI8Ima
-        v3VHwnIAd49pi3blh1Jkk40FKHa9PZXuK3odOfqsBn3AN2aHylOD6xiVWrotelBkSr7bmixn48Sc
-        2vEGNKrKw9y9HzWFIouqiit/u3TrZMuWVVgPM2H2EQOBAQq/jj6q4C8F/OeX+i3qIntTu7wIYPYO
-        /ymPizBBSRMbEDTFm8aalqr91OZFggI4PsLY03uDt9KLrgERlGELHlYCfor2oqyLvGytIoVoV3Rv
-        VoIz7PdqH6znE4B4z7dFC7JPqfWG/OM/hRv+0TbJPnrSB7t6bAmypJ1eV7H2N+uDzTwafJ7rnYun
-        D5S9G8VvM1LU0w/SvvN4hXWTfCcsgvmDwhfiT+olzEATv3Vc1LApC9RAMXjF3L4cTaCEhCqrUtU2
-        WtuEp1TXF0/fnv4FALpY4JYHAAA=
+        H4sIAAAAAAAC/22US5OiSBSF9/UrKtzSNQLynJ2CIC9FBBEmJiYS5ClkIiQKdPR/H6u6q7uqZ1gQ
+        cM/JezNPZHxfn56fZzGA5+IMcNLN/nz+61F5fv769n7VEMQJxA/hvfQoNqDFv7zfn68fvh+WtIcx
+        LhCUQFV9WvxDh6BOHvVZluB/IoQu/xQwRbMvv9tAm3X/s/yhFF0EXxuQLzzHLl4oihdeTrPffN8+
+        /X/73H6Gc9RnOT4UGQS4b9/2IyFLXZ43uKgFsCGNLJADzz7zGhWu/fZ2wJE2lDUbjCcvvIpMY+jO
+        kW2jBbxZkcOu7SFdwWZJBkdeSW+LDIaLws3Flbtr5sGkehbVuSy8bemJyed6fSpXK20xyqlro3q/
+        6xdY9Hc4u02cnd/1ZWyaJJy23m1j7c2OGOpccsS0Z8U0MpA7EXIoEAqzEOTDCBxzOERULds3Yq3s
+        PG05haKimgHVxV3t+kdWr5e0uc0aVIVKZtdArTlGiDhWqof+4AxOrkw85EyeKTWDn5AQ2vR1tw95
+        XmsrDasnzYMUp9Smlk4jv7EO+U2RRr4NbpEut1fO36I8WLtMkuw2BxtEUjpEslNzhdYQqrmlK66T
+        eXbjLsYK7LuVMdDn+WqlDpl7oifycCVgNeda9XbZLYeblUkaI9ag08mpuWYq7w6axgnSkb3HAt+u
+        YtPvj+LQega7P5ymQU/v3anU5rHk6j0/9tyGhVTNXeyLcbASobiqeVAezYQOdsQy5AeqGA9MXC3u
+        ZHUJ1uZWzGtWIFJV9OOk3zjKZb/cSnXeNxdnLMOclHb0lhfXI++QTRoRQNL0E1WKa2bt4VIJO13t
+        qYDWB7/f06QDMrVTY1MsBnLEZ6YDk8MmyrWHDZ4TVDc4j0D354XarRcrKdxYNUPFd0OFdl2NDszW
+        ud9v3CXv2LUYKlNN5EdkldcFQSG8lomeLc3buZq329VJyEUttRwxNIdsEWnu4x6UPT42nKld1l7c
+        LGWyCZIBt+u9veQPTtjHFjvQN50Pj5gmXAbluQbsOJ+XBHG+5HR6DgWG6NgotSHc+ke0D7bhyOuo
+        Ha+4DU5HRKq0Z2iCnOwRMVh3u4FiQPnhRCrJJVHa9LqDVgNAeYJTE61rv3AN0c6OYubbnr5hFvv8
+        ugd0uBExsSXvRTT6/mD3xdZZcXJH9dEqToqRudr7ENYedh93p4gngtY6oqwKTwkrW9ja0xIO3kZR
+        GHob9WcDNagXsbqUDePeqtklRwPwdVjOkedja3ERmrtuDJegk+fOdAhukgr20twpFdJYmt5dVvM5
+        WSbArVm0KYFOeYzufCTJL4r8/YsgsxZVb8So0Tmp3u0/ETNLC1h0uZOADr1x6uDu7J98mxXwnAyP
+        Mvn0PuCt9azvQJZYCQYPHIOf4Js1Laob7KJLAiXUv+GYEsTv3T7g+5OBftcxwqD6JDE08+U/jTv5
+        MbaoPnL9A/IfpwRVgcfXo7jrk/sB1Y8Bn/f1nsXTh8jeYfvbHknu6Udo33M8Jm1XfA8sS+pHhC/0
+        H+xLWoEuf5s4a5OuQbBLtPOrR6s3HtjZhhFPyhV3NolVt1veZ0/fnv4FpONaj9oGAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -68,11 +65,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:13:35 GMT
+      - Wed, 24 Sep 2025 21:22:42 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2389
+      - gfet4t7; dur=1807
       Transfer-Encoding:
       - chunked
       Vary:
@@ -98,15 +95,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -115,7 +112,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -129,39 +126,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21W2ZKjSBJ8768o0ys7C+IUY7YPgEBIQgKJm7W1Mo5E3GeCgLb+96Gqr6rZ0QOC
-        CM+ISDdI969fXl42oV9FaeRD0G/+fPnvGnl5+fp+fcvVFQQVXBM/Q2uw8Tv4G/v99/XD/QqJhyqE
-        aV0JflF8WvwjX/klWOOb19cy7fw+rBvwGtdd6UMIotd6gM0AX2FdF6+vm3/9fbHfPfp/KPo+2eN9
-        FxRJ/n3VW3YIijT03+Z6nYHfrUAcw+h/QMIUFu/zXdIeBnVX/fliJOBFSiu/eBHLJu3A/431NtgA
-        k/qt7IbvVlLr6kVf/0DX19Xmb+hvn56/fS62WcsMjwTq6aPy4dC9jyK04pmLZJiWSD1Kpr1l0WU8
-        TNSyi/C9JAJwSGcdKHuTxeqaLSiCV3vGlJLhvOiKzuGXy4PNkb1g4ZeWHiyU15zkWB9D3N2T8wE/
-        OwJ5MJrOcqpKJEZUwO5rF2PM06uHiaYtVJaCzPPiXk5eGR85uKu5B99xN7Nwk2VEyURAcmJ0iTq1
-        7p6C2h1h68dxGzWe5UpbJWws1FXSfCFmlDejc/20l9M4uI/6BiVD0o0OuD2th6FsoZx6i5BkG9dJ
-        06In8+aZ/biT9OnY2aRGsrzE3S1/MJCumsiwoM3EMO+0KF/0Jpj0ey8fneA5WuluexjrHX7UUfRw
-        Oalm1zk+3D6LHuvZMAOHaS6DOW214Ey7AEu83bXsn35ZespTLzCUMINzYatuEPVpTko3frg/xJlX
-        GYmubjdyJy86hsVUW6lMmKEhurCBT+CdaInkY+tW4m2+xkcx7xuFRWJFo5Z5pXpb0qQ3YehJWo6n
-        3oSoSO3DjCSfdnupTgxkWSSLQJ4aZbvslk4eAA7dZyVmo2EdFJNvK8rBC4RMSiW0eYmRx4Hyy7yM
-        mKcpXZ+UPSxOuoAk39YkudDDVYBut2vZK21SVi5i4LLH+EtQ6AJrdOdjx6VUlBAjj92uBcKTOpbA
-        eksGnT4FKsSfaO0YkZPdE4nOtzsBVQRXxbvrE8Q0yeioeVRRqmQYzBeVAZDSya+1LeP60hUo5yrV
-        M0J0KTVKgGL7OuEe05nIBO56ihBTn8xIegq8/BgfxU3g2IzBWgcj0pi/5l4EPOQGMNlD1AfaHX2H
-        vjxLm5KwzAup6mRH9/zSQJ7Ayck/hq1Pa/mC6VMfp0ZLMnnD5mrQNqCpHAs10WNtsQjNYhO51J4E
-        QuvM5HPTg5T0r0eLOpkpy3qJ3BKtkyPKqImTZPWoftzip63j3BQ9N9rhsAzLPJhcZ53Lo8bFojtP
-        8zgnhd9LM/KQcCEPS+GJuaatcSdR5ieD8netPsm5W8v3wI6mq2JKrNdmMpUEt/X9ogckeUpYfdX5
-        RGdpVb6I+uU2z7rUe+MhuepDHe7KedHhgI4eNBlsSra0fC8b4bF3H0jIPLHTw5udmFjkGgrPQD2E
-        mnKOyiIWgzD26jvu8KcyTDHOCoGI7CYm57Tmtpcj6ZyU2QEl00laclox0syAnXMk+0kwnGackWqb
-        hAiaJjsDnhumIYiQhWyhzmd1kltBLMi8LDDHZi6cj0bGgbo4RE31feJcMVgTbcYPXmvbs+fG8wmP
-        L+ECW3tyBEp58LF6x0Sq9nuO25WGVqGe1AdKZgIw19EIUUMBmWHgQqRVEsoO5ZFUbakrDrVJy6nj
-        52Tqi/d0vCBQt0Efq3Jp9fsHAklmtw9vvC8WZooVQOrvF1cNtJNKJKoksyd68h8NjM+VyGgdSgUE
-        eqLkCttBRTF7p+SlSWa4ew4KNZe5O77f08OFKoZTq0K/2zLrN2TkzKDxEzkiDbsNATLHe20UmGwk
-        OyQq2YCzMK9cfAIoC7IVIhoujT/Iysj22ZZ9KsLd24rIMBK5pOwFtzekbJGqUxzHZGo0YWDgl/uA
-        nmB9BXLBiok97OGxd3x8bIjyFAy9dbhVsWi4PtF650yYJhbs9uX43NLW85r6yI1ziyrIzgMGqu0t
-        4+tYsQzNIATllvgZ7WNcAUIkrNMi6+HBLsoE7U4O8zgP6wmntY432gFia3mxrdWU0IFLrAepwLpI
-        TimVc+W6Vt2ljcvdPHnori542pp2mE/nKtK15pIus1sZkBcngXFGX/LiWX/gZEU4BnqoDbGzhWwK
-        htqUyr6zRXBopMV0gv4/H9XxtzL+77cqbrr6uyCXdQSKn/BfsrmJ0yrtkzvw36R2hemGqv1S6E26
-        ivC0hrEvPxu8l94M/eoXLgD6q/vxfzmKTdPVZQONOgeVUA/v7gend9+rfXBLnwAk+yMPa+gXn1I0
-        +cNifCzc79e2afHRRn1wWOsu/SKF89tWDNExPpiNtcHnuX5y8eUDZT8NxOcZCZz98oO07zxaqzVJ
-        vxP2AOVK4R/4v6k/4vVES947bjrQN3XVg2P0hnFfZd2/vlZCo3gt7DXieMjK227z5duXvwBnSBoN
-        SQoAAA==
+        H4sIAAAAAAAC/21V2Y6bWBR876+w/OrJgNkZaR5swGAWs3kBRqPWZceshosxRPn3obvTSXcmPLCc
+        U/csJVT19WmxWAagCrMQwKhb/rX4Z44sFl9f7y+5uoJRBefEe2gONqCFP7Fv19cP7zMk7qsAZnXF
+        gaL4dPh7vgJlNMeXz89l1oIuqJvoOa7bEkAYhc91D5sePsO6Lp6fl3/8ehi0Sfeboi+ZHqZ1+1J4
+        285b1dXCnh9R29XV/8rMcJjB4nUMLeugX7fVX4tjGi12WQWKhVA2WRv97lgDkleuSIL4Xbb3iywA
+        L9s/jxF4mQZDUeoX4LdP398+11nOW/RJCu0sqQDs29cZOdiJm1CCWblKjAPt3DiztaBDcSe7NlgM
+        XrOb1Tcn/1oZwXaoGrq8PAC+FnWnE8sTYDhAKTyJHwiRF3J3Sltld0hc2eaTQSJl4bAvOMWLeONA
+        MavV7QQ6P9ZbkBRxsU2Gohsy4D6m7jHGfXa4MFxM056keAQldqpwy/gjHpICjcmhXK9ddnW4+ODm
+        DBGU5dt2NxjUOozu5Abh8inBt6SZd4cbsrXt3I1Xj/OJZAu2cpHKhKLN8WSEBKpm2Kmk4DoRqBjM
+        doTm4O650VnsTBhZcLdbSyOawosRkZXcpL0PK4zXNhubIxLFJYP7cX+T5A0FdS2IcV7vMrPY8kGG
+        sNHO1+SUGGxh8IyAPHgUHiLxFeliiavppMW7xETP/UkcgSSWoYOyjIwOtnoyQ+DnduyV2BV1uIYJ
+        jhyljOq+iN2CnlxWUmu1Ha9suQtA0um5Q8dSXeIe7U5nhbbGYlXcV6SjObea5x2r1YktQ3VWeR2C
+        C925qwnvk1q076JkBpXgFXJIaqqxTxj9jKCt8sgU2lOOHrXd0TLqs2DrmBRDiqtbc90jZJMiecLn
+        WysdcExEKr/Mab5PA/8yqJFwV9g4eaRlclGo7nFnaR/boyLvrjlPnsjjFBc+nTpEqjo8Q+N67vfr
+        HIu4bSrwnHmmOxMBRcOflChTLXpN87SpT5iHbNmDf2mN3QPRTFVPipWwI9RHRcJ9IBhClETjdiI9
+        IhdG2UViYHv3k5ttcCjcpzLEQWqaDoHjplVydOewJIZvTNHH0KlwiAJsch3b14kIEcSJwza4pFKd
+        yiuGid02Pt8227Nwu55JzZDFMFjp6wTN70bo2L10akWqyV3YEkgqRjW0jvdZ4Q75NBYiU6CkolA8
+        HktjYyaN067ilGWv+fq0RjaIUImTKuHZASCXqaEVbXtph5yAGukMxnTppqgwGJvqVWbUkujC6MFN
+        iVSTuphpJEn7AV9dwcEIWx+akhRImHqM2Uea+GfrTkvnPKxzWQ6UQtq4WTD/+pjq6BYdSWCPDK1O
+        ru93xpfYQFAT4UpQyG4UkZ3ljtKOzdwuB8JNEwULP3fX5tED71ZWD2VUhIfsneNOP7O7/Z5pLBpN
+        VGKzz/mdZpeyY7AT5jxWQiTHSWI2F6sR4nU2erwh5MUk0OiK3B0FikW7YLruR/qmp82RVr3WbFh2
+        VOFJj4e//14+/U69/v2pXMu2flPTsg6j4h3+Q9qWcVZlXWpF4EWNZ5h91I0f8rrMZp1+zGH06b3B
+        a+ll381qq0UQzA4Ffqj+smnrsoHHOo8qru5fHQqjmLdqHxztE4Bgv+dhDUHxKUVi2B//K9zxc9us
+        +Gh1H1xw3hIUGRxfVjkKzvGDU8wNPs/1zsXTB8reRf7zjBhKPn0n7Y3H8+xe2RthSVTOFH7B/iS/
+        xAXo0teOyzbqmrrqon34gpFF6QQOX3S5wboS5sYQcZAx8+XTt6f/AHLj6hrtBwAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -170,11 +158,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:13:39 GMT
+      - Wed, 24 Sep 2025 21:22:44 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=3226
+      - gfet4t7; dur=1888
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_async.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -36,66 +36,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21Yx9LsVm7e6ylU/5YjMydXecHQzDmzXa4pNkMz56zSu7t1NZLuHZsLFgngAAc4
-        Afjw608///yVJn1WZcmaL1//+fN/fyg///zrt/fvvKFf8379MP4kfYhjMq9/y/7x/Prd90ek2Pp0
-        rYaeS9r2h8H/4vdJl3/oX+98/edrGJp/Vn0xfP3j38WS+b38P8M/nGp59b8rgH4hCRz9BYZJ6pfo
-        69/kfvvh/7cf1X+t5bC9y9Wt3n2ybvO3+XAbFTKZtFYdVUG6L1nLyjXgzRIegDDzkw3nDiFfgdkg
-        ZGg3CkPmI+5nku2JchHEpP0cAS3H1BAUqiEvofSyJwcR7C2/ttttrHWz76VWztctzBI+O7qVrrX0
-        hPWQjejmsgCY1Cs1XgiuDe6MzA+YnZR1hlTJTGRlKhlHhEr1XHPTIB5OE3Vbays79Y5gjFGcKyQF
-        nMXKZfBincugSjrUbT+qAS6eT2DiS58BwOTFQjvp8Jg7s9TzoEjUa+7j2phcNyyRfLryQuqdh9PW
-        syFokjSYCAbN0+D6siZivKAmZwziErzVin6LHI45wQwh9OPIawF5InvvR/3VBPRYPHpSEgO1Npy3
-        6EthL6dtFBjaQlGTlfpgq0aGERraicY+4rAjCK3p5th3vEXxobNgBYUKJ6+8xLilcOLnbdmRfk62
-        9dqSoVUmKYpYRNvHDUpbS5xDVa8S7ebD1jbOWmJSeUY5j48fr42jWwZ1ytLSUDE0GErJ7OOaVtdH
-        VzfGuV1JjvEgDV9GlTDrFuQqZTpxRN284KrO6ppZDGCVB4i0Egp51JWq8JXpQOeu2G6EX5ew6xS7
-        nK8cx5dhkQdbI/CVeaSQDlvp/qIMxN4z6+7utIOYgNOKdqkKerKxWOmwqun2ufOfbRHOatMIxmxW
-        W3K/Lb0Lc6atmEV6upZzoya3bcI8Imj0ksSxBA+fBql6nxTZVI83SC9urKB+uhaMPovRcxYIQWsJ
-        5RV3Z+qRZ/BYzJeESekFekV4Kw0Ulm7zesTUhPDNnG1cfa0hEFeluRmesegPqcLtkccrfSyFIu3X
-        VlLSsB0gJk1t0kSB1nXmkfXmZpqwVqJTA9EePbyjZXW49kyQ/Hl26KoP51h1qLeU4QhR+KYgCAhS
-        WmymsT0qyOENUGjFO8npJviYeQ+SkDbJ6iWGm8/qG90i66dyNmUJ+1CsPgEu1cBoow49LuuilwYb
-        Z/cAhiPcwVCtSiMkGmMVNdHMg+SrX66o7vpnikv3tUNBIsGkzfWNxBQElRUbzxsjaT7WHCHnYn+Q
-        dicZA7UAJBptxrbePBxucnAQz7toRd1YmtVjj8daWakQv3cA0RFWxCX0dCqAWleX7li3Fje/s9xV
-        ezGWLcAdOxKXpjQvo4X7QGeS1HHfKFp0Bm/G2IOQELM0uGvfor3Rhh4WeJem4+wRyF4sWbMfc4K1
-        UaK5gwneN7d0J1nloSOUfO6MZ3js5IsONYcsMH7bOgG3upUBjcdeF4Z7JeyLdooZbLEX0bbSWQIJ
-        7mRGgLW2mpWGozuA5I+PPsPUyXwWEesdKDKsUMjNM2Cm52z0rTliw8crdvbP63k8685wQZwGDup4
-        idDtvjZ6Mk5j7LK3PCbk0SaGxrucxtUuioC1jlPFW5/yCZJbuG0b/4YrH+figZEIOV5Y85lo1iQt
-        2AxW0yQoONc+I1gDu8KkeowjremBgDLoAjEXZO/FKiQW3zageh/TUNA46Zvo5FzqYkce7iC6VNNP
-        HqN50kKy4KZ3/Xy+arSSJJ97XPrdDO4UHM9T9RMLZfq3rL8fFli0T/aWFtC61xXeTJb2gcGTec/L
-        4S23GpkSQ198R/Q21N3dps5piOMKyqGLktqwNs4rlfvTez2kYr1vdUAYcpQtd5m0CZyoTUP1j4Nr
-        oJ943EQYA9UV0LFhtieN1nmUMNozk3pX7Uf5EutzhnGEhSZRxBChM5GlyBcSkBfQ9KjRRWd2Vq9n
-        SwYzmWqDoKxHQADu6iWhye0pcLC8BYCQxnS4KJ818ILJ3/4pfrZBUy5sx5VMgfpFatZS2VJx98kO
-        4x6ZkPqiyMDsQyeZD1ArcZmQdpOK6BFt37q8jn3is9X0tOET6J5ANqWfo9bVWGBMAWA+giJXprs4
-        y1EDpdJ1k4tDMBnsL2hZNcznCS2VOKCs9NxvkxhrktEAeUVTgAboVxfFNJUe6WoNNgnf2VMTjSPT
-        bdm1RkK+L3RpEkKwfG0u+vwqOwoJFYoCZdlRdWg1G5mm8yGcsVGH1JE36LPgCxosdhResmn1O9yj
-        9XkUyjgaRYc6TmIRVI7vEiiUzVstJk7jTUlrWLvhdYZOXaDpPIa6G2abyXPhUVyL1hHzo/cKaKq+
-        w3OJ+rBBwoLJj8Umlo3STN0AHbiC7+H0nuBOS4n+aN20htgpWqaoXa6Wzh7VYNvdzpcv8jVE1BgQ
-        XcxiRacVS8MKjxNoAWVZP1FHF2pso1Hi1bYNr82nnf7WbTj3kaBDR/S2xDeW1LjcHC7kDdXycI7m
-        fpcM0cQE0Z/aMu69BbEsypBCahXRg4gvcnl5LL7Q7tN0EZyW3dcqUe5GIcjdO8atRqdcRP4jVaNw
-        sXYZvFjJXvTrNBbHd0POqmRQ8lJRcfP38JaliqISw5ItykM7aL7c1qfYBF/IiIBFD+pHzw7zmhkD
-        JWTmYi5yOI82iyWGae1C7X0tgt7/bkZ9qIYbd4qbyY7YwBEyQovjEaEfHUqN7ZWgxzIjma2giBjQ
-        +xbrAveTawgLEsOWQA8xc9CIP+bnC3izlc8WC2mcwJoRqoCJEJd4Dwfa9zTEFYarIHK81mgYRP6o
-        3nwz3HjyjAoJT9meO2+2LRKKzVQ9jzD+DpTMS15c9Tl41OVPTUePT6MVYazahQu4h+KVBs/RIckA
-        6l2ef3dLgBXGkzVecTbF2zAZk78n/sm5G8Kg74kOEWCHL5cMiDrkJEtF0otoXPYF3jj+tuqTEYmq
-        UpGZVNNbs8vVCFq5I2UKYfrb31UdgFjt1JuDe705nUqX+bZ0oENZmo+NS94NTEdPkNgF6GbhToEk
-        YQk8VVXdbXdaq17tvQn5jgZTAlsK5GX0227b0cO4GbeVHCXcHKWqQMag6Lo5ppBxcRdjAkqSbltk
-        HohddAW1r55J0kcBJGnKOy36rEQkUD0oaDyTn91XVFb9J7HKGuTKTFARFYht2/KIoAp5ecdxhVwN
-        Re4ncfvu/qp04e3eEIghjZCIxymPoXkq2wEvxHSEwExCiHFcBSDALY3fFkMhVV0e7/WhMEUNVfCQ
-        kXzCMD4pmrwcvOD30lg95qj87R45cDx07a43ib5N55kJWUHLc6119INIRzp6L/Ie7iUXKY9FG0ht
-        HPeDQHLGU81H+uh9aEucHDCJWcNdk5trMcqDRLZtxcM9UPwE4F2FtIXaHA6mFB93BvapUUGqcgGw
-        GyZZz6nPpe775om8Sc9fXcSiaW5raIOJ+doUKZEy9JUEhaelJGYfL2Zy2pLB0/m5Wi6fq8nCpdmQ
-        SvK1OXcqy3fT3agsK1s0T53Jg9o9SBVhNVnQDwvho31tbOdR3WSF1S+TgyS30K1RIjuz8wbUKOBo
-        jlXrJZDU3BdO6jVeFYoRC4BcyqQ5jWizV2LqqdK7x1HYQyisuEirunmPsQc31wcAvWkX12ZYutbi
-        5s9HE67lW50v0tkh52m+0JKDnOGEBJ/IkFI3ZhVWgjdYPpX1mmApX9HhBnFzLh9XY5nG7kbnmznB
-        pJDq/oZLfIAB4INbgiy720HbKdgePkU3R3JPiIxy8pYwYHKRakZswfhgJXF9xnHazyOpPHeUNFeN
-        ESW6DVFSEXbeAc0t/qwhH6YbtYTgAxzeCVNYhuADG+AVmEQxZgTaJNV3N4la5pRz1mMcC2Va6VqN
-        6yRwCC59vdpXAeOCGRNsHONwjmFUW5FaI1qUv8bNUUuzsgdoFohd4yHvE9plfo+kJB87YVn5yT1o
-        UBE1xTjzUud6C+l8/Zh3wrtXc+HbS0LnyFOqUywhohEcJBuINCZQ+TnDQuq9URENMUudJy9E5Fey
-        UuAA9bANCfVDrew7WJ5R8FJfXbFur711cMIyHkpWJRd59wx/U7D+SavZDkxrmX4q4GD7OGwJVt92
-        cWJtvZ9zIyneRDxN5lzB9tyRVq0ez6PAamHgSULrMZSeV5cVmUP1GmVA6tJj9n1KpnMV6CRkliFM
-        89eoJvxzshdW6PiRVc8WufTD/q/vUfjfCPx//kbfX/PQfkPb3ZDl7Z/if8Hzr6Lqq6V08mQZvmF8
-        1zOtv3oDX1Wf5eeHDP30p4Fvqr+2JXnner4mWbImfzUNvsZ56MbVG5q854btWysDpug/tH3X+vhB
-        APmTvw5r0v7AolHkH/9H8cJ/zFbt9z2R79olHy+Ttlqv313xHpH3XZvjY+DHef0Zi5++C9mfjYof
-        50jC2E//CtofcQzyean+CNg77z4h/AX5D/yXok2W8pvFrzlfxqFfcjn7XSYodjcxc1yUr8/uX6w7
-        s5pPkfL1028//S8W9+MoFhIAAA==
+        H4sIAAAAAAAC/21Vx47bSBS8z1cMdJVnmdMCe2CQRIpBFIMoarEwGJo5BzEY/veVxx57xrs8EOxX
+        1e91F4GqL0/Pz5vAq8I09AbQb/58/vtReX7+8vr+htXVAKrhAbyVHsXG64Zf3O/Pl3ffD0o0VsGQ
+        1hXvFcWHzT/wyivBo76JwfDZr+v8c1pF9ebT7zSvi/v/2f5A0t6vvjWAXyiSwF4QhKJfrpvfeF8/
+        rL9+bL8ZknqMk8FM48obxu71PHytimwoDmkJ7VSGtYAzhfx2xqJgnYY9mqkic+dzCDoXhnNjEkso
+        8uFIisvugkPuzW8mK3IpgkNqqFozSpJt1ON2A7rLSWGtOz/CY+eoa4PWdrq0hVRFhClOkqbYHnhP
+        KfDkSntqsuyATVu6dA8heEa2e4f38SU/JgFf3iCcGXNf8yes5YoJdWgs38JC2HIzbMj+KWqGZjkE
+        Q3Cclblda9icqrIzPNZKS0mGaHwYiwC2DDFVl46Ag8XQCloR7GncHnHB9oK4Xakpi7DCtg2IP+5W
+        VsClCggTv4cyjBszOpn7M8nLNXJ1+vFixR4FIglm/AwBMIfpwwQjeIs02Z05C2ZMzj62QEjts6ab
+        YNIq16JzltiSX85HnLJ1y9qHhmaFYkOU7YJe59ZNO6eQnTI62GRiHKEaxNsZLzOnGG5pqiS0qxOo
+        0U73mG0X2XOZe9+QNF9vZeDmKJ3eKSpBNV2nzUOvrwki5VjenpTacz1w32W+1AvqoCF+dIxzqKKT
+        7igzLgaF9MUQ2QBBTrVpmP6JiPAtgpByOVY3Q1wL1UOi2VTcEyKV9xaBE3axj2HjiVFV5HzLyDVx
+        1MwGKRT2aCQQxfBudNxZvnda9+NqqKJGYPvzdNauTnsDS6wIXSRYNLrq64kvUFb191yMMj5ylVoi
+        O7AFN46FeJkmUAXx3hVNH+elaqrQQXcB7I2AyNGAEx7w4zeo03w+zUh4jDRkWRhQcH6DcEJ0MF2f
+        v4p3tRwkkPXpZR/HA6JdYiYSA/d6S2h40fmHjFYsz+7gnfFZVLqtqXM41GZRE58EajGSqZjxE0lK
+        u71Zhi55EhbEVtS1mrwrDrY9nfkskTg52DWBwmXexTGcuyXXlIn1XebruSjK22C8KAok6dtxa8Zs
+        PR6u1BbkBamyZXHY2XhmOyfCbAjIlig43562481XGiqVZ3T2x4MiaCvt60OkJ7wUUSYUdwk3osRB
+        GIREuc855Z5uZKBeBc0yJAgGZchZZdLCoZM6phxm2MCu7ilKfXjkYxYe1ztrpr2LVx3NkXG8Vpil
+        I0uQ1eRU1lngi/dbpTOhGRV2QqXoLtUs4gLle332a1dy3eTO6vZKLBfhtrMj99q40o0lHGddkv39
+        QPahwITRZfK1Wgd4GeeNLJiKtsIYtmfWvsE5DJgBQLuZjsPUuMmlfM5yCa80vKY9dvLuXMhw5HJb
+        PbXie3k3p2hSQrTCnFV3ca6EuhNbcLsI7l/vXe+X4/3zy+02XV28ultZh6B4o/+0w02UVmmfGMDr
+        61dPNa2T/tOLN2kVgvlRhp/eBry23oy9FwMVDN4jOryfJr1purpsBqvOQcXX42t0IDTzvdu7qPlA
+        QN/woR684gOEY/in/zTuhcfYtHifQe/i6XFLr0iH5dtVrN3VehcrjwEfz/WmxdM7yd6C4bczIuTT
+        D9G+63gBXZ9+FywG5UPCF/QP4iUqvD55nbjpQN/UVQ+k8BtHc0TbO6W4LAHQDr1eg/SInt3N09en
+        fwGJwgn4hgcAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -104,11 +68,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:56:05 GMT
+      - Wed, 24 Sep 2025 21:23:01 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=5370
+      - gfet4t7; dur=1772
       Transfer-Encoding:
       - chunked
       Vary:
@@ -134,15 +98,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -151,7 +115,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -165,32 +129,29 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21VyXKjyBbd+ysU2tLdgAAhegcYMQlJzKAXHY4U84wgGaSK+veH7XK1XV0sILn3
-        3OlE5D3fnlardQDqMAsBjPr136v/LZbV6tvb+9XX1DCq4eL4MC3GFnTwX+z78+3TeYHEQx3ArKl5
-        UJZfgn/4a1BFi3398lJlHeiDpo1e4qarAIRR+NIMsB3gC2ya8uVl/cevwaBL+t8kfesseZuCIslf
-        o17jBpg23WtZrltmbuqVuXyirm/q/xRZ4DCD5VuTWtbDa9PVf6+sNFrtsxqUK6Fqsy76XVg7XMss
-        AK/Tv9wj8Fpvg2HbX4Dfv/x//5pnvfQ5JCk0s6QGcOjeuuB7Yc+GEswqREGciXPgLXO9UPE0R50c
-        nOE2jIqxoEIutsI4s8gpJVVm0cYqd9LoDFsk8XyzNJKusM5C1MyGTRBxkxcZIz/8GVwIRC/SG422
-        yenmlzlGT4V2knj+bB6nI4NiF4sY2P4EtYGv72jSi1rV8ze1xoNTwSRanl2O1rMk9OmcAqvbXvhi
-        OkhnYyzvcmiFQls2PazJpII4eRrTJdkm5GfHK7h0s9nGObi4uXMzpIyWUPNyGRkTZzuHokfSk83S
-        e7BmGleMKypjej0AcQuU2ESUSbEwxkTDDh02m5M2XETHrPX7WTrCMN8fmLpy7Uc4aZwVhAaaClLS
-        kLwh0ptOspFiL4uuToq7ueFoJKpuqe0ruC+1ADkQDtFaGxCavmg3SOwQTKJazsQHeH60kgEWyhFa
-        fexvZWJGWi1VtNEmafxykPEqK2N6G/LL7LsMY49HS9BlCXXSreYxY70/8fsQg+0sl0WCWJxS5Z2A
-        pfqzjt73AY7oxOFosFBT4TxZWcwuXDNTOWJ+x17TeLBnn6ZTJEfPMhrd5JPDtLvbYQ7Ienunk8F0
-        3Sty4ssb61SVtr9C35vzG6lpcUI+pNZO0E2wkXZZltMju7URojnhhjSePHyHFPftTWXUTtf3Mi9X
-        0YwCdOBNLlKK5/SSULPMmqUIBZ8gO8/MG5tU2vNAeCOYXH+uLpezpwexWOyEUwSmcyWhKjEe4SXC
-        HpG781sy5mpDpYlYqiFEW1RlmMQ7WfLtgNlS4htxPHM7HvgpxaZMNt8fz5t4wpLtmAqsNdEpi+TV
-        1VTjsBahi2cJ8XAopTRRUkUiXZBQKU7Q9tY5IupklTwR4nUUGdXOJ0eiz2hlx89z3vWPdkecpTrV
-        uQeYeDR1Ax33SrjcdiFHKEPDqrbFJzuKszvNEmZwiAkOObDPxtbGEIpoHgfkEHESd6w4RRz0JI/7
-        JqdjVqWPnqle8zDYWKp8kfhe597vK/PgBZEfzqhxp9Q9L+c1o9Fh3wrO1bc99Zzdq+g23uNH2g27
-        iQIec8R8QqZYBXhCBZQ0466RH+EBniZiEaAYy9mI1gg1HT2OBWlI6v4hR9ykGsQUmhu2eUb7GUT2
-        g0WlSjISv7OtJg2wyk2U2ZLPhU8Kxy5mqCJkI6QNkpvrMeWsG0e2y0zB7aihYfnEL3XBE71TX9dz
-        Qkl1S50kHWfvTUIWGj5lArBo4RSINA73nFdfvJqSidywO1eT3KtLgIpJe77tpqZ452Hn5c6VSgg/
-        bzspM6uCm/L7xdadghFa17au593eYbsHBddPv9uU//y7Jddd876bqyaMyg/4zzW6jrM661MjAq+7
-        fYGZ1un8c1mvs2Xrz4sZe/oo8JZ6PfSLfmgRBIsagp8Ks267pmqh1RRRzTfDmxputrv3bJ/U8wuA
-        ZH74YQNB+cVF4fQf/0ncPy9ls/KzrH5S3GVKUGbw/jqKJXjWJ91ZCnzt64OLp0+UfQjK1x4XWXr6
-        Qdo7j86ihdk7YUlULRT+ufmL+jMuQZ++VVx3Ud82dR/J4SvGPY8mUF1mf+VhBYvzOHq3G7tbP31/
-        +j+EQUKaWQgAAA==
+        H4sIAAAAAAAC/21V25KiSBB9768wfHV3QQTBeeMmqICIIMjGRgdICaUFhVCIMjH/vmhPz3T3Lg9c
+        Mk9mnjpEnPz+MhgMD1GRwCQioB5+G/zdRwaD78/7I4cLAgrSJ95DfbCMKvIb+3Z9//DeQ45NcSAQ
+        F3KE0Kfin/kiykEfH76+5rCK6gMuwesRV3lECEhecUPKhrwSjNHr6/CPr8VRldb/0/TJLH2egmPZ
+        r1WPbBMjeIgevF7vIKp6IEPT0/9BEkjQk58JaxLjqvg2cDMwmMMiQgM1L2EF/kPrQawhGX60HUpV
+        LyouBtv+AaoaF8Mv6B+fvn98bjbs2zRpRrYwLSLSVE8qcslqYqITmM921ZhlSjQxp1HsXONgfPEV
+        9dSBTtjwXCYLuTqdYHWqIEPtJB/TbJhEHFb2SbhbEZFqKT+Ym9fx6ULt8ejewotHuuR+u1twXWee
+        hGG8OV3PundonCa1S0O5WvdIDYw96qRtJYdht6xga8he3tkA3LWlwndTQpvMfl0zbAq2AAkW7gy0
+        kFjegauN45vN/hAvjxMzTWhz6qym5Q54ksZyq4K/BtLuyk1KbFf23thbuREzLujoa4OsLJkoIj7V
+        +eEa6hmzF497wQV2C5GxAtoymOI7d8f8qquCIDmRbcHt2A0+nTRKXjK8UmmVaVZct2okhVrTS51m
+        ksSVYYyIJa9Lwyiz6ZZ4F6EZ2XfNmh+lcdeK3CjcTs2TODHGeWmyS268jnm5nHj+ODDoYjmptXnh
+        dbqqLMTLOPHHXsOE4/wA1kFsqY7sMlq4SXVkzlKtHckuVY4cip6xIt//tibEyzIXJm5+m88qibIs
+        PGkPM2Zj4SWs6HIx36NjeDhup92uK72WjW8CWCt8qUPpMmMdjp1uxi7mm1ms51yIMqTvaM4PXfeW
+        hJe1hba6zHvTwAkLNmzizUWxV1qOWa/MRnljdflFWFX89oSwqtvgwviUaZd+uVMXR+ZkVizmO6Jd
+        JKqVyLy+SZnsLSkto/gEec3ZqAuIF952o2moHfsbO2j3pn+fBEiyASWt7027OV7rgFf0RJ9HbgsY
+        I7KFm0rdVAVNL+dzyxYW6652p/QkZmfmQnFgJHO5SGXEdsWFb3NXt515Z9YxKn8be5XCbdzMgeq6
+        Clwk6mdDtyitnSfSBhgp7I73EdFNPYjrxZ5KHM2LFmQ0bthAksu90MR6Fd/ahp4p09VOFNb1KF3W
+        aVzuzbC41YYmJfIh3EIWdCHKj4eZPd43XDGfh7POM5fMKLXvJKfulh0umPOBDQpfRyOYzPTcDg7C
+        xsWnG4SK1Ak3XitPTu1PRfdG5lYmnTjcQB64S8nxcdMYqqdydJUh+noVKSYS11VLESCy5TLWLjMn
+        OgYgyJJiVPlMq6nGZr5dC0eyaDxbSNirE3kMKsj43FFYCUDTOQos1uv7CC9pRhfpDSN4J+e8G4Vp
+        Kmof3ea30/zz22WGFX4zuBwnAL3Df9nQ8AgLWGcOiB7W1cO27tr+5XhD2JvarQ/TL+8Dnq2HTd37
+        rwlI1G+T6JdDD8sK5yVx8RkUMm6e24SZCm/dPmyfTwB29jNPMInQlxT/x38a10o/FqKPa+nDxupP
+        GSFI7o+juGrgfjDvfsBnXu9avHyQ7N2QP3McCw8BnqK96bjrrR6+CZaCvJfwT+Yv7s8jiursOXFY
+        gbrERQ0WyQNjMboXWZPZSujmF1LbNNHcWmyHLz9e/gXepYJnmQcAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -199,11 +160,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:56:08 GMT
+      - Wed, 24 Sep 2025 21:23:03 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1852
+      - gfet4t7; dur=2049
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_async_stream.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -37,11 +37,11 @@ interactions:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
         {\"name\": \"get_book_info\",\"args\": {\"isbn\": \"0-7653-1178-X\"}},\"thoughtSignature\":
-        \"CiQB0e2Kb8LJ4DZGHO9qMjvYB6Zobyn+T01tAiRTSQSmK6qg+Q0KbQHR7Ypvvb4Na8ZX+GKF7TubTnyKPIyDdIaC4SKfNeqYObWU9clX0AgKcPWhmwPSSc9LLAQ2sw0YFFWq9fcQ2e1nF5/HMQu0rsZe2CvrtOe/h06GnpfotPazL0KlcQgw3FwLJ2lwj9ZBlIQkfBcK9gEB0e2Kb52e6sRKQ4EULLA2xDKI/bOkBj1fO0K1FQxHCIYorsxQqysDnCh2Wlw/dFCJ5cCSVqS5VMwg1tKDbT79NwwZiqnujHe4HfhGKDr+91N3zMXkTltV94J+eiUgC/bbLpcWP63/M5XPao/z3YjdC/strCoYvGOOpOMPCgLsEg4o82Wbmv8vRx1lc3QUO4pQvk372ujiZ72LatPqUaomkkzZ8PRQ/za8NiKY4WW3l1djN5cjB81qAOODGiWSOWTuZJ5EGOMCHpiD0CeMEe8jAfPA1U/+X7fTDXOUNVhzxdjujJSDwKEo/pUT0aHJIWzMilhOSp0KxQEB0e2Kb8G+Sb51dE31oXu3Fh1BdYDgaO7n2YJYn56n7TMTMd3fqn3utN8ppSETyWH6ihXdge1sDDNY2t4N3/9/lArhxNg563F1SYoBH4NqQfonU6SEx6nx8MkU2fg1CwiAbyBIu08ldLQ/VbmVIg1e0v71qpe2QwrBTBPjSXDkggFCF0LQz6HvUFKP2QTLf/wXymBXIYkyUn+wwlYBLLM4xmPbtdppqwkE+iz90vX9yvay60xhPZoWHkWlILmfaUCVaPkuBgriAQHR7YpvUs4H3EurJE7NU4U9ymElgxZpvm8scP0fnTZETAtXg6/N8lSmaN+yPJf37h4MPqc0mm0vZKypBpsEUxfZk7Xice77JfOw5xLkjw4QCEnSWINXuZOLqsQxlcDtI3lEWuAp0bEIdkB49f9Npgnb0iF/GDasARpqxZLmr40u2R9nzxM2slyuNye5AP54ugYglvB+q1hpqI3p7GKtv38u0nxTkjOeCtkVTZAHRdXVA3Nxv5wFlNrL6nLtYe6c0MoEEBp4jm6+h9D1SLSHifkft1UJT01in1t5X9U6WGbuCOoK8gEB0e2Kb8DpiVILx9/L9iQKA7CBnfBBjm58cTvT4mBzbF7DrVUQNnm178G1gE1zPVlYiKyUOXO9H6iGTWv88ty0nRiCvbp2+NcWlbJRRj4WdX5FE4/V59frwpyQP87M9orPycoYGEUW9b7QtYtgQhnp0pRS+fExA8G4w7HMO/wRor+dZUbIs27sZ0GlWncJtM2zK4FR81kVXrKkJudbp9cdxQ19DyB2e3oL50hGO4u/6CIQffW8mwnCoRv4FWgQi1Pud1Itx7ZO8tNflmiyX7E3bgbSciXI3vGmwijkMPxxiFo9TlbJ8NWPmPqOFsgEoPRA/QrUAQHR7Ypv+o/uIiT5qLJd/Vjnp+d5Ay5pkUegrUgEXid0XKIDBEeTm5LNhY0O3H2oLsRv9fTJfAz4zAJo1a44blrEZb1hs9jNst2E1WSzso1e0cOvDoVNZE87243O95NmAqv8uUnymLQvPnvdsj+ENebxR4SgmUqBt9xxi7QwN9KX5QJe6/4dKRstsCac6JmdNlzLcwatIsnc/cMRfMOTGwRiiAPgAaht2UNU3d2hozBq/KfSPwjxQw2fCtk9+zy9SBYZQGFzCtwvVjjwWKkwMEq3PnxvCq8BAdHtim/DBgLyrr49KG3+Pr5+ScdwR7m/6t8MArwju6yhWZaKwOP99XJkI75s4jc+Sno7JbdX/40oQgy9btxvDS23Th38aAZ5Y2e5uJKHJDUZBoACq6hq5J+FGZfuvCIfDEws8bzc/MTQSP2ntPCuTlHo8IoXHFwk3ZNq1obMhzCVVvowuD0UwYNCq8T3jJuS2t9LQFu3OrLxU4xvTjC2l5ao1zJOuZR9reVlKNfeNgrWAQHR7YpvaYCcfxZwiefLaVqiBI6MCjNILtq5GeX1huWtdn5OfDaAMDJVMVdoDGMmIZWO4qXfEQoi3Hc6Ksw3s9hLuoOGUPR8ojZoNaPO9m/htWvBlGsqpHMmnnJ8dX6pQFTHjcP0yHSDmYPVdB6lX7hyA1Znzg+bakK1bTrcRsQw1Va3mEtsrO6rMct6I9clcuWZcHgu7Gd5K3VOMeiRdWMpyYDc+QB37eEFomCDvX6wr10J1Tzbv8fO6DJ+c65K1yfs0n5kEJLS+xRnKO1XLJ9dB0Lm2SkK6gEB0e2Kb1Di/f9GUPEn+5zDJCowF1Brs9X4ti/EbrMLsZZV74Wqe7iVhHnh6CVepf7SwBezmaKN3i1CNjux+5ABmJwvzbJ3GYeJvP9Un/JEpRZmWbpk8pTVJOGh4fl9T3+sPSR7tM368jSeCw/4jXdhZQtCjYvt0k/iI03n2UQDIKyWYVPRMai8W89k4HhKWmjFf0v40nR5HPr1Es8M19eFXwUXmcB84lNFaeTLVFUSW80OpL5WO9RtL9M0Uyz+BHJkUxYbzKOOb/fsRB2uzHWnzZtSWgSBNqs9W4uzAc7knv3rj/iFNYoBFg8K3QEB0e2Kb9Bgq/mdZBJkuu1d9GKXvOd2Odks++cQCWIVsUa2LKWsC0y4TaDd6QrhBfV7jJmkVaGGFU8ifHxO/d+0TzGQBn+3W2fhiEdSHBCqgUtNl7FEfPETWiFn8e9Hdb+W53jhAc2npuwoPMtMaVYtZog5FOF83i3UI3StbJAB8DjyFK19CK6clCX5JbnV36aCkS8e9U7jGWWQaCieaxVsaeMVfPJHwRm/jDhBLLvjzY9LBISu/GgvnwFShndUQZ62xco6WjW6yuDnkBdZhqliEOGMh+O/vMYR/8XuCwqcAgHR7YpvJ2N24at5BjPLK/KwSVMXF7vNX0NIS601UoQrGQu+bDytB3C+kDKfJXWtZvCM1FRwLxbdbKzCZxhnkQSHMIg+AlJRK3SJUasGWnYLok6g33n4RJ28U5ue45l4RSNWXCeQPiCuTT+Mt5lroBWd8wXB4dBgC2jvrw8tLv+uTyrGrigx5zqA8A0IzzMKm0enjj5AEHepZBX7N69Xk9MvcOg/OV7eMI7hVGNhocaysdJLMhvuOXcm7yCnZyANypxgml7avRaWCUX6sIYj0JQs8Vr12hklYNMibqf4nmQWhpFEKyPpA6DG6bm81v4UDDtvSqJpUnG4IR7yQykRNxXQ5BhiAG239B9SqsR/DbRy3aQQbDmi9wI9rricCoACAdHtim9guurFyw3jO4umEgQXPYC6WkGbcciXmz+uHP0m4Bb7Zw3tJj0G9NXOHNuuiGNU3YzPb00FdyV+zre0f0+xMaZ0Gw5gEUHjyAhrZmCE7tquuRymM5VDA+IeSp8256+N1hV8GH0M8hfYTasKj0I/OGR7pPyiMLtOmkvt7vaMRDAyzKm4MGSISw/2wBZ8iCjpwk6CXqUo5pY6Wu39c+K+arL9o++7Fsp3215vKqOHwGkRc5w5UClU+JHZ7T0EuCQZk3wb2dxDvjto21riEgF65dPfQdFl6z/WeMfb1dPZt7jTr5zOxU7I11dxgSUoJ+uO+kVHLXtUvFV+IsrW3gqCAgHR7YpvXWcjzJUAqEZ6mK3eeV6O8lFesKb1rAsFHh9O3OM33pQ0x1jbLmf5jduCg7g1f1fWkDt02YODLlLLbcgsgT/y/PKP0FDa53Hp9Ez5AdH/ACKxAcMtI34eH3vKkDWdBSDiB1huj42lYEBkBMK9s6EcSIlW2UZfs4W3mNlZsP0OL6V6Wh9SSyNPUJJAOMyJdfh/loYe3iRCP3SGoVQKWllVMxIvjQIujjZRYBgITiVIi/D5KwtqxbzpIZNq00gCXmY5FjdeywQR5bA9CPLOB5V2QygQb9Vd+bonQpzL2fiV7PMClHmovi45xSQuRPBfqvsrp8Nhh4mT8fOITNjsOwr7AQHR7YpvViqMrri0huIMlQU3kVkDLIc+maMuIeDryY/E4abvHTplNPCjqHgGNCXKrQAvvvbO5DSxVDkKgkbq8jA/r2Sf0FFXS2H4W500tIEPbg0tIv/CzBAHwPrwmyfPNOlQldUZUjSo5OtsJzWJ1tB2cYNSkCC3+yhO6/9+orYJKdcLyLDDkqNgU0SeO8ja+W2nKWRMfHBmS9bWYqEqGrocIpzKGQOEdfQVeplt7OGqEEsS+vWgEE8W22u9ZgyURYAA/t3LYSexZfgj1FCFFyEDwd6iTe1gvLzTXxpQ6ZsXwmgwHcIMtcONCyk5KwgiyqsAsl47iDr2VXlcCpQCAdHtim/VZ5ktE7iE0IeUoJqSUKZDR2Zl74gxq35D44t37m64Xv06PVcihnAJe+wDI93NZd7XmUIE3w8peid95ggln19Wjhfj7g1gt36inDAQJuJLreZ8k2d+7fndsV8minZK04feDbqfahBcBZjHJmDPfhSX24//r0OmVVU1PSfrIcn/DLpO7lLaW4m8MhNy1jdreBT1B0HKAbnTVPoaZ60Xl62ch9JThj9Hy8+Yst8K2++U7h+ZElJXgeZVvC00QJ72HWT/nksMzbW3D+Bo+KI0oTao15yS9Xvc4TocdWT3kNNW869zoGJWjS4vHyOdhbR5UWzh1bVwkomRw8GATB+XHazXjQu+cvpIutAuu6Y49B1ECr8BAdHtim+v6gdPQHnXMil1PNb1k3Qzwo04LHIFrBkoLL4csYjac7vduFHBEaGtJfOT4Cc4YZTg5i+AvUZ6qYixb7OAO6E9yrqhnMhbHVrak38csUO82pGi5hCveY8CXvphoNYrRtfZjFSOeoan9fNLTG0P0FwWhhzXzfU2lXI9UHxbj/x5Mkn3sdlsX1DXQxijxH+C+ZCrHI31Kgenxk0ZB3Sq7jkZE6Ht9d5meyNh8QU0otSuA9zGkxvt3v5uW3MK0gEB0e2Kb993TzAprN5IiiZZFseuBH9g84owqAkPXaO5ldhJwxW19JfGEeN6aOmpyhvAmvg8M367Vp4iAfSmYNl3GIPRU91MhOuBt+HMgyY/vWfnom4md8ET5Ol0LGuRjn8gGez+EMvk6buOU6l1kfGN7WwySTOvr8cz+hx8LixlJwtwrdXD2wCkwLI2KLdbESh3sLqjj5ENPruBdM63fB7EepcJNvTwno1wq4ME9ahsXoYyG4kz/IU6Kq05tBKl3dy/D2tEudJ+roVIhxyhERg6oDAK6wEB0e2Kb2fp6/J1mOEK1TEvOPiJ/HmRL4/PGnlzDDsK949WbeimpmYmJc85wpjHLmmnxlHlC8fq5TA9wSDeZeHkVm0/FcQwRXzhyU51Mloi1Re0FO2gwTXxnWF3XbQbPoUf4eAgvDByFX7O6yCKhQ8hNxyyaYL7FWE6LWtSPM+09b/zmCy9zXk0eYdPMhA3yGJNUSp6unCs2+2zpXql5mzy4huUkZIvs3bK+kFryhxuYglLc0PTqIJy54aXc/Dq96T7MyCJMrMbeUCleurl2wvXXKQjGDons4FAytQwWplRerC9vQPSnemNMiXzCuwBAdHtim8X8vgp4djJbuPkAwgIQSovwLrgMREkW7oZUyJUxKyZM41oLNsLbuh1NmdVCNqHw/swqpn0D3NYNRJ05JljXASDl7+EAlNuvroXg5gwUars8I89m9jOTix7fxdHN1QEhFldfLHKtUzqbQXArryZcIVfKfP5GRm7n9PPcok0sy9FHoD0xElucLF7B7gYa8eaBdK80mI/B/lPG/koV0WwA5iJATuE4qIWqMAfLEJoINQ3G4Xl0+bGl6XhJRooelGEFhQmXXydGv+BDOP/sCpJoIKoKBHFUXXvHwMT+FdZ42T7I1eycclUyOAK7wEB0e2KbzX3ceIEhrcPFtozGMZa/p+DFynFCmEUrufkQNSotTr5VhI1m4F4DA9pbssUDzDacscD1HsG3hsL+9A6ArRKfoGEW4gti8Z6g2g8LLujTEc5x886opBW3isHVD3oUEDiTfxuHtzO2fYTf2f7KyUsu+oyHRdFnJKZA0uK4aPJFrwIObrfQJ42EsrLFK9FMVNqgpJNowB1n/HCQW4uYKSofG4iaZ3jN03P7TjpUSmrBLUi9o/Nqk/MsQBPOuF891iQuQGCs3fuK25P4J3w6YdGLvx2y4gAR6RqnxsVe4yCBu5/nIMgp2Gl6QD6nQrSAQHR7YpvuWSyKOZonWC4NUj3C9uxiPOQc6FRyp2UvjJtA179p9olg6XnpArdbUEaFJCjczeDmpCLXGMM1dCHSZWrHO16+Y89bVSOA3gDgRpZ1jAhbWDgdPCcIyTGY8ZqrTyu6i0U1FhfJlWbV2wf3m4VgIk1QFWvCoAbbDITiHg90hpQTfJSPqSVg4wPsd+uUI3wySuHOnO6IC9N+6RzmgvQmvMw1SnDtdAP+vwMYq7TEzuHA+VUIKi6ro1EmlsJEWvcRAi93KWzYvXGvOAL0CXAvwqMAQHR7YpvhiCMQjR+ALSB6b5O0F+dplrBiXKdMb/s36mGr2ZWXSeZQ2nN5zZvApwd+vE1XYWSwimvkkbCu4TDdO4UWC4AArTWZ1aRNPNeDn5+pW6z+ORKlSVO6yD1n2A2z5eGU/EmBdsSpYm17wlj+/mmWYzB1NtT9v/bchpNORr9UHAQyNaD47jqW32N\"}],\"role\":
+        \"CiQB0e2Kb3QQYcLjVzHGoFudR1iVLCUfcK3lDUBeoM4XQjTjYdEKeQHR7YpvGulLK5UQARhyOnuV0Menspn4KbJ4gtbGt1VLgrRyBstVEcGHiB3yMDto0SoN4Jrvnr+7rKszJWtGQo9U7SH9PYRcCBw1B8XrSO/HOlsfx1eK9BC/44LN3kJXnQmqEvhvc/sElYnrd+dJT8LGkuszcmVQExIK6gEB0e2Kb+ZIaBk7Zq/WerVmgaZ1OoFuiBKShiw38/Vd7REv3lrKZDHfwXDa9n9TrKEINYkHGM0wxiiahrNofZvWLqddd6nA4g//Rpu2iUgxuPDAPP4/Nd3uGKK38NjJguXv+OMExzT6YA8AJGyegAGorNOkPcLOc0CxfoVYGIidXAPZ8a/H9ttv9AnXPrkSFF5stG7oXXop5EPZcrrsxBk6LupLkpvE1fS3hoZgv343AYt9uEqB+j69A1oH1ndQKKLoRQipUSgdq6D6pzZ59OEIdmYjTWoCd+y8ajQix2yJWFMXbznxMKa3TNAKiAIB0e2Kb/f/fEPvAO0CwzYGIhdh7IE89DLAIxEzyTPB/eU2QlShtRyBx8T9/leKu0BfCAmmE4cff2xualQD2RVxdsNNY203xxNTNbWdEart8Sodp0oZsa5QJszdl3B9WGyvVLnUDCQc9wHpQGFC/L721CTXkgtyx0mWpJdEUm6cGJe9AE6/Hyo2ks5VHP/ckkPxnqVRTdKrjNY8iANS7BSdf4StLh3mK9udFGYCtHlUnh3gDal2WWHPL9zveN7cl71Q66/2xuJrCT9RmYljC83FpTWMJyWV+Mr2nr7rJhT7uCQ3srQSfjOWdTTDbXnmS6HNTnmHjNLudXi4PN/Y4GInPliAd0kPtAgKMwHR7Ypvv36AAnk63puFcL0OxpAtsQ+gqUhqvpM80J+tjjZ9LoI75k6ayoAUeyaaG7Gd/A==\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 1250,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 1032},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"tfHSaOqbGaTUz7IP5L77wAU\"}\r\n\r\n"
+        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 338,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 120},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"lGHUaMefDrD7qtsPqNKy2AY\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -50,11 +50,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:15:08 GMT
+      - Wed, 24 Sep 2025 21:24:37 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=8142
+      - gfet4t7; dur=1157
       Transfer-Encoding:
       - chunked
       Vary:
@@ -80,15 +80,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -97,7 +97,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -111,13 +111,13 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"author\":
-        \"Brandon Sanderson\",\"publication_year\": 2006,\"title\": \"Mistborn: The
-        Final Empire\",\"pages\": 544}},\"thoughtSignature\": \"CiQB0e2KbxEb0pu9k5033tCaoHGxBf20PLCzXetRPgQ/CxurjYgKgAEB0e2Kb1vuC7UFf+PcPIlVG2fdTDPInewcnnNjORwY1A4+Gf2zwxnoIhEuJ1E45IxUs9ic7vMlDAQdECmLe99aFANWwXtda+XaKRYBRenLxvblry4Sjnf73ehTmhHb8QWgydh0G0ccMEE0RbqhQMt7E9T9ZzvPMNjAVxbawmq7hQqYAgHR7Ypv+XHATXL+Lr1KMKdbsmkXP2dEe0pVNxTpD40joozR3GU/jPNhw2iuJcxxb8FKOHJOD73pWAzuTh2krRJxc1q6bwb+XRLp29w3PbE/uu2XAX1JN7WzrLFSLTAefBkvJq5EEJ63GWJGsADhpyyoqItGZWjF+jWYHB46NCptrq22H7BJIynJsT7UIVFR4joI/esG1aqsXguH3s1jmqMtFNaT7ZemH321P+806n63tlVCPaSmlHFamHe7O56+I85zsHkcTROy61FMX71FNJIhll6Zlzi0GjlP1LR7KmyaMymFRxJwh3yWz0oGd3ssiCgDqB6I6K3GQbmTS0qtExzA9ltANV49WcNFgAYUS9qcq6UlFx57wawK8gEB0e2Kb6Tp0mmCgGbVZ6fHCykyjTZvAzFtLHJR9VuXgOWPkrxe0WwASwCMMm5BJRi8tQZs3p8pB+gXeLhP54LcFAvR3sy2+HcfLKjda//kddNxVY4DHnruZ0P6mQFP0m7eD8epswxcyAO0tMhIh0RU1PV4q5F59F8m4Avp4wDQxzyMh3oDL8d89g4RqfN0u10gSST0Uc1RhwSuuKq8U6QgdVU1l2soTrQWDi6g0WrZXq9GGhzKmWpyhLKslcuIwi37vUz5PRezixzqSsLxX2C1egsGzBnqS+SdMYouZMs5oel92m1WzR3Jy3zr3ZM1j/9hzwr1AQHR7YpvY+QFSXIE+B+x8vwYL5+hLDX7rbaQuSgLa4/pNEeg/e9Wz58rTN+4yAiPhXV+/eKY20IVLv5KbY3zqIwR2ELExDYeloTMpO+TyjwTxsChm8rfMOeg45b4NtSI2tUO9v2d7tASUlqa5YUS7oH2PVxuBoY/U0m24H7eT6ZZ3nJaheNOyb/iQQgkGv3R8ilR0ljR2v/gTBMKC96c3Jxg2Slj1uyBnCLBBPyoRhzTEchJ+d5j6eT48KCq2HwOjN4G3BitreJ7BlLaoqFQEJ6OgDRvd8OQkU3r4wxZbLaumMYAShSL7D4E5BOkWnI3kkCd+Loe\"}],\"role\":
+        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"publication_year\":
+        2006,\"author\": \"Brandon Sanderson\",\"pages\": 544,\"title\": \"Mistborn:
+        The Final Empire\"}},\"thoughtSignature\": \"CiQB0e2Kb6QklIPGPiWemixoI19eIGIjxQHBokRZ+JdpCcQAQpQKcgHR7Ypv7Xd/ok7bYJgmsuO3YoSOBXO0R4sRWD//xnv3k1RE4nDf4T8aKNc1lkaTYN0ZNlZxvfQ5jtz+b16As798XD3aY6DkPc1noqjTO0TTIKH3NCoe3LXeQHZuWCJyuG9+QmbyGn/ieEmMTOdCpOXwuwrdAQHR7Ypv6jdSUw+zWxS8+zFjDS7WuY69uZkLe9K/EOP5URZ8dQ5jK+BKn3RV7Xm93bSCBKjlIg4+8aE1fLiR0Dkoyr0C2kqKCKw1Wzk84M9CRYNtmYVJhjZWOw9df9uy8ZSa1hlBUGliMwGUyv846yeht7nzlvQbbM+JbvKvfZvBhjnE0uQ09RUJVHENKuYFRYYPhku9sx6nC1XeWpZZO/RnxLIuRDk5LnsuNRdYHxkEX/DQtAiyhkxHsVJt0wjNoLoXmQqbaruJrprXLqeen36KFk4h4m1lbEq/xo5HCrUBAdHtim+g4JBkD65UToMmkSf3eidN/EjeFOUrUAAAjtbJ1/rQePj37zZ0+y4OBHkUhqmt0ZuUBiAndKI1wPk1yBePMWJdks1Zr0GZ5B9LLjgA3TRsRb2wZNZaw3yahx+5Bvg0hjxuREU6SOGc3PZR3rs+mVW1+1h72uxTbX90w8+SpbmJXPpsuZcsUZ5xDcZuZ1Yo9WOmJVN2pe3Pr1s0I1GovbGEZvzP69AUNJb/RmP7HFstxgrMAQHR7YpvvKWHv+1Tc32GjIXZgv/xcBXRRzFZR2VFhtxLyF4NfbjjsXnuvcOKS7FFz/JQ09Uz41zuXN3v5J9xjc8LsQ6fY6InkbVxZ1c3aniI7QCaQDZmwLSOBs5LlLpXCbfsfWna4+b7rEn4potGfus5yue5tRxiK+f4bnQgo5sOKbKz1DvDYwe39hVwf12eYVn6PgH4elni0ADBQPfuqPvKH53lceeryICdPCNJl+L1w49ykZxYYicbwr863KpoZor2qVcLPAaJxBvAYQqQAQHR7Ypv4cFVPCOmWXIkrPdBuHyAwaoyTuByuQ9iDlLw/lgP7hP2Kpwk94eAgJvb43Anb5boak1nZh4/20OX5F1uqqpWrvYO6htrCWNYuvdeVIqWTCgFOR0y316kxtQV2F4BbgNppJ7XWahnzgPVcso6LZtS3dPvZfLYDEokfD9fThlY6CbUHPcXhA5Z6Es9fQqNAgHR7Ypvon24REQm4UyX3dqO4t8umdlNqtj3bv7ZrmxPmnVVI8tLqhbgtN+RJZ2WyaSVvYMvum3U14w60/a2PLY6HPvO7r/9MMuISdPE35pbyRaG5r38V9AbFMf0XBOCXuy9SXmaqWwFu1cde9L0xtWaoJnaGkBhAUNMlPHkjCDi6zb4rt/fCVBWASq103lTA6YZIDPDdR3XIRiglr4SDsral+c5d9eP2ZE/j3a7GAVbQ2WUeGPD4HVpsBBQdXvjDNxVUcpiFaZPjGkQlfPigYOAa5G6Z9BE0DSGqsI/JqCBXY9sYRFDN8A3X3MH77BDwXcKGSNmvhKLE/JaYZRGeG9DA2PuK5vpcmRahZAbCmMB0e2Kb97As5/5A0pOfdFCQb6Or0tlDq8Kov6ACPnRdZD87pRlICJr11QI4o8Fy73DML3gv4BAUuve8jZd0frBzadm9rVFpAJNdnWmO3jABfOXOGTzofesb2kly5dyWcMCrr0=\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 485,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 168},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"vfHSaLSyJIvVz7IP9LaCyAw\"}\r\n\r\n"
+        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 594,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 277},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"lWHUaK2BGoSlmtkPpN6P8QI\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -126,11 +126,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:15:11 GMT
+      - Wed, 24 Sep 2025 21:24:39 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2196
+      - gfet4t7; dur=2297
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_stream.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -37,11 +37,11 @@ interactions:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
         {\"name\": \"get_book_info\",\"args\": {\"isbn\": \"0-7653-1178-X\"}},\"thoughtSignature\":
-        \"CiQB0e2KbwKDxo4oNUyXvBm/wGfAlBXhDr0fo9tlmJx4+BMsFGYKfwHR7YpvEhEbPYvZGuPm03Yh/KO8N0dZhdhpl3u92gTfQi6nDIE+Am1Be6ygp0wfAfRYCdUkG6zvD022BX8RQS6IEtqZftk5vXIMoIfb0GhpKhJvTdygY+0qlMO0ep2XY+q6EEBP8dN1VeE1EdLqBuWQMpXN56D4C+ihL9o7oyUK2gEB0e2Kb5Npfiqwya4t4Sy3YQWadg0dSn1UKqIM0SaXwIAu5y62PS7xN4meXhlgTs3u9ZXk5KQVuxFz15mwzJ98diHdVqUktS060w+NyNlNAZmXTmkNQLS6ku4IJ9NSY6S12kpbhcaUXiC0ZpDgf7VhDP1GN2QIPjqiQfuZWLPVXrf4hoWLv9NLbc9FQ72oqn/T6GH7We0yYLoI22pG+MC7oJO9IbiPxVRvawQ+Ip/nxe8qkPkBKGJGF6KchI2oEo3QAKz+yE/vEmAWmIDmiVxjWTfssM8K8/kcwQryAQHR7YpvflCHUKDnaSGw904dDAPDEKaHQvuCG2/cVDBHG80vnXIci25M2bYf2VCXj3dtqiSwmZjS5+4SA7E5IZT1O2qx8jjejIg5Wyqw9db1QeI0mlXiLYuEY0NwfSNp86sTRDZz4j8s9EUd7YGw4JBh90X1p+QTb6eSr3t/Sw1Ni99yKfXrPUxMUCE7E1iRzgLT3lOegf2CgA1xcEFhKlvALmNFw1YnnU0aBSqcg9veIvtuN4c3D22EdmbuPifIwouA8iYzfXx7F0/AXE3GVQY0e1tQV2cdYsfTIZrCj78wARQ6v2843wZxWuqJfWgVDjdSCqwBAdHtim/hN0jZ00MSmmqjnNaX0vuxVGECjvFomw6CmRtwGCQ6e6y5zvjrRKsCo/ydSe32FSrln74FDeKq9BXLBR9uIdxXOlZeGnwZgLuXe5d++UfkXyALg50M9y76usuf34IncoZpSXzcdLW+sZkSbtkaxvBJaQ+43DmXXHO7IKLJ07AnXaoh1Ud+ZG97NHW1pmCJjnb3NfGweGPbN59JMU11ZD6Qwi0L6cuOkQoiAdHtim/r/w1zhtKIOCeo1O6fxp+mipIrqQzGwTdYCj8v5w==\"}],\"role\":
+        \"CiQB0e2Kb2MWu/bjn1FXQXrkz2iK2i9R4BLCOwRGe0dBAe6V+EMKeQHR7YpvIHi3Fz6ICHzvBudWFAtQ9wnR+83tN5G2ZPuu4O2I3lA5UEbftgKPusie7I/yJLIAPA6VolI+qGyBWwUe4jCiq487Xsb+3U7/6sFYL6sxpCpSS0rNVZOogQ64per0Li+0YutJYpHvdjJdwi8Qzxv7H/OiFSYK5gEB0e2Kb5oE5Qs6qWB0gvP+ybiDpoLNrkm7UYKmzHktMAqTJQx2jAiJsHoZAvgpVLA41QGAmZchFrjXg4ZEzmddIWEYDN9KSZcEjvW0lkFKvpwLQIGY7ct4t45Pp8ghepnCsaWrjpHlj4LDKVvN6glyp29SWtLXjNp79MOh6Trwfe8smBLrmEmvVSv4WszNSgYWRO9/HMQ1P6RbMZc9+/k7yR3uwcpD8o/qHR5mkOdj1W9KZgYY85/bNU/BwA1aoo+a+qeu7M3VZJfGTC/LhosZWn2pDQp6EAR0gNreo6/VKmH5m6nu0wrWAQHR7YpvAX6Eyo+/sZlzPf/kGbHkg0kGAGKrxCdmixLsbLboWuDbdqFySxxRPddeZHftDZAj7A6yMxfLijlZiluDHdCEHcGLB5xS193tQMkCxgb5YEnDs13JVM0weGsCcw/2bPr37FSXYrr+OcWN5ZZGr1k7Z2ifPg8Wr/IsDDdUi06/huZfLqYuCK5Wp+nXmfDczeBlB1C630SVZyLI3Eo7lkpaj8cin/jbK/XUMOIYtQhRHb6FHZM/0URDuvb47lHQ0Xp2SevHmRF657/okRoYIXRR3qA=\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 386,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 168},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"kfHSaNKiBrXUz7IP08ah6Qg\"}\r\n\r\n"
+        189,\"candidatesTokenCount\": 29,\"totalTokenCount\": 326,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 189}],\"thoughtsTokenCount\": 108},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"UWHUaJX6Cf66qtsPwIHz0QY\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -50,11 +50,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:14:26 GMT
+      - Wed, 24 Sep 2025 21:23:29 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1511
+      - gfet4t7; dur=957
       Transfer-Encoding:
       - chunked
       Vary:
@@ -80,15 +80,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -97,7 +97,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -111,13 +111,13 @@ interactions:
   response:
     body:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"functionCall\":
-        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"pages\": 544,\"author\":
-        \"Brandon Sanderson\",\"title\": \"Mistborn: The Final Empire\",\"publication_year\":
-        2006}},\"thoughtSignature\": \"CiQB0e2Kb2JoPfNfR0XOBOYfhPKNfusdCz+susZ3r2fHtooWCRsKgwEB0e2Kb7wgtr/hOvmrBAQYwy5QhjweBSUf+2cGXmbLrPAlTrsujGYTKDjmGkbRBn9K4ouk7I0iYenOHkAXSmooS5iwntM0W95MVVS6yE3Mc2Obh1XK5rGfJgH6+utJvDSwmTIIG/l3jg1Ngm8TWDFchAy53LxXzr/aQYtd9F6dr7097grVAQHR7YpvD3rI414aYbdvIZIxnyMmrduIQXwoxSumPh5AD6GkldPtaEKk8wk9kXiM6eWVwGmwSK81AXz/ai9l8vGZU+71AzZHe2wFemFYPp4AojV5RirpVMAf80wtRAaP13vp+BCKKr+WjaZMc1VT9pGjP1z0MMzjtss5R4DoESEyrN7eA/ilMDOPmJ0m62emQRJj3nYpUTaR5PcHBEmd9yVi9KHFbd/VU3uORQdYmVayZeeqzZyEhEKMT2hqo7goEUfzGUq34uNQOcJbcIibcHNDpTSnswqUAgHR7Ypv68IctO0XdYuRLFjYNCKVY6iL7IuOxIq9PB96ZBIstjHTbHBKNyrmtfold1dMgdPVJCoXqEdFuV0GM+MF+yytwwGuWER+b2BhFfkWle9TVfyx1ktT/m6DKCks5HJYdrlz7pmeDuvsV6PQrNqY841OwijFhOtTK8R1A/GCif1dsRQt87PooBB+KFv+iu1KjCYaHrgm2hgiQLPmLedltlXqf6/r3S3nkjEFXesajgMZCWGwAOnSCBXzHo60gI7ybjejDNXuu6SNe4XCSgJymr7B5sjnbMWyfMki5vwCLviVBDld9ID156tSww9F2c7sp2pViUJzdJlFS5tBm18KHigytM+kKIAasDfbHD2MAAnUKwqGAgHR7YpvHPh5zVbll79SJy4XtLsfnQWMU0pApEkYQ3Qut9UesVAhr+4UoWrVYw5d4HYgjoz5rctZrMwiAVXg8pGmpt8wFVIkmbZtX1BTIYxiA8ttHUbCBBu+1xb0KX+ucI8NBq/zq2zwCAaOMP1cNAw5/H3Ani6JseePgzA/AdgmtMWofwZMSSkAR26r336ciqL6Lx0ltFkLTblBBHFFdHQWrAc/v9LzMSfhrQ0HQrLmObWw0Atw2R2dab2M/vmL2PRTs7l/0CBTTSBmHBoUg+V4yn/GzaYM4dLa7pjdejAFYujWodHQTZaj9ABcckwKq9VBxPgh27RUJcNx73znDJG1dYM0cmoKJwHR7YpvzUSDkO60sIGE+N3GVomE0FjVbj+RT427J3DLzKtTlMuv3g==\"}],\"role\":
+        {\"name\": \"__mirascope_formatted_output_tool__\",\"args\": {\"pages\": 544,\"title\":
+        \"Mistborn: The Final Empire\",\"publication_year\": 2006,\"author\": \"Brandon
+        Sanderson\"}},\"thoughtSignature\": \"CiQB0e2Kb3fA8Usdh3Dmnj5ltydFMciM2i0khKuScX2Aqi6YTccKdAHR7YpvOc39VGGmTj5tt7zi5pbvwG1SyRsQyybvy3HzvEObteeIIDRbL95icIJdpZ0/XrBmORBuljK2bMfeUl9TnOgR35vQIC3PHFk/MBe4hVRRBwVLoRPOqmS+ui5VjwqXP8Nui3A2H191QjLuYediYrNrCt4BAdHtim8DbR46udqLc7qkMMA9RXpecKYUHKVNC1SRlP3fFtznr/aEThN7cSG1KkBaEmveCdMG0U4cQAnY/msoK+NI6e7x+thP/2y5by+lLffbT8vJG22s56R9Vv4wSu0Pvp4TsIclFA05GG+J9z7fxNpEadre2qfUWObZQt9q7PcDEARIrzIoDC2nAg8ezCUAAF9yMJv6p3ZQAMmgz16KjMnNRZwJ+AQIxKdGeKxiPxkzjMD9RIhcKQeOOamRUn4CcLcoTcQtDAIoCkJZ5dAwx/EGPBGA1cmZljsRzTe6CrsBAdHtim/XcsuFB5lnSPptjJJ1q8Rz0rKPbd0yVRZdA+EjvEFWZSTzfIPLSs1wKZmEcRQ/Dt13SYIcdUZxL6WrzfbrJvJ19Fh/nm/8FazPVYj4aOnoSTFDFF912d46dMayIwm5xVeTYgnuqRnisQhWwmrmmu10U8038IUkp/YdHmdtU3TPvya0ivckCXOwvy0e1qfK/a7bXJtinvoiNeUSE8atZ3RoDCy3JaYZSmIwTBIr3AvXxynwuTIa3wq4AQHR7YpvX6d4TYkGPG0csrOh2RqUDrYeWq3fLWVt02os2Iw14WwCw4lsIa66ld6B/pABp6126x4oYEuRt/OqXxj81nDbUcMBkGJyur0Gg7o7gkSvxfVzb7ZVV3oWogvN4jBOJWwDJYltxZeRVmWax1D7oPQTak/TMrsStqv9QQaMtwOHG6VJHk2yN7MlRsliutNXfkfgEzpyInYyj4a9Uwmjb/KZ1CcBXmEbtGsmjsQOg40QFZsFxdMKqQIB0e2KbzSYsG6wUhdDUQQrZXwrree/wZZvGtUN3au6zuZHLRMnRou0aFSAzXpWNyooSVjItQig1nZqdaYsZvZU0ZnBFE1CA249aQ1x9NXv/8NRbeStno6ERFy96ENnwzyG1PR9wm1oybpebk40YKQeg/ZYPi1QX5mJMt/F2AuKxTvWXyklw82PdwwtkiEqLBVhZumrfLCJGcXu3m4SEwhT7ti1RTbRrdY/Y3pH6LpKY5wHbO/411MFrag3lPcVD1xOzSfqNHygQhiqnBz60/qYsevBaegPC04XpQeOCVm3It/A8+KY56q4B4EQ+YW1YQPGkDbCa3/aKuUlwrgVF7kXUin2kvNz/PgtBOvgo0+QL8/T1pGP05ymQszTG5xZvdJxOxYE2ZlXAa4KvAEB0e2Kb4BaEzLrqyohRDip43hCmg068eisiqQ00hpFHoTM0tnxIzL19rSo3heyoGaz17GZExuokPow1irHYi+4hY6X5/vwUu2o0iVBGI+rP3KJV9vCrtNOXaYtx1WEgS5iRCMeS7xo9r7brvLWUjPW3/uk/biEhgDscNjJxuv3hosfAZhFZeD8MXtoZG+CFhsmROQnwTiVPlqNnDwd9iYKXOohfXnz2yEedlL2inHOktrqSfIEHCTWZ9xlowqkAQHR7Ypv71akF5tvSiG17anQqaHr1UfkynAJS77IuwgIUqlM5eZNzAqqk/nO1emBq5H7NBBbeNq5+113+F/mwHdCiHzNB9LcekAkXsnCkYMMhvwhtrx05JgNgsWdj53AQcD/p0Ee8V6VM6lyiLqw/Dmj2NcHEXzw+c+OS7LDkgky8m27PaM8nj6+OFrItv6zpyh/Z8qBWd0SYP7vw0EuzQ0L04t8Ck8B0e2Kbw4ut3HEkP3q32lWyj1/om4mf60Nhrv1wZblHbkdb69kKVjor7bO+27UbjrSomKDsbB5Jxj2gv3LVw8D8at6djFFvfDS3CHa3BFn\"}],\"role\":
         \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 490,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 173},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"kvHSaLPFLt2Cz7IPqZjZwAo\"}\r\n\r\n"
+        268,\"candidatesTokenCount\": 49,\"totalTokenCount\": 640,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 268}],\"thoughtsTokenCount\": 323},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"UmHUaPbzDpGUmtkP_7fN6QI\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -126,11 +126,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 23 Sep 2025 19:14:28 GMT
+      - Wed, 24 Sep 2025 21:23:32 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2099
+      - gfet4t7; dur=2322
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/google/tool_sync.yaml
@@ -5,15 +5,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -22,7 +22,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1147'
+      - '1113'
       content-type:
       - application/json
       host:
@@ -36,26 +36,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21U25KiSBR876/o8JXplYsIbsQ+qICgiCAgl42NiRKKi9yhQHBi/n1pe3pGZ5cH
-        gjqZlacqiZPfXl5fJx7I/dgHCDaTP1//Hiuvr9/u73esyBHM0Qh8lsZiCWr0i/vxfHv4HilBm3so
-        LvI1SNOnzT/wHGRwrE9CiL6eiyL5GudBMfnyOw3UYfM/20ckbs75uwD+xsxp6o0gGPbNnvzG+/60
-        /v4sP0FR0YYR0uMwB6it7+dZ156w9EUUZ4vFSnYD4TDTKKhGBVai+Jq6bbmzCFba5YO6ZWGE03nD
-        39J169TO6XAs5hVi8SQ3OqxiQmN3uBz1wQ1qJcIKWFI9I2IEvmnUFt91W7Dnu7VlnA4rVscIJwkY
-        ydY4gcakKjxTmYHtMYs2DNveyuoZtxFGdISsGliLgRgA+RqEyF6J/oo76U5clUXVebda7juJo87i
-        WlGcGro1nkW2aIqGeV6TMjj4kpckmCcbEoQhxwozrOimaB4IMe9wGuEVBZ6fapfK97v1Tid75tp6
-        xPJ2aYiWUCvggTiYFpWT4GePb6Gndqtd7RNFf5neOEFOaE+juMVg8dvdUS4tFoT8Qs5EFROaOpnT
-        SuqJjknEugJN2EWHXXK06QPfKXmr5X46lXDRPPTXan+C7VDqM4Fl9saUnU8zhyqG2ktTFok+uxS2
-        siwE7pZb6VvFqbZmZO3dNug7w/LS2qk8ZUCldXVFzjXWIQ9NfOBJS6oqu8n5RXY9MzrdzG8UNVjk
-        Uq7aaM+5tBgVlJmL/IpnhRgzQl8oHQbNFwY2azdMWXFIYpYOQ1+OFm/W7pbVPWa59GNdT49DeYr6
-        VXlb1KG5qTRhuimj6e6YHg3PUPuojhXX8o29OKOVk+mybWbO5nZ2SATSUqw2jqSO3gVhk8S3/U5f
-        pvV01U5tzdwqmSssyVaLclXDavuknSRBzFjWmvn1cNMt7dghKuT8AGwQIy2q7Yllm40t+ywDDfpo
-        DgSBWe7NMOadFKeNQKoMv68kZ8kJMAH90aWCzXbDis4UKmSUb7G9H3klcJhT3KYrZRcKARj7dh1p
-        iIvUnM9gMSxiEl1EGXfeJbRtvWSbSEVEyiQCiPZw7iyiuFdIB88uuIJZea8breuCCGDTA7fsS3Ym
-        qE7kZB4v+GcPTTFKT+ty0R88mGt4M1y027FuuVbikKmQqzlLr2Jjdl1L7YoPrCXh/PU45b8m/J9f
-        0z2pi/Q+zVnhw/ST/nP8J0Gcx010hKAp7hmiGwf1Z/ZM4tyH/VjGXz4b3KUnbQNCuIcIjFEJfobS
-        pKyLrERGkcB8XbT3qCTYxYfaQ7Q+EchPHBUIpE8QtcC//Ee44ca24w98yNyHOB5vCdIYDe9XMXjb
-        eIjRscHzuT69eHmw7DMIn89IMOTLD9M+fDzBuok/DAthNlr4Rv5BvwUpaKJ7x0kNm7LIGyj575yT
-        KupAPu95emNmKFEr91JlGjt5+f7yL8YspY12BgAA
+        H4sIAAAAAAAC/21U25KiSBR876/o4JXpRW4iGzEPgiAXERQRZGNjopASaC4lUCjaMf8+tD09o7PL
+        A0GdzDqnKonMt6fnZ2IPqjiLAYYt8ffzP0Pl+fnt9n7HUIVhhQfgszQUj6DBv7kfz9vd90A5dNUe
+        Z6iSQVE8bP6JV6CEQ51IIP4WIZR/y6oDIr78SQNN0v7P9gHJ2qh6bzB6EcY8+0LTwuQlIP7gfX9Y
+        f39sT+AUdUmK3SypAO6a23nkRlemsYazUmQVV3oVN4YNx25T7TU5B4znL61CzJLxYiasgtbWychZ
+        eEK6tbjdEVhnQSV9i6ToRRE7lO6EMu3YFy+HV5t3zXlE21tgK4FvstfGZKmFcdJjUkZTcGQv9oEU
+        +qXu6JTSuF3Ur6oy4kJW4SF72uTGZLzJYynjokpxCqPeaqbML0Rvz8RWjVTrdY0kFlexT9qmdVmO
+        QsEFrSG4/L6B1j6X8G5HtcVO86u4sSy3FhfmWHKkOKpm4dzjpwk7/JFka0adwdchz7ySDBPKoRaU
+        fTNGrefJZkE2/VFtk/MqEHqL0VjE5TtmTueFL3Hrqd+ziqH1hjKGNuMqcSeu6pGkOpvgxOmXWKt0
+        b6lmlrrKRPGVG1FnN/UCkfTCYwCLfPVKS9tkrujUUjkpmpzuVT/wVpPAMsYuDAzFLyaT16xlJDBJ
+        Xdp3KB7LXN0KzrooxSzf+adSANQmkJYQyBlGk0aj0biydNZyOXxo9obmW2DdpcYF2Xg0vuYxWinq
+        6aIataYHPXZrmTTCsBnjfmbNWRDNivoq2AgtmHV04n2f1a+zkEbmkmtX26MuteTOqukFKZBQ7qdT
+        CUOPKrPdpkpVbpzGZ5lb2khJFrqQCs10UdbmIZuHZdr7V6rXHYSbPIErtdiczv2y9KeZP2EvRpVP
+        RFzYG9VQR3lHratTVJtGYfUsSQ1jF5m1zU6oM7kreaYB3y3Ynl/vvXJ6zmRordcNvQz3bUROdEQL
+        gpRvybrsS/Ho5YwWFjk4qcBA3ajaI25WyyZaff1675rfjvn3t1uIBhU3d5QohsUn/ZediENWZW26
+        hqBFN0+6G9v55WUiq2LYD+XR0+eAW2uia0ECLYjBED3gl8mJY4PKI96gHFYy6m7RQ0/Ej253UfVA
+        YD5xjDAoHiCW57/8p3E7G8ZmxX2G3cXbcEtQZPjyfpWNEmzuYmkY8HiuTy2e7iT7DJbHM9Ks8PRT
+        tA8dt7Bpsw/BElgOEr4wf/EvhwK06W0i0cD2iKoW6vE7Zz7XPGAxhrQbFzVunRN+4ZnVjnj6/vQD
+        tPfpEMYFAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -64,11 +62,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:13:24 GMT
+      - Wed, 24 Sep 2025 21:22:32 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1749
+      - gfet4t7; dur=1500
       Transfer-Encoding:
       - chunked
       Vary:
@@ -94,15 +92,15 @@ interactions:
       {"parts": [{"text": "Always respond to the user''s query using the __mirascope_formatted_output_tool__
       tool for structured output."}], "role": "user"}, "tools": [{"functionDeclarations":
       [{"description": "Use this tool to extract data in BookSummary format for a
-      final response.", "name": "__mirascope_formatted_output_tool__", "parametersJsonSchema":
-      {"properties": {"title": {"title": "Title", "type": "string"}, "author": {"title":
-      "Author", "type": "string"}, "pages": {"title": "Pages", "type": "integer"},
-      "publication_year": {"title": "Publication Year", "type": "integer"}}, "required":
-      ["title", "author", "pages", "publication_year"], "title": "BookSummary", "type":
-      "object"}}, {"description": "Look up book information by ISBN.", "name": "get_book_info",
-      "parameters": {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}},
-      "required": ["isbn"], "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig":
-      {"mode": "ANY"}}, "generationConfig": {}}'
+      final response.", "name": "__mirascope_formatted_output_tool__", "parameters":
+      {"properties": {"title": {"title": "Title", "type": "STRING"}, "author": {"title":
+      "Author", "type": "STRING"}, "pages": {"title": "Pages", "type": "INTEGER"},
+      "publication_year": {"title": "Publication Year", "type": "INTEGER"}}, "required":
+      ["title", "author", "pages", "publication_year"], "type": "OBJECT"}}, {"description":
+      "Look up book information by ISBN.", "name": "get_book_info", "parameters":
+      {"properties": {"isbn": {"title": "Isbn", "type": "STRING"}}, "required": ["isbn"],
+      "type": "OBJECT"}}]}], "toolConfig": {"functionCallingConfig": {"mode": "ANY"}},
+      "generationConfig": {}}'
     headers:
       accept:
       - '*/*'
@@ -111,7 +109,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1458'
+      - '1424'
       content-type:
       - application/json
       host:
@@ -125,29 +123,32 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/21V2ZKiSBR9r68wfHV6kE2g38SFRUGUTZ2YqEgh2SEFElk6+t+HqurqruoeHlju
-        PXc7QZ777WkymXqg8GMfYFhPv07+GS2TybfX+4sPFRgWeHS8m0bjHVT4F/bt+vbhfYQETeHhGBUr
-        kGWfgn/4C5DD0T59fs7jCtQeusPnAFU5wBj6z6jB9wY/Y4Sy5+fpX78Hgyqs/yfpa2fh6xQsw/we
-        9eJtblnsgZe+nnsIqhFIzeeL/0GCBkfoxT8Vq5EdVEzM8QGrGhV/tDPCcYyz13G0uMY3VBVfJ1YE
-        J9u4ANlkk9/jCk5/i/r+6fv756TTsXoTRtiMwwLgpnrNvUKptPRlHOcEE6vNFZxOqN8Ikhbkm0g7
-        t4/kmox8q0OYEiteZdaGjtfiVqfLtLN3t5gp95naJa6V7oX1hrgC/k6qka/sjtBWRTlpEr0ELWvy
-        D9rRJNs07YBQxeC2jwmTnWsVYtSO94RHebyVJnG+mJUbiKLokEa/j1TZSEIjWMQdL5r+ZYD+2RUZ
-        qj+y4lL0fQduE3Btt47bNMdVoBMd7vxLNr/7c5kLF9TSPmmbGuR1JjBkJDDdJoC+EXRCF0cZYW6U
-        GaAEYjfIVK8zbEcWJzc59ISL0Incnsr22CG5XW0uSOs8jVWFjefd+Lt6EuOCizR72TBmuPWJxCKo
-        ctsoZRvc4TaVnLSdlaFLehQ3s5y9UDDcZru+UmWmkOQwu0o9hAGzNKRgnyaG5HPM6bZD52qG5YSs
-        tuvj6bwA3EUB9wJCU8ahNKiSfai9nbxqGfbCmFolIjDcyAcFnQdDFezGQebDtWr3RNGMdoyNA6ih
-        tL/gS7DDA2E/AN2HN4wP0eXeBHTZ1koh6fLRhfudbOsUm/rLEwtl+bTSk2u50IpltSjrbeigtp45
-        F4Wm5rmsEj1LaxZTnh2nlYlWP3BLJsR8H3Vosc8fyNfhERJXusRXix5u+FwuZ4fkTIk5o9LCvaDa
-        yNjsuTVzDSLxQQVuEgfzmJH0PhMVNiR8TpNSyN+EU9Rd4uUDeLerzXFMxGHS2e20Tkisy3pOp+P5
-        CdZVRPc3Wk+ccssx/LrYP5Axb1PRFs5U+nCTzrgM+o3Uw3NsnO16dtaNaB6iVFEWhuYGydwHSl6x
-        6cNaGOkVRY2853gQuTw33FaFzdOdfqdAutV6uR+OhLiu9+m1s3LrEF9vnO/CYrkM7HO7MwaN108A
-        9Dsil4g9hp7gEOzQ5+4QxDYrCqzO93PJ4vyw3YnVI7ww9JCq8ml2Ztdxf2G2BwT3jZ3iVF8k+cZb
-        DqdtMb+EldX3Z1mk4xB67nqxFo6bmbL1YmPGe+Va5/jaNvLOi7zNIS1samgt8rKT2MKEj9WupZ2k
-        ihQ9UiRCWY6/+8w7mqm6J3FrLRauSmNDIAg2vc9EDqyG/nzIQzL6qCi/1OTfX0oyrdCbKuXIh9k7
-        /KfUTIO4iOvoBMGLqo0w0zoYP9VtGo96143m+dN7gdfU06YeNVaDGIwbA/xU4em9QvkdWyiFxQo1
-        rxuDWvBv2T5smE8ARvjhxwiD7JOLJcm//khcr8eycfZx9XzYSuOUIItx/zKKtTlbH4R6LPC5r3cu
-        nj5Q9i66n3skBebpB2lvPDrjFojfCAthPlL4hfqb/RJkoI5eK04rWN9RUUPFf8E4D9kEys5YCnBf
-        4tpA/OpLeNxMn74//QdMYyYBfQcAAA==
+        H4sIAAAAAAAC/21VW5OiSBN971/R4Su7qyIX3YjvgasoKKgIwhcbHcX9XlAUgkzMf1+6e3u2e3Z4
+        4JLnZJ6sjCDPt6fn55kPqiANAA7b2Z/P/58iz8/f3u6vGKxwWOEJ+AhNwRog/C/3/fr26X2iRF3l
+        4xRWAiiKL8n/4BUowyk+e3kpUwRaH9bhSwRRCTAOgxfY4brDLxjC4uVl9tvPyQDF7S+KvnbWeUXq
+        g1fll0cI0MQiFwvm5wqvNTqcwFd8xqPp/LB6vkyPELWw+o/gRMcpLt4aPqQt9iCq/nw2k/BZTitQ
+        PEtlnaLwV2k1iN+mSlPUT+D3L9/fv+bOpt66OMGXNK4A7tCbstDuFC5QcFpudGYNl6HeJFkfWJky
+        glA+u3fIH7qD6wzuyQNMq2/LWj3GmBoaUBY7U8zQlTbtc/K43nzCHgTg6zU+0fnoqyv1FoLHOICE
+        Jf3ENQ9867O8Hc9DrOsjM2Dfk/jMw40cqJ3tGoFaitE+lnOVwqxFxsQVO6h/4ATRLErhUC0fXH3X
+        hYSeZ2YxwGr0775GFU2xIpel4Rx0VM7txFT7yBrNeT3u3TtQQgae660cGTkjdkN/UcJBZ0p+0eXl
+        HvZJFNuDkp+pXoN1HhZ0a+c7WlJ2mnzckQLXr6NTiG6QYMm5mHOZMd9YS77wFjrFu26nVR7sdce5
+        +LV5gfIeXW9tzbLCaKwQvOVprnl0aLYhaDo/XBDiKPF7RfTazj8Qj2h+PpLDCAn0WBI2UoUDFqRV
+        d58b22Z1G3y/G4VD4Ug2Y1rUaldugzPHaIjiIiKvTuNlcfUGFJV9gKhqYDNCkaoBZ1yTdhR7LiPs
+        qqFN0qMWLEvHK2OOCVi+cVY3U9uw4zJU3LxL80K/+QMKV+6uT4RsFViIYfbs47p0wrtvcdkhGAxp
+        kVvTj+zKma1t5PgyRtIdqcQgNaF6PZR+W1FpNbWyxmZ7pDerGxovoW4h+rQDgR4cMiHZCZKydq1o
+        G7RrsmX30vzIzYvT0Qds6fW8EV/NI5mlJTc/3jZp5KjY0pmuh4BM73kfU3TFx8WVcPKzuFsblbW5
+        RNirzCW0jfTGXylJR+A2rzFtOXZZup5OR4GfHXK92RySrcOdCcvQThmxhKUaF3jpL1TH9VTRtxsl
+        DCzWYqBDaM2Q8s2GWIxLVS9O6SoxwssSLZ2dERzoKo+93djS9RZgtpOoAXEudbYVo7dOJ3DqC3ZI
+        7YV4s06aPRSrfWcPROchTF/T5qqdjKQ1ybQcXDHeWaiPgNgvChJEy3urntW5I0jHeiM3B5BemMCK
+        y2U0d5pCiW7LrSPyd/YuaKjJ/RMAupzaIafIVa86RbsnjgSKEiol79FNA/ROqYOzIcid1xpqwMdN
+        m14qZo/9btvu0JrRObw9XciUh1sobC3mmOer+CHPZQO6xmGFrIXAwG6Q4Dx3jy7dLiVRmu+7itzv
+        A14QmwR5u3gU6eL60JXNytbybCXJc8KmLL4/zhdR0TMrGttGRi8VGiW35MDLQuEc2COmsFjJKXEn
+        qzZNhHAg12KtYn2LAq1c6E5uKhsgsKdauvJJ4pmtcd47eKOOF7zI0A6PTVHKzV1JFxfGIZNFciab
+        yybmmqNFVhtohRJfxCtZnP6tjGM5ziMXvE0wuXoUKkVMIrfUtXusJyq7f2hDxXZh0QhFlTFD/L/Z
+        06+26F//btAZgu+7uoRBWHzQf6zYWZRWaZucQ/C66yfaxdSNH8t7lk4uMEzhxdOHwFvpWddOu/wQ
+        YjA5JfjhPrMawbLGJszDSoDdm1OSzPq92idn/UKgNv/gGGJQfIFomv7tP4VbcZJNi8+W+8mNp1OC
+        IsWP16OY0s385EOTwNe+Pmbx9GlkH2bztUdy9Up+G9r7HK3JG9P3gcVhOY3wd/IP+veoAG3ypjhD
+        YVvDqg13wStnWypXcIzWYsSMJc4NBgJMcqfZ0/envwHIuxcIdQgAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -156,11 +157,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 23 Sep 2025 19:13:26 GMT
+      - Wed, 24 Sep 2025 21:22:34 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1713
+      - gfet4t7; dur=2120
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/async.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,19 +45,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFPBjpswEL3zFdacQwU0kCzHbVVVe0mlqtsqm5VlzEDcGNuyTdVtlH+v
-        gARIdiuVA7Lm+c28eTM+BoSAKCEnwPfM88bI8MNDcpBxEW2qu32y+SSSw/YxQ2k+8+LPBhYdQxc/
-        kfsL6x3XjZHohVYDzC0yj13WeJWus3S5TuMeaHSJsqPVxodLHSZRsgyjdRhlZ+JeC44OcvIUEELI
-        sf93ElWJvyEn0eISadA5ViPk4yVCwGrZRYA5J5xnysNiArlWHlWnWrVSzgCvtaScSTkVHr7j7Dz5
-        xKSk94fv99+ix6YoouVD/FVE1ZePyd12O6s3pH4xvaCqVXz0Z4aP8fymGCGgWNNza/S00PpAhar0
-        TQJCgNm6bVD5TjwcdyBcoXaQ7yAKV1n6Pozj1Tr8sYMTXDFPwVvn55ktFqvWMfnaL6aU9qyT3Rv2
-        fEZO42ykro3VhbuhQiWUcHtqkbm+5bnzwUVILwHaq+GCsboxnnp9wL5ovDxvAky7N6FJcga99kzO
-        WNkFuMpHS/RM9NMfF44zvsdyok6Lx9pS6BkQzHp/reat3EP/QtX/k34COEfjsaTGYin4dcfTNYvd
-        0/zXtdHlXjA4tL8ER+oF2m4eJVaslcOrAffiPDa0EqpGa6zonw5UhvKiilfrNM1WEJyCvwAAAP//
-        AwBJKvU3QwQAAA==
+        H4sIAAAAAAAAAwAAAP//jFNNj5swEL3zK6w5hwqySUi47qofW2mrpodu1ayQMWPirrEt20SJovz3
+        CkiAZLdSOSBrnt/MmzfjY0AIiAJSAmxLPauMDO8f1x9Xj1F8t/7+vJ/6/NP9gW+lXO9//BRPMGkY
+        Ov+DzF9YH5iujEQvtOpgZpF6bLLGyXyZzJarVdwClS5QNrTS+HCmw2k0nYXRMowWZ+JWC4YOUvI7
+        IISQY/tvJKoC95CSaHKJVOgcLRHS/hIhYLVsIkCdE85T5WEygEwrj6pRrWopR4DXWmaMSjkU7r7j
+        6Dz4RKXM/H5XfkH+LS8fvj5UO/706zPl3Najel3qg2kF8Vqx3p8R3sfTm2KEgKJVyy3RZ7nWr5lQ
+        XN8kIASoLesKlW/Ew3EDwuVqA+kGojBZzO/COE6W4fMGTnDFPAXvnV9GtljktaPyrV9UKe1pI7s1
+        7OWMnPrZSF0aq3N3QwUulHDbzCJ1bctj54OLkFYC1FfDBWN1ZXzm9Su2RePZeRNg2L0BnU7PoNee
+        yhFrcQGu8mUFeira6fcLxyjbYjFQh8WjdSH0CAhGvb9V817urn+hyv9JPwCMofFYZMZiIdh1x8M1
+        i83T/Ne13uVWMDi0O8Ew8wJtM48COa1l92rAHZzHKuNClWiNFe3TAW4ylvM4Wc7niwSCU/AXAAD/
+        /wMAPQ7BcUMEAAA=
     headers:
       CF-RAY:
-      - 983c5d128d4fdefb-SEA
+      - 9845576ccaac7e5a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:14:11 GMT
+      - Wed, 24 Sep 2025 21:23:12 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '454'
+      - '501'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '661'
+      - '524'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,15 +105,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_a0b171dcd4c6468daab19c9af9bb51aa
+      - req_7812380a882446608d90af95bec6b38b
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_BkWBU0Vmbb04J1Si0fPD29ZZ","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_txvgIefObgDKDmvfNYHaffru","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_BkWBU0Vmbb04J1Si0fPD29ZZ"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      2006-07-25","tool_call_id":"call_txvgIefObgDKDmvfNYHaffru"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -128,8 +128,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -157,18 +157,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4ySTYvbMBCG7/4VYs5JcbxxEnxsaQ9lS1k2lEK9GEUe22pkjZDkkjTkvxcp2djp
-        B/QikJ55RzPvzClhDGQNBQPRcS96o+bvPmZ79WX/dDiunp9oi+nD9jGVh8/7n/brI8yCgnbfUfhX
-        1RtBvVHoJekLFha5x5B1sc43q3y5yRcR9FSjCrLW+PmS5lmaLefpZp6ursKOpEAHBfuWMMbYKZ6h
-        RF3jAQqWzl5fenSOtwjFLYgxsKTCC3DnpPNce5iNUJD2qGPVpxK89ApLKEr4JJ3fkdUF23bIPkjN
-        FXvfG2mxhFkJfPAd2Rj51nJdk2bPXNdoHekYYHiLroQiXy7DbdgpKXgwozoiD8IsTVfnaSUWm8Hx
-        YIQelJoArjX5qI0evFzJ+da1otZY2rnfpNBILV1XWeSOdOjQeTIQ6Tlh7CW6O9wZBsZSb3zlaY/x
-        uyy9ugvjPEf6kF2hJ8/VRHUDd/mqGj2Xyk3mA4KLDutROg6TD7WkCUgmXf9Zzd9yXzqXuv2f9CMQ
-        Ao3HujIWaynuOx7DLIZ1/1fYzeVYMDi0P6TAyku0YRI1NnxQl00Ed3Qe+6qRukVrrLysY2MqsWsW
-        602er9aQnJNfAAAA//8DAO3q4bSXAwAA
+        H4sIAAAAAAAAAwAAAP//jJJNb9swDIbv/hUCz8ngOJ/1bRsaYCu2Q1f0UheGItG2UlkUJHldV+S/
+        D3LS2NkHsIsA6eFLkS/5mjAGSkLOQDQ8iNbq6cfPt9v3Qt3Xz/P59vl2/3Rz8/Xu/tP1z9mW9jCJ
+        CtrtUYQ31TtBrdUYFJkjFg55wJh1tl5u1ovN1VXWg5Yk6iirbZguaJql2WKabqbp6iRsSAn0kLOH
+        hDHGXvszlmgk/oCcpZO3lxa95zVCfg5iDBzp+ALce+UDNwEmAxRkApq+6tcCggoaC8gL+KJ82JEz
+        ObtrkG2V4Zpdt1Y5LGBSAO9CQ66P/OC4kWTYN24kOk+mD7C8Rl9Avlws4q3baSV4NKN8QR6FWZqu
+        DuNKHFad59EI02k9AtwYCr229+DxRA7nrjXV1tHO/yaFShnlm9Ih92Rihz6QhZ4eEsYee3e7C8PA
+        OmptKAM9Yf9dlp7chWGeA51nJxgocD1SncFFvlJi4Er70XxAcNGgHKTDMHknFY1AMur6z2r+lvvY
+        uTL1/6QfgBBoA8rSOpRKXHY8hDmM6/6vsLPLfcHg0X1XAsug0MVJSKx4p4+bCP7FB2zLSpkanXXq
+        uI6VLcWumq03y+VqDckh+QUAAP//AwAAC7MglwMAAA==
     headers:
       CF-RAY:
-      - 983c5d177bfcdefb-SEA
+      - 98455770bbf27e5a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -176,7 +176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:14:12 GMT
+      - Wed, 24 Sep 2025 21:23:12 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -194,13 +194,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '677'
+      - '644'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '705'
+      - '703'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -216,7 +216,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_440d3a967a524992a86906794b6e3c45
+      - req_29d7c112518646f096670f9f68911d4e
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/async_stream.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,46 +44,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_HOQ64tNdVOJXkZB8AxQBziOL","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"nX5l"}
+      string: 'data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_4VjDex3fZhV7tIAmFdYY6u45","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"N5yy"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"CQbIQCX6yXnfy7v"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"vxxNBKJa1qlpNPi"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"huVT3gNbRALStU"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"RCIMwdXVoDNzQH"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"OC"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ax"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"d9"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2P"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Rm"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"mR"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"uS"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"b7"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"xE"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"7x"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"B"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"g"}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2nd7PrOaQ6DyXM3K4zc070e0ZRA","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"K"}
+        data: {"id":"chatcmpl-CJRGBMsruSe8gK81plQIpZF71Bem4","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"o"}
 
 
         data: [DONE]
@@ -92,13 +92,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c616bbf4eebbe-SEA
+      - 984558f93e537557-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:17:09 GMT
+      - Wed, 24 Sep 2025 21:24:15 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -116,13 +116,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '311'
+      - '315'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '337'
+      - '336'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -138,15 +138,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_4f1e5ff5dadb42f7b7372bdbd59374e2
+      - req_520f699256f34b34b6dd04ae049dee95
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_HOQ64tNdVOJXkZB8AxQBziOL","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_4VjDex3fZhV7tIAmFdYY6u45","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_HOQ64tNdVOJXkZB8AxQBziOL"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      2006-07-25","tool_call_id":"call_4VjDex3fZhV7tIAmFdYY6u45"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -161,8 +161,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -189,95 +189,95 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"AzRnvICkA5S"}
+      string: 'data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"5FbRKRkGRWU"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Xo3URzUVhq"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"FNcj7sawsO"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"SMUcxOvR"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"m4UlDKti"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"vJcHZOVe"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"NvNVs9RL"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"dPJZh4gKx"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"ghPHe38rx"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"wgKVvnbqJ"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"f0NRm60RW"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"MC0WK15bkWne"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"qdUB0t38TIzx"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"P9etPb74G"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"MzlMUh5RH"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"dTjQezU"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"UcY8rTU"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"6jBdd2"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"uweFDB"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"DHlR0jGZ"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"t0FJXfFp"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"xgl55Ov"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"BQEJTcv"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"DLoed8GR"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"4ZOlC3dX"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"4fLL0yidJmi"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"PL8ibSNNqeW"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"E1Vi1evM"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"nBPTBOQ5"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"cPv8a8Ke"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"SrOrILM0"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"hTe87W2S"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"8xez9kW6"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Rkd3GUVh"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"jh0StE7c"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"jNMYNC62"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"knZTvUuc"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"7BZ0SpS3Vo"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"NFsESTbdu9"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"rkMX6XKwz5"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"fD4Bd28DjW"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"DIVlkSJ1Px"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"xLPJdet5XA"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"xh"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"dX"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"LFHjpP44"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"ecPGLlgK"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"NKb7jHrwNE"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"mcFkA90MpP"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"MTs0LjqtsN"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"jEvaxTeWup"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"TSbNUs2c2zm2"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"U8uqM17wVgdP"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"HuO3V9nYWX9y"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"qf0aBxXgfe6s"}
 
 
-        data: {"id":"chatcmpl-CJ2ndLoB1g9yOw5Prh1PLSAZX5GKW","object":"chat.completion.chunk","created":1758655029,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"9eSBYyu"}
+        data: {"id":"chatcmpl-CJRGBw6d7M6OZeGES8WWD1foeRymg","object":"chat.completion.chunk","created":1758749055,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"dfiGqeu"}
 
 
         data: [DONE]
@@ -286,13 +286,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c616f48ebebbe-SEA
+      - 984558fc99847557-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:17:10 GMT
+      - Wed, 24 Sep 2025 21:24:16 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -310,13 +310,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '498'
+      - '440'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '526'
+      - '478'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -326,13 +326,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799947'
+      - '799946'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_c77a5aedcf6d45beb7d42ce385508093
+      - req_57325d07eed7400aac100160b237469a
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_async.yaml
@@ -23,8 +23,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -52,19 +52,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNNj5swEL3zK6w5hwoI2bDcqrSXrlpttVW7VbNCxgzEibGpbZpuo/z3
-        CpMAyW6lckDWPL83bz588AgBXkBKgG2oZXUj/NWHaHf/p/zyzSRv83jJHj5/v+N8/zW5S7ZzmHUM
-        lW+R2TPrDVN1I9ByJXuYaaQWO9VwuUhuFnES3TqgVgWKjlY11o+VHwVR7AeJH9yciBvFGRpIyQ+P
-        EEIO7t9ZlAX+hpQEs3OkRmNohZAOlwgBrUQXAWoMN5ZKC7MRZEpalJ1r2QoxAaxSImNUiDFx/x0m
-        57FPVIjsU/h+Fet8/y56yG+3+/vVz307l/LjJF8v/dw4Q2Ur2dCfCT7E06tkhICkteNWaLNcqV3G
-        ZamuBAgBqqu2Rmk783BYAze5XEO6hsBf3izmfhguE/9xDUe4YB69185Pk7ZoLFtDxct+USmVpZ1t
-        17CnE3IcZiNU1WiVmysqlFxys8k0UuNKnnbeOxtxFqC9GC40WtWNzazaoUsahUmvCuPuTdDoBFpl
-        qZjE49P+XOplBVrK3fSHhWOUbbAYqePi0bbgagJ4k9pfunlNu6+fy+p/5EeAMWwsFlmjseDssuLx
-        msbuaf7r2tBlZxgM6l+cYWY56m4eBZa0Ff2rAfNsLNZZyWWFutHcPR0omyxMomVRBGyxAO/o/QUA
-        AP//AwDLaGCRQwQAAA==
+        H4sIAAAAAAAAA4xTTW+jMBC98yusOYcVJKRQbm2TrtTDHrKHrrSpkDEDcWtsr2267Ub57ysgAZJ2
+        peWArHl+b958eO8RAryAlADbUcdqLfy7h83aRpvV4425Fd9+x6/L5BfPv/IVKhHCrGWo/BmZO7G+
+        MFVrgY4r2cPMIHXYqobxMomj5DqOOqBWBYqWVmnnR8qfB/PIDxI/uDoSd4oztJCSnx4hhOy7f2tR
+        FvgGKQlmp0iN1tIKIR0uEQJGiTYC1FpuHZUOZiPIlHQoW9eyEWICOKVExqgQY+L+20/OY5+oENnm
+        cX2/ru2fuzeuvy/Ec7JIbh7yFU7y9dLvujNUNpIN/ZngQzy9SEYISFp33Apdliv1knFZqgsBQoCa
+        qqlRutY87LfAbS63kG4h8OOr5cIPwzjxf2zhAGfMg/fZ+WnSFoNlY6n42C8qpXK0td017OmIHIbZ
+        CFVpo3J7QYWSS253mUFqu5KnnfdORjoL0JwNF7RRtXaZUy/YJZ2HSa8K4+5N0PkRdMpRMYlHx/05
+        18sKdJR30x8WjlG2w2KkjotHm4KrCeBNav/o5jPtvn4uq/+RHwHGUDssMm2w4Oy84vGawfZp/uva
+        0OXOMFg0r5xh5jiadh4FlrQR/asB+24d1lnJZYVGG949HSh1FibzuCgCtlyCd/D+AgAA//8DAMWq
+        +AJDBAAA
     headers:
       CF-RAY:
-      - 983c5c8ada0e2edd-SEA
+      - 9845570148b4db8c-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -72,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:50 GMT
+      - Wed, 24 Sep 2025 21:22:54 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -90,13 +90,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '778'
+      - '585'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '807'
+      - '610'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -112,7 +112,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 11ms
       x-request-id:
-      - req_a80a8c3695cf48d7a233fdd222c57449
+      - req_65b39a2a9e1b4ba19e875349ca48cd92
     status:
       code: 200
       message: OK
@@ -126,9 +126,9 @@ interactions:
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
       \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_N1EC4rbwD2Sb9jwPCqwu3nnM","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_RWEFEmszCxipS3lj838AJbDe","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_N1EC4rbwD2Sb9jwPCqwu3nnM"}],"model":"gpt-4o","response_format":{"type":"json_object"},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_RWEFEmszCxipS3lj838AJbDe"}],"model":"gpt-4o","response_format":{"type":"json_object"},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
       accept:
@@ -142,8 +142,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -171,18 +171,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xTS2/bMAy++1cIPCeD4zqP+dghw9ahw4qtp7owFImxlciSINFDiyD/fbCcxunW
-        ArvowO8h8qN0SBgDJaFgIBpOonV6+ukm29/R2nzbfd88qXS3/3q/X4sfN3R/e/cFJr3CbnYo6EX1
-        QdjWaSRlzQALj5ywd50t56vFPF9dpRForUTdy2pH09xOszTLp+lqmi5OwsYqgQEK9pAwxtghnn2L
-        RuITFCzaxEqLIfAaoTiTGANvdV8BHoIKxA3BZASFNYQmdn0oDWMlkCKNJRSshFsVaGO9KdivBtln
-        Zbhm69YpjyVMBjbvqLF+oF97bqQ17Cc3En2w5sxyvMbQk+Z5/lLqNloJ3udTPSOPFlmaLkpzvOzP
-        47YLvI/HdFpfANwYS1Eek3k8IcdzFtrWzttN+EsKW2VUaCqPPFjTzx3IOojoMWHsMWbevYoRnLet
-        o4rsHuN12XI1+MG45RHNZyeQLHE91q9mHydv+FUSiSsdLrYGgosG5SgdV8w7qewFkFxM/W83b3kP
-        kytT/4/9CAiBjlBWzqNU4vXEI81j/wneo51Tjg1DQP9bCaxIoe83IXHLOz28TwjPgbCttsrU6J1X
-        wyPdumq2ypZSpmI+h+SY/AEAAP//AwDctOvPrQMAAA==
+        H4sIAAAAAAAAAwAAAP//jFNLj9owEL7nV1hzhipkk4XNEcRWqtpDH7dmFRl7SEwd27In7a4Q/71y
+        AoRtt1IvPsz38Mw39jFhDJSEkoFoOYnO6fnmw5ctvZf+41Z1arP+/KtJswPfPJvDutjBLCrs7oCC
+        Lqp3wnZOIylrRlh45ITRdbEsVst89bAsBqCzEnWUNY7muZ1naZbP09U8vT8LW6sEBijZ94Qxxo7D
+        GVs0Ep+hZOnsUukwBN4glFcSY+CtjhXgIahA3BDMJlBYQ2iGro+VYawCUqSxgpJV8EkF2llvSvat
+        RfaoDNds2znlsYLZyOY9tdaP9LXnRlrDvnIj0QdrrizHGwyRVOT5pdTvtBI85lO/IB8ssjS9r8zp
+        tj+P+z7wGI/ptb4BuDGWBvmQzNMZOV2z0LZx3u7CH1LYK6NCW3vkwZo4dyDrYEBPCWNPQ+b9qxjB
+        eds5qsn+wOG6bLka/WDa8oTmizNIlrie6neLh9kbfrVE4kqHm62B4KJFOUmnFfNeKnsDJDdT/93N
+        W97j5Mo0/2M/AUKgI5S18yiVeD3xRPMYP8G/aNeUh4YhoP+pBNak0MdNSNzzXo/vE8JLIOzqvTIN
+        eufV+Ej3rl6ssqWUqSgKSE7JbwAAAP//AwCpkIN1rQMAAA==
     headers:
       CF-RAY:
-      - 983c5c90ed282edd-SEA
+      - 98455705aa8fdb8c-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:50 GMT
+      - Wed, 24 Sep 2025 21:22:55 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -208,13 +208,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '599'
+      - '559'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '628'
+      - '582'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -230,7 +230,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_03113077b6024fbf9d4c2de2a63c00ce
+      - req_5ce3cef8245a450cb54fae4f3852a0fc
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_async_stream.yaml
@@ -23,8 +23,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -51,46 +51,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_vgS8SVlJ6JJ2hEgrp3dx6oP6","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"vpHd"}
+      string: 'data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_kt0AyI4y0FRQbfphwsvXvNN3","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"De68"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ugXSf0Wo0WaotJD"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"T1qTG0mMGGiaKTi"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"DicB5KsGZVDq4P"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"EuHq2GGtzM7Vbj"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"xO"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"UG"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"7b"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"pU"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"qQ"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"SJ"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Hp"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"CD"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"R9"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Bd"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Y"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4"}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lSUmC95CKzPj1Yf3CvyDpThr5Z","object":"chat.completion.chunk","created":1758654894,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"C"}
+        data: {"id":"chatcmpl-CJRFqMEOMEygeJ0V3HAdVG2B1u2Ui","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"n"}
 
 
         data: [DONE]
@@ -99,13 +99,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5e249f62b9c7-SEA
+      - 984558766a46c39c-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:55 GMT
+      - Wed, 24 Sep 2025 21:23:54 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -123,13 +123,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '440'
+      - '285'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '462'
+      - '318'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -139,13 +139,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799842'
+      - '799841'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 11ms
       x-request-id:
-      - req_22e1462368914ed5a948c9ae47ab7451
+      - req_b905eae97e6c4e9193f30664b39c7ae5
     status:
       code: 200
       message: OK
@@ -159,9 +159,9 @@ interactions:
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
       \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_vgS8SVlJ6JJ2hEgrp3dx6oP6","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_kt0AyI4y0FRQbfphwsvXvNN3","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_vgS8SVlJ6JJ2hEgrp3dx6oP6"}],"model":"gpt-4o","response_format":{"type":"json_object"},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_kt0AyI4y0FRQbfphwsvXvNN3"}],"model":"gpt-4o","response_format":{"type":"json_object"},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
       accept:
@@ -175,8 +175,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -203,95 +203,146 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"amwkq3vtydh"}
+      string: 'data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"YqzZVe9cchB"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"hg29ahc5K8"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"{\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"yYKYdajWI3"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"4VGVWuew"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"xbx8FgASKtLF"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"5Q57P3UV"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"8uNREKgVVN"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"TgJmH560Y"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"3KdO9Myp"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"RRa9ouh38"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"4jmPJG0kIE"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"fKtityNDnHYK"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"aVRI2y8XWN"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"0j14tdGuF"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"Yk4q0kqe3"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"zrJh9Za"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"eoQdJs6xQ"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"bSnLEs"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"YtSCp5IGbQz8"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"47KlaMdQ"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"hP841iMFT"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"3CVL6qn"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"bUYTRW6"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"R2eeD2H0"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"TxrIuf"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"NJqF29UBU8L"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"4JyLB5Lf"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"ac5ZrAem"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"JuVZOsXBH2iT"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"LSRDmFS8"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"L4ZMXH7pJh"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"wX1R8xuk"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"rkObvSF"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"MiOJetTD"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"CWipe1p8o7"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"8V6hkt1z"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"7Z7Ru5zdCB"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"lxo7QXyQMd"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"MWyXLRF2zSh"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"eDawzPFMEt"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"GFmILqJi"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"k97Xt1pLvT"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"ebPFS5Ra"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"Z8"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"bQXld4iN"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"AEBPaYiI"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"uOYVOvlR"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"7TuvXunVov"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"Qra13XmvH8hg"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"Lh3ZkDK1xZ"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"UXE8wxjLuG"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"OJjUKIXmDOiA"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"XVRGmSsb"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"axAhzCHBuzri"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"hxYX1Lm6je"}
 
 
-        data: {"id":"chatcmpl-CJ2lTJmobNOT5raDLwpQ96idnbaPA","object":"chat.completion.chunk","created":1758654895,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"E8N8gTE"}
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"MGeulySyo2lM"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"gBCpsC8hcG"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":",\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"SnKyhkDxGG"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"U94Os65MLgk4"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"PdIcdL3XQI"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"Wc"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"ziR2zyIT"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"v96RIg154d"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"4AYFrwvvzafA"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"rOoOx9spsM"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"s2LzuAL6rCd4"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\n"},"logprobs":null,"finish_reason":null}],"obfuscation":"x4SCGRRi979"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"OgqlhWDfMV3s"}
+
+
+        data: {"id":"chatcmpl-CJRFqVfpsttcRl2mp7bjhubjQnj3n","object":"chat.completion.chunk","created":1758749034,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"JUlnO6L"}
 
 
         data: [DONE]
@@ -300,13 +351,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5e296c3fb9c7-SEA
+      - 9845587a4c5cc39c-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:56 GMT
+      - Wed, 24 Sep 2025 21:23:54 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -324,13 +375,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '342'
+      - '199'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '363'
+      - '232'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -346,7 +397,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_b0f45a43385a46258c422793ce9fe264
+      - req_e1f9851bbc324d8d9ed3dc73e761b1a8
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_stream.yaml
@@ -23,8 +23,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -51,46 +51,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_xu4jyMWyA8g6fO7LcvqQNFVZ","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"KK6x"}
+      string: 'data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_gQS5c1vZckyC70czakz6nT2r","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"71Dk"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Yebp331yImOMX7l"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"3dMbRbIw5vhe04e"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ruwAmC5rkR6yOZ"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"F4j5udd2lzDvJt"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"p7"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Sb"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"WF"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Gp"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ku"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"1A"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4P"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"iZ"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Nk"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"IX"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"A"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"S"}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ksdJx6KlIUkIsGvakYTtRTEn7s","object":"chat.completion.chunk","created":1758654858,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"6"}
+        data: {"id":"chatcmpl-CJRFLeXgtGW91BfY6zSjrYDayAF9N","object":"chat.completion.chunk","created":1758749003,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"4"}
 
 
         data: [DONE]
@@ -99,13 +99,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5d412f037522-SEA
+      - 984557b8bc27ba4c-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:18 GMT
+      - Wed, 24 Sep 2025 21:23:24 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -123,13 +123,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '396'
+      - '354'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '418'
+      - '370'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -145,7 +145,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 11ms
       x-request-id:
-      - req_4332762e8b524fd79fcf98bb019709a3
+      - req_d39d8ceef2ca4174af266ceefb2dac68
     status:
       code: 200
       message: OK
@@ -159,9 +159,9 @@ interactions:
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
       \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_xu4jyMWyA8g6fO7LcvqQNFVZ","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_gQS5c1vZckyC70czakz6nT2r","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_xu4jyMWyA8g6fO7LcvqQNFVZ"}],"model":"gpt-4o","response_format":{"type":"json_object"},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_gQS5c1vZckyC70czakz6nT2r"}],"model":"gpt-4o","response_format":{"type":"json_object"},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
       accept:
@@ -175,8 +175,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -203,95 +203,128 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"zTfe5zRRXeL"}
+      string: 'data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"Cb58TkeTuqt"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"aDHGyYDzYc"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"{"},"logprobs":null,"finish_reason":null}],"obfuscation":"W0eStSnjAe06"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"j3Nqzm9A"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"49PrlCIVMw"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Xk2mLDrJ"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"0bwg3zxc"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"6xfjSKYlf"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"lW8QdFUyuT"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"yCc2Ntprc"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"aQ0OxLkZXE"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"P0bSeYXgGhSp"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"zXnoWuACI"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"JXVO06Rd1"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"UCyE5akxk"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"tEdaFPI"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"9XS4vJVhNkZA"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"6SU2iV"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"eBUqkiYd7"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"ZBOn4MyP"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"RVpRBkT"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"hQfz2wi"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"z82tKa"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"fqMGnkZe"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\","},"logprobs":null,"finish_reason":null}],"obfuscation":"pINZhKYaTd"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"VE1SnzHBDHF"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"1NMMWGJJHn"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"P0lSTMSM"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"XljWKLn"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
-        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"tKDUP4ke"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"tpmJYjQ3Du"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"snzRfMI4"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"NTFY1gOsa5"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"srxNPXvK"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"tktyvtZ4su4"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"b56D78K1"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"73X3BLXt"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"DINGRHwhuq"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"yNtwr5Oz"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"aJkLlPagAv"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"GRMlEYkd"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"msfmsHvf4o"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\","},"logprobs":null,"finish_reason":null}],"obfuscation":"KXlo49gUGL"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"Db"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"mmvgxiDQBv"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"FNKXmqmX"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"R2CmnREQ"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"KUhAJtp7Ws"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"Z6BOkHc83T"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"GjZY8aRBDo"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"xT59gpN7bwEM"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"B0znoknXLqq3"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"PAgnxSEBOM"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"SD1YjILq5o8e"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"xCyCoFNRW7qJ"}
 
 
-        data: {"id":"chatcmpl-CJ2ktMzz58fThM9hAfox5t71Mv0Fs","object":"chat.completion.chunk","created":1758654859,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"Hw32Wup"}
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        \""},"logprobs":null,"finish_reason":null}],"obfuscation":"m4fRM9WoFZ"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"mV"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"hbjYeTEO"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"CX20Xo7IJ4"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        "},"logprobs":null,"finish_reason":null}],"obfuscation":"Vp4HhoEiiWrH"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"wTcZp4P12I"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"lS133Qn7kQvh"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{"content":"
+        }"},"logprobs":null,"finish_reason":null}],"obfuscation":"qeZEnOBzP2N"}
+
+
+        data: {"id":"chatcmpl-CJRFMyxazy4WZNWk6O4C8TgNFQ5cJ","object":"chat.completion.chunk","created":1758749004,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_1827dd0c55","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"pPkrD2H"}
 
 
         data: [DONE]
@@ -300,13 +333,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5d45bc497522-SEA
+      - 984557bcb8ecba4c-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:19 GMT
+      - Wed, 24 Sep 2025 21:23:24 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -324,13 +357,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '493'
+      - '224'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '534'
+      - '245'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -346,7 +379,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_d90c9e567f82428ca74b83420351b475
+      - req_45ea51f60ac847b581119776086efa41
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/json_sync.yaml
@@ -23,8 +23,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -52,19 +52,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xTXWvbMBR9968Q97ketpsv/Jat26CDDfYwypZiZOna0SJLmiRnbUP+e7Gc2k7a
-        wfxgxD065577oUNECAgOOQG2pZ41RsYfbrOfbP3l+sky+t1W+LHmTzc/6v2udJ8MXHUMXf5G5l9Y
-        75hujEQvtOphZpF67FTT5Xy1mM/SRRKARnOUHa02Pp7pOEuyWZys4mRxIm61YOggJ78iQgg5hH9n
-        UXF8gJwEmRBp0DlaI+TDJULAatlFgDonnKfKw9UIMq08qs61aqWcAF5rWTAq5Zi4/w6T89gnKmXx
-        2d+1fD1f/zX7qnw/u324+cNo+fXbJF8v/WiCoapVbOjPBB/i+UUyQkDRJnBr9EWp9a4QqtIXAoQA
-        tXXboPKdeThsQLhSbSDfQBIvF/PrOE2Xq/huA0c4Yx6jt873k7ZYrFpH5et+UaW0p53t0LD7E3Ic
-        ZiN1bawu3QUVKqGE2xYWqQslTzsfvRgJFqA9Gy4YqxvjC693GJJm6apXhXH3Jmh2Ar32VE7is9P+
-        nOsVHD0VYfrDwjHKtshH6rh4tOVCT4BoUvtrN29p9/ULVf+P/AgwhsYjL4xFLth5xeM1i93T/Ne1
-        ocvBMDi0e8Gw8AJtNw+OFW1l/2rAPTqPTVEJVaM1VoSnA5Up0lW25Dxh8zlEx+gZAAD//wMA4tUU
-        dkMEAAA=
+        H4sIAAAAAAAAA4xTXWvbMBR9968Q9zkeTurUjl/LKLSFQUr3wVKMIl3bWmXJSPJIFvLfh+XEdtIO
+        5gcj7tE599wPHQJCQHDICLCKOlY3Mrx7WH/+Uiq+w0r/SJ6e9tvWxrSukrs/z19h1jH09hcyd2Z9
+        YrpuJDqhVQ8zg9RhpzpPlmkSp6s49kCtOcqOVjYujHW4iBZxGKVhdHsiVlowtJCRnwEhhBz8v7Oo
+        OO4gI9HsHKnRWloiZMMlQsBo2UWAWiuso8rBbASZVg5V51q1Uk4Ap7XMGZVyTNx/h8l57BOVMn+w
+        blXQev244+zb85Kt7h9fivULn+TrpfeNN1S0ig39meBDPLtKRggoWntuiS7fav2WC1XoKwFCgJqy
+        rVG5zjwcNiDsVm0g20AUJrfLm3A+T9Lw+waOcME8Bh+dXydtMVi0lsr3/aJKaUc7275hryfkOMxG
+        6rIxemuvqFAIJWyVG6TWlzztfHA24i1AezFcaIyuG5c7/YY+6WKe9qow7t4EXZxApx2Vk3h82p9L
+        vZyjo8JPf1g4RlmFfKSOi0dbLvQECCa1v3fzkXZfv1Dl/8iPAGPYOOR5Y5ALdlnxeM1g9zT/dW3o
+        sjcMFs1vwTB3Ak03D44FbWX/asDurcM6L4Qq0TRG+KcDRZPP00XCecSWSwiOwV8AAAD//wMAAI33
+        5UMEAAA=
     headers:
       CF-RAY:
-      - 983c4c338848dedd-SEA
+      - 9845564789f7af49-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -72,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:02:40 GMT
+      - Wed, 24 Sep 2025 21:22:25 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -90,13 +90,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '561'
+      - '610'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '581'
+      - '781'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -112,7 +112,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 11ms
       x-request-id:
-      - req_9af0c5f5f5a84053b18d55e7323581ff
+      - req_93ef9b04dd844e2abfff0eb74ea4d07d
     status:
       code: 200
       message: OK
@@ -126,9 +126,9 @@ interactions:
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
       \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_GtXudA5AwpvfbB4JxDqcabNO","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_Jst9famRKxdcWS5c9GKUfRUd","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_GtXudA5AwpvfbB4JxDqcabNO"}],"model":"gpt-4o","response_format":{"type":"json_object"},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_Jst9famRKxdcWS5c9GKUfRUd"}],"model":"gpt-4o","response_format":{"type":"json_object"},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
       accept:
@@ -142,8 +142,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -171,18 +171,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNLb9QwEL7nV1hz3kXZNPsgN4oACYF4VRxoqshrzyamjm3ZE0q12v+O
-        7Gw321IkLj7M9/DMN/Y+YwyUhIqB6DiJ3un56/fFD1F8+Xz77hN9+H41rEP79dVlfneR33UOZlFh
-        tz9R0IPqhbC900jKmhEWHjlhdF2sl5vVslys8gT0VqKOstbRvLTzIi/Keb6Z56ujsLNKYICKXWeM
-        MbZPZ2zRSPwNFUs2qdJjCLxFqE4kxsBbHSvAQ1CBuCGYTaCwhtCkrve1YawGUqSxhorV8FEF2lpv
-        KnbVIXurDNfsTe+UxxpmI5sP1Fk/0i89N9Ia9o0biT5Yc2I53mKIpGVZPpSGrVaCx3yae+TJosjz
-        VW0O5/153A2Bx3jMoPUZwI2xlOQpmZsjcjhloW3rvN2GJ1LYKaNC13jkwZo4dyDrIKGHjLGblPnw
-        KEZw3vaOGrK3mK4r1pvRD6YtT2i5OIJkieupfrF4OXvGr5FIXOlwtjUQXHQoJ+m0Yj5IZc+A7Gzq
-        v7t5znucXJn2f+wnQAh0hLJxHqUSjyeeaB7jJ/gX7ZRyahgC+l9KYEMKfdyExB0f9Pg+IdwHwr7Z
-        KdOid16Nj3TnmsWmWEuZi+USskP2BwAA//8DAHBn9BmtAwAA
+        H4sIAAAAAAAAAwAAAP//jFNba9swFH73rxDnORlO5lzqt7Z0g8CguzKYi1GkE1uJLAnpeKwN+e9F
+        dhKnWwt70cP5LjrnO9I+YQyUhJyBqDmJxunx7erL3f3qvnmip/XtbvXj5/eP6c023Yn59vozjKLC
+        rrco6KR6J2zjNJKypoeFR04YXSeL2XKRLa+yWQc0VqKOssrROLPjaTrNxulynM6PwtoqgQFy9ith
+        jLF9d8YWjcQ/kLN0dKo0GAKvEPIziTHwVscK8BBUIG4IRgMorCE0Xdf7wjBWACnSWEDOCvikAq2t
+        Nzn7ViP7oAzX7K5xymMBo57NW6qt7+k3nhtpDfvKjUQfrDmzHK8wRNIsy06ldq2V4DGf8hF5ZzFN
+        03lhDpf9edy0gcd4TKv1BcCNsdTJu2QejsjhnIW2lfN2Hf6SwkYZFerSIw/WxLkDWQcdekgYe+gy
+        b1/ECM7bxlFJdofdddPFsveDYcsDmk2OIFnieqi/n1yNXvErJRJXOlxsDQQXNcpBOqyYt1LZCyC5
+        mPrfbl7z7idXpvof+wEQAh2hLJ1HqcTLiQeax/gJ3qKdU+4ahoD+txJYkkIfNyFxw1vdv08Ij4Gw
+        KTfKVOidV/0j3bhyspwupEzFbAbJIXkGAAD//wMAswWBAa0DAAA=
     headers:
       CF-RAY:
-      - 983c4c387da1dedd-SEA
+      - 9845564cebacaf49-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:02:41 GMT
+      - Wed, 24 Sep 2025 21:22:25 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -208,13 +208,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '639'
+      - '443'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '804'
+      - '469'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -224,13 +224,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799816'
+      - '799817'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_1419d00845f54d4098fe51d86c84bbae
+      - req_70f60098a8de479d9683156f11cc1cbe
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/stream.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,46 +44,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_nlPzRyF0DR73zQpt1hCmi7RK","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"axWa"}
+      string: 'data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_j4gk8mlqvLtdPZuMQqj1DNTM","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"pVJu"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"sBtYaudJNNqyZpb"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"O46CIHWPUyaBwuy"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"uh7InIZdhK33iw"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"X29VlOkSr5bvro"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Zm"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"xi"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"9r"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Si"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ss"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"1Y"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"IH"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"fc"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"1H"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Ym"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"5"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"I"}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lEEKOpW5w84f7p5R7JROkhH38c","object":"chat.completion.chunk","created":1758654880,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"8"}
+        data: {"id":"chatcmpl-CJRFe9HKCpEjZJHfHqBWWssmCqQlT","object":"chat.completion.chunk","created":1758749022,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"p"}
 
 
         data: [DONE]
@@ -92,13 +92,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5dc7cdb39b68-SEA
+      - 9845582d293c7609-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:41 GMT
+      - Wed, 24 Sep 2025 21:23:42 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -116,13 +116,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '950'
+      - '374'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '973'
+      - '444'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -138,15 +138,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_4b953acb26a14c4cba5d6c9563c28ef1
+      - req_03f1bb777cbd4abcba0586cf9c235366
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_nlPzRyF0DR73zQpt1hCmi7RK","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_j4gk8mlqvLtdPZuMQqj1DNTM","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_nlPzRyF0DR73zQpt1hCmi7RK"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      2006-07-25","tool_call_id":"call_j4gk8mlqvLtdPZuMQqj1DNTM"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -161,8 +161,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -189,95 +189,95 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"IWbm0Lrs2QV"}
+      string: 'data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"821bS6vixAw"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"z6E6gixNqL"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"n6M6AgnCsY"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"kydLllFN"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"QoId5Vkc"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"99vdteXt"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"zL9HISsl"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"OsGJf1zBT"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"JdpEfPCTg"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"4kA9lKKYs"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"E9pPUNPnS"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"2opZibmpizgE"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"EfxIeBodkFmc"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"GtNk5g55l"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"OmBp75e6d"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"QrNoLlM"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"hb6DB0D"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"9ZE8TI"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"20JR2a"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"8uJsuPab"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"yenniBhB"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"okwraBF"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"32XosRc"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Q3GK5oQm"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"LWroU3xR"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"ND3YfsGU3Ci"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"gJVcRnRu1cK"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"raCBJZEm"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"GLABjvZB"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"LiqAwxuc"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"iEhYEOqU"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"SP8701n8"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"D2FoXc38"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Zyx6yiIq"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"si0oA1JB"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"LsqZ5smB"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"dRaxxxQZ"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"jMwtKy5F9j"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"MPwt5fKqlL"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"2CcB2PCDr0"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"uvZ5g9mPn6"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"VroW9INkNS"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"5WUtjUPwjr"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"W9"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"vB"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"kEQqhkfX"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"qnSvVDEq"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"K68Tx4bWMg"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"bwYZcnOBr7"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"3vg2MeY2uQ"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"aBdtYv6Pyp"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"1yU31qNYUiO3"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"otrLd8G6cLkP"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"DToKyKlWtEqa"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"xjriZjvKoSAV"}
 
 
-        data: {"id":"chatcmpl-CJ2lHqPwD8eMqJ0ze5QMDR7r43yhu","object":"chat.completion.chunk","created":1758654883,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"SWKDjcz"}
+        data: {"id":"chatcmpl-CJRFf1lGA6SISVvHbj78pBeuZ2lF0","object":"chat.completion.chunk","created":1758749023,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"LOiA0K3"}
 
 
         data: [DONE]
@@ -286,13 +286,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5ddade8a9b68-SEA
+      - 98455831bc237609-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:44 GMT
+      - Wed, 24 Sep 2025 21:23:43 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -310,13 +310,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '783'
+      - '306'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1408'
+      - '368'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -332,7 +332,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_90ed015acd6a403b84ecf7e27aac7d15
+      - req_fef0794f56c242fda93cecfded2c475e
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_async.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=7rtRaWrLaIhRFsFq24zeyFZPPbQtV5qHP3dTv3SLuvE-1758653687-1.0.1.1-6QejFMB2z6BmqwQ9jfWem7hgs9RUh0FIfzG76aTTsbuKYaZmX20_0oFsdyiYCygvafzfx4wZ9VtS87XcqFYgcJ.CXjBrgIczMF0eBN7wZPI;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -35,7 +35,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -45,19 +45,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNNj5swEL3zK6w5hwqyIUQcN72kVbtS2/QzK2TMQNwYm7XN7qZR/nuF
-        SYBkt1I5IGue38ybN+ODRwjwHBICbEstq2rhL99Ndyu7fFh9fZY/qvDzahZ9e8rjO7Zf508waRkq
-        +43MnllvmKpqgZYr2cFMI7XYZg3jaDGPZovp1AGVylG0tLK2/kz502A684OFH8xPxK3iDA0k5JdH
-        CCEH928lyhyfISHB5Byp0BhaIiT9JUJAK9FGgBrDjaXSwmQAmZIWZataNkKMAKuUSBkVYijcfYfR
-        efCJCpF++vLnw/52efP24yNr1vu7oHy/vi0ffo7qdan3tRNUNJL1/ozwPp5cFSMEJK0ct0SbZkrt
-        Ui4LdZWAEKC6bCqUthUPhw1wk8kNJBsI/Hge3fhhGC/87xs4wgXz6L12vh/ZorFoDBUv/aJSKktb
-        2c6w+xNy7GcjVFlrlZkrKhRccrNNNVLjWh47752FOAnQXAwXaq2q2qZW7dAVDWenTYBh9wa02zY3
-        WUvFiDU/Axf50hwt5W76/cIxyraYD9Rh8WiTczUCvFHvL9W8lrvrn8vyf9IPAGNYW8zTWmPO2WXH
-        wzWN7dP817XeZScYDOpHzjC1HHU7jxwL2oju1YDZG4tVWnBZoq41d08HijplWRHGiyiax+Advb8A
-        AAD//wMA1PVvaEMEAAA=
+        H4sIAAAAAAAAAwAAAP//jFNNb9swDL37Vwg8x4OTJnbm27IOBdrLWgxrtqUQZJl2tOoLkry1C/Lf
+        BzuJ7bQdMB8MgU+PfHykdhEhIErICfAtC1xZGX+8vvskV/frWVrcqOySXQVpm0Q9Kb8Nc5i0DFP8
+        RB5OrHfcKCsxCKMPMHfIArZZp9limc2X79OsA5QpUba02oZ4buJZMpvHyTJO0iNxawRHDzn5ERFC
+        yK77txJ1iU+Qk2Ryiij0ntUIeX+JEHBGthFg3gsfmA4wGUBudEDdqtaNlCMgGCMpZ1IOhQ/fbnQe
+        fGJS0svft/e36z/hw0pVX64/X60u7m6+f/1WjuodUj/bTlDVaN77M8L7eP6iGCGgmeq4NQZaGPNI
+        ha7MiwSEAHN1o1CHVjzsNiB8oTeQbyCJs3RxEU+n2TJeb2APZ8x99Nb5YWSLw6rxTL72i2ltAmtl
+        d4Y9HJF9PxtpautM4V9QoRJa+C11yHzX8tj56CSkkwDN2XDBOqNsoME8Yld0Oj9uAgy7N6Cz2REM
+        JjA5YqUn4CwfLTEw0U2/XzjO+BbLgTosHmtKYUZANOr9tZq3ch/6F7r+n/QDwDnagCW1DkvBzzse
+        rjlsn+a/rvUud4LBo/slONIg0LXzKLFijTy8GvDPPqCildA1OutE93SgspQX1TRbLhZpBtE++gsA
+        AP//AwB0exBtQwQAAA==
     headers:
       CF-RAY:
-      - 983c5c5b6eeddee4-SEA
+      - 984556d37c25fa3b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,13 +65,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:44 GMT
+      - Wed, 24 Sep 2025 21:22:47 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        path=/; expires=Tue, 23-Sep-25 19:43:44 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -87,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2143'
+      - '668'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2301'
+      - '726'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -109,15 +105,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_d1d8928426a94a71be7d5f00ed05ced4
+      - req_2b7197ef877d4f2aaac687da4d068f57
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_RTzMyBC3DNvcuUyO0gKUBgqZ","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_DwQWQXztABmfTJPGB3RKZVYd","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_RTzMyBC3DNvcuUyO0gKUBgqZ"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      2006-07-25","tool_call_id":"call_DwQWQXztABmfTJPGB3RKZVYd"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -132,8 +128,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -161,18 +157,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4ySTW/bMAyG7/4VAs/J4HrOB3xcsRbYZ4HtsGIuDEWibTWyJEh00CLIfx/kpLGz
-        rUAvAqSHL0W+5D5hDJSEgoFoOYnO6fn1p2z7+eb2+50g3n25T7vH62+7p7vddnf7awuzqLCbRxT0
-        ononbOc0krLmiIVHThizXq0W6+UiX2f5ADorUUdZ42ie23mWZvk8Xc/T5UnYWiUwQMF+J4wxth/O
-        WKKR+AQFS2cvLx2GwBuE4hzEGHir4wvwEFQgbghmIxTWEJqh6n0JpEhjCUUJX1WgjfWmYD9bZDfK
-        cM0+dk55LGFWAu+ptX6I/OC5kdawH9xI9MGaIcDxBkMJxSLP463faCV4NKN6Rh6FWZouD9NKPNZ9
-        4NEI02s9AdwYS4N28ODhRA7nrrVtnLeb8JcUamVUaCuPPFgTOwxkHQz0kDD2MLjbXxgGztvOUUV2
-        i8N3WXpyF8Z5jvR9doJkieuJ6gwu8lUSiSsdJvMBwUWLcpSOw+S9VHYCkknX/1bzv9zHzpVp3pJ+
-        BEKgI5SV8yiVuOx4DPMY1/21sLPLQ8EQ0O+UwIoU+jgJiTXv9XETITwHwq6qlWnQO6+O61i7Smzq
-        q9V6sViuIDkkfwAAAP//AwAJxoW7lwMAAA==
+        H4sIAAAAAAAAAwAAAP//jJLbbtQwEIbv8xTWXO+idLsnclegSCBAolRCiFSRY08SF8e27AlLtdp3
+        r+zdblIOEjeW7G/+8cw/s88YAyWhYCA6TqJ3ev76/c21zuvdu/t21+o3X68+XX7Ir+S3z/3u9gZm
+        UWHrexT0pHohbO80krLmiIVHThizXmxW281y+3K9SaC3EnWUtY7mSztf5IvlPN/O8/VJ2FklMEDB
+        vmeMMbZPZyzRSPwFBctnTy89hsBbhOIcxBh4q+ML8BBUIG4IZiMU1hCaVPW+BFKksYSihI8qUG29
+        Kdhth+ytMlyz694pjyXMSuADddanyFeeG2kN+8KNRB+sSQGOtxhKKFbLZbwNtVaCRzOqB+RRuMjz
+        9WFaicdmCDwaYQatJ4AbYylpkwd3J3I4d61t67ytw29SaJRRoas88mBN7DCQdZDoIWPsLrk7PDMM
+        nLe9o4rsD0zfLfKTuzDOc6SXixMkS1xPVGfwLF8lkbjSYTIfEFx0KEfpOEw+SGUnIJt0/Wc1f8t9
+        7FyZ9n/Sj0AIdISych6lEs87HsM8xnX/V9jZ5VQwBPQ/lcCKFPo4CYkNH/RxEyE8BMK+apRp0Tuv
+        juvYuErUzcVmu1qtN5AdskcAAAD//wMAdiaywJcDAAA=
     headers:
       CF-RAY:
-      - 983c5c6abc5ddee4-SEA
+      - 984556d8cab6fa3b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -180,7 +176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:45 GMT
+      - Wed, 24 Sep 2025 21:22:48 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -198,13 +194,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '834'
+      - '519'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '872'
+      - '538'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -220,7 +216,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_2622caa5f5ac477696f9921a947547d2
+      - req_916c41af763348eab92e4dbbf774b712
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_async_stream.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,46 +44,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_lym2hCN2lnWo5LLhDFhQDcCd","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"MrJq"}
+      string: 'data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_cjevQinj1jOPWxHF1dU4zMmo","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"itqR"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"UTQcO3j0ZNRLnIx"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2q9JPsjaAacUBAU"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"dFkyWUeqYF4CHD"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Y41sn3zxHHIrkO"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"CQ"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Se"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Cv"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ZZ"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"HE"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Mx"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"vx"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Yn"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"g3"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"iE"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"S"}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2lJU1be1vLfTByTjtUytNoPdBA8","object":"chat.completion.chunk","created":1758654885,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"f"}
+        data: {"id":"chatcmpl-CJRFgUkenAE0ROmileBLfwEx1yPdq","object":"chat.completion.chunk","created":1758749024,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"A"}
 
 
         data: [DONE]
@@ -92,13 +92,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5dead8652367-SEA
+      - 9845583a9c2a756d-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:46 GMT
+      - Wed, 24 Sep 2025 21:23:44 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -116,13 +116,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '304'
+      - '313'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '357'
+      - '336'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -138,15 +138,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_9e49598ffc484a6eb48b1355908895ec
+      - req_6014480c503f4081a4914d8d361aa4a8
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_lym2hCN2lnWo5LLhDFhQDcCd","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_cjevQinj1jOPWxHF1dU4zMmo","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_lym2hCN2lnWo5LLhDFhQDcCd"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      2006-07-25","tool_call_id":"call_cjevQinj1jOPWxHF1dU4zMmo"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -161,8 +161,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -189,95 +189,95 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"sYvlgHc0il1"}
+      string: 'data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"BSDetWZeogN"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"ALl1qjUV52"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"DzVKEzRi4r"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"F5K02WsX"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"fTy86Ihx"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"mqvJrxOZ"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"dhj8klL6"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"oRxTTZoB4"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"S4tjVIkFh"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"FVf17MaFu"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"gT0FVBb4w"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"eWr6kCEqc6dA"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"hQ31QsHyC7kB"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"YdZZbrj1p"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"ewcBpl5xc"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"g2H2KFq"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"R59Vgbj"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"mwKw5A"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"nHpS5v"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Rm8eV1pv"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"NMr0eIeX"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"hqlBogH"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"ts6Vnef"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"CYnzbN9P"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"HeMzEzAx"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"QC4VYYS5upD"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"Yd809J6ek8S"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"EsVWhj6J"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"Bj62yaxh"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"1xZF849n"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"fyjo5MM4"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"hlbvygjq"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"yN7mIwDc"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"2C8owcgw"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"Mf5cZ1JU"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"W4GelGjg"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"xNKVXUnW"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"mU4TrEL9mt"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"rx9f6Zfelw"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"0Y3p1axfBw"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"9KZSi6Z3Rt"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"MpVNI4c86y"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"VxFTVR56cR"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"S8"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"0K"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"qwmYIuJt"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"3n2dmsDk"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"kDroFUNJEO"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"w8g8TWr7ml"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"rvIv88oW0P"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"vbxR2u94HY"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"IyVksHvJ6rS7"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"U8ckflDNiuwL"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"HOZTvBLNTRqw"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"PhqS37DPaeO3"}
 
 
-        data: {"id":"chatcmpl-CJ2lKRjQIrlSkl9q3JjTX0Z89NHk7","object":"chat.completion.chunk","created":1758654886,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"GeIkDgn"}
+        data: {"id":"chatcmpl-CJRFheLsVHntik4fVdsLcSikLbkf3","object":"chat.completion.chunk","created":1758749025,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"vcS5fLR"}
 
 
         data: [DONE]
@@ -286,13 +286,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5deecccd2367-SEA
+      - 9845583e5828756d-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:47 GMT
+      - Wed, 24 Sep 2025 21:23:45 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -310,13 +310,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '827'
+      - '322'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '916'
+      - '339'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -332,7 +332,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_c35fd0ab64f844fc88564f4e0c580568
+      - req_0c36a26113db41c6b1eb21098669766d
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_stream.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,46 +44,32 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_MbBdVxoY72QRc0wQbKhbhrdZ","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"cmV4"}
+      string: 'data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null},"logprobs":null,"finish_reason":null}],"obfuscation":"YB7nX8B6"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_YJsJE8QRPmdDAHFe5H5QJUAQ","type":"function","function":{"name":"get_book_info","arguments":""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"UqloE"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"N7vHQQiTWIy6SAn"}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"is"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"FXAfMsQq2zVNAq"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"rGYubMu3wDbOZD"}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"bn\":
+        "}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"NYiydpAf3aRUc"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"nn"}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"0-765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"gnR15uCVPD7s"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"fj"}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3-11"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"BDPVBk72ajILjCt"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"78-X\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"oCYrZri012cL0"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"QR"}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"3b"}
 
 
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Xj"}
-
-
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"U8"}
-
-
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"e"}
-
-
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
-
-
-        data: {"id":"chatcmpl-CJ2knD12NQsxb2CIDRn7VxL9jjp3y","object":"chat.completion.chunk","created":1758654853,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"7"}
+        data: {"id":"chatcmpl-CJRFGuWk9P8zMvWqqe1CSUjpcuU4d","object":"chat.completion.chunk","created":1758748998,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"Z"}
 
 
         data: [DONE]
@@ -92,13 +78,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5d1fdae67522-SEA
+      - 984557973af0ba4c-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:13 GMT
+      - Wed, 24 Sep 2025 21:23:18 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -116,13 +102,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '372'
+      - '573'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '579'
+      - '597'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -138,15 +124,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_000dc0cdfe1447b499f55a4268456278
+      - req_202bc2c230b54c35947fd97dc0fe442c
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_MbBdVxoY72QRc0wQbKhbhrdZ","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_MbBdVxoY72QRc0wQbKhbhrdZ"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_YJsJE8QRPmdDAHFe5H5QJUAQ","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":
+      \"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title: Mistborn: The Final
+      Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","tool_call_id":"call_YJsJE8QRPmdDAHFe5H5QJUAQ"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"stream":true,"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -157,12 +143,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1234'
+      - '1235'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -189,95 +175,95 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"xPWKU7HaXDC"}
+      string: 'data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"Onr5VOQXn5R"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"sFGhUVeE8Q"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"{\""},"logprobs":null,"finish_reason":null}],"obfuscation":"UuH6n0wYBI"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"nuQTXZ8t"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"title"},"logprobs":null,"finish_reason":null}],"obfuscation":"JdPwwQHb"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"lIBvzjwE"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"GyuKxhgd"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"HJxpsnVwa"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Mist"},"logprobs":null,"finish_reason":null}],"obfuscation":"KI67yaI9K"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"nwfnXf3qj"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"born"},"logprobs":null,"finish_reason":null}],"obfuscation":"MWqAOPySc"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"beqBmixNhVVL"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":":"},"logprobs":null,"finish_reason":null}],"obfuscation":"mrgsjaIHvJPP"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"VdVn1kQpF"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        The"},"logprobs":null,"finish_reason":null}],"obfuscation":"QMlg9mtTa"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"73zXOKz"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Final"},"logprobs":null,"finish_reason":null}],"obfuscation":"xdqBJpK"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"FLZyF7"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Empire"},"logprobs":null,"finish_reason":null}],"obfuscation":"HCU9Xp"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"VdXDNp9Q"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"mepetKyz"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"7bfdNf1"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"author"},"logprobs":null,"finish_reason":null}],"obfuscation":"ds7RUXq"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"DL6Rg7T0"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":\""},"logprobs":null,"finish_reason":null}],"obfuscation":"7FtzQGfN"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"bUK1SwgGKqg"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Br"},"logprobs":null,"finish_reason":null}],"obfuscation":"wZEpf06XOGZ"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"mvq8mvE2"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"andon"},"logprobs":null,"finish_reason":null}],"obfuscation":"EcXyraJn"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
-        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"tMJfRTeE"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Sand"},"logprobs":null,"finish_reason":null}],"obfuscation":"ItwFHskO"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"WFOzK9qj"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"erson"},"logprobs":null,"finish_reason":null}],"obfuscation":"NAxNOMMb"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"TTbgVDEe"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"me1KiaPu"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"r9jL9bGQ"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"pages"},"logprobs":null,"finish_reason":null}],"obfuscation":"ciYwRnaV"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"vAe3O1Wji2"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"nFzOKSBuS7"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"tnjIYJiP2f"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"544"},"logprobs":null,"finish_reason":null}],"obfuscation":"pHhqn6bm4k"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"8ar1znimyV"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":",\""},"logprobs":null,"finish_reason":null}],"obfuscation":"rvcy21G8Rs"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"Kw"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"publication"},"logprobs":null,"finish_reason":null}],"obfuscation":"Vl"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"zt40wh9K"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"_year"},"logprobs":null,"finish_reason":null}],"obfuscation":"AhJHmOCI"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"vrkkrYxfGg"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"\":"},"logprobs":null,"finish_reason":null}],"obfuscation":"Hv3cHA5WuU"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"mDpkuQwDJp"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"200"},"logprobs":null,"finish_reason":null}],"obfuscation":"b5QXfZEIvW"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"y8E6OLsPQ1UJ"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"6"},"logprobs":null,"finish_reason":null}],"obfuscation":"pCQJtARBZp4g"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"GxWGDJWcNVs5"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"}"},"logprobs":null,"finish_reason":null}],"obfuscation":"YCdNaEgs13nf"}
 
 
-        data: {"id":"chatcmpl-CJ2ko7lkBJvijrNJQshojla6pX3i6","object":"chat.completion.chunk","created":1758654854,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"eTdpCP0"}
+        data: {"id":"chatcmpl-CJRFH83PBfupW3W1MAFMahm0kBVyq","object":"chat.completion.chunk","created":1758748999,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"JiuXBnF"}
 
 
         data: [DONE]
@@ -286,13 +272,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5d25287d7522-SEA
+      - 9845579bdf17ba4c-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:14 GMT
+      - Wed, 24 Sep 2025 21:23:19 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -310,13 +296,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '455'
+      - '353'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '495'
+      - '375'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -332,7 +318,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_32b64715c62e416294624479eab669ca
+      - req_08b7d12da4bc4a4e9d85661e0a6e69a5
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/strict_sync.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,19 +45,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNRb5swEH7nV1j3HCagIaG8blOkbVo1KQ9dlwo59kG8GtuzTZY2yn+v
-        IAmQtJPGA7Lu83f33XfnfUAICA45AbahntVGhh+/JMu/apm9iCaK739uf7zQr+mfz7j4zqtbmLQM
-        vf6NzJ9ZH5iujUQvtDrCzCL12GaN52k2S2+yKOuAWnOULa0yPpzqMImSaRhlYTQ7ETdaMHSQk18B
-        IYTsu38rUXHcQU6iyTlSo3O0Qsj7S4SA1bKNAHVOOE+Vh8kAMq08qla1aqQcAV5rWTAq5VD4+O1H
-        58EnKmXxSS0TkS62d5WPnuXt7uEb5YuHu92o3jH1s+kElY1ivT8jvI/nV8UIAUXrjluhL9ZaPxVC
-        lfoqASFAbdXUqHwrHvYrEG6tVpCvIArns/QmjON5Ft6v4AAXzEPw3vlxZIvFsnFUvvWLKqU9bWV3
-        hj2ekEM/G6krY/XaXVGhFEq4TWGRuq7lsfPBWUgnAZqL4YKxuja+8PoJu6Lx9LQJMOzegCbJCfTa
-        Uzlizc7ARb6Co6eim36/cIyyDfKBOiwebbjQIyAY9f5WzXu5j/0LVf1P+gFgDI1HXhiLXLDLjodr
-        Ftun+a9rvcudYHBot4Jh4QXadh4cS9rI46sB9+w81kUpVIXWWNE9HShNwdZlPM/SdDaH4BC8AgAA
-        //8DAM95eB1DBAAA
+        H4sIAAAAAAAAAwAAAP//jFNNb9swDL37Vwg8x0O+nfjWtdshyDqkBboCSyEoMu2olSVBkrd2Qf77
+        YCWxnbQD5oMh8OmRj4/ULiIERAYpAb5lnpdGxteLuy+L5fL2VZR/Pqsb8zCe/85Hi6v53Xx0A72a
+        oTfPyP2J9Ynr0kj0QqsDzC0yj3XWQTKZJePZfDQPQKkzlDWtMD4e63jYH47j/izuT4/ErRYcHaTk
+        Z0QIIbvwryWqDF8hJf3eKVKic6xASJtLhIDVso4Ac044z5SHXgtyrTyqWrWqpOwAXmtJOZOyLXz4
+        dp1z6xOTkt5f3X9fDW1WfV3p2+fVN7/cPoof16xT75D6zQRBeaV4408Hb+LpRTFCQLEycAv0dKP1
+        CxUq1xcJCAFmi6pE5WvxsFuDcBu1hnQN/TiZTkbxYJDM4sc17OGMuY8+Oj91bLGYV47J934xpbRn
+        texg2NMR2TezkbowVm/cBRVyoYTbUovMhZa7zkcnIUECVGfDBWN1aTz1+gVD0cH4uAnQ7l6LDodH
+        0GvPZIc1PQFn+WiGnokw/WbhOONbzFpqu3isyoTuAFGn9/dqPsp96F+o4n/StwDnaDxm1FjMBD/v
+        uL1msX6a/7rWuBwEg0P7S3CkXqCt55Fhzip5eDXg3pzHkuZCFWiNFeHpQG4o3+SDZDaZTBOI9tFf
+        AAAA//8DAFExbnJDBAAA
     headers:
       CF-RAY:
-      - 983c43a07f4a76f7-SEA
+      - 98455625bac3af49-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:49 GMT
+      - Wed, 24 Sep 2025 21:22:19 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '470'
+      - '438'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '492'
+      - '651'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,15 +105,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_19128437454948e08367890c9ce4e8c0
+      - req_82f9f170a164494faace67ef19388e76
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_DnT2i5GvOgt0yl9xZLadGZOx","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_SASOQ2rduFQoNjQMtLhXiWCa","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_DnT2i5GvOgt0yl9xZLadGZOx"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      2006-07-25","tool_call_id":"call_SASOQ2rduFQoNjQMtLhXiWCa"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -128,8 +128,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -157,18 +157,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJJNb9swDIbv/hUCz8ngunGS+phhOwztaSkwYC4MWaJtrbIoSHKRrsh/
-        H+SksbMPYBcB0sOXIl/yLWEMlISCgeh4EL3Vy49fsv3h/uHg6267f87kZpc/fvv5QvtHsbuHRVRQ
-        /QNFeFd9ENRbjUGROWHhkAeMWW82+Xad327TuxH0JFFHWWvDckXLLM1Wy3S7TNdnYUdKoIeCfU8Y
-        Y+xtPGOJRuIBCpYu3l969J63CMUliDFwpOMLcO+VD9wEWExQkAloxqrfSggqaCyhKOFB+VCTMwXb
-        d8g+K8M1+9Rb5bCERQl8CB25MXLnuJFk2FduJDpPZgywvEVfQpGvVvE21FoJHs2oXpFHYZam6+O8
-        EofN4Hk0wgxazwA3hsKoHT14OpPjpWtNrXVU+9+k0CijfFc55J5M7NAHsjDSY8LY0+jucGUYWEe9
-        DVWgZxy/y9KzuzDNc6K32RkGClzPVBdwla+SGLjSfjYfEFx0KCfpNEw+SEUzkMy6/rOav+U+da5M
-        +z/pJyAE2oCysg6lEtcdT2EO47r/K+zi8lgweHQvSmAVFLo4CYkNH/RpE8G/+oB91SjTorNOndax
-        sZWom5vNNs/XG0iOyS8AAAD//wMANscXgpcDAAA=
+        H4sIAAAAAAAAAwAAAP//jJLbitswEIbv/RRirpPidZ3D+rLLFpploScotF6MLI9tbWVJSOOSJeTd
+        i5Q0dnqA3gikb/7RzD9zSBgD2UDBQPScxGDV8m738f7hvX7Y1/vhg9Ffvzzq3bs7bZ93t/sOFkFh
+        6mcU9Ev1SpjBKiRp9AkLh5wwZL3ZrLabfHubpxEMpkEVZJ2lZW6WWZrly3S7TNdnYW+kQA8F+5Yw
+        xtghnqFE3eAeChbTxJcBvecdQnEJYgycUeEFuPfSE9cEiwkKowl1rPpQAklSWEJRwqP0VBunC/a5
+        R/ZWaq7Y/WClwxIWJfCReuNi5BvHdWM0+8R1g84bHQMs79CXUKzyPNzGWknBgxnVC/IgzNJ0fZxX
+        4rAdPQ9G6FGpGeBaG4ra6MHTmRwvXSvTWWdq/5sUWqml7yuH3BsdOvRkLER6TBh7iu6OV4aBdWaw
+        VJH5jvG7LD27C9M8J/o6O0MyxNVMdQFX+aoGiUvlZ/MBwUWPzSSdhsnHRpoZSGZd/1nN33KfOpe6
+        +5/0ExACLWFTWYeNFNcdT2EOw7r/K+ziciwYPLofUmBFEl2YRIMtH9VpE8G/eMKhaqXu0FknT+vY
+        2krU7c1mu1qtN5Ack58AAAD//wMAC1Mz5JcDAAA=
     headers:
       CF-RAY:
-      - 983c43a48abd76f7-SEA
+      - 9845562a8ad9af49-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -176,7 +176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 18:56:50 GMT
+      - Wed, 24 Sep 2025 21:22:20 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -194,13 +194,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '602'
+      - '707'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '614'
+      - '737'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -216,7 +216,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_95af93802b8940a4addea468ad294759
+      - req_03a643bba59344ebbf73fb39742a5fa2
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/sync.yaml
@@ -16,8 +16,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,19 +45,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNRb5swEH7nV1j3HKZAE8J4XNSqqtY9RNPUbamQMQdxY2xkmyZNlP8+
-        4SRA0k4qD8i6z9/dd9+d9x4hwHNICLAVtayqhT9/CNd3P+//LNS9mDz8etrMXzbxbrtd3ywWcxi1
-        DJW9ILNn1hemqlqg5UoeYaaRWmyzBrNpHE0ncfDVAZXKUbS0srb+RPnhOJz449gfRyfiSnGGBhLy
-        1yOEkL37txJljltIyHh0jlRoDC0Rku4SIaCVaCNAjeHGUmlh1INMSYuyVS0bIQaAVUqkjArRFz5+
-        +8G594kKkd7tHr9F8/D3bhM0t5j9mL/G9vuj2gzqHVO/1U5Q0UjW+TPAu3hyVYwQkLRy3BJtmim1
-        Trks1FUCQoDqsqlQ2lY87JfATSaXkCxh7M+i6Y0fBLPYf1rCAS6YB++j8/PAFo1FY6h47xeVUlna
-        ynaGPZ+QQzcbocpaq8xcUaHgkptVqpEa1/LQee8sxEmA5mK4UGtV1Ta1ao2uaDA5bQL0u9ejYXgC
-        rbJUDFjRGbjIl+ZoKXfT7xaOUbbCvKf2i0ebnKsB4A16f6/mo9zH/rksP5O+BxjD2mKe1hpzzi47
-        7q9pbJ/m/651LjvBYFC/coap5ajbeeRY0EYcXw2YN2OxSgsuS9S15u7pQFGnLCuCWTydRjPwDt4/
-        AAAA//8DAHBvkXFDBAAA
+        H4sIAAAAAAAAAwAAAP//jFNNj5swEL3zK6w5hwqyCRBubbWXSiu1kVbqR1aWsQfwrrGRbba7jfLf
+        K0gCJLuVygFZ8/xm3rwZ7wNCQArICfCaed60Kvz8ZXv7qO7jUqTZffT6m23v7F0ttl+/bc0tLHqG
+        KR6R+zPrAzdNq9BLo48wt8g89lnjdJ2lq2yTrAegMQJVT6taH65MuIyWqzDKwig5EWsjOTrIya+A
+        EEL2w7+XqAW+QE6ixTnSoHOsQsjHS4SANaqPAHNOOs+0h8UEcqM96l617pSaAd4YRTlTaip8/Paz
+        8+QTU4puVPG8tX8+vfzgm583XHzMEJOyjmb1jqlf20FQ2Wk++jPDx3h+VYwQ0KwZuBV6WhjzRKUu
+        zVUCQoDZqmtQ+1487HcgXaF3kO8gCtNkfRPGcZqF33dwgAvmIXjv/DCzxWLZOabe+sW0Np71sgfD
+        Hk7IYZyNMlVrTeGuqFBKLV1NLTI3tDx3PjgLGSRAdzFcaK1pWk+9ecKhaLw6bQJMuzehy+UJ9MYz
+        NWMlZ+AiHxXomRymPy4cZ7xGMVGnxWOdkGYGBLPe36p5L/exf6mr/0k/AZxj61HQ1qKQ/LLj6ZrF
+        /mn+69ro8iAYHNpnyZF6ibafh8CSder4asC9Oo8NLaWu0LZWDk8HypbyoozTbL1OUggOwV8AAAD/
+        /wMAUdnL4UMEAAA=
     headers:
       CF-RAY:
-      - 983c5c4cca97df03-SEA
+      - 984556c669277205-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:40 GMT
+      - Wed, 24 Sep 2025 21:22:45 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '665'
+      - '612'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '827'
+      - '640'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -105,15 +105,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_82d92602dd4f4ee28813c649651ebdb7
+      - req_c177733accb64d618c96dfd266da574c
     status:
       code: 200
       message: OK
 - request:
     body: '{"messages":[{"role":"user","content":"Please look up the book with ISBN
-      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_FzMB6C2Yzw1uEebNCv8tLMow","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      0-7653-1178-X and provide detailed info and a recommendation score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_9lbvRrzBxYc9Z3cdA8ee6fh0","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_FzMB6C2Yzw1uEebNCv8tLMow"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      2006-07-25","tool_call_id":"call_9lbvRrzBxYc9Z3cdA8ee6fh0"}],"model":"gpt-4o","response_format":{"type":"json_schema","json_schema":{"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
@@ -128,8 +128,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -157,18 +157,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jJJNj9MwEIbv+RXWnFuUDf1SjmyhaCUOCPZEVpFrTxKzjm3ZE6BU/e/I
-        brdJ+ZC4WLKfeccz78wxYwyUhJKB6DiJ3un5/UPxvPtO24f3H++3SoTD9ucu7HZt+8gfB5hFhd1/
-        RUEvqlfC9k4jKWvOWHjkhDHr3Xq5WS0XmyJPoLcSdZS1juYLOy/yYjHPN/N8dRF2VgkMULIvGWOM
-        HdMZSzQSf0DJUpr00mMIvEUor0GMgbc6vgAPQQXihmA2QmENoUlVHysgRRorKCv4oALtrTcl+9wh
-        e6cM1+xt75THCmYV8IE661PkG8+NtIZ94kaiD9akAMdbDBWUy8Ui3oa9VoJHM+oD8igs8nx1mlbi
-        sRkCj0aYQesJ4MZYStrkwdOFnK5da9s6b/fhNyk0yqjQ1R55sCZ2GMg6SPSUMfaU3B1uDAPnbe+o
-        JvuM6bsiv7gL4zxH+rq4QLLE9UR1BTf5aonElQ6T+YDgokM5Ssdh8kEqOwHZpOs/q/lb7nPnyrT/
-        k34EQqAjlLXzKJW47XgM8xjX/V9hV5dTwRDQf1MCa1Lo4yQkNnzQ502EcAiEfd0o06J3Xp3XsXG1
-        2Dd3681yuVpDdsp+AQAA//8DAIzMWKSXAwAA
+        H4sIAAAAAAAAAwAAAP//jJJNi9swEIbv/hVizknxps5Hfew2oQS2hW1v9WIUaWxrK0tCGpeGJf+9
+        SMnGTj+gF4H0zDuaeWdeMsZASSgZiI6T6J2e3+8ft89693D8NLgGC/643X3+qPb7dX4/fIBZVNjD
+        Mwp6Vb0RtncaSVlzxsIjJ4xZ79bLzbrYvFstE+itRB1lraN5YeeLfFHM8808X12EnVUCA5TsW8YY
+        Yy/pjCUaiT+hZPns9aXHEHiLUF6DGANvdXwBHoIKxA3BbITCGkKTqn6pgBRprKCs4EEFOlhvSva1
+        Q7ZThmu27Z3yWMGsAj5QZ32KfO+5kdawL9xI9MGaFOB4i6GCclkU8TYctBI8mlEfkUfhIs9Xp2kl
+        Hpsh8GiEGbSeAG6MpaRNHjxdyOnatbat8/YQfpNCo4wKXe2RB2tih4Gsg0RPGWNPyd3hxjBw3vaO
+        arLfMX23yC/uwjjPkb5dXCBZ4nqiuoKbfLVE4kqHyXxAcNGhHKXjMPkglZ2AbNL1n9X8Lfe5c2Xa
+        /0k/AiHQEcraeZRK3HY8hnmM6/6vsKvLqWAI6H8ogTUp9HESEhs+6PMmQjgGwr5ulGnRO6/O69i4
+        Whyau/VmuVytITtlvwAAAP//AwDITZENlwMAAA==
     headers:
       CF-RAY:
-      - 983c5c52c831df03-SEA
+      - 984556cb2e7e7205-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -176,7 +176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:41 GMT
+      - Wed, 24 Sep 2025 21:22:46 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -194,13 +194,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '756'
+      - '481'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1120'
+      - '528'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -216,7 +216,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_fecfd2a1107044d38ece143d985e743e
+      - req_a7024af3d6fa48c98ca33624a4244b99
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_async.yaml
@@ -6,7 +6,7 @@ interactions:
       score"}],"model":"gpt-4o","tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1120'
+      - '1098'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,19 +48,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNdb5swFH3nV1j3OUwkDQnjddW0ZGo1VfvotlTImAvxYmzLNtWiKP+9
-        wiRA0k4aD8i6x+fccz98CAgBXkBKgG2pY7UW4Yf1bPc9Qle8X/1ci6/fHvYiXn2mjx/5w+oLTFqG
-        yv8gc2fWO6ZqLdBxJTuYGaQOW9XpMk4W8Ty5iT1QqwJFS6u0C+cqnEWzeRglYbQ4EbeKM7SQkt8B
-        IYQc/L+1KAv8CymJJudIjdbSCiHtLxECRok2AtRabh2VDiYDyJR0KFvXshFiBDilRMaoEEPi7juM
-        zkOfqBDZp2exz3+Ud+J2oe/l/d1a/bqNVlEzytdJ77U3VDaS9f0Z4X08vUpGCEhae26FLsuV2mVc
-        lupKgBCgpmpqlK41D4cNcJvLDaQbiMLlIr4Jp9NlEj5u4AgXzGPw1vlp1BaDZWOpeN0vKqVytLXt
-        G/Z0Qo79bISqtFG5vaJCySW328wgtb7kceeDsxFvAZqL4YI2qtYuc2qHPuk0TjpVGHZvQGezE+iU
-        o2LESk77c6mXFego99PvF45RtsVioA6LR5uCqxEQjGp/7eYt7a5+Lqv/kR8AxlA7LDJtsODssuLh
-        msH2af7rWt9lbxgsmmfOMHMcTTuPAkvaiO7VgN1bh3VWclmh0Yb7pwOlzlheTpdJHC+WEByDFwAA
-        AP//AwDJGDbtQwQAAA==
+        H4sIAAAAAAAAA4xT0Y7TMBB8z1dY+9ygpiRNyCOFk+AEBXScQPQUuc4mNXVsy3bQnar+O4rTJmnv
+        kMhDZHk8s7Oz9iEgBHgJOQG2o441WoSrj99uFhg93n6I99q+rfS7JP5csmy1bt7fwaxjqO1vZO7M
+        esVUowU6rmQPM4PUYacapUmWxtmbLPZAo0oUHa3WLoxVuJgv4nCehfPlibhTnKGFnPwKCCHk4P+d
+        RVniI+RkPjvvNGgtrRHy4RAhYJTodoBay62j0sFsBJmSDmXnWrZCTACnlCgYFWIs3H+HyXrMiQpR
+        3N/s73+uoy/r9Tr7voq/6lsXteJTMqnXSz9pb6hqJRvymeDDfn5VjBCQtPHcGl2xVWpfcFmpKwFC
+        gJq6bVC6zjwcNsDtVm4g38A8TJfJ6zCK0iz8sYEjXDCPwUvrh0ksBqvWUvE8LyqlcrSz7QN7OCHH
+        YTZC1dqorb2iQsUlt7vCILW+5WnywdmItwDtxXBBG9VoVzi1R180SuJeFca7N6KLxQl0ylExYaXL
+        2Qt6RYmOcj/94cIxynZYjtTx4tG25GoCBJPen7t5Sbvvn8v6f+RHgDHUDstCGyw5u+x4PGawe5r/
+        Ojak7A2DRfOHMywcR9PNo8SKtqJ/NWCfrMOmqLis0WjD/dOBShdsW0VpliTLFIJj8BcAAP//AwDv
+        GKZKQwQAAA==
     headers:
       CF-RAY:
-      - 983c5cb3ab6c093b-SEA
+      - 9845573f8e9e75c7-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:56 GMT
+      - Wed, 24 Sep 2025 21:23:05 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -86,13 +86,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '697'
+      - '686'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '729'
+      - '724'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -108,7 +108,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_066812a7ffae46bf896754066ee042f2
+      - req_168625a7f46f48f1af45593e1aab2e3b
     status:
       code: 200
       message: OK
@@ -116,12 +116,12 @@ interactions:
     body: '{"messages":[{"role":"system","content":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_HvlybWfMlD6pNnNMJoZD0I0u","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_VFkVYO1POOO8UC4QpKt1ulM5","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_HvlybWfMlD6pNnNMJoZD0I0u"}],"model":"gpt-4o","tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_VFkVYO1POOO8UC4QpKt1ulM5"}],"model":"gpt-4o","tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -130,12 +130,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1478'
+      - '1456'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -163,20 +163,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFTLbtswELzrK4g924XtyIqhY4o0aIA6BwfooQ6INbWSmFAkQVJBXcP/
-        XpBOLOVRoDoIFGdnOPugDhljICsoGYgWg+ismn69XTz9bJ437TX6/eb+phA33fqPurvv9cUaJpFh
-        do8kwivrizCdVRSk0SdYOMJAUXV+uVwVy3x1USSgMxWpSGtsmOZmupgt8ulsNZ0VL8TWSEEeSvYr
-        Y4yxQ3pHi7qi31Cy2eR1pyPvsSEoz0GMgTMq7gB6L31AHWAygMLoQDq61r1SIyAYo7hApYaDT89h
-        tB7qhEpx097O1/nT+u6KHp831d3VcpXPiz/fR+edpPc2Gap7Lc71GeHn/fLdYYyBxi5xOe+kQy+M
-        JV4b12EIVHHTB9sHnrzzd7KMAbqm70iHmBIcthBkULSFcgs/pA8743TJ7lti36RGxa47Kx1tYbIF
-        7ENrXIq8cqgro9kGdUXOG50CLDbkt1Au8zx+9TslBcYc+J4wEhezWXGEN4aO2Wfrh1EPHNW9R/Wx
-        Oai1CUk/defhBTmeB0GZxjqz8++oUEstfcsdoU/1Hbc5ezWSLED/ZpLAOtPZWNonSocu5quTKgyD
-        PqD5xQsYTEA1YhXzySd6vKKAMo3aeboFipaqgTpMOfaVNCMgG+X+0c1n2qf8pW7+R34AhCAbx8w6
-        qqR4m/EQ5ij+B/4Vdq5yMgye3LMUxIMkF/tRUY29Ol1R8HsfqOO11A0562S6p1BbLnb1/HK1XBaX
-        kB2zvwAAAP//AwAGG40esAQAAA==
+        H4sIAAAAAAAAAwAAAP//jFTLbtswELzrK4g924XsSLajW9I0QJMW6CNNE9SBsKZWFlOKJEiqiGH4
+        3wvSiaU8ClQHgeLsDGcf1DZhDEQFBQPeoOetkeP3F9/Oj65Td3mN1c8vi5PN1eWn+S2ennVXsxMY
+        BYZe3RP3T6x3XLdGkhda7WFuCT0F1ck8X8yzxfEij0CrK5KBtjZ+nOnxNJ1m43QxTmePxEYLTg4K
+        9ithjLFtfAeLqqIHKFg6etppyTlcExSHIMbAahl2AJ0TzqPyMOpBrpUnFVyrTsoB4LWWJUcp+4P3
+        z3aw7uuEUpYfvzY32c35/SS/fTiezI6+/biwN2eyGpy3l96YaKjuFD/UZ4Af9osXhzEGCtvILctW
+        WHRcGyprbVv0nqpSd950vozeyxeyjAHaddeS8iEl2C7BCy9pCcUSPgvnV9qqgl01xM6FQsk+tEZY
+        WsJoCdj5RtsYeWpRVVqx76gqsk6rGGBwTW4JRZ5l4atbScEx5FBuCANxmqazHTwztEveWt8NemCp
+        7hzK181BpbSP+rE7d4/I7jAIUq+N1Sv3ggq1UMI1pSV0sb7DNidPRqIF6J5NEhirWxNK+5viodNJ
+        tleFftB7NDt6BL32KAesfD56Q6+syKOIo3aYbo68oaqn9lOOXSX0AEgGub9285b2Pn+h1v8j3wOc
+        kwljZixVgj/PuA+zFP4D/wo7VDkaBkf2j+BUekE29KOiGju5v6LgNs5TW9ZCrckaK+I9hdqUfFVP
+        5os8n80h2SV/AQAA//8DALvsRROwBAAA
     headers:
       CF-RAY:
-      - 983c5cb94f4e093b-SEA
+      - 984557456b7d75c7-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -184,7 +184,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:57 GMT
+      - Wed, 24 Sep 2025 21:23:06 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -202,13 +202,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '717'
+      - '924'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '735'
+      - '974'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -224,7 +224,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 6ms
       x-request-id:
-      - req_0a179f988d034af5be7bf09b77d22b12
+      - req_90a133930b944e7bb16fc57f7086184c
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_async_stream.yaml
@@ -6,7 +6,7 @@ interactions:
       score"}],"model":"gpt-4o","stream":true,"tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1134'
+      - '1112'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -47,46 +47,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_Lw5p8QHULSIEiF8rB8ZD3kjj","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"SnXZ"}
+      string: 'data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_dkOmjFqa4hx2vhkuf6vW2Na3","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"hcvf"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"mCnXGkyVbSy6F3n"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"P1t2aExnxP9N3Yk"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"S0zomg6kY9TPCJ"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ifvCkSGnARNDjK"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ox"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"eq"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"eU"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4L"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"F3"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2V"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"n5"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"h2"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"vR"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"7A"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"h"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"8"}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2ljn5tGoEJiB234zpT1FcG3r4P3","object":"chat.completion.chunk","created":1758654911,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"X"}
+        data: {"id":"chatcmpl-CJRFzUAQhsHqdHVwN9vKKV8uQOE9j","object":"chat.completion.chunk","created":1758749043,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"q"}
 
 
         data: [DONE]
@@ -95,13 +95,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5e8e8d6f19d7-SEA
+      - 984558b32bd9a362-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:15:12 GMT
+      - Wed, 24 Sep 2025 21:24:04 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -119,13 +119,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '642'
+      - '438'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '660'
+      - '474'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -141,7 +141,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_dd552411aba14817a70001412e8b2515
+      - req_6fa1831a08c04792b6dafab435429632
     status:
       code: 200
       message: OK
@@ -149,12 +149,12 @@ interactions:
     body: '{"messages":[{"role":"system","content":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_Lw5p8QHULSIEiF8rB8ZD3kjj","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_dkOmjFqa4hx2vhkuf6vW2Na3","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_Lw5p8QHULSIEiF8rB8ZD3kjj"}],"model":"gpt-4o","stream":true,"tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_dkOmjFqa4hx2vhkuf6vW2Na3"}],"model":"gpt-4o","stream":true,"tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -163,12 +163,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1492'
+      - '1470'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=LRTkNCRF2dwcND2J56HfBvEE27P5xdOGq3aRnFe_OfU-1758654824-1.0.1.1-e7Maghz7DCF2g921V1VS4utjq98HJT9btfS5sPF6WMSTV_DKZrdOScqKYzJDHL0rUAel_AG5wQK9rJdfjmelze_DL_ZacEbmhw4w0Iuqd_U;
-        _cfuvid=S4IEJ6KxPNl0NBgjmE_ekIwmg1kCuCTkEWCEsDMqN5Y-1758653687284-0.0.1.1-604800000
+      - __cf_bm=86sN._mE.r8J1zIv3TCt9l4f3F0TQhWW7ENkcNb.9fo-1758748826-1.0.1.1-lzp8MtMCcsk2O0uqtqEkvyJHkxoR3wvo.dfpk3BQPrMcAXcey69ZI95BdGb9kpnvS6Vj6Ayre6kG677zMVYzNf4m5TK3rWDOivmKB6Ld60A;
+        _cfuvid=Y8hCqDJt47VZayVBUK.0Oax026f6U6TaTKTnAflKvco-1758748826665-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -195,95 +195,95 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_t5KbP46quafTH471JT5ZcJhS","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"kl46fLdYfJsJ0U"}
+      string: 'data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_BBTBBIi7qHaCPqxql5j0DTDK","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"Y5lkthgyNVYDzj"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"DzfvuhPA9U70bd"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ILkL2i3IonWdmo"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"RPdMCh6rmC4xKg"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"YxLwNAEU0NV05T"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Mist"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"B2XKbBK87RGXAjB"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Mist"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"k239sng8J5WSKi9"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"born"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"A41iMMRcokKmNgh"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"born"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4yCL3a6E95nfddo"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"xq"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"K2"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        The"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"bKPLF9tYjMjLVMX"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        The"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"VubLv0r5gdyrr63"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Final"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"c43fnkBH59IpJ"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Final"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"iFym3jA5kEyPP"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Empire"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"s1SRPsFPspk9"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Empire"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ULfx33nq6Ru0"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"mZAEuM6oJHo7K9"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"F2F5hyRqvAjm66"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2utUPLw3Hx7Jk"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"dRmXYhWn4jRuc"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"PmW1KyAaaERknu"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"F0bHRz6FQW4AAY"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Br"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"r"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Br"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"0"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"andon"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"iBW4AXBEYso2K3"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"andon"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"VtAPLQi4mhkQKw"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Sand"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"y8hWPORx7ZS7BW"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Sand"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ToaX2w4MV3m9D8"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"GuJCbqZXDJgKui"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Ck8zagPaxEiiyy"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"n6TNdXHU8xDHlR"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"aTX7SZBEZdnSv3"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"pages"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"smxuSurojxSyrN"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"pages"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"jrIapAvo37sSN5"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"544"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"544"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"publication"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"S81FQ3QO"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"publication"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"mKDf87ym"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_year"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"JdR4DRmj6a4iyE"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_year"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"lSLpK8u9D4nWKP"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"200"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"200"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"6"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Dm"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"6"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"aL"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"kC"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2J"}
 
 
-        data: {"id":"chatcmpl-CJ2llmzqPkK7YCVIkjABcOEiGCq9j","object":"chat.completion.chunk","created":1758654913,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"i"}
+        data: {"id":"chatcmpl-CJRG0x4spAiBK7PM3R63QgIs4KRSW","object":"chat.completion.chunk","created":1758749044,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"6"}
 
 
         data: [DONE]
@@ -292,13 +292,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5e95295f19d7-SEA
+      - 984558b7f8f5a362-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:15:13 GMT
+      - Wed, 24 Sep 2025 21:24:04 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -316,13 +316,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '641'
+      - '368'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '679'
+      - '382'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -338,7 +338,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 6ms
       x-request-id:
-      - req_83472bbd0cf443de96f2c099e3a11c99
+      - req_1ef401396ac1483aabbdcaabc160ae9d
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_stream.yaml
@@ -6,7 +6,7 @@ interactions:
       score"}],"model":"gpt-4o","stream":true,"tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1134'
+      - '1112'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -47,46 +47,46 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_pqX5DWuENRx4lyLSUk1Yc1i3","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"dwef"}
+      string: 'data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_AVVNrNkchlxyMXVZXREZv97h","type":"function","function":{"name":"get_book_info","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"sLRj"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"QFBIz9NqofrAibw"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"isbn"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"9uV5D8kmEiL6zVQ"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"pzxtOv58UVdezm"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"QGG1GVzRkRjJzG"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"fN"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"0"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"q7"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"kY"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Sh"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"765"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"TM"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"3"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"C2"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"kd"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"RN"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"117"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"QQ"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"8"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ag"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"P"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"-X"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"h"}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l2Sm0DZlYeVKEc0La8bOdanrtn","object":"chat.completion.chunk","created":1758654868,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"S"}
+        data: {"id":"chatcmpl-CJRFU239gnINbgIfIzZyNKvyjMVEi","object":"chat.completion.chunk","created":1758749012,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"x"}
 
 
         data: [DONE]
@@ -95,13 +95,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5d7f0fae75ca-SEA
+      - 984557ee7899c6c8-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:28 GMT
+      - Wed, 24 Sep 2025 21:23:32 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -119,13 +119,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '461'
+      - '607'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '480'
+      - '629'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -141,7 +141,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_271587392ce9498e954d13d708494667
+      - req_61837fb2c19849c990ab505c0aacb628
     status:
       code: 200
       message: OK
@@ -149,12 +149,12 @@ interactions:
     body: '{"messages":[{"role":"system","content":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_pqX5DWuENRx4lyLSUk1Yc1i3","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_AVVNrNkchlxyMXVZXREZv97h","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_pqX5DWuENRx4lyLSUk1Yc1i3"}],"model":"gpt-4o","stream":true,"tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_AVVNrNkchlxyMXVZXREZv97h"}],"model":"gpt-4o","stream":true,"tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -163,12 +163,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1492'
+      - '1470'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -195,95 +195,95 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_xUiIxrO6AyjlLndewW4rAxJd","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"qJZKytVmuX88vw"}
+      string: 'data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":null,"tool_calls":[{"index":0,"id":"call_pDb8LHQyWoaFFrQBIv2XwUuO","type":"function","function":{"name":"__mirascope_formatted_output_tool__","arguments":""}}],"refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"LCgsQqSjSaodsw"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"rjcpgsBAJJlsA0"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"title"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"mIrK76JS3GTzzG"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"gGfDRvNncX7UHm"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"7TPg26EJHz43sn"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Mist"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"g8kQ7LldwyI66ik"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Mist"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Vx4WIhyR3h9K1QP"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"born"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"tV1IFARa4iH9ICK"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"born"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"jySXZgkBZSZBth6"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"2G"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"xM"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        The"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ghLpFIaU4u5Jdxv"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        The"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"69bmpskGLFBfQRt"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Final"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4bkh0BZYCVU76"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Final"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"lnGuGUyT2EgiT"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Empire"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"AMWJRsaL91ns"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Empire"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"vQ5oJv5yn7Fu"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"J1gZpXqyDboll2"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"33tpNm9fjI21e4"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"DK4ghAD6asVKd"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"author"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"EXJIpOJOwfStA"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"EDsJ6ahnE4oBvM"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"r9H8GvLHdXfWwv"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Br"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"v"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"Br"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"N"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"andon"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"tf4Ox2tjhQQg41"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"andon"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"5GYOCKbKggjfg1"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
-        Sand"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"skCwbYKmNEv2Rk"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"
+        Sand"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"4skNwPKpFGk178"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"HklC9XtT3ZHD6X"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"erson"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"bIB0eUFZMU1Hir"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"tbXEbOXaXDOH0D"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"pyzUAUcy8PfgTD"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"pages"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"daIASI4wglJFyx"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"pages"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"tZQGsvJIZYVPut"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"544"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"544"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":",\""}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"publication"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"SZ5D7dZt"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"publication"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"w8ngn9T0"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_year"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Axes1rcFaDVlKP"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"_year"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"ZzdFQwTABkGNTg"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"\":"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"200"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"200"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":""}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"6"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"Zq"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"6"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"rl"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"nP"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"}"}}]},"logprobs":null,"finish_reason":null}],"obfuscation":"I5"}
 
 
-        data: {"id":"chatcmpl-CJ2l3NwywrQAqJBnf8A5jNAbvp6xM","object":"chat.completion.chunk","created":1758654869,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"o"}
+        data: {"id":"chatcmpl-CJRFVjBANYCwhRMfvTREOSCi8lScZ","object":"chat.completion.chunk","created":1758749013,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"tool_calls"}],"obfuscation":"F"}
 
 
         data: [DONE]
@@ -292,13 +292,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 983c5d85ffed75ca-SEA
+      - 984557f42febc6c8-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 23 Sep 2025 19:14:30 GMT
+      - Wed, 24 Sep 2025 21:23:33 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -316,13 +316,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '454'
+      - '560'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '595'
+      - '629'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -338,7 +338,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 6ms
       x-request-id:
-      - req_6c178467ea1540b881ddb8521d7553dc
+      - req_66835e4af4354a5cb7639e3a5a02a0ac
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/openai/tool_sync.yaml
@@ -6,7 +6,7 @@ interactions:
       score"}],"model":"gpt-4o","tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -15,12 +15,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1120'
+      - '1098'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=CxfTBlUD6Ofq0UZnDxNJI6SZGErhgRzfkuWEFHSDq_k-1758653668-1.0.1.1-7I9UM2OZcBYiGfJVz5pI7zloYuhKmbF0lM0xjKTv0iYhnWbmNutPvU1NN_SYnbcdZIAGe.8WQshX_gmuIck2XvaiXobWz6IXN9pKDlqmQAw;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,19 +48,19 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFNNj5swEL3zK6w5h4rQkCBu7barZtMc+h2pWSFjBuLG2JZtqk2j/PcK
-        SIBkt1I5IGue35s3Hz56hADPISHAdtSxSgv/7iHchz+y1ZfoT0XvV0/LD+W7zXK953dv1QomDUNl
-        v5C5C+sVU5UW6LiSHcwMUoeN6nQRxfNoFgfzFqhUjqKhldr5M+WHQTjzg9gP5mfiTnGGFhLy0yOE
-        kGP7byzKHJ8gIcHkEqnQWloiJP0lQsAo0USAWsuto9LBZACZkg5l41rWQowAp5RIGRViSNx9x9F5
-        6BMVIpXfPsfv6V4f7tfrT8G6WG52H79+f/MwytdJH3RrqKgl6/szwvt4cpOMEJC0arklujRTap9y
-        WagbAUKAmrKuULrGPBy3wG0mt5BsIfAX8+i1P50uYn+zhRNcMU/eS+fHUVsMFrWl4nm/qJTK0cZ2
-        27DHM3LqZyNUqY3K7A0VCi653aUGqW1LHnfeuxhpLUB9NVzQRlXapU7tsU06jeJOFYbdG9AwPINO
-        OSpGrPi8P9d6aY6O8nb6/cIxynaYD9Rh8WidczUCvFHtz928pN3Vz2X5P/IDwBhqh3mqDeacXVc8
-        XDPYPM1/Xeu73BoGi+Y3Z5g6jqaZR44FrUX3asAerMMqLbgs0WjD26cDhU5ZVkwXcRTNF+CdvL8A
-        AAD//wMA6Aymk0MEAAA=
+        H4sIAAAAAAAAAwAAAP//jFNRb5swEH7nV1j3HCaShpDyNm1TtUrbpG5r1y0VMuYAp8YmtpmWRvnv
+        EyYBkmbSeEDWff7uvvvuvPMIAZ5BTICV1LKqFv6727sPj+XVx583b9X3xcvt183jzcPs0+cwzV6+
+        waRlqHSNzB5Zb5iqaoGWK9nBTCO12GadRuEymi+vw7kDKpWhaGlFbf258mfBbO4HSz9YHIil4gwN
+        xOSXRwghO/dvJcoM/0BMgskxUqExtECI+0uEgFaijQA1hhtLpYXJADIlLcpWtWyEGAFWKZEwKsRQ
+        uPt2o/PgExUi2bznZblJ8/u7L9k8vV6v9f06YNtxvS71tnaC8kay3p8R3sfjs2KEgKSV4xZok1Sp
+        54TLXJ0lIASoLpoKpW3Fw24F3KRyBfEKAj9ahFf+dBot/R8r2MMJc+9dOj+NbNGYN4aK135RKZWl
+        rWxn2NMB2fezEaqotUrNGRVyLrkpE43UuJbHzntHIU4CNCfDhVqrqraJVc/oik67hXJTPe7egM5m
+        B9AqS8WIFS0mF/IlGVrK3fT7hWOUlZgN1GHxaJNxNQK8Ue+v1VzK3fXPZfE/6QeAMawtZkmtMePs
+        tOPhmsb2af7rWu+yEwwG9W/OMLEcdTuPDHPaiG6LwWyNxSrJuSxQ15q7pwN5nbA0n0bLMFxE4O29
+        vwAAAP//AwC5bRdRQwQAAA==
     headers:
       CF-RAY:
-      - 983c5bfad9df751c-SEA
+      - 98455684eb38754a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,13 +68,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:26 GMT
+      - Wed, 24 Sep 2025 21:22:34 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        path=/; expires=Tue, 23-Sep-25 19:43:26 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -90,13 +86,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '539'
+      - '493'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '686'
+      - '513'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -112,7 +108,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_9521041feb7a4059b1a34440ee86dc3d
+      - req_d51d966c57c245cbb63f78d8503ee406
     status:
       code: 200
       message: OK
@@ -120,12 +116,12 @@ interactions:
     body: '{"messages":[{"role":"system","content":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_nUR8EakpyFMMQ0MfIXhLTVAJ","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
+      score"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_qDihhqbfVROd4b9jjrVj0cyt","type":"function","function":{"name":"get_book_info","arguments":"{\"isbn\":\"0-7653-1178-X\"}"}}]},{"role":"tool","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","tool_call_id":"call_nUR8EakpyFMMQ0MfIXhLTVAJ"}],"model":"gpt-4o","tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
+      2006-07-25","tool_call_id":"call_qDihhqbfVROd4b9jjrVj0cyt"}],"model":"gpt-4o","tool_choice":"required","tools":[{"type":"function","function":{"name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}},{"type":"function","function":{"name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}}]}'
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}}]}'
     headers:
       accept:
       - application/json
@@ -134,12 +130,12 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1478'
+      - '1456'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=AOWZXDunZ3OAKSzm4Uwca_ca6hxud2WPAg7axK4LxvI-1758654806-1.0.1.1-oACb5Lz6wmUBmpj49HKarJOeL2H7EFKIbNX93nsHrnJC3Xdy5jYP7.tkAavk1pqtFOxkj2wPRjcY3Pw02Nqv4MOViBxDyVJvWNvdQZHx73s;
-        _cfuvid=3LW4aE79lr1DBej.WjvVw8mLLJidrvQqn8gIqOUziX8-1758653668945-0.0.1.1-604800000
+      - __cf_bm=UnhiCJyFvC71cLefnM2sH76bvTW.esCfGgVznWXgJuA-1758748809-1.0.1.1-iHZtu7rvDm0rIMA1w6G8rSRYtzt2bz4yPZ8dFau46Mqc1sahmoeQujbKh20Ckjf3jFoWUuVQgaGq6cosjRBnbRCIYSv0o0ASWC1LfUARr5g;
+        _cfuvid=EZe7EEB6BX0ExMGGCQ7BOYagBmEQcRDGZ3lvkSqkHfI-1758748809274-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -167,20 +163,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFTJbtswEL3rK4g524XseIuOaVM0BdpDNyCoA2JEjSTWFMmSVJDU8L8X
-        pBNLWQpUB4Him/f4ZqH2GWMgKygYiBaD6Kyavv043525z2v8vfJn34OdXZ5/uNL9Be0u2hImkWHK
-        XyTCI+uNMJ1VFKTRR1g4wkBRdbZeblbLxSZfJ6AzFalIa2yYLsx0ns8X03wzzVcPxNZIQR4K9jNj
-        jLF9ekeLuqI7KFg+edzpyHtsCIpTEGPgjIo7gN5LH1AHmAygMDqQjq51r9QICMYoLlCp4eDjsx+t
-        hzqhUvy6ene7vtPlF/dj9+d2vqw359dXpd6NzjtK39tkqO61ONVnhJ/2i2eHMQYau8TlvJMOvTCW
-        eG1chyFQxU0fbB948s6fyTIG6Jq+Ix1iSrDfQpBB0RaKLXySPpTG6YJ9a4m9lxoVu+ysdLSFyRaw
-        D61xKfLCoa6MZl9RV+S80SnAYkN+C8VysYhffamkwJgDvyeMxHmerw7wxNAhe219M+qBo7r3qF42
-        B7U2Iemn7tw8IIfTICjTWGdK/4wKtdTSt9wR+lTfcZuzRyPJAvRPJgmsM52Npd1ROnQ+2xxVYRj0
-        AV2cPYDBBFQj1mo2eUWPVxRQplE7TbdA0VI1UIcpx76SZgRko9xfunlN+5i/1M3/yA+AEGTjmFlH
-        lRRPMx7CHMX/wL/CTlVOhsGTu5WCeJDkYj8qqrFXxysK/t4H6ngtdUPOOpnuKdSWi7KerTfL5WoN
-        2SH7CwAA//8DAA4lINiwBAAA
+        H4sIAAAAAAAAAwAAAP//jFRdb9MwFH3Pr7Duc4vSkLQlj0NDrAimwQQIOlmuc5N4c2zPdqZVVf/7
+        ZHdrsg8k8hA5Pvccn/vh7BJCQFRQEuAt87wzcvpx9f30z5ez6/NvF7ObbNtc4P3qJhMXZ3716xYm
+        gaE318j9E+sd152R6IVWB5hbZB6D6mxRLBf58kNRRKDTFcpAa4yf5nqapVk+TZfTdP5IbLXg6KAk
+        fxNCCNnFd7CoKryHkqSTp50OnWMNQnkMIgSslmEHmHPCeaY8TAaQa+VRBdeql3IEeK0l5UzK4eDD
+        sxuthzoxKenKmHp+n37+nd2dZz+LGk/Sy9t5y0bnHaS3Jhqqe8WP9Rnhx/3yxWGEgGJd5FLaCcsc
+        1wZprW3HvMeK6t6b3tPonb6QJQSYbfoOlQ8pwW4NXniJayjX8FU4v9FWleSyRfJJKCbJaWeExTVM
+        1sB632obI08sU5VW5AdTFVqnVQwwrEG3hrLI8/DVb6TgLORAt8gCMUvT+R6eGdonb62vRj2wWPeO
+        ydfNYUppH/Vjd64ekf1xEKRujNUb94IKtVDCtdQic7G+4zYnT0aiBeifTRIYqzsTSnuD8dBslh9U
+        YRj0Ac3fP4JeeyZHrGIxeUOPVuiZiKN2nG7OeIvVQB2mnPWV0CMgGeX+2s1b2of8hWr+R34AOEcT
+        xsxYrAR/nvEQZjH8B/4VdqxyNAwO7Z3gSL1AG/pRYc16ebii4LbOY0droRq0xop4T6E2lG/q2WJZ
+        FPMFJPvkAQAA//8DAIMn0rGwBAAA
     headers:
       CF-RAY:
-      - 983c5c004ef4751c-SEA
+      - 98455688ce80754a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -188,7 +184,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 23 Sep 2025 19:13:27 GMT
+      - Wed, 24 Sep 2025 21:22:35 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -206,13 +202,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '629'
+      - '597'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '735'
+      - '625'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -228,7 +224,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 6ms
       x-request-id:
-      - req_32ce50583fb34e138d74c6159a283593
+      - req_82812ff49fbe48ec91aa67567df133a4
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/snapshots/structured_output/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/anthropic_snapshots.py
@@ -30,7 +30,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -39,10 +39,22 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -81,7 +93,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -90,10 +102,22 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -131,7 +155,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -140,10 +164,22 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -158,7 +194,7 @@ stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 18,
+        "n_chunks": 19,
     }
 )
 async_stream_snapshot = snapshot(
@@ -182,7 +218,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -191,10 +227,22 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -209,6 +257,6 @@ async_stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 14,
+        "n_chunks": 21,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/google_snapshots.py
@@ -24,7 +24,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -33,10 +33,33 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -70,7 +93,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -79,10 +102,33 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -115,7 +161,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -124,10 +170,33 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -161,7 +230,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -170,10 +239,33 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",

--- a/python/tests/e2e/snapshots/structured_output/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_anthropic_snapshots.py
@@ -20,6 +20,27 @@ sync_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -27,8 +48,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -58,13 +78,14 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
-```json
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
-}
-```\
+}\
 """
                     )
                 ]
@@ -74,10 +95,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -92,6 +125,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -99,8 +153,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -133,6 +186,27 @@ async_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -140,8 +214,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -174,7 +247,10 @@ Respond only with valid JSON that matches this exact schema:
 ```json
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }
 ```\
@@ -187,10 +263,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -205,6 +293,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -212,8 +321,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -245,6 +353,27 @@ stream_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -252,8 +381,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -283,13 +411,14 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
-```json
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
-}
-```\
+}\
 """
                     )
                 ]
@@ -299,10 +428,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -317,6 +458,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -324,8 +486,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -344,7 +505,7 @@ Respond only with valid JSON that matches this exact schema:
 """,
         },
         "tools": [],
-        "n_chunks": 6,
+        "n_chunks": 9,
     }
 )
 async_stream_snapshot = snapshot(
@@ -358,6 +519,27 @@ async_stream_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -365,8 +547,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -396,13 +577,14 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
-```json
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
-}
-```\
+}\
 """
                     )
                 ]
@@ -412,10 +594,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -430,6 +624,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -437,8 +652,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -457,6 +671,6 @@ Respond only with valid JSON that matches this exact schema:
 """,
         },
         "tools": [],
-        "n_chunks": 6,
+        "n_chunks": 10,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/json_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_google_snapshots.py
@@ -20,6 +20,27 @@ sync_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -27,8 +48,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -60,7 +80,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -72,10 +95,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -90,6 +125,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -97,8 +153,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -131,6 +186,27 @@ async_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -138,8 +214,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -171,7 +246,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -183,10 +261,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -201,6 +291,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -208,8 +319,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -241,6 +351,27 @@ stream_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -248,8 +379,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -281,7 +411,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -293,10 +426,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -311,6 +456,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -318,8 +484,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -338,7 +503,7 @@ Respond only with valid JSON that matches this exact schema:
 """,
         },
         "tools": [],
-        "n_chunks": 3,
+        "n_chunks": 4,
     }
 )
 async_stream_snapshot = snapshot(
@@ -352,6 +517,27 @@ async_stream_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -359,8 +545,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -392,7 +577,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -404,10 +592,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -422,6 +622,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -429,8 +650,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",

--- a/python/tests/e2e/snapshots/structured_output/json_openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_openai_snapshots.py
@@ -20,6 +20,27 @@ sync_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -27,8 +48,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -60,7 +80,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -72,10 +95,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -90,6 +125,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -97,8 +153,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -131,6 +186,27 @@ async_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -138,8 +214,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -171,7 +246,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -183,10 +261,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -201,6 +291,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -208,8 +319,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -241,6 +351,27 @@ stream_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -248,8 +379,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -281,7 +411,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -293,10 +426,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -311,6 +456,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -318,8 +484,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -338,7 +503,7 @@ Respond only with valid JSON that matches this exact schema:
 """,
         },
         "tools": [],
-        "n_chunks": 33,
+        "n_chunks": 49,
     }
 )
 async_stream_snapshot = snapshot(
@@ -352,6 +517,27 @@ async_stream_snapshot = snapshot(
                     text="""\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -359,8 +545,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -392,7 +577,10 @@ Respond only with valid JSON that matches this exact schema:
                         text="""\
 {
   "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
   "rating": 7
 }\
 """
@@ -404,10 +592,22 @@ Respond only with valid JSON that matches this exact schema:
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -422,6 +622,27 @@ Respond only with valid JSON that matches this exact schema:
             "formatting_instructions": """\
 Respond only with valid JSON that matches this exact schema:
 {
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
   "description": "A book with a rating. The title should be in all caps!",
   "properties": {
     "title": {
@@ -429,8 +650,7 @@ Respond only with valid JSON that matches this exact schema:
       "type": "string"
     },
     "author": {
-      "title": "Author",
-      "type": "string"
+      "$ref": "#/$defs/Author"
     },
     "rating": {
       "description": "For testing purposes, the rating should be 7",
@@ -449,6 +669,6 @@ Respond only with valid JSON that matches this exact schema:
 """,
         },
         "tools": [],
-        "n_chunks": 33,
+        "n_chunks": 49,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/openai_snapshots.py
@@ -24,7 +24,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -33,10 +33,23 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -70,7 +83,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -79,10 +92,23 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -115,7 +141,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -124,10 +150,23 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -142,7 +181,7 @@ stream_snapshot = snapshot(
             "formatting_instructions": None,
         },
         "tools": [],
-        "n_chunks": 23,
+        "n_chunks": 32,
     }
 )
 async_stream_snapshot = snapshot(
@@ -161,7 +200,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -170,10 +209,23 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -188,6 +240,6 @@ async_stream_snapshot = snapshot(
             "formatting_instructions": None,
         },
         "tools": [],
-        "n_chunks": 23,
+        "n_chunks": 32,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/strict_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/strict_google_snapshots.py
@@ -24,7 +24,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -33,10 +33,33 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -70,7 +93,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -79,10 +102,33 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -115,7 +161,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -124,10 +170,33 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -161,7 +230,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -170,10 +239,33 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "propertyOrdering": ["first_name", "last_name"],
+                    },
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",

--- a/python/tests/e2e/snapshots/structured_output/strict_openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/strict_openai_snapshots.py
@@ -24,7 +24,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -33,10 +33,23 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -70,7 +83,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -79,10 +92,23 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -115,7 +141,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -124,10 +150,23 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -142,7 +181,7 @@ stream_snapshot = snapshot(
             "formatting_instructions": None,
         },
         "tools": [],
-        "n_chunks": 23,
+        "n_chunks": 32,
     }
 )
 async_stream_snapshot = snapshot(
@@ -161,7 +200,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -170,10 +209,23 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                        "additionalProperties": False,
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -188,6 +240,6 @@ async_stream_snapshot = snapshot(
             "formatting_instructions": None,
         },
         "tools": [],
-        "n_chunks": 23,
+        "n_chunks": 32,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_anthropic_snapshots.py
@@ -30,7 +30,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -39,10 +39,22 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -81,7 +93,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -90,10 +102,22 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -131,7 +155,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -140,10 +164,22 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -158,7 +194,7 @@ stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 13,
+        "n_chunks": 18,
     }
 )
 async_stream_snapshot = snapshot(
@@ -182,7 +218,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
                 ]
             ),
@@ -191,10 +227,22 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -209,6 +257,6 @@ async_stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 15,
+        "n_chunks": 18,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/tool_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_google_snapshots.py
@@ -30,7 +30,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"rating": 7, "author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND"}'
+                        text='{"rating": 7, "author": {"last_name": "Rothfuss", "first_name": "Patrick"}, "title": "THE NAME OF THE WIND"}'
                     )
                 ]
             ),
@@ -39,10 +39,22 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -81,7 +93,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
                 ]
             ),
@@ -90,10 +102,22 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -131,7 +155,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"author": {"last_name": "Rothfuss", "first_name": "Patrick"}, "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
                 ]
             ),
@@ -140,10 +164,22 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -182,7 +218,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND", "rating": 7}'
+                        text='{"author": {"last_name": "Rothfuss", "first_name": "Patrick"}, "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
                 ]
             ),
@@ -191,10 +227,22 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",

--- a/python/tests/e2e/snapshots/structured_output/tool_openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_openai_snapshots.py
@@ -30,7 +30,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -39,10 +39,22 @@ sync_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -81,7 +93,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -90,10 +102,22 @@ async_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -131,7 +155,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -140,10 +164,22 @@ stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -158,7 +194,7 @@ stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 22,
+        "n_chunks": 31,
     }
 )
 async_stream_snapshot = snapshot(
@@ -182,7 +218,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
                 ]
             ),
@@ -191,10 +227,22 @@ async_stream_snapshot = snapshot(
             "name": "Book",
             "description": "A book with a rating. The title should be in all caps!",
             "schema": {
+                "$defs": {
+                    "Author": {
+                        "description": "The author of a book.",
+                        "properties": {
+                            "first_name": {"title": "First Name", "type": "string"},
+                            "last_name": {"title": "Last Name", "type": "string"},
+                        },
+                        "required": ["first_name", "last_name"],
+                        "title": "Author",
+                        "type": "object",
+                    }
+                },
                 "description": "A book with a rating. The title should be in all caps!",
                 "properties": {
                     "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
+                    "author": {"$ref": "#/$defs/Author"},
                     "rating": {
                         "description": "For testing purposes, the rating should be 7",
                         "title": "Rating",
@@ -209,6 +257,6 @@ async_stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 22,
+        "n_chunks": 31,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/anthropic_snapshots.py
@@ -152,7 +152,7 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 15,
+        "n_chunks": 16,
     }
 )
 async_stream_snapshot = snapshot(
@@ -201,6 +201,6 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 15,
+        "n_chunks": 17,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/google_snapshots.py
@@ -78,7 +78,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
                 ]
             ),

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_anthropic_snapshots.py
@@ -139,6 +139,63 @@ lucky number 7.\
                 content=[
                     Text(
                         text="""\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": "Patrick Rothfuss",
+  "rating": 7
+}
+```\
+"""
+                    )
+                ]
+            ),
+        ],
+        "format": {
+            "name": "Book",
+            "description": None,
+            "schema": {
+                "properties": {
+                    "title": {"title": "Title", "type": "string"},
+                    "author": {"title": "Author", "type": "string"},
+                    "rating": {"title": "Rating", "type": "integer"},
+                },
+                "required": ["title", "author", "rating"],
+                "title": "Book",
+                "type": "object",
+            },
+            "mode": "json",
+            "formatting_instructions": """\
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+""",
+        },
+        "tools": [],
+        "n_chunks": 7,
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "provider": "anthropic",
+        "model_id": "claude-sonnet-4-0",
+        "finish_reason": FinishReason.END_TURN,
+        "messages": [
+            SystemMessage(
+                content=Text(
+                    text="""\
+Always recommend The Name of the Wind.
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+"""
+                )
+            ),
+            UserMessage(content=[Text(text="Please recommend a book to me!")]),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="""\
 {
   "title": "THE NAME OF THE WIND",
   "author": "Patrick Rothfuss",
@@ -171,66 +228,5 @@ lucky number 7.\
         },
         "tools": [],
         "n_chunks": 6,
-    }
-)
-async_stream_snapshot = snapshot(
-    {
-        "provider": "anthropic",
-        "model_id": "claude-sonnet-4-0",
-        "finish_reason": FinishReason.END_TURN,
-        "messages": [
-            SystemMessage(
-                content=Text(
-                    text="""\
-Always recommend The Name of the Wind.
-Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-The title should be in all caps, and the rating should always be the
-lucky number 7.\
-"""
-                )
-            ),
-            UserMessage(content=[Text(text="Please recommend a book to me!")]),
-            AssistantMessage(
-                content=[
-                    Text(
-                        text="""\
-Here's a fantastic book recommendation for you:
-
-```json
-{
-  "title": "THE NAME OF THE WIND",
-  "author": "Patrick Rothfuss",
-  "rating": 7
-}
-```
-
-This is the first book in The Kingkiller Chronicle series and follows Kvothe, a legendary figure telling his own story. It's a beautifully written fantasy novel with incredible world-building, magic systems, and storytelling within storytelling. Perfect for anyone who loves epic fantasy with rich prose and compelling characters!\
-"""
-                    )
-                ]
-            ),
-        ],
-        "format": {
-            "name": "Book",
-            "description": None,
-            "schema": {
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
-                    "rating": {"title": "Rating", "type": "integer"},
-                },
-                "required": ["title", "author", "rating"],
-                "title": "Book",
-                "type": "object",
-            },
-            "mode": "json",
-            "formatting_instructions": """\
-Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-The title should be in all caps, and the rating should always be the
-lucky number 7.\
-""",
-        },
-        "tools": [],
-        "n_chunks": 12,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_google_snapshots.py
@@ -29,7 +29,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
                 ]
             ),
@@ -78,7 +78,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
                 ]
             ),
@@ -126,7 +126,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
+                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
                 ]
             ),

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_anthropic_snapshots.py
@@ -152,7 +152,7 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 13,
+        "n_chunks": 15,
     }
 )
 async_stream_snapshot = snapshot(
@@ -201,6 +201,6 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 15,
+        "n_chunks": 16,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_google_snapshots.py
@@ -29,7 +29,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND", "rating": 7}'
+                        text='{"author": "Patrick Rothfuss", "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
                 ]
             ),
@@ -78,7 +78,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"rating": 7, "title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss"}'
+                        text='{"author": "Patrick Rothfuss", "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
                 ]
             ),
@@ -126,7 +126,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        text='{"author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND", "rating": 7}'
                     )
                 ]
             ),
@@ -175,7 +175,7 @@ lucky number 7.\
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"rating": 7, "title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss"}'
+                        text='{"rating": 7, "author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND"}'
                     )
                 ]
             ),

--- a/python/tests/e2e/snapshots/structured_output_with_tools/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/anthropic_snapshots.py
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_0149h3mTFRJja7et1w7eGGik",
+                        id="toolu_01X938L27f3CWqAH83EPuvEA",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -41,7 +41,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_0149h3mTFRJja7et1w7eGGik",
+                        id="toolu_01X938L27f3CWqAH83EPuvEA",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -121,7 +121,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_019qFiAbk5E5QNNJ3uPF4MTR",
+                        id="toolu_0132Koj3pJwruaQ1avSbp8hT",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -130,7 +130,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_019qFiAbk5E5QNNJ3uPF4MTR",
+                        id="toolu_0132Koj3pJwruaQ1avSbp8hT",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -209,7 +209,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01BsqozubHv7TU8fqpY2dezk",
+                        id="toolu_01EFnkkQ3MFkjB8QzjJrRdgK",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -218,7 +218,7 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01BsqozubHv7TU8fqpY2dezk",
+                        id="toolu_01EFnkkQ3MFkjB8QzjJrRdgK",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -298,7 +298,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_013uwfr6r7wwydG4x8AFsjKA",
+                        id="toolu_01GJCbSbjrMEMRZLc8bSt3tP",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -307,7 +307,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_013uwfr6r7wwydG4x8AFsjKA",
+                        id="toolu_01GJCbSbjrMEMRZLc8bSt3tP",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -363,6 +363,6 @@ async_stream_snapshot = snapshot(
                 "strict": False,
             }
         ],
-        "n_chunks": 21,
+        "n_chunks": 20,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/google_snapshots.py
@@ -50,7 +50,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"pages": 544, "publication_year": 2006, "title": "Mistborn: The Final Empire", "author": "Brandon Sanderson"}'
+                        text='{"author": "Brandon Sanderson", "title": "Mistborn: The Final Empire", "pages": 544, "publication_year": 2006}'
                     )
                 ]
             ),
@@ -139,7 +139,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"author": "Brandon Sanderson", "publication_year": 2006, "pages": 544, "title": "Mistborn: The Final Empire"}'
+                        text='{"publication_year": 2006, "author": "Brandon Sanderson", "pages": 544, "title": "Mistborn: The Final Empire"}'
                     )
                 ]
             ),
@@ -227,7 +227,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"pages": 544, "publication_year": 2006, "title": "Mistborn: The Final Empire", "author": "Brandon Sanderson"}'
+                        text='{"publication_year": 2006, "author": "Brandon Sanderson", "pages": 544, "title": "Mistborn: The Final Empire"}'
                     )
                 ]
             ),
@@ -316,7 +316,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title": "Mistborn: The Final Empire", "publication_year": 2006, "author": "Brandon Sanderson", "pages": 544}'
+                        text='{"title": "Mistborn: The Final Empire", "pages": 544, "publication_year": 2006, "author": "Brandon Sanderson"}'
                     )
                 ]
             ),

--- a/python/tests/e2e/snapshots/structured_output_with_tools/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/json_anthropic_snapshots.py
@@ -65,7 +65,7 @@ Respond only with valid JSON that matches this exact schema:
                         text="I'll look up the book information for ISBN 0-7653-1178-X."
                     ),
                     ToolCall(
-                        id="toolu_01XAV8SzAYW1s424CW83ThCy",
+                        id="toolu_0192oUhN2BzCBAKdg39U8iTq",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
@@ -74,7 +74,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01XAV8SzAYW1s424CW83ThCy",
+                        id="toolu_0192oUhN2BzCBAKdg39U8iTq",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -224,7 +224,7 @@ Respond only with valid JSON that matches this exact schema:
                         text="I'll look up the book information for ISBN 0-7653-1178-X."
                     ),
                     ToolCall(
-                        id="toolu_018tw1WJDw6DLu46vd8id2m8",
+                        id="toolu_01SMkrsGBQCzUuVSmxVBfoQF",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
@@ -233,7 +233,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_018tw1WJDw6DLu46vd8id2m8",
+                        id="toolu_01SMkrsGBQCzUuVSmxVBfoQF",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -243,14 +243,12 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
-```json
 {
   "title": "Mistborn: The Final Empire",
   "author": "Brandon Sanderson",
   "pages": 544,
   "publication_year": 2006
-}
-```\
+}\
 """
                     )
                 ]
@@ -380,17 +378,20 @@ Respond only with valid JSON that matches this exact schema:
             ),
             AssistantMessage(
                 content=[
+                    Text(
+                        text="I'll look up the book information for ISBN 0-7653-1178-X."
+                    ),
                     ToolCall(
-                        id="toolu_01R3Vtivons4MceJSju6zEcg",
+                        id="toolu_0157vdFBvDnj25jqaEUsXf8k",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
-                    )
+                    ),
                 ]
             ),
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01R3Vtivons4MceJSju6zEcg",
+                        id="toolu_0157vdFBvDnj25jqaEUsXf8k",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -400,14 +401,12 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
-```json
 {
   "title": "Mistborn: The Final Empire",
   "author": "Brandon Sanderson",
   "pages": 544,
   "publication_year": 2006
-}
-```\
+}\
 """
                     )
                 ]
@@ -542,7 +541,7 @@ Respond only with valid JSON that matches this exact schema:
                         text="I'll look up the book information for ISBN 0-7653-1178-X."
                     ),
                     ToolCall(
-                        id="toolu_01Frb4XcLWS36HNUZy4ANF1W",
+                        id="toolu_01LKpFA5MpBZxWdLp5iLMwB9",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
@@ -551,7 +550,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01Frb4XcLWS36HNUZy4ANF1W",
+                        id="toolu_01LKpFA5MpBZxWdLp5iLMwB9",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -561,12 +560,14 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
+```json
 {
   "title": "Mistborn: The Final Empire",
   "author": "Brandon Sanderson",
   "pages": 544,
   "publication_year": 2006
-}\
+}
+```\
 """
                     )
                 ]
@@ -644,6 +645,6 @@ Respond only with valid JSON that matches this exact schema:
                 "strict": False,
             }
         ],
-        "n_chunks": 6,
+        "n_chunks": 7,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/json_openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/json_openai_snapshots.py
@@ -62,7 +62,7 @@ Respond only with valid JSON that matches this exact schema:
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_GtXudA5AwpvfbB4JxDqcabNO",
+                        id="call_Jst9famRKxdcWS5c9GKUfRUd",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -71,7 +71,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_GtXudA5AwpvfbB4JxDqcabNO",
+                        id="call_Jst9famRKxdcWS5c9GKUfRUd",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -218,7 +218,7 @@ Respond only with valid JSON that matches this exact schema:
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_N1EC4rbwD2Sb9jwPCqwu3nnM",
+                        id="call_RWEFEmszCxipS3lj838AJbDe",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -227,7 +227,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_N1EC4rbwD2Sb9jwPCqwu3nnM",
+                        id="call_RWEFEmszCxipS3lj838AJbDe",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -373,7 +373,7 @@ Respond only with valid JSON that matches this exact schema:
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_xu4jyMWyA8g6fO7LcvqQNFVZ",
+                        id="call_gQS5c1vZckyC70czakz6nT2r",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -382,7 +382,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_xu4jyMWyA8g6fO7LcvqQNFVZ",
+                        id="call_gQS5c1vZckyC70czakz6nT2r",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -391,7 +391,7 @@ Respond only with valid JSON that matches this exact schema:
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        text='{ "title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006 }'
                     )
                 ]
             ),
@@ -468,7 +468,7 @@ Respond only with valid JSON that matches this exact schema:
                 "strict": False,
             }
         ],
-        "n_chunks": 30,
+        "n_chunks": 38,
     }
 )
 async_stream_snapshot = snapshot(
@@ -522,7 +522,7 @@ Respond only with valid JSON that matches this exact schema:
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_vgS8SVlJ6JJ2hEgrp3dx6oP6",
+                        id="call_kt0AyI4y0FRQbfphwsvXvNN3",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -531,7 +531,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_vgS8SVlJ6JJ2hEgrp3dx6oP6",
+                        id="call_kt0AyI4y0FRQbfphwsvXvNN3",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -540,7 +540,14 @@ Respond only with valid JSON that matches this exact schema:
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        text="""\
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}\
+"""
                     )
                 ]
             ),
@@ -617,6 +624,6 @@ Respond only with valid JSON that matches this exact schema:
                 "strict": False,
             }
         ],
-        "n_chunks": 30,
+        "n_chunks": 43,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/openai_snapshots.py
@@ -26,7 +26,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_FzMB6C2Yzw1uEebNCv8tLMow",
+                        id="call_9lbvRrzBxYc9Z3cdA8ee6fh0",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -35,7 +35,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_FzMB6C2Yzw1uEebNCv8tLMow",
+                        id="call_9lbvRrzBxYc9Z3cdA8ee6fh0",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -110,7 +110,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_BkWBU0Vmbb04J1Si0fPD29ZZ",
+                        id="call_txvgIefObgDKDmvfNYHaffru",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -119,7 +119,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_BkWBU0Vmbb04J1Si0fPD29ZZ",
+                        id="call_txvgIefObgDKDmvfNYHaffru",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -193,7 +193,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_nlPzRyF0DR73zQpt1hCmi7RK",
+                        id="call_j4gk8mlqvLtdPZuMQqj1DNTM",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -202,7 +202,7 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_nlPzRyF0DR73zQpt1hCmi7RK",
+                        id="call_j4gk8mlqvLtdPZuMQqj1DNTM",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -277,7 +277,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_HOQ64tNdVOJXkZB8AxQBziOL",
+                        id="call_4VjDex3fZhV7tIAmFdYY6u45",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -286,7 +286,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_HOQ64tNdVOJXkZB8AxQBziOL",
+                        id="call_4VjDex3fZhV7tIAmFdYY6u45",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/strict_openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/strict_openai_snapshots.py
@@ -26,7 +26,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_DnT2i5GvOgt0yl9xZLadGZOx",
+                        id="call_SASOQ2rduFQoNjQMtLhXiWCa",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -35,7 +35,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_DnT2i5GvOgt0yl9xZLadGZOx",
+                        id="call_SASOQ2rduFQoNjQMtLhXiWCa",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -110,7 +110,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_RTzMyBC3DNvcuUyO0gKUBgqZ",
+                        id="call_DwQWQXztABmfTJPGB3RKZVYd",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -119,7 +119,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_RTzMyBC3DNvcuUyO0gKUBgqZ",
+                        id="call_DwQWQXztABmfTJPGB3RKZVYd",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -193,16 +193,16 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_MbBdVxoY72QRc0wQbKhbhrdZ",
+                        id="call_YJsJE8QRPmdDAHFe5H5QJUAQ",
                         name="get_book_info",
-                        args='{"isbn":"0-7653-1178-X"}',
+                        args='{"isbn": "0-7653-1178-X"}',
                     )
                 ]
             ),
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_MbBdVxoY72QRc0wQbKhbhrdZ",
+                        id="call_YJsJE8QRPmdDAHFe5H5QJUAQ",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -277,7 +277,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_lym2hCN2lnWo5LLhDFhQDcCd",
+                        id="call_cjevQinj1jOPWxHF1dU4zMmo",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -286,7 +286,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_lym2hCN2lnWo5LLhDFhQDcCd",
+                        id="call_cjevQinj1jOPWxHF1dU4zMmo",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_anthropic_snapshots.py
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01WFtUV8u28UBvci6rqMpcLb",
+                        id="toolu_019ZBPYQh7GgUjvNftVR7Ad6",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -41,7 +41,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01WFtUV8u28UBvci6rqMpcLb",
+                        id="toolu_019ZBPYQh7GgUjvNftVR7Ad6",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -121,7 +121,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_017jBdUCtpx7wkgvF75fsXfa",
+                        id="toolu_01MG4aiH83w4ZMouQmBpwjF5",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -130,7 +130,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_017jBdUCtpx7wkgvF75fsXfa",
+                        id="toolu_01MG4aiH83w4ZMouQmBpwjF5",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -209,7 +209,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01T78R9RhRKa6RVp3i3ULwF6",
+                        id="toolu_01T9iLpCByETWMjzeAmhmnQH",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -218,7 +218,7 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01T78R9RhRKa6RVp3i3ULwF6",
+                        id="toolu_01T9iLpCByETWMjzeAmhmnQH",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -274,7 +274,7 @@ stream_snapshot = snapshot(
                 "strict": False,
             }
         ],
-        "n_chunks": 18,
+        "n_chunks": 21,
     }
 )
 async_stream_snapshot = snapshot(
@@ -298,7 +298,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_0123Cov1FnLM5pAaTevWyVZG",
+                        id="toolu_01JiDp1aGXRvpjowMAaBsGs3",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -307,7 +307,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_0123Cov1FnLM5pAaTevWyVZG",
+                        id="toolu_01JiDp1aGXRvpjowMAaBsGs3",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -363,6 +363,6 @@ async_stream_snapshot = snapshot(
                 "strict": False,
             }
         ],
-        "n_chunks": 20,
+        "n_chunks": 19,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_google_snapshots.py
@@ -50,7 +50,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"pages": 544, "publication_year": 2006, "author": "Brandon Sanderson", "title": "Mistborn: The Final Empire"}'
+                        text='{"publication_year": 2006, "author": "Brandon Sanderson", "title": "Mistborn: The Final Empire", "pages": 544}'
                     )
                 ]
             ),
@@ -139,7 +139,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"pages": 544, "author": "Brandon Sanderson", "title": "Mistborn: The Final Empire", "publication_year": 2006}'
+                        text='{"pages": 544, "publication_year": 2006, "title": "Mistborn: The Final Empire", "author": "Brandon Sanderson"}'
                     )
                 ]
             ),
@@ -227,7 +227,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"pages": 544, "author": "Brandon Sanderson", "title": "Mistborn: The Final Empire", "publication_year": 2006}'
+                        text='{"pages": 544, "title": "Mistborn: The Final Empire", "publication_year": 2006, "author": "Brandon Sanderson"}'
                     )
                 ]
             ),
@@ -316,7 +316,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"author": "Brandon Sanderson", "publication_year": 2006, "title": "Mistborn: The Final Empire", "pages": 544}'
+                        text='{"publication_year": 2006, "author": "Brandon Sanderson", "pages": 544, "title": "Mistborn: The Final Empire"}'
                     )
                 ]
             ),

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_openai_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_openai_snapshots.py
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_nUR8EakpyFMMQ0MfIXhLTVAJ",
+                        id="call_qDihhqbfVROd4b9jjrVj0cyt",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -41,7 +41,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_nUR8EakpyFMMQ0MfIXhLTVAJ",
+                        id="call_qDihhqbfVROd4b9jjrVj0cyt",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -121,7 +121,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_HvlybWfMlD6pNnNMJoZD0I0u",
+                        id="call_VFkVYO1POOO8UC4QpKt1ulM5",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -130,7 +130,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_HvlybWfMlD6pNnNMJoZD0I0u",
+                        id="call_VFkVYO1POOO8UC4QpKt1ulM5",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -209,7 +209,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_pqX5DWuENRx4lyLSUk1Yc1i3",
+                        id="call_AVVNrNkchlxyMXVZXREZv97h",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -218,7 +218,7 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_pqX5DWuENRx4lyLSUk1Yc1i3",
+                        id="call_AVVNrNkchlxyMXVZXREZv97h",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -298,7 +298,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="call_Lw5p8QHULSIEiF8rB8ZD3kjj",
+                        id="call_dkOmjFqa4hx2vhkuf6vW2Na3",
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
@@ -307,7 +307,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="call_Lw5p8QHULSIEiF8rB8ZD3kjj",
+                        id="call_dkOmjFqa4hx2vhkuf6vW2Na3",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )

--- a/python/tests/e2e/test_structured_output.py
+++ b/python/tests/e2e/test_structured_output.py
@@ -11,6 +11,22 @@ from tests.utils import (
     stream_response_snapshot_dict,
 )
 
+
+class Author(BaseModel):
+    """The author of a book."""
+
+    first_name: str
+    last_name: str
+
+
+class Book(BaseModel):
+    """A book with a rating. The title should be in all caps!"""
+
+    title: str
+    author: Author
+    rating: int = Field(description="For testing purposes, the rating should be 7")
+
+
 # ============= SYNC TESTS =============
 
 
@@ -24,13 +40,6 @@ def test_structured_output_sync(
     snapshot: Snapshot,
 ) -> None:
     """Test synchronous structured output without context."""
-
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -49,7 +58,8 @@ def test_structured_output_sync(
         assert response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:
@@ -66,13 +76,6 @@ def test_structured_output_sync_context(
     snapshot: Snapshot,
 ) -> None:
     """Test synchronous structured output with context."""
-
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -92,7 +95,8 @@ def test_structured_output_sync_context(
         assert response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:
@@ -114,13 +118,6 @@ async def test_structured_output_async(
 ) -> None:
     """Test asynchronous structured output without context."""
 
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
-
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
     )
@@ -138,7 +135,8 @@ async def test_structured_output_async(
         assert response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:
@@ -156,13 +154,6 @@ async def test_structured_output_async_context(
     snapshot: Snapshot,
 ) -> None:
     """Test asynchronous structured output with context."""
-
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -182,7 +173,8 @@ async def test_structured_output_async_context(
         assert response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:
@@ -202,13 +194,6 @@ def test_structured_output_stream(
     snapshot: Snapshot,
 ) -> None:
     """Test streaming structured output without context."""
-
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -230,7 +215,8 @@ def test_structured_output_stream(
         assert stream_response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:
@@ -247,13 +233,6 @@ def test_structured_output_stream_context(
     snapshot: Snapshot,
 ) -> None:
     """Test streaming structured output with context."""
-
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -276,7 +255,8 @@ def test_structured_output_stream_context(
         assert stream_response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:
@@ -298,13 +278,6 @@ async def test_structured_output_async_stream(
 ) -> None:
     """Test async streaming structured output without context."""
 
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
-
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
     )
@@ -325,7 +298,8 @@ async def test_structured_output_async_stream(
         assert stream_response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:
@@ -343,13 +317,6 @@ async def test_structured_output_async_stream_context(
     snapshot: Snapshot,
 ) -> None:
     """Test async streaming structured output with context."""
-
-    class Book(BaseModel):
-        """A book with a rating. The title should be in all caps!"""
-
-        title: str
-        author: str
-        rating: int = Field(description="For testing purposes, the rating should be 7")
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -372,7 +339,8 @@ async def test_structured_output_async_stream_context(
         assert stream_response_snapshot_dict(response) == snapshot
 
         book = response.parse()
-        assert book.author == "Patrick Rothfuss"
+        assert book.author.first_name == "Patrick"
+        assert book.author.last_name == "Rothfuss"
         assert book.title == "THE NAME OF THE WIND"
         assert book.rating == 7
     except llm.FormattingModeNotSupportedError as e:

--- a/python/tests/e2e/test_structured_output_with_formatting_instructions.py
+++ b/python/tests/e2e/test_structured_output_with_formatting_instructions.py
@@ -13,6 +13,21 @@ from tests.utils import (
     stream_response_snapshot_dict,
 )
 
+
+class Book(BaseModel):
+    title: str
+    author: str
+    rating: int
+
+    @classmethod
+    def formatting_instructions(cls) -> str:
+        return inspect.cleandoc("""
+        Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+        The title should be in all caps, and the rating should always be the
+        lucky number 7.
+        """)
+
+
 # ============= SYNC TESTS =============
 
 
@@ -26,19 +41,6 @@ def test_structured_output_with_formatting_instructions_sync(
     snapshot: Snapshot,
 ) -> None:
     """Test synchronous structured output without context."""
-
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -73,19 +75,6 @@ def test_structured_output_with_formatting_instructions_sync_context(
     snapshot: Snapshot,
 ) -> None:
     """Test synchronous structured output with context."""
-
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -126,19 +115,6 @@ async def test_structured_output_with_formatting_instructions_async(
 ) -> None:
     """Test asynchronous structured output without context."""
 
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
-
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
     )
@@ -173,19 +149,6 @@ async def test_structured_output_with_formatting_instructions_async_context(
     snapshot: Snapshot,
 ) -> None:
     """Test asynchronous structured output with context."""
-
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -225,19 +188,6 @@ def test_structured_output_with_formatting_instructions_stream(
 ) -> None:
     """Test streaming structured output without context."""
 
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
-
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
     )
@@ -274,19 +224,6 @@ def test_structured_output_with_formatting_instructions_stream_context(
     snapshot: Snapshot,
 ) -> None:
     """Test streaming structured output with context."""
-
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
@@ -330,19 +267,6 @@ async def test_structured_output_with_formatting_instructions_async_stream(
 ) -> None:
     """Test async streaming structured output without context."""
 
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
-
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
     )
@@ -380,19 +304,6 @@ async def test_structured_output_with_formatting_instructions_async_stream_conte
     snapshot: Snapshot,
 ) -> None:
     """Test async streaming structured output with context."""
-
-    class Book(BaseModel):
-        title: str
-        author: str
-        rating: int
-
-        @classmethod
-        def formatting_instructions(cls) -> str:
-            return inspect.cleandoc("""
-            Output a structured book as JSON in the format {title: str, author: str, rating: int}.
-            The title should be in all caps, and the rating should always be the
-            lucky number 7.
-            """)
 
     format = (
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book

--- a/python/tests/e2e/test_structured_output_with_tools.py
+++ b/python/tests/e2e/test_structured_output_with_tools.py
@@ -15,6 +15,14 @@ BOOK_DB = {
     "0-7653-1178-X": "Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25"
 }
 
+
+class BookSummary(BaseModel):
+    title: str
+    author: str
+    pages: int
+    publication_year: int
+
+
 # ============= SYNC TESTS =============
 
 
@@ -33,12 +41,6 @@ def test_structured_output_with_tools_sync(
     def get_book_info(isbn: str) -> str:
         """Look up book information by ISBN."""
         return BOOK_DB.get(isbn, "Book not found")
-
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
 
     format = (
         llm.format(BookSummary, mode=formatting_mode)
@@ -88,12 +90,6 @@ def test_structured_output_with_tools_sync_context(
     def get_book_info(ctx: llm.Context[dict[str, str]], isbn: str) -> str:
         """Look up book information by ISBN."""
         return ctx.deps.get(isbn, "Book not found")
-
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
 
     format = (
         llm.format(BookSummary, mode=formatting_mode)
@@ -149,12 +145,6 @@ async def test_structured_output_with_tools_async(
         """Look up book information by ISBN."""
         return BOOK_DB.get(isbn, "Book not found")
 
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
-
     format = (
         llm.format(BookSummary, mode=formatting_mode)
         if formatting_mode is not None
@@ -204,12 +194,6 @@ async def test_structured_output_with_tools_async_context(
     async def get_book_info(ctx: llm.Context[dict[str, str]], isbn: str) -> str:
         """Look up book information by ISBN."""
         return ctx.deps.get(isbn, "Book not found")
-
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
 
     format = (
         llm.format(BookSummary, mode=formatting_mode)
@@ -263,12 +247,6 @@ def test_structured_output_with_tools_stream(
     def get_book_info(isbn: str) -> str:
         """Look up book information by ISBN."""
         return BOOK_DB.get(isbn, "Book not found")
-
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
 
     format = (
         llm.format(BookSummary, mode=formatting_mode)
@@ -325,12 +303,6 @@ def test_structured_output_with_tools_stream_context(
     def get_book_info(ctx: llm.Context[dict[str, str]], isbn: str) -> str:
         """Look up book information by ISBN."""
         return ctx.deps.get(isbn, "Book not found")
-
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
 
     format = (
         llm.format(BookSummary, mode=formatting_mode)
@@ -393,12 +365,6 @@ async def test_structured_output_with_tools_async_stream(
         """Look up book information by ISBN."""
         return BOOK_DB.get(isbn, "Book not found")
 
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
-
     format = (
         llm.format(BookSummary, mode=formatting_mode)
         if formatting_mode is not None
@@ -455,12 +421,6 @@ async def test_structured_output_with_tools_async_stream_context(
     async def get_book_info(ctx: llm.Context[dict[str, str]], isbn: str) -> str:
         """Look up book information by ISBN."""
         return ctx.deps.get(isbn, "Book not found")
-
-    class BookSummary(BaseModel):
-        title: str
-        author: str
-        pages: int
-        publication_year: int
 
     format = (
         llm.format(BookSummary, mode=formatting_mode)


### PR DESCRIPTION
Now the formatting module creates a tool schema, and the providers use
their existing schema -> provider specific tool represetnation pipeline.

I modified the standard structured output test case to include nested
models and this had the salubrious effect of testing tools with nested
models as function arguments; particularly I had to fix a bug with
resolving refs for Google usage.