### PR TITLE
feat: add client resume api

### DIFF
--- a/python/mirascope/llm/clients/base/client.py
+++ b/python/mirascope/llm/clients/base/client.py
@@ -11,7 +11,7 @@ from typing_extensions import Self, TypeVar
 
 from ...context import Context, DepsT
 from ...formatting import Format, FormattableT
-from ...messages import Message
+from ...messages import Message, UserContent, user
 from ...responses import (
     AsyncContextResponse,
     AsyncContextStreamResponse,
@@ -483,3 +483,473 @@ class BaseClient(Generic[ParamsT, ModelIdT, ProviderClientT], ABC):
     ):
         """Stream a context response asynchronously."""
         ...
+
+    @overload
+    def resume(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: Response,
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> Response: ...
+
+    @overload
+    def resume(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: Response[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> Response[FormattableT]: ...
+
+    @overload
+    def resume(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: Response | Response[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> Response | Response[FormattableT]: ...
+
+    def resume(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: Response | Response[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> Response | Response[FormattableT]:
+        """Generate a new `Response` by extending another `Response`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.call()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return self.call(
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncResponse,
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncResponse: ...
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncResponse[FormattableT]: ...
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncResponse | AsyncResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
+
+    async def resume_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncResponse | AsyncResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Generate a new `AsyncResponse` by extending another `AsyncResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.call_async()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return await self.call_async(
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )
+
+    @overload
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextResponse[DepsT, None],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> ContextResponse[DepsT, None]: ...
+
+    @overload
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> ContextResponse[DepsT, FormattableT]: ...
+
+    @overload
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
+
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
+        """Generate a new `ContextResponse` by extending another `ContextResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.context_call()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return self.context_call(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )
+
+    @overload
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextResponse[DepsT, None],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncContextResponse[DepsT, None]: ...
+
+    @overload
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncContextResponse[DepsT, FormattableT]: ...
+
+    @overload
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextResponse[DepsT, None]
+        | AsyncContextResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> (
+        AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]
+    ): ...
+
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextResponse[DepsT, None]
+        | AsyncContextResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
+        """Generate a new `AsyncContextResponse` by extending another `AsyncContextResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.context_call_async()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return await self.context_call_async(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )
+
+    @overload
+    def resume_stream(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: StreamResponse,
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> StreamResponse: ...
+
+    @overload
+    def resume_stream(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: StreamResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> StreamResponse[FormattableT]: ...
+
+    @overload
+    def resume_stream(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: StreamResponse | StreamResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> StreamResponse | StreamResponse[FormattableT]: ...
+
+    def resume_stream(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: StreamResponse | StreamResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> StreamResponse | StreamResponse[FormattableT]:
+        """Generate a new `StreamResponse` by extending another `StreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.call()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume_stream logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return self.stream(
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )
+
+    @overload
+    async def resume_stream_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncStreamResponse,
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncStreamResponse: ...
+
+    @overload
+    async def resume_stream_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncStreamResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncStreamResponse[FormattableT]: ...
+
+    @overload
+    async def resume_stream_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncStreamResponse | AsyncStreamResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
+
+    async def resume_stream_async(
+        self,
+        *,
+        model_id: ModelIdT,
+        response: AsyncStreamResponse | AsyncStreamResponse[FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
+        """Generate a new `AsyncStreamResponse` by extending another `AsyncStreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.stream_async()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume_stream logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return await self.stream_async(
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )
+
+    @overload
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextStreamResponse[DepsT, None],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> ContextStreamResponse[DepsT, None]: ...
+
+    @overload
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> ContextStreamResponse[DepsT, FormattableT]: ...
+
+    @overload
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextStreamResponse[DepsT, None]
+        | ContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> (
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
+    ): ...
+
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: ContextStreamResponse[DepsT, None]
+        | ContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> (
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Generate a new `ContextStreamResponse` by extending another `ContextStreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.context_call()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume_stream logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return self.context_stream(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )
+
+    @overload
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextStreamResponse[DepsT, None],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncContextStreamResponse[DepsT, None]: ...
+
+    @overload
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
+
+    @overload
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> (
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ): ...
+
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: ModelIdT,
+        response: AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+        params: ParamsT | None = None,
+    ) -> (
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Generate a new `AsyncContextStreamResponse` by extending another `AsyncContextStreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        This base method wraps around calling `client.context_stream_async()` with a messages array
+        derived from the response messages. However, clients may override this with
+        first-class resume_stream logic, if supported.
+        """
+        messages = response.messages + [user(content)]
+        return await self.context_stream_async(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=response.toolkit.tools,
+            format=response.format,
+            params=params,
+        )

--- a/python/mirascope/llm/models/model.py
+++ b/python/mirascope/llm/models/model.py
@@ -11,7 +11,7 @@ from typing_extensions import Unpack
 from ..clients import ParamsT, get_client
 from ..context import Context, DepsT
 from ..formatting import Format, FormattableT
-from ..messages import Message
+from ..messages import Message, UserContent
 from ..responses import (
     AsyncContextResponse,
     AsyncContextStreamResponse,
@@ -487,6 +487,372 @@ class Model(Generic[ParamsT]):
             messages=messages,
             tools=tools,
             format=format,
+            params=self.params,
+        )
+
+    @overload
+    def resume(
+        self,
+        *,
+        response: Response,
+        content: UserContent,
+    ) -> Response: ...
+
+    @overload
+    def resume(
+        self,
+        *,
+        response: Response[FormattableT],
+        content: UserContent,
+    ) -> Response[FormattableT]: ...
+
+    @overload
+    def resume(
+        self,
+        *,
+        response: Response | Response[FormattableT],
+        content: UserContent,
+    ) -> Response | Response[FormattableT]: ...
+
+    def resume(
+        self,
+        *,
+        response: Response | Response[FormattableT],
+        content: UserContent,
+    ) -> Response | Response[FormattableT]:
+        """Generate a new `Response` by extending another `Response`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return get_client(self.provider).resume(
+            model_id=self.model_id,
+            response=response,
+            content=content,
+            params=self.params,
+        )
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse,
+        content: UserContent,
+    ) -> AsyncResponse: ...
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncResponse[FormattableT]: ...
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse | AsyncResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
+
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse | AsyncResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Generate a new `AsyncResponse` by extending another `AsyncResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return await get_client(self.provider).resume_async(
+            model_id=self.model_id,
+            response=response,
+            content=content,
+            params=self.params,
+        )
+
+    @overload
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextResponse[DepsT, None],
+        content: UserContent,
+    ) -> ContextResponse[DepsT, None]: ...
+
+    @overload
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> ContextResponse[DepsT, FormattableT]: ...
+
+    @overload
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
+
+    def context_resume(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
+        """Generate a new `ContextResponse` by extending another `ContextResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return get_client(self.provider).context_resume(
+            ctx=ctx,
+            model_id=self.model_id,
+            response=response,
+            content=content,
+            params=self.params,
+        )
+
+    @overload
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextResponse[DepsT, None],
+        content: UserContent,
+    ) -> AsyncContextResponse[DepsT, None]: ...
+
+    @overload
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> AsyncContextResponse[DepsT, FormattableT]: ...
+
+    @overload
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextResponse[DepsT, None]
+        | AsyncContextResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> (
+        AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]
+    ): ...
+
+    async def context_resume_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextResponse[DepsT, None]
+        | AsyncContextResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
+        """Generate a new `AsyncContextResponse` by extending another `AsyncContextResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return await get_client(self.provider).context_resume_async(
+            ctx=ctx,
+            model_id=self.model_id,
+            response=response,
+            content=content,
+            params=self.params,
+        )
+
+    @overload
+    def resume_stream(
+        self,
+        *,
+        response: StreamResponse,
+        content: UserContent,
+    ) -> StreamResponse: ...
+
+    @overload
+    def resume_stream(
+        self,
+        *,
+        response: StreamResponse[FormattableT],
+        content: UserContent,
+    ) -> StreamResponse[FormattableT]: ...
+
+    @overload
+    def resume_stream(
+        self,
+        *,
+        response: StreamResponse | StreamResponse[FormattableT],
+        content: UserContent,
+    ) -> StreamResponse | StreamResponse[FormattableT]: ...
+
+    def resume_stream(
+        self,
+        *,
+        response: StreamResponse | StreamResponse[FormattableT],
+        content: UserContent,
+    ) -> StreamResponse | StreamResponse[FormattableT]:
+        """Generate a new `StreamResponse` by extending another `StreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return get_client(self.provider).resume_stream(
+            model_id=self.model_id,
+            response=response,
+            content=content,
+            params=self.params,
+        )
+
+    @overload
+    async def resume_stream_async(
+        self,
+        *,
+        response: AsyncStreamResponse,
+        content: UserContent,
+    ) -> AsyncStreamResponse: ...
+
+    @overload
+    async def resume_stream_async(
+        self,
+        *,
+        response: AsyncStreamResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncStreamResponse[FormattableT]: ...
+
+    @overload
+    async def resume_stream_async(
+        self,
+        *,
+        response: AsyncStreamResponse | AsyncStreamResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
+
+    async def resume_stream_async(
+        self,
+        *,
+        response: AsyncStreamResponse | AsyncStreamResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
+        """Generate a new `AsyncStreamResponse` by extending another `AsyncStreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return await get_client(self.provider).resume_stream_async(
+            model_id=self.model_id,
+            response=response,
+            content=content,
+            params=self.params,
+        )
+
+    @overload
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextStreamResponse[DepsT, None],
+        content: UserContent,
+    ) -> ContextStreamResponse[DepsT, None]: ...
+
+    @overload
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> ContextStreamResponse[DepsT, FormattableT]: ...
+
+    @overload
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextStreamResponse[DepsT, None]
+        | ContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> (
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
+    ): ...
+
+    def context_resume_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: ContextStreamResponse[DepsT, None]
+        | ContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> (
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Generate a new `ContextStreamResponse` by extending another `ContextStreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return get_client(self.provider).context_resume_stream(
+            ctx=ctx,
+            model_id=self.model_id,
+            response=response,
+            content=content,
+            params=self.params,
+        )
+
+    @overload
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextStreamResponse[DepsT, None],
+        content: UserContent,
+    ) -> AsyncContextStreamResponse[DepsT, None]: ...
+
+    @overload
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
+
+    @overload
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> (
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ): ...
+
+    async def context_resume_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        response: AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT],
+        content: UserContent,
+    ) -> (
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Generate a new `AsyncContextStreamResponse` by extending another `AsyncContextStreamResponse`'s messages with additional user content.
+
+        Uses the other response's tools and output format.
+        """
+        return await get_client(self.provider).context_resume_stream_async(
+            ctx=ctx,
+            model_id=self.model_id,
+            response=response,
+            content=content,
             params=self.params,
         )
 

--- a/python/mirascope/llm/responses/response.py
+++ b/python/mirascope/llm/responses/response.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Generic, overload
 from ..content import ToolOutput
 from ..context import Context, DepsT
 from ..formatting import Format, FormattableT
-from ..messages import AssistantMessage, Message, UserContent, user
+from ..messages import AssistantMessage, Message, UserContent
 from ..tools import (
     AsyncContextTool,
     AsyncContextToolkit,
@@ -87,11 +87,9 @@ class Response(BaseResponse[Toolkit, FormattableT]):
         Returns:
             A new `Response` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return self.model.call(
-            messages=messages,
-            tools=self.toolkit.tools,
-            format=self.format,
+        return self.model.resume(
+            response=self,
+            content=content,
         )
 
 
@@ -162,11 +160,9 @@ class AsyncResponse(BaseResponse[AsyncToolkit, FormattableT]):
         Returns:
             A new `AsyncResponse` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return await self.model.call_async(
-            messages=messages,
-            tools=self.toolkit.tools,
-            format=self.format,
+        return await self.model.resume_async(
+            response=self,
+            content=content,
         )
 
 
@@ -244,12 +240,10 @@ class ContextResponse(
         Returns:
             A new `ContextResponse` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return self.model.context_call(
+        return self.model.context_resume(
             ctx=ctx,
-            messages=messages,
-            tools=self.toolkit.tools,
-            format=self.format,
+            response=self,
+            content=content,
         )
 
 
@@ -328,10 +322,8 @@ class AsyncContextResponse(
         Returns:
             A new `AsyncContextResponse` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return await self.model.context_call_async(
+        return await self.model.context_resume_async(
             ctx=ctx,
-            messages=messages,
-            tools=self.toolkit.tools,
-            format=self.format,
+            response=self,
+            content=content,
         )

--- a/python/mirascope/llm/responses/stream_response.py
+++ b/python/mirascope/llm/responses/stream_response.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Generic, overload
 from ..content import ToolOutput
 from ..context import Context, DepsT
 from ..formatting import Format, FormattableT
-from ..messages import Message, UserContent, user
+from ..messages import Message, UserContent
 from ..tools import (
     AsyncContextTool,
     AsyncContextToolkit,
@@ -147,9 +147,9 @@ class StreamResponse(BaseSyncStreamResponse[Toolkit, FormattableT]):
         Returns:
             A new `StreamResponse` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return self.model.stream(
-            messages=messages, tools=self.toolkit.tools, format=self.format
+        return self.model.resume_stream(
+            response=self,
+            content=content,
         )
 
 
@@ -274,11 +274,9 @@ class AsyncStreamResponse(BaseAsyncStreamResponse[AsyncToolkit, FormattableT]):
         Returns:
             A new `AsyncStreamResponse` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return await self.model.stream_async(
-            messages=messages,
-            tools=self.toolkit.tools,
-            format=self.format,
+        return await self.model.resume_stream_async(
+            response=self,
+            content=content,
         )
 
 
@@ -411,12 +409,10 @@ class ContextStreamResponse(
         Returns:
             A new `ContextStreamResponse` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return self.model.context_stream(
+        return self.model.context_resume_stream(
             ctx=ctx,
-            messages=messages,
-            tools=self.toolkit.tools,
-            format=self.format,
+            response=self,
+            content=content,
         )
 
 
@@ -553,10 +549,8 @@ class AsyncContextStreamResponse(
         Returns:
             A new `AsyncContextStreamResponse` instance generated from the extended message history.
         """
-        messages = self.messages + [user(content)]
-        return await self.model.context_stream_async(
+        return await self.model.context_resume_stream_async(
             ctx=ctx,
-            messages=messages,
-            tools=self.toolkit.tools,
-            format=self.format,
+            response=self,
+            content=content,
         )


### PR DESCRIPTION
For now, none of the providers use it, but it's implemented as a
fallback on the base client that matches the behavior that used to be
locked in to the response implementations.

All existing code works as written, and we have full coverage because
test_call_with_tools e2e test already hits all the resume paths.