### PR TITLE
refactor: pass toolkits not tools

### DIFF
--- a/python/mirascope/llm/calls/calls.py
+++ b/python/mirascope/llm/calls/calls.py
@@ -65,7 +65,7 @@ class Call(BaseCall[P, Prompt, Toolkit, FormattableT], Generic[P, FormattableT])
         """Generates a response using the LLM."""
         messages = self.fn(*args, **kwargs)
         return self.model.call(
-            messages=messages, tools=self.toolkit.tools, format=self.format
+            messages=messages, tools=self.toolkit, format=self.format
         )
 
     @overload
@@ -84,7 +84,7 @@ class Call(BaseCall[P, Prompt, Toolkit, FormattableT], Generic[P, FormattableT])
         """Generates a streaming response using the LLM."""
         messages = self.fn(*args, **kwargs)
         return self.model.stream(
-            messages=messages, tools=self.toolkit.tools, format=self.format
+            messages=messages, tools=self.toolkit, format=self.format
         )
 
 
@@ -127,7 +127,7 @@ class AsyncCall(
         """Generates a response using the LLM asynchronously."""
         messages = await self.fn(*args, **kwargs)
         return await self.model.call_async(
-            messages=messages, tools=self.toolkit.tools, format=self.format
+            messages=messages, tools=self.toolkit, format=self.format
         )
 
     @overload
@@ -146,7 +146,7 @@ class AsyncCall(
         """Generates a streaming response using the LLM asynchronously."""
         messages = await self.fn(*args, **kwargs)
         return await self.model.stream_async(
-            messages=messages, tools=self.toolkit.tools, format=self.format
+            messages=messages, tools=self.toolkit, format=self.format
         )
 
 
@@ -201,7 +201,7 @@ class ContextCall(
         """Generates a response using the LLM."""
         messages = self.fn(ctx, *args, **kwargs)
         return self.model.context_call(
-            ctx=ctx, messages=messages, tools=self.toolkit.tools, format=self.format
+            ctx=ctx, messages=messages, tools=self.toolkit, format=self.format
         )
 
     @overload
@@ -228,7 +228,7 @@ class ContextCall(
         """Generates a streaming response using the LLM."""
         messages = self.fn(ctx, *args, **kwargs)
         return self.model.context_stream(
-            ctx=ctx, messages=messages, tools=self.toolkit.tools, format=self.format
+            ctx=ctx, messages=messages, tools=self.toolkit, format=self.format
         )
 
 
@@ -283,7 +283,7 @@ class AsyncContextCall(
         """Generates a response using the LLM asynchronously."""
         messages = await self.fn(ctx, *args, **kwargs)
         return await self.model.context_call_async(
-            ctx=ctx, messages=messages, tools=self.toolkit.tools, format=self.format
+            ctx=ctx, messages=messages, tools=self.toolkit, format=self.format
         )
 
     @overload
@@ -311,5 +311,5 @@ class AsyncContextCall(
         """Generates a streaming response using the LLM asynchronously."""
         messages = await self.fn(ctx, *args, **kwargs)
         return await self.model.context_stream_async(
-            ctx=ctx, messages=messages, tools=self.toolkit.tools, format=self.format
+            ctx=ctx, messages=messages, tools=self.toolkit, format=self.format
         )

--- a/python/mirascope/llm/clients/anthropic/clients.py
+++ b/python/mirascope/llm/clients/anthropic/clients.py
@@ -24,9 +24,13 @@ from ...responses import (
 )
 from ...tools import (
     AsyncContextTool,
+    AsyncContextToolkit,
     AsyncTool,
+    AsyncToolkit,
     ContextTool,
+    ContextToolkit,
     Tool,
+    Toolkit,
 )
 from ..base import BaseClient, Params
 from . import _utils
@@ -96,7 +100,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> Response: ...
@@ -107,7 +111,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> Response[FormattableT]: ...
@@ -118,7 +122,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]: ...
@@ -128,7 +132,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
@@ -164,7 +168,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None]: ...
@@ -176,7 +182,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, FormattableT]: ...
@@ -188,7 +196,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
@@ -199,7 +209,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
@@ -234,7 +246,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse: ...
@@ -245,7 +257,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncResponse[FormattableT]: ...
@@ -256,7 +268,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
@@ -266,7 +278,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
@@ -302,7 +314,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None]: ...
@@ -314,7 +328,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, FormattableT]: ...
@@ -326,7 +342,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -339,7 +357,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
@@ -374,7 +394,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> StreamResponse: ...
@@ -385,7 +405,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> StreamResponse[FormattableT]: ...
@@ -396,7 +416,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]: ...
@@ -406,7 +426,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
@@ -442,7 +462,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT]: ...
@@ -454,7 +476,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, FormattableT]: ...
@@ -466,7 +490,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]: ...
@@ -477,7 +503,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
@@ -512,7 +540,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse: ...
@@ -523,7 +551,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncStreamResponse[FormattableT]: ...
@@ -534,7 +562,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
@@ -544,7 +572,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         *,
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
@@ -580,7 +608,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT]: ...
@@ -592,7 +622,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
@@ -604,7 +636,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -617,7 +651,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         ctx: Context[DepsT],
         model_id: AnthropicModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse | AsyncContextStreamResponse[DepsT, FormattableT]:

--- a/python/mirascope/llm/clients/base/client.py
+++ b/python/mirascope/llm/clients/base/client.py
@@ -22,7 +22,16 @@ from ...responses import (
     Response,
     StreamResponse,
 )
-from ...tools import AsyncContextTool, AsyncTool, ContextTool, Tool
+from ...tools import (
+    AsyncContextTool,
+    AsyncContextToolkit,
+    AsyncTool,
+    AsyncToolkit,
+    ContextTool,
+    ContextToolkit,
+    Tool,
+    Toolkit,
+)
 from .params import Params
 
 ModelIdT = TypeVar("ModelIdT", bound=str)
@@ -71,7 +80,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> Response: ...
@@ -83,7 +92,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> Response[FormattableT]: ...
@@ -95,7 +104,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]: ...
@@ -106,7 +115,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
@@ -121,7 +130,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None]: ...
@@ -134,7 +145,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, FormattableT]: ...
@@ -147,7 +160,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
@@ -159,7 +174,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
@@ -173,7 +190,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse: ...
@@ -185,7 +202,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncResponse[FormattableT]: ...
@@ -197,7 +214,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
@@ -208,7 +225,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
@@ -223,7 +240,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None]: ...
@@ -236,7 +255,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, FormattableT]: ...
@@ -249,7 +270,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -263,7 +286,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
@@ -277,7 +302,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> StreamResponse: ...
@@ -289,7 +314,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> StreamResponse[FormattableT]: ...
@@ -301,7 +326,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]: ...
@@ -312,7 +337,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
@@ -327,7 +352,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, None]: ...
@@ -340,7 +367,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, FormattableT]: ...
@@ -353,7 +382,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -367,7 +398,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
@@ -383,7 +416,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse: ...
@@ -395,7 +428,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncStreamResponse[FormattableT]: ...
@@ -407,7 +440,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
@@ -418,7 +451,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         *,
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
@@ -433,7 +466,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, None]: ...
@@ -446,7 +481,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
@@ -459,7 +496,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -474,7 +513,9 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         ctx: Context[DepsT],
         model_id: ModelIdT,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
@@ -533,7 +574,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         return self.call(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )
@@ -587,7 +628,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         return await self.call_async(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )
@@ -646,7 +687,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )
@@ -709,7 +750,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )
@@ -763,7 +804,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         return self.stream(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )
@@ -817,7 +858,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         return await self.stream_async(
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )
@@ -882,7 +923,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )
@@ -949,7 +990,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
             ctx=ctx,
             model_id=model_id,
             messages=messages,
-            tools=response.toolkit.tools,
+            tools=response.toolkit,
             format=response.format,
             **params,
         )

--- a/python/mirascope/llm/clients/google/_utils.py
+++ b/python/mirascope/llm/clients/google/_utils.py
@@ -35,10 +35,7 @@ from ...responses import (
     FinishReasonChunk,
     RawChunk,
 )
-from ...tools import (
-    FORMAT_TOOL_NAME,
-    ToolSchema,
-)
+from ...tools import FORMAT_TOOL_NAME, BaseToolkit, ToolSchema
 from ..base import Params, _utils as _base_utils
 from .model_ids import GoogleModelId
 
@@ -212,7 +209,7 @@ def _convert_tool_to_function_declaration(
 def prepare_google_request(
     model_id: GoogleModelId,
     messages: Sequence[Message],
-    tools: Sequence[ToolSchema] | None = None,
+    tools: Sequence[ToolSchema] | BaseToolkit | None = None,
     format: type[FormattableT] | Format[FormattableT] | None = None,
     params: Params | None = None,
 ) -> tuple[
@@ -224,6 +221,7 @@ def prepare_google_request(
     if params:
         raise NotImplementedError("param use not yet supported")
 
+    tools = tools.tools if isinstance(tools, BaseToolkit) else tools or []
     config_params = {}
     google_tools: list[genai_types.Tool] = []
 

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -25,9 +25,13 @@ from ...responses import (
 )
 from ...tools import (
     AsyncContextTool,
+    AsyncContextToolkit,
     AsyncTool,
+    AsyncToolkit,
     ContextTool,
+    ContextToolkit,
     Tool,
+    Toolkit,
 )
 from ..base import BaseClient, Params
 from . import _utils
@@ -98,7 +102,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> Response: ...
@@ -109,7 +113,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> Response[FormattableT]: ...
@@ -120,7 +124,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]: ...
@@ -130,7 +134,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
@@ -166,7 +170,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None]: ...
@@ -178,7 +184,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, FormattableT]: ...
@@ -190,7 +198,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
@@ -201,7 +211,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
@@ -236,7 +248,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse: ...
@@ -247,7 +259,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncResponse[FormattableT]: ...
@@ -258,7 +270,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
@@ -268,7 +280,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
@@ -304,7 +316,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None]: ...
@@ -316,7 +330,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, FormattableT]: ...
@@ -328,7 +344,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -341,7 +359,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
@@ -376,7 +396,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> StreamResponse: ...
@@ -387,7 +407,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> StreamResponse[FormattableT]: ...
@@ -398,7 +418,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]: ...
@@ -408,7 +428,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
@@ -442,7 +462,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT]: ...
@@ -454,7 +476,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, FormattableT]: ...
@@ -466,7 +490,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]: ...
@@ -477,7 +503,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
@@ -510,7 +538,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse: ...
@@ -521,7 +549,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncStreamResponse[FormattableT]: ...
@@ -532,7 +560,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
@@ -542,7 +570,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         *,
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
@@ -578,7 +606,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT]: ...
@@ -590,7 +620,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
@@ -602,7 +634,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -615,7 +649,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         ctx: Context[DepsT],
         model_id: GoogleModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse | AsyncContextStreamResponse[DepsT, FormattableT]:

--- a/python/mirascope/llm/clients/openai/clients.py
+++ b/python/mirascope/llm/clients/openai/clients.py
@@ -24,9 +24,13 @@ from ...responses import (
 )
 from ...tools import (
     AsyncContextTool,
+    AsyncContextToolkit,
     AsyncTool,
+    AsyncToolkit,
     ContextTool,
+    ContextToolkit,
     Tool,
+    Toolkit,
 )
 from ..base import BaseClient, Params
 from . import _utils
@@ -94,7 +98,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> Response: ...
@@ -105,7 +109,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> Response[FormattableT]: ...
@@ -116,7 +120,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]: ...
@@ -126,7 +130,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
@@ -162,7 +166,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None]: ...
@@ -174,7 +180,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, FormattableT]: ...
@@ -186,7 +194,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
@@ -197,7 +207,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
@@ -232,7 +244,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse: ...
@@ -243,7 +255,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncResponse[FormattableT]: ...
@@ -254,7 +266,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
@@ -264,7 +276,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
@@ -300,7 +312,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None]: ...
@@ -312,7 +326,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, FormattableT]: ...
@@ -324,7 +340,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -337,7 +355,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
@@ -372,7 +392,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> StreamResponse: ...
@@ -383,7 +403,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> StreamResponse[FormattableT]: ...
@@ -394,7 +414,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]: ...
@@ -404,7 +424,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
@@ -441,7 +461,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT]: ...
@@ -453,7 +475,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, FormattableT]: ...
@@ -465,7 +489,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]: ...
@@ -476,7 +502,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
@@ -512,7 +540,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse: ...
@@ -523,7 +551,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncStreamResponse[FormattableT]: ...
@@ -534,7 +562,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
@@ -544,7 +572,7 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         *,
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
@@ -583,7 +611,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT]: ...
@@ -595,7 +625,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
@@ -607,7 +639,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
@@ -620,7 +654,9 @@ class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
         ctx: Context[DepsT],
         model_id: OpenAIModelId,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse | AsyncContextStreamResponse[DepsT, FormattableT]:

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -22,7 +22,16 @@ from ..responses import (
     Response,
     StreamResponse,
 )
-from ..tools import AsyncContextTool, AsyncTool, ContextTool, Tool
+from ..tools import (
+    AsyncContextTool,
+    AsyncContextToolkit,
+    AsyncTool,
+    AsyncToolkit,
+    ContextTool,
+    ContextToolkit,
+    Tool,
+    Toolkit,
+)
 
 if TYPE_CHECKING:
     from ..clients import (
@@ -125,7 +134,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
     ) -> Response: ...
 
@@ -134,7 +143,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> Response[FormattableT]: ...
 
@@ -143,7 +152,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> Response | Response[FormattableT]: ...
 
@@ -151,7 +160,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> Response | Response[FormattableT]:
         """Generate a response using the model."""
@@ -168,7 +177,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
     ) -> AsyncResponse: ...
 
@@ -177,7 +186,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> AsyncResponse[FormattableT]: ...
 
@@ -186,7 +195,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> AsyncResponse | AsyncResponse[FormattableT]: ...
 
@@ -194,7 +203,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate a response asynchronously using the model."""
@@ -211,7 +220,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
     ) -> StreamResponse: ...
 
@@ -220,7 +229,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> StreamResponse[FormattableT]: ...
 
@@ -229,7 +238,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> StreamResponse | StreamResponse[FormattableT]: ...
 
@@ -237,7 +246,7 @@ class Model:
         self,
         *,
         messages: Sequence[Message],
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Stream a response using the model."""
@@ -254,7 +263,7 @@ class Model:
         self,
         *,
         messages: list[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
     ) -> AsyncStreamResponse: ...
 
@@ -263,7 +272,7 @@ class Model:
         self,
         *,
         messages: list[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> AsyncStreamResponse[FormattableT]: ...
 
@@ -272,7 +281,7 @@ class Model:
         self,
         *,
         messages: list[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]: ...
 
@@ -280,7 +289,7 @@ class Model:
         self,
         *,
         messages: list[Message],
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Stream a response asynchronously using the model."""
@@ -298,7 +307,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
     ) -> ContextResponse[DepsT, None]: ...
 
@@ -308,7 +319,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> ContextResponse[DepsT, FormattableT]: ...
 
@@ -318,7 +331,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]: ...
 
@@ -327,7 +342,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate a response using the model."""
@@ -346,7 +363,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
     ) -> AsyncContextResponse[DepsT, None]: ...
 
@@ -356,7 +375,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> AsyncContextResponse[DepsT, FormattableT]: ...
 
@@ -366,7 +387,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> (
         AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]
@@ -377,7 +400,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate a response asynchronously using the model."""
@@ -396,7 +421,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: None = None,
     ) -> ContextStreamResponse[DepsT, None]: ...
 
@@ -406,7 +433,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> ContextStreamResponse[DepsT, FormattableT]: ...
 
@@ -416,7 +445,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -427,7 +458,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -448,7 +481,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: list[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: None = None,
     ) -> AsyncContextStreamResponse[DepsT, None]: ...
 
@@ -458,7 +493,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: list[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]: ...
 
@@ -468,7 +505,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: list[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> (
         AsyncContextStreamResponse[DepsT, None]
@@ -480,7 +519,9 @@ class Model:
         *,
         ctx: Context[DepsT],
         messages: list[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> (
         AsyncContextStreamResponse[DepsT, None]

--- a/python/mirascope/llm/responses/response.py
+++ b/python/mirascope/llm/responses/response.py
@@ -35,19 +35,20 @@ class Response(BaseResponse[Toolkit, FormattableT]):
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         assistant_message: AssistantMessage,
         finish_reason: FinishReason | None,
     ) -> None:
         """Initialize a `Response`."""
+        toolkit = tools if isinstance(tools, Toolkit) else Toolkit(tools=tools)
         super().__init__(
             raw=raw,
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=Toolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             assistant_message=assistant_message,
@@ -103,19 +104,22 @@ class AsyncResponse(BaseResponse[AsyncToolkit, FormattableT]):
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         assistant_message: AssistantMessage,
         finish_reason: FinishReason | None,
     ) -> None:
         """Initialize an `AsyncResponse`."""
+        toolkit = (
+            tools if isinstance(tools, AsyncToolkit) else AsyncToolkit(tools=tools)
+        )
         super().__init__(
             raw=raw,
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=AsyncToolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             assistant_message=assistant_message,
@@ -178,19 +182,24 @@ class ContextResponse(
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         assistant_message: AssistantMessage,
         finish_reason: FinishReason | None,
     ) -> None:
         """Initialize a `ContextResponse`."""
+        toolkit = (
+            tools if isinstance(tools, ContextToolkit) else ContextToolkit(tools=tools)
+        )
         super().__init__(
             raw=raw,
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=ContextToolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             assistant_message=assistant_message,
@@ -259,19 +268,26 @@ class AsyncContextResponse(
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         assistant_message: AssistantMessage,
         finish_reason: FinishReason | None,
     ) -> None:
         """Initialize an `AsyncContextResponse`."""
+        toolkit = (
+            tools
+            if isinstance(tools, AsyncContextToolkit)
+            else AsyncContextToolkit(tools=tools)
+        )
         super().__init__(
             raw=raw,
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=AsyncContextToolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             assistant_message=assistant_message,

--- a/python/mirascope/llm/responses/stream_response.py
+++ b/python/mirascope/llm/responses/stream_response.py
@@ -96,17 +96,18 @@ class StreamResponse(BaseSyncStreamResponse[Toolkit, FormattableT]):
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[Tool] | None = None,
+        tools: Sequence[Tool] | Toolkit | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         chunk_iterator: ChunkIterator,
     ) -> None:
         """Initialize a `StreamResponse`."""
+        toolkit = tools if isinstance(tools, Toolkit) else Toolkit(tools=tools)
         super().__init__(
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=Toolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
@@ -220,17 +221,20 @@ class AsyncStreamResponse(BaseAsyncStreamResponse[AsyncToolkit, FormattableT]):
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[AsyncTool] | None = None,
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         chunk_iterator: AsyncChunkIterator,
     ) -> None:
         """Initialize an `AsyncStreamResponse`."""
+        toolkit = (
+            tools if isinstance(tools, AsyncToolkit) else AsyncToolkit(tools=tools)
+        )
         super().__init__(
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=AsyncToolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
@@ -350,17 +354,22 @@ class ContextStreamResponse(
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[Tool | ContextTool[DepsT]] | None = None,
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         chunk_iterator: ChunkIterator,
     ) -> None:
         """Initialize a `ContextStreamResponse`."""
+        toolkit = (
+            tools if isinstance(tools, ContextToolkit) else ContextToolkit(tools=tools)
+        )
         super().__init__(
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=ContextToolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,
@@ -487,17 +496,24 @@ class AsyncContextStreamResponse(
         provider: "Provider",
         model_id: "ModelId",
         params: "Params",
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]] | None = None,
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
         format: Format[FormattableT] | None = None,
         input_messages: Sequence[Message],
         chunk_iterator: AsyncChunkIterator,
     ) -> None:
         """Initialize an `AsyncContextStreamResponse`."""
+        toolkit = (
+            tools
+            if isinstance(tools, AsyncContextToolkit)
+            else AsyncContextToolkit(tools=tools)
+        )
         super().__init__(
             provider=provider,
             model_id=model_id,
             params=params,
-            toolkit=AsyncContextToolkit(tools=tools),
+            toolkit=toolkit,
             format=format,
             input_messages=input_messages,
             chunk_iterator=chunk_iterator,

--- a/python/mirascope/llm/tools/__init__.py
+++ b/python/mirascope/llm/tools/__init__.py
@@ -11,6 +11,7 @@ from .tool_schema import (
 from .toolkit import (
     AsyncContextToolkit,
     AsyncToolkit,
+    BaseToolkit,
     ContextToolkit,
     Toolkit,
     ToolkitT,
@@ -23,6 +24,7 @@ __all__ = [
     "AsyncContextToolkit",
     "AsyncTool",
     "AsyncToolkit",
+    "BaseToolkit",
     "ContextTool",
     "ContextToolkit",
     "Tool",

--- a/python/tests/llm/clients/openai/test_client.py
+++ b/python/tests/llm/clients/openai/test_client.py
@@ -61,7 +61,9 @@ def test_strict_unsupported_legacy_model() -> None:
 
     with pytest.raises(llm.FormattingModeNotSupportedError):
         openai_utils.prepare_openai_request(
-            model_id="gpt-4", messages=messages, format=format
+            model_id="gpt-4",
+            messages=messages,
+            format=format,
         )
 
 

--- a/python/tests/llm/responses/test_response.py
+++ b/python/tests/llm/responses/test_response.py
@@ -32,7 +32,7 @@ def test_response_initialization_with_text_content() -> None:
 
     assert response.provider == "openai"
     assert response.model_id == "gpt-4o-mini"
-    assert response.toolkit == llm.Toolkit(tools=[])
+    assert response.toolkit == llm.tools.Toolkit(tools=[])
     assert response.raw == {"test": "response"}
     assert response.finish_reason == llm.FinishReason.END_TURN
 
@@ -640,7 +640,6 @@ def test_response_execute_tools() -> None:
         assistant_message=assistant_message,
         finish_reason=llm.FinishReason.TOOL_USE,
     )
-
     outputs = response.execute_tools()
     assert len(outputs) == 2
     assert outputs[0].value == 10
@@ -680,3 +679,51 @@ async def test_async_response_execute_tools() -> None:
     assert len(outputs) == 2
     assert outputs[0].value == 10
     assert outputs[1].value == "HELLO"
+
+
+def test_response_tools_initialization() -> None:
+    assistant_message = llm.messages.assistant("oh hi")
+
+    response = llm.Response(
+        raw={},
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        finish_reason=None,
+        input_messages=[],
+        assistant_message=assistant_message,
+    )
+    assert isinstance(response.toolkit, llm.Toolkit)
+
+    response = llm.AsyncResponse(
+        raw={},
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        finish_reason=None,
+        input_messages=[],
+        assistant_message=assistant_message,
+    )
+    assert isinstance(response.toolkit, llm.AsyncToolkit)
+
+    response = llm.ContextResponse(
+        raw={},
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        finish_reason=None,
+        input_messages=[],
+        assistant_message=assistant_message,
+    )
+    assert isinstance(response.toolkit, llm.ContextToolkit)
+
+    response = llm.AsyncContextResponse(
+        raw={},
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        finish_reason=None,
+        input_messages=[],
+        assistant_message=assistant_message,
+    )
+    assert isinstance(response.toolkit, llm.AsyncContextToolkit)

--- a/python/tests/llm/responses/test_stream_response.py
+++ b/python/tests/llm/responses/test_stream_response.py
@@ -24,7 +24,6 @@ def create_sync_stream_response(
         provider="openai",
         model_id="gpt-4o-mini",
         params={},
-        tools=[],
         input_messages=[llm.messages.user("Test")],
         chunk_iterator=iterator,
     )
@@ -46,7 +45,6 @@ def create_async_stream_response(
         provider="openai",
         model_id="gpt-4o-mini",
         params={},
-        tools=[],
         input_messages=[llm.messages.user("Test")],
         chunk_iterator=iterator,
     )
@@ -1028,7 +1026,6 @@ class TestRawChunkTracking:
             provider="openai",
             model_id="gpt-4o-mini",
             params={},
-            tools=[],
             input_messages=[llm.messages.user("Test")],
             chunk_iterator=chunk_iterator(),
         )
@@ -1060,7 +1057,6 @@ class TestRawChunkTracking:
             provider="openai",
             model_id="gpt-4o-mini",
             params={},
-            tools=[],
             input_messages=[llm.messages.user("Test")],
             chunk_iterator=chunk_iterator(),
         )
@@ -1381,3 +1377,45 @@ async def test_async_stream_response_execute_tools() -> None:
     assert len(outputs) == 2
     assert outputs[0].value == 10
     assert outputs[1].value == "HELLO"
+
+
+def test_response_toolkit_initialization() -> None:
+    def chunk_iter() -> llm.ChunkIterator: ...
+
+    def async_chunk_iter() -> llm.AsyncChunkIterator: ...
+
+    response = llm.StreamResponse(
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        input_messages=[],
+        chunk_iterator=chunk_iter(),
+    )
+    assert isinstance(response.toolkit, llm.Toolkit)
+
+    response = llm.AsyncStreamResponse(
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        input_messages=[],
+        chunk_iterator=async_chunk_iter(),
+    )
+    assert isinstance(response.toolkit, llm.AsyncToolkit)
+
+    response = llm.ContextStreamResponse(
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        input_messages=[],
+        chunk_iterator=chunk_iter(),
+    )
+    assert isinstance(response.toolkit, llm.ContextToolkit)
+
+    response = llm.AsyncContextStreamResponse(
+        provider="openai",
+        model_id="gpt-4o-mini",
+        params={},
+        input_messages=[],
+        chunk_iterator=async_chunk_iter(),
+    )
+    assert isinstance(response.toolkit, llm.AsyncContextToolkit)


### PR DESCRIPTION
- Client APIs can now take either toolkit or tools
- Response constructor **must** take toolkit
- Call decorator still takes tools not toolkit

This is a non-breaking API change (calls to client can still just pass
tools). It does get a nice performance improvement because we now only
construct toolkits in two cases:
- When call decorator is invoked and creates a Call
- When user has called client with tools rather than toolkit

All other cases, we pass the toolkit by reference rather than
constructing it anew. This is good because constructing toolkit is
O(number of tools). We should still probably put a LRU cache in, but
it's much less urgent now that the library code constructs toolkits only
where truly necessary.