### PR TITLE
test: safer exception snapshotting

### DIFF
--- a/python/tests/e2e/snapshots/structured_output/strict_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/strict_anthropic_snapshots.py
@@ -3,9 +3,7 @@ from inline_snapshot import snapshot
 sync_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -15,9 +13,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -27,9 +23,7 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -39,9 +33,7 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_anthropic_snapshots.py
@@ -3,9 +3,7 @@ from inline_snapshot import snapshot
 sync_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -15,9 +13,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -27,9 +23,7 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -39,9 +33,7 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",

--- a/python/tests/e2e/snapshots/structured_output_with_tools/json_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/json_google_snapshots.py
@@ -3,9 +3,7 @@ from inline_snapshot import snapshot
 sync_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:json with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",
@@ -14,9 +12,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:json with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",
@@ -25,9 +21,7 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:json with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",
@@ -36,9 +30,7 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:json with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",

--- a/python/tests/e2e/snapshots/structured_output_with_tools/strict_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/strict_anthropic_snapshots.py
@@ -3,9 +3,7 @@ from inline_snapshot import snapshot
 sync_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -15,9 +13,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -27,9 +23,7 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",
@@ -39,9 +33,7 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "type": "FormattingModeNotSupportedError",
-        "args": (
-            "Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'",
-        ),
+        "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
         "feature": "formatting_mode:strict",
         "formatting_mode": "strict",
         "model_id": "claude-sonnet-4-0",

--- a/python/tests/e2e/snapshots/structured_output_with_tools/strict_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/strict_google_snapshots.py
@@ -3,9 +3,7 @@ from inline_snapshot import snapshot
 sync_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:strict with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",
@@ -14,9 +12,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:strict with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",
@@ -25,9 +21,7 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:strict with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",
@@ -36,9 +30,7 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "type": "FeatureNotSupportedError",
-        "args": (
-            "Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'",
-        ),
+        "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
         "feature": "formatting_mode:strict with tools",
         "model_id": "gemini-2.5-flash",
         "provider": "google",

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -82,7 +82,7 @@ def exception_snapshot_dict(exception: Exception) -> dict:
     return {
         "type": type(exception).__name__,
         **{
-            attr: getattr(exception, attr)
+            attr: str(getattr(exception, attr))
             for attr in dir(exception)
             if not attr.startswith("_") and not callable(getattr(exception, attr))
         },


### PR DESCRIPTION
Tweak to exception snapshots so that it won't break if exceptions have
complex objects attached (necessary for next PR).