### PR TITLE
feat: unbreak google when penalty params are present

### DIFF
--- a/python/tests/e2e/cassettes/call_with_params/google/async.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/google/async.yaml
@@ -2,8 +2,7 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "What is 4200 + 42?"}], "role": "user"}],
       "generationConfig": {"temperature": 0.7, "topP": 0.3, "topK": 50.0, "maxOutputTokens":
-      500, "stopSequences": ["4242"], "presencePenalty": 0.1, "frequencyPenalty":
-      0.1, "seed": 42}}'
+      500, "stopSequences": ["4242"], "seed": 42}}'
     headers:
       accept:
       - '*/*'
@@ -12,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '256'
+      - '207'
       content-type:
       - application/json
       host:
@@ -26,9 +25,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/6vmUlBQSi0qyi9SslKoBnKA3OT8lFQgz8TAQAcikJtaXJyYDhJTCkjNS8wpqVTI
-        LFbIyy9RAPKSclJTFNLyixRygdpyivXTU3Mz8zJ1jfRMddNyEoszlKCGFJcklpQWg8zw9Atz9PF0
-        iXcMcg/1dfULUQIqqOWq5QIAWNHZOYwAAAA=
+        H4sIAAAAAAAC/2WRy27CMBBF9/kKy9tCRQOoiC10gQRtoFFVqenCIpNHm9hRPKl4iH/v2GnAUb2w
+        RnNv5o5Pzh5jfC9knMcCQfM5+6AOY2d7G01JBIkkdC1qVqLGm7c9Z6cmC8LBfMRDxZJcxgwzYLop
+        mUrYxB+NGEVSMWBH1TARW71kqFKgop5HMpLGFsk7GjbxIzm0J5Lciblc68/BbblaFWCSSxVD0dkv
+        nYHTNrnOdiC0ksb2Gr4E/KrSqnCg9sjrAuxo3miRwgZQECZxhcGrWpUVhuob5EI1FtPDuB3mUO3p
+        Y/9PR4Wi6Emz6eDfWL2k0LxwaTs/gt4oihyPlvTTe8gdDtjfqgPhObw4ZqpJM+xvODGPt8Bahm9Q
+        67yFlUJJ+Ib+/XSYFEJnNo/XoCslNaxi4zl9Lfdis1ivn5Pd6XEV/MyCQG+33Lt4v56L3kJuAgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -37,11 +39,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Tue, 30 Sep 2025 19:18:03 GMT
+      - Tue, 30 Sep 2025 19:34:38 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=139
+      - gfet4t7; dur=1626
       Transfer-Encoding:
       - chunked
       Vary:
@@ -55,6 +57,6 @@ interactions:
       X-XSS-Protection:
       - '0'
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
 version: 1

--- a/python/tests/e2e/cassettes/call_with_params/google/async_stream.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/google/async_stream.yaml
@@ -2,8 +2,7 @@ interactions:
 - request:
     body: '{"contents": [{"parts": [{"text": "What is 4200 + 42?"}], "role": "user"}],
       "generationConfig": {"temperature": 0.7, "topP": 0.3, "topK": 50.0, "maxOutputTokens":
-      500, "stopSequences": ["4242"], "presencePenalty": 0.1, "frequencyPenalty":
-      0.1, "seed": 42}}'
+      500, "stopSequences": ["4242"], "seed": 42}}'
     headers:
       accept:
       - '*/*'
@@ -12,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '256'
+      - '207'
       content-type:
       - application/json
       host:
@@ -25,22 +24,27 @@ interactions:
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Penalty is
-        not enabled for models/gemini-2.5-flash\",\n    \"status\": \"INVALID_ARGUMENT\"\n
-        \ }\n}\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"To
+        find the sum of 4200 and 42, you add them together:\\n\\n4200\\n+   42\\n------\\n\"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
+        13,\"candidatesTokenCount\": 32,\"totalTokenCount\": 85,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 13}],\"thoughtsTokenCount\": 40},\"modelVersion\":
+        \"gemini-2.5-flash\",\"responseId\": \"1zDcaOv4FYSfz7IPo_HSuQQ\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Length:
-      - '140'
+      Content-Disposition:
+      - attachment
       Content-Type:
       - text/event-stream
       Date:
-      - Tue, 30 Sep 2025 19:18:35 GMT
+      - Tue, 30 Sep 2025 19:34:48 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=118
+      - gfet4t7; dur=1570
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Origin
       - X-Origin
@@ -52,6 +56,6 @@ interactions:
       X-XSS-Protection:
       - '0'
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
 version: 1

--- a/python/tests/e2e/cassettes/call_with_params/google/stream.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/google/stream.yaml
@@ -22,25 +22,34 @@ interactions:
       x-goog-api-client:
       - google-genai-sdk/1.31.0 gl-python/3.10.16
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "{\n  \"error\": {\n    \"code\": 400,\n    \"message\": \"Penalty is
-        not enabled for models/gemini-2.5-flash\",\n    \"status\": \"INVALID_ARGUMENT\"\n
-        \ }\n}\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"4200\"}],\"role\":
+        \"model\"}}],\"usageMetadata\": {\"promptTokenCount\": 13,\"totalTokenCount\":
+        13,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 13}]},\"modelVersion\":
+        \"gemini-2.0-flash\",\"responseId\": \"gMTaaKmOIpHmgbUPidTOuQo\"}\r\n\r\ndata:
+        {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \" + 42 = \"}],\"role\":
+        \"model\"},\"finishReason\": \"STOP\"}],\"usageMetadata\": {\"promptTokenCount\":
+        12,\"candidatesTokenCount\": 10,\"totalTokenCount\": 22,\"promptTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 12}],\"candidatesTokensDetails\":
+        [{\"modality\": \"TEXT\",\"tokenCount\": 10}]},\"modelVersion\": \"gemini-2.0-flash\",\"responseId\":
+        \"gMTaaKmOIpHmgbUPidTOuQo\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      Content-Length:
-      - '140'
+      Content-Disposition:
+      - attachment
       Content-Type:
       - text/event-stream
       Date:
-      - Fri, 26 Sep 2025 00:57:06 GMT
+      - Mon, 29 Sep 2025 17:40:16 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=120
+      - gfet4t7; dur=459
+      Transfer-Encoding:
+      - chunked
       Vary:
       - Origin
       - X-Origin
@@ -52,6 +61,6 @@ interactions:
       X-XSS-Protection:
       - '0'
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
 version: 1

--- a/python/tests/e2e/cassettes/call_with_params/google/sync.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/google/sync.yaml
@@ -22,13 +22,16 @@ interactions:
       x-goog-api-client:
       - google-genai-sdk/1.31.0 gl-python/3.10.16
     method: POST
-    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/6vmUlBQSi0qyi9SslKoBnKA3OT8lFQgz8TAQAcikJtaXJyYDhJTCkjNS8wpqVTI
-        LFbIyy9RAPKSclJTFNLyixRygdpyivXTU3Mz8zJ1jfRMddNyEoszlKCGFJcklpQWg8zw9Atz9PF0
-        iXcMcg/1dfULUQIqqOWq5QIAWNHZOYwAAAA=
+        H4sIAAAAAAAC/61RwU6DQBC98xWbvSrNulAFEw9GPTSpWi1RE+NhKgMlwi5ht0Zt+Hd3obSLZzmQ
+        zbw38+a92XqE0HcQaZGCRkXPyaupELLt/haTQqPQBhhKplhDow/c/ts6b0PR+GWbaMgZI0ck5OSC
+        UIfS7t9vx4fBjSzRdlUyxXKgtwOBZoUo1PoRQUlhacvkfkH3KHzmc5nXjVzZ3Xw2YYxFLI75aTAN
+        gjiMoykPvUG8k6UbBTneogZjH/YmqRlS1TqRHyiu5Kazf8J7ISetMc52uJYayhHEh1ZnrLo2okXp
+        pugEbPxDWehvazK5eUmok5EebzWE5DlZ/t3xv8TYWMzb3aY/1xM2qujvkmNlLuXzCfOzEtS6m0gb
+        VLUUCmep5WRRAjBfru7qKv05my00PF+qB0m91vsFuEOmmpUCAAA=
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -37,11 +40,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 26 Sep 2025 00:48:24 GMT
+      - Mon, 29 Sep 2025 17:40:16 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=124
+      - gfet4t7; dur=547
       Transfer-Encoding:
       - chunked
       Vary:
@@ -55,6 +58,6 @@ interactions:
       X-XSS-Protection:
       - '0'
     status:
-      code: 400
-      message: Bad Request
+      code: 200
+      message: OK
 version: 1

--- a/python/tests/e2e/snapshots/call_with_params/google_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_params/google_snapshots.py
@@ -1,58 +1,133 @@
 from inline_snapshot import snapshot
 
+from mirascope.llm import (
+    AssistantMessage,
+    FinishReason,
+    Text,
+    UserMessage,
+)
+
 sync_snapshot = snapshot(
     {
-        "exception": {
-            "type": "ClientError",
-            "args": "(\"400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}\",)",
-            "code": "400",
-            "details": "{'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}",
-            "message": "Penalty is not enabled for models/gemini-2.5-flash",
-            "response": "<Response [400 Bad Request]>",
-            "status": "INVALID_ARGUMENT",
-        },
+        "response": (
+            {
+                "provider": "google",
+                "model_id": "gemini-2.0-flash",
+                "params": {
+                    "temperature": 0.7,
+                    "max_tokens": 500,
+                    "top_p": 0.3,
+                    "top_k": 50,
+                    "frequency_penalty": 0.1,
+                    "presence_penalty": 0.1,
+                    "seed": 42,
+                    "stop_sequences": ["4242"],
+                },
+                "finish_reason": FinishReason.END_TURN,
+                "messages": [
+                    UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                    AssistantMessage(content=[Text(text="4200 + 42 = ")]),
+                ],
+                "format": None,
+                "tools": [],
+            },
+        ),
         "logging": [],
     }
 )
 async_snapshot = snapshot(
     {
-        "exception": {
-            "type": "ClientError",
-            "args": "(\"400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}\",)",
-            "code": "400",
-            "details": "{'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}",
-            "message": "Penalty is not enabled for models/gemini-2.5-flash",
-            "response": "<Response [400 Bad Request]>",
-            "status": "INVALID_ARGUMENT",
-        },
-        "logging": [],
+        "response": (
+            {
+                "provider": "google",
+                "model_id": "gemini-2.5-flash",
+                "params": {
+                    "temperature": 0.7,
+                    "max_tokens": 500,
+                    "top_p": 0.3,
+                    "top_k": 50,
+                    "frequency_penalty": 0.1,
+                    "presence_penalty": 0.1,
+                    "seed": 42,
+                    "stop_sequences": ["4242"],
+                },
+                "finish_reason": FinishReason.END_TURN,
+                "messages": [
+                    UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                    AssistantMessage(
+                        content=[
+                            Text(
+                                text="""\
+To find the sum of 4200 and 42, you add them together:
+
+4200
++   42
+------
+"""
+                            )
+                        ]
+                    ),
+                ],
+                "format": None,
+                "tools": [],
+            },
+        ),
+        "logging": [
+            "parameter frequency_penalty is not supported for model gemini-2.5-flash - ignoring",
+            "parameter presence_penalty is not supported for model gemini-2.5-flash - ignoring",
+        ],
     }
 )
 stream_snapshot = snapshot(
     {
-        "exception": {
-            "type": "ClientError",
-            "args": "(\"400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}\",)",
-            "code": "400",
-            "details": "{'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}",
-            "message": "Penalty is not enabled for models/gemini-2.5-flash",
-            "response": "<Response [400 Bad Request]>",
-            "status": "INVALID_ARGUMENT",
-        },
+        "response": (
+            {
+                "provider": "google",
+                "model_id": "gemini-2.0-flash",
+                "finish_reason": FinishReason.END_TURN,
+                "messages": [
+                    UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                    AssistantMessage(content=[Text(text="4200 + 42 = ")]),
+                ],
+                "format": None,
+                "tools": [],
+                "n_chunks": 4,
+            },
+        ),
         "logging": [],
     }
 )
 async_stream_snapshot = snapshot(
     {
-        "exception": {
-            "type": "ClientError",
-            "args": "(\"400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}\",)",
-            "code": "400",
-            "details": "{'error': {'code': 400, 'message': 'Penalty is not enabled for models/gemini-2.5-flash', 'status': 'INVALID_ARGUMENT'}}",
-            "message": "Penalty is not enabled for models/gemini-2.5-flash",
-            "response": "<Response [400 Bad Request]>",
-            "status": "INVALID_ARGUMENT",
-        },
-        "logging": [],
+        "response": (
+            {
+                "provider": "google",
+                "model_id": "gemini-2.5-flash",
+                "finish_reason": FinishReason.END_TURN,
+                "messages": [
+                    UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                    AssistantMessage(
+                        content=[
+                            Text(
+                                text="""\
+To find the sum of 4200 and 42, you add them together:
+
+4200
++   42
+------
+"""
+                            )
+                        ]
+                    ),
+                ],
+                "format": None,
+                "tools": [],
+                "n_chunks": 3,
+            },
+        ),
+        "logging": [
+            "parameter frequency_penalty is not supported for model gemini-2.5-flash - ignoring",
+            "parameter presence_penalty is not supported for model gemini-2.5-flash - ignoring",
+        ],
     }
 )

--- a/python/tests/e2e/test_call_with_params.py
+++ b/python/tests/e2e/test_call_with_params.py
@@ -24,8 +24,13 @@ ALL_PARAMS: llm.Params = {
     "stop_sequences": ["4242"],
 }
 
+PROVIDER_MODEL_IDS_WITH_LEGACY_GEMINI = [
+    (provider, model_id if model_id != "gemini-2.5-flash" else "gemini-2.0-flash")
+    for (provider, model_id) in PROVIDER_MODEL_ID_PAIRS
+]  # Use gemini-2.0-flash for e2e testing of the `frequency_penalty` and `presence_penalty` params
 
-@pytest.mark.parametrize("provider,model_id", PROVIDER_MODEL_ID_PAIRS)
+
+@pytest.mark.parametrize("provider,model_id", PROVIDER_MODEL_IDS_WITH_LEGACY_GEMINI)
 @pytest.mark.vcr
 def test_call_with_params_sync(
     provider: llm.Provider,
@@ -55,7 +60,7 @@ def test_call_with_params_sync(
         assert snapshot_data == snapshot
 
 
-@pytest.mark.parametrize("provider,model_id", PROVIDER_MODEL_ID_PAIRS)
+@pytest.mark.parametrize("provider,model_id", PROVIDER_MODEL_IDS_WITH_LEGACY_GEMINI)
 @pytest.mark.vcr
 def test_call_with_params_stream(
     provider: llm.Provider,


### PR DESCRIPTION
In testing, the 2.0 series accepts presence parameters, and the 2.5
series fails when they are used. So, I updated the implementation to log
a warning and skip parameter when they can't be used.

Once the next generation comes out, we can infer whether Google is
dropping support for this long term or if 2.5 is the exception, and
maybe switch to "default exclude" for the parameter.

For now I did a coverage exclusion for convenience, because the e2e
testing setup doesn't make it easy to run the same tests for multiple
models with the same provider (would need to change how we name snapshot
files and cassettes to disambiguate). However I'm open to figuring
something else out.