### PR TITLE
refactor: improve type safety of google utils

### DIFF
--- a/python/tests/llm/clients/google/test_client.py
+++ b/python/tests/llm/clients/google/test_client.py
@@ -105,7 +105,7 @@ def test_prepare_google_request_frequency_penalty_logging(
 
     assert len(caplog.records) == 0
     assert config is not None
-    assert config.frequency_penalty == 0.5
+    assert config.get("frequency_penalty") == 0.5
 
 
 def test_prepare_google_request_presence_penalty_logging(
@@ -138,4 +138,4 @@ def test_prepare_google_request_presence_penalty_logging(
 
     assert len(caplog.records) == 0
     assert config is not None
-    assert config.presence_penalty == 0.3
+    assert config.get("presence_penalty") == 0.3


### PR DESCRIPTION
Now we use the actual `genai_types.GenerateContentConfigDict` type when
constructing the google config, meaning that if we typo a property
assignment (e.g. trying to pass `max_tokens` instead of
`max_output_tokens`), then we get a type error.

The old code constructed the dict without type safety, and then created
the pydantic model version (GenerateContentConfig). If we want to, we
can also construct the pydantic model for extra safety, but I think it's
in keeping with our design approach to depend on the type system here.