### PR TITLE
feat: stub out openai:responses provider

### DIFF
--- a/python/mirascope/llm/calls/decorator.py
+++ b/python/mirascope/llm/calls/decorator.py
@@ -12,6 +12,7 @@ from ..clients import (
     GoogleModelId,
     ModelId,
     OpenAIModelId,
+    OpenAIResponsesModelId,
     Params,
     Provider,
 )
@@ -167,6 +168,19 @@ def call(
     **params: Unpack[Params],
 ) -> CallDecorator[ToolT, FormattableT]:
     """Decorate a prompt into a Call using OpenAI models."""
+    ...
+
+
+@overload
+def call(
+    *,
+    provider: Literal["openai:responses"],
+    model_id: OpenAIResponsesModelId,
+    tools: list[ToolT] | None = None,
+    format: type[FormattableT] | Format[FormattableT] | None = None,
+    **params: Unpack[Params],
+) -> CallDecorator[ToolT, FormattableT]:
+    """Decorate a prompt into a Call using OpenAI models (Responses API)."""
     ...
 
 

--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -11,6 +11,7 @@ from .base import (
 )
 from .google import GoogleClient, GoogleModelId
 from .openai import OpenAIClient, OpenAIModelId
+from .openai_responses import OpenAIResponsesClient, OpenAIResponsesModelId
 from .providers import PROVIDERS, ModelId, Provider, client, get_client
 
 __all__ = [
@@ -24,6 +25,8 @@ __all__ = [
     "ModelId",
     "OpenAIClient",
     "OpenAIModelId",
+    "OpenAIResponsesClient",
+    "OpenAIResponsesModelId",
     "Params",
     "Provider",
     "client",

--- a/python/mirascope/llm/clients/openai_responses/__init__.py
+++ b/python/mirascope/llm/clients/openai_responses/__init__.py
@@ -1,0 +1,6 @@
+"""OpenAI Responses API client implementation."""
+
+from .clients import OpenAIResponsesClient, client, get_client
+from .model_ids import OpenAIResponsesModelId
+
+__all__ = ["OpenAIResponsesClient", "OpenAIResponsesModelId", "client", "get_client"]

--- a/python/mirascope/llm/clients/openai_responses/clients.py
+++ b/python/mirascope/llm/clients/openai_responses/clients.py
@@ -1,0 +1,649 @@
+"""OpenAI Responses API client implementation."""
+
+import os
+from collections.abc import Sequence
+from contextvars import ContextVar
+from functools import lru_cache
+from typing import overload
+from typing_extensions import Unpack
+
+from openai import AsyncOpenAI, OpenAI
+
+from ...context import Context, DepsT
+from ...formatting import Format, FormattableT
+from ...messages import Message
+from ...responses import (
+    AsyncContextResponse,
+    AsyncContextStreamResponse,
+    AsyncResponse,
+    AsyncStreamResponse,
+    ContextResponse,
+    ContextStreamResponse,
+    Response,
+    StreamResponse,
+)
+from ...tools import (
+    AsyncContextTool,
+    AsyncContextToolkit,
+    AsyncTool,
+    AsyncToolkit,
+    ContextTool,
+    ContextToolkit,
+    Tool,
+    Toolkit,
+)
+from ..base import BaseClient, Params
+from .model_ids import OpenAIResponsesModelId
+
+OPENAI_RESPONSES_CLIENT_CONTEXT: ContextVar["OpenAIResponsesClient | None"] = (
+    ContextVar("OPENAI_RESPONSES_CLIENT_CONTEXT", default=None)
+)
+
+
+@lru_cache(maxsize=256)
+def _openai_responses_singleton(
+    api_key: str | None, base_url: str | None
+) -> "OpenAIResponsesClient":
+    """Return a cached `OpenAIResponsesClient` instance for the given parameters."""
+    return OpenAIResponsesClient(api_key=api_key, base_url=base_url)
+
+
+def client(
+    *, api_key: str | None = None, base_url: str | None = None
+) -> "OpenAIResponsesClient":
+    """Return an `OpenAIResponsesClient`."""
+    api_key = api_key or os.getenv("OPENAI_API_KEY")
+    base_url = base_url or os.getenv("OPENAI_BASE_URL")
+    return _openai_responses_singleton(api_key, base_url)
+
+
+def get_client() -> "OpenAIResponsesClient":
+    """Get the current `OpenAIResponsesClient` from context."""
+    current_client = OPENAI_RESPONSES_CLIENT_CONTEXT.get()
+    if current_client is None:
+        current_client = client()
+        OPENAI_RESPONSES_CLIENT_CONTEXT.set(current_client)
+    return current_client
+
+
+class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
+    """The client for the OpenAI Responses API."""
+
+    @property
+    def _context_var(self) -> ContextVar["OpenAIResponsesClient | None"]:
+        return OPENAI_RESPONSES_CLIENT_CONTEXT
+
+    def __init__(
+        self, *, api_key: str | None = None, base_url: str | None = None
+    ) -> None:
+        """Initialize the OpenAI Responses client."""
+        self.client = OpenAI(api_key=api_key, base_url=base_url)
+        self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
+
+    @overload
+    def call(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> Response:
+        """Generate an `llm.Response` without a response format."""
+        ...
+
+    @overload
+    def call(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> Response[FormattableT]:
+        """Generate an `llm.Response` with a response format."""
+        ...
+
+    @overload
+    def call(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> Response | Response[FormattableT]:
+        """Generate an `llm.Response` with optional response format."""
+        ...
+
+    def call(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> Response | Response[FormattableT]:
+        """Generate an `llm.Response` by synchronously calling the OpenAI Responses API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.Response` object containing the LLM-generated content.
+        """
+        raise NotImplementedError("responses API not yet implemented")
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse:
+        """Generate an `llm.AsyncResponse` without a response format."""
+        ...
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncResponse[FormattableT]:
+        """Generate an `llm.AsyncResponse` with a response format."""
+        ...
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Generate an `llm.AsyncResponse` with optional response format."""
+        ...
+
+    async def call_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Generate an `llm.AsyncResponse` by asynchronously calling the OpenAI Responses API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.AsyncResponse` object containing the LLM-generated content.
+        """
+        raise NotImplementedError(
+            "Async calls not yet implemented for OpenAI Responses API"
+        )
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> StreamResponse:
+        """Generate a `llm.StreamResponse` without a response format."""
+        ...
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> StreamResponse[FormattableT]:
+        """Generate a `llm.StreamResponse` with a response format."""
+        ...
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> StreamResponse | StreamResponse[FormattableT]:
+        """Generate a `llm.StreamResponse` with optional response format."""
+        ...
+
+    def stream(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> StreamResponse | StreamResponse[FormattableT]:
+        """Generate a `llm.StreamResponse` by synchronously streaming from the OpenAI Responses API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            A `llm.StreamResponse` object containing the LLM-generated content stream.
+        """
+        raise NotImplementedError(
+            "Streaming not yet implemented for OpenAI Responses API"
+        )
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse:
+        """Generate a `llm.AsyncStreamResponse` without a response format."""
+        ...
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse[FormattableT]:
+        """Generate a `llm.AsyncStreamResponse` with a response format."""
+        ...
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
+        """Generate a `llm.AsyncStreamResponse` with optional response format."""
+        ...
+
+    async def stream_async(
+        self,
+        *,
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
+        """Generate a `llm.AsyncStreamResponse` by asynchronously streaming from the OpenAI Responses API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            A `llm.AsyncStreamResponse` object containing the LLM-generated content stream.
+        """
+        raise NotImplementedError(
+            "Async streaming not yet implemented for OpenAI Responses API"
+        )
+
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT]:
+        """Generate a `llm.ContextResponse` without a response format."""
+        ...
+
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT, FormattableT]:
+        """Generate a `llm.ContextResponse` with a response format."""
+        ...
+
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT] | ContextResponse[DepsT, FormattableT]:
+        """Generate a `llm.ContextResponse` with optional response format."""
+        ...
+
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT] | ContextResponse[DepsT, FormattableT]:
+        """Generate a `llm.ContextResponse` by synchronously calling the OpenAI Responses API with context.
+
+        Args:
+            ctx: The context object containing dependencies.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            A `llm.ContextResponse` object containing the LLM-generated content and context.
+        """
+        raise NotImplementedError(
+            "Context calls not yet implemented for OpenAI Responses API"
+        )
+
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT]:
+        """Generate a `llm.AsyncContextResponse` without a response format."""
+        ...
+
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT, FormattableT]:
+        """Generate a `llm.AsyncContextResponse` with a response format."""
+        ...
+
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT] | AsyncContextResponse[DepsT, FormattableT]:
+        """Generate a `llm.AsyncContextResponse` with optional response format."""
+        ...
+
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT] | AsyncContextResponse[DepsT, FormattableT]:
+        """Generate a `llm.AsyncContextResponse` by asynchronously calling the OpenAI Responses API with context.
+
+        Args:
+            ctx: The context object containing dependencies.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            A `llm.AsyncContextResponse` object containing the LLM-generated content and context.
+        """
+        raise NotImplementedError(
+            "Async context calls not yet implemented for OpenAI Responses API"
+        )
+
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT]:
+        """Generate a `llm.ContextStreamResponse` without a response format."""
+        ...
+
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT, FormattableT]:
+        """Generate a `llm.ContextStreamResponse` with a response format."""
+        ...
+
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
+        """Generate a `llm.ContextStreamResponse` with optional response format."""
+        ...
+
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
+        """Generate a `llm.ContextStreamResponse` by synchronously streaming from the OpenAI Responses API with context.
+
+        Args:
+            ctx: The context object containing dependencies.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            A `llm.ContextStreamResponse` object containing the LLM-generated content stream and context.
+        """
+        raise NotImplementedError(
+            "Context streaming not yet implemented for OpenAI Responses API"
+        )
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextStreamResponse[DepsT]:
+        """Generate a `llm.AsyncContextStreamResponse` without a response format."""
+        ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
+        """Generate a `llm.AsyncContextStreamResponse` with a response format."""
+        ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> (
+        AsyncContextStreamResponse[DepsT]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Generate a `llm.AsyncContextStreamResponse` with optional response format."""
+        ...
+
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: OpenAIResponsesModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> (
+        AsyncContextStreamResponse[DepsT]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Generate a `llm.AsyncContextStreamResponse` by asynchronously streaming from the OpenAI Responses API with context.
+
+        Args:
+            ctx: The context object containing dependencies.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Not supported in Responses API (yet).
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            A `llm.AsyncContextStreamResponse` object containing the LLM-generated content stream and context.
+        """
+        raise NotImplementedError(
+            "Async context streaming not yet implemented for OpenAI Responses API"
+        )

--- a/python/mirascope/llm/clients/openai_responses/model_ids.py
+++ b/python/mirascope/llm/clients/openai_responses/model_ids.py
@@ -1,0 +1,8 @@
+"""OpenAI Responses registered LLM models."""
+
+from typing import TypeAlias
+
+from openai.types import ResponsesModel
+
+OpenAIResponsesModelId: TypeAlias = ResponsesModel | str
+"""The OpenAI Responses model ids registered with Mirascope."""

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -1197,6 +1197,17 @@ def model(
 @overload
 def model(
     *,
+    provider: Literal["openai:responses"],
+    model_id: OpenAIModelId,
+    **params: Unpack[Params],
+) -> Model:
+    """Create an `llm.Model` instance for OpenAI models (responses API)."""
+    ...
+
+
+@overload
+def model(
+    *,
     provider: Provider,
     model_id: ModelId,
     **params: Unpack[Params],

--- a/python/tests/llm/clients/openai_responses/test_client.py
+++ b/python/tests/llm/clients/openai_responses/test_client.py
@@ -1,0 +1,51 @@
+"""Tests for OpenAIClient"""
+
+from mirascope import llm
+
+
+def test_context_manager() -> None:
+    """Test nested context manager behavior and get_client() integration."""
+
+    global_client = llm.get_client("openai:responses")
+
+    client1 = llm.client("openai:responses", api_key="key1")
+    client2 = llm.client("openai:responses", api_key="key2")
+
+    assert llm.get_client("openai:responses") is global_client
+
+    with client1 as ctx1:
+        assert ctx1 is client1
+        assert llm.get_client("openai:responses") is client1
+
+        with client2 as ctx2:
+            assert ctx2 is client2
+            assert llm.get_client("openai:responses") is client2
+
+        assert llm.get_client("openai:responses") is client1
+
+    assert llm.get_client("openai:responses") is global_client
+
+
+def test_client_caching() -> None:
+    """Test that client() returns cached instances for identical parameters."""
+    client1 = llm.client(
+        "openai", api_key="test-key", base_url="https://api.example.com"
+    )
+    client2 = llm.client(
+        "openai", api_key="test-key", base_url="https://api.example.com"
+    )
+    assert client1 is client2
+
+    client3 = llm.client(
+        "openai", api_key="different-key", base_url="https://api.example.com"
+    )
+    assert client1 is not client3
+
+    client4 = llm.client(
+        "openai", api_key="test-key", base_url="https://different.example.com"
+    )
+    assert client1 is not client4
+
+    client5 = llm.client("openai:responses", api_key=None, base_url=None)
+    client6 = llm.get_client("openai:responses")
+    assert client5 is client6

--- a/python/tests/llm/clients/test_providers.py
+++ b/python/tests/llm/clients/test_providers.py
@@ -4,40 +4,45 @@ import os
 
 import pytest
 
-from mirascope.llm.clients import (
-    AnthropicClient,
-    GoogleClient,
-    OpenAIClient,
-    get_client,
-)
+from mirascope import llm
 
 
 def test_get_client_anthropic() -> None:
     """Test that get_client('anthropic') returns same instance on multiple calls."""
-    client1 = get_client("anthropic")
-    client2 = get_client("anthropic")
+    client1 = llm.get_client("anthropic")
+    client2 = llm.get_client("anthropic")
 
-    assert isinstance(client1, AnthropicClient)
+    assert isinstance(client1, llm.clients.AnthropicClient)
     assert client1 is client2
     assert client1.client.api_key == os.getenv("ANTHROPIC_API_KEY")
 
 
 def test_get_client_google() -> None:
     """Test that get_client('google') returns same instance on multiple calls."""
-    client1 = get_client("google")
-    client2 = get_client("google")
+    client1 = llm.get_client("google")
+    client2 = llm.get_client("google")
 
-    assert isinstance(client1, GoogleClient)
+    assert isinstance(client1, llm.clients.GoogleClient)
     assert client1 is client2
     assert client1.client._api_client.api_key == os.getenv("GOOGLE_API_KEY")
 
 
 def test_get_client_openai() -> None:
     """Test that get_client('openai') returns same instance on multiple calls."""
-    client1 = get_client("openai")
-    client2 = get_client("openai")
+    client1 = llm.get_client("openai")
+    client2 = llm.get_client("openai")
 
-    assert isinstance(client1, OpenAIClient)
+    assert isinstance(client1, llm.clients.OpenAIClient)
+    assert client1 is client2
+    assert client1.client.api_key == os.getenv("OPENAI_API_KEY")
+
+
+def test_get_client_openai_responses() -> None:
+    """Test that get_client('openai:responses') returns same instance on multiple calls."""
+    client1 = llm.get_client("openai:responses")
+    client2 = llm.get_client("openai:responses")
+
+    assert isinstance(client1, llm.clients.OpenAIResponsesClient)
     assert client1 is client2
     assert client1.client.api_key == os.getenv("OPENAI_API_KEY")
 
@@ -45,4 +50,4 @@ def test_get_client_openai() -> None:
 def test_get_client_unknown_provider() -> None:
     """Test that get_client raises ValueError for unknown providers."""
     with pytest.raises(ValueError, match="Unknown provider: unknown"):
-        get_client("unknown")  # type: ignore
+        llm.get_client("unknown")  # type: ignore


### PR DESCRIPTION
We add a new provider, "openai:responses" with a corresponding
`OpenAIResponsesClient`. Currently the client raises NotImplementedError
for every method, so this is just showing how it will fit into the
codebase (for now).

Currently I'm leaving the chat completions client as just "openai"
provider, so this approach privileges chat completions as the default
option and naming reflects this (`OpenAIClient` vs
`OpenAIResponsesClient`). I don't see this as the final design, more
just a starting point while the responses client gets developed. Before
launching beta we should revisit this. Added a TODO to this effect.