### PR TITLE
nit: remove inconsistent prepare_request docstrings

### DIFF
--- a/python/mirascope/llm/clients/anthropic/_utils.py
+++ b/python/mirascope/llm/clients/anthropic/_utils.py
@@ -164,6 +164,7 @@ def prepare_anthropic_request(
     format: type[FormattableT] | Format[FormattableT] | None = None,
     params: Params | None = None,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, MessageCreateKwargs]:
+    """Prepares a request for the `Anthropic.messages.create` method."""
     kwargs: MessageCreateKwargs = {
         "model": model_id,
         "max_tokens": 1024,

--- a/python/mirascope/llm/clients/google/_utils.py
+++ b/python/mirascope/llm/clients/google/_utils.py
@@ -228,6 +228,7 @@ def prepare_google_request(
     genai_types.ContentListUnionDict,
     GoogleKwargs,
 ]:
+    """Prepares a request for the genai `Client.models.generate_content` method."""
     google_config: GoogleKwargs = _base_utils.map_params_to_kwargs(
         params, {}, PARAMS_TO_KWARGS, "Google"
     )

--- a/python/mirascope/llm/clients/openai/completions/_utils.py
+++ b/python/mirascope/llm/clients/openai/completions/_utils.py
@@ -222,7 +222,7 @@ PARAMS_TO_KWARGS: _base_utils.ParamsToKwargs = {
 }
 
 
-def prepare_openai_request(
+def prepare_completions_request(
     *,
     model_id: OpenAICompletionsModelId,
     messages: Sequence[Message],
@@ -230,21 +230,7 @@ def prepare_openai_request(
     format: type[FormattableT] | Format[FormattableT] | None = None,
     params: Params | None = None,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, ChatCompletionCreateKwargs]:
-    """Prepare OpenAI API request parameters.
-
-    Args:
-        model: The OpenAI model string. Used for model-specific behavior around whether
-          strict structured outputs are supported.
-        messages: A sequence of Mirascope `Message`s.
-        tools: A sequence of Mirascope tools (or None).
-        format: A format type (or None).
-
-    Returns:
-        A tuple containing:
-            - A sequence of Mirascope `Message`s, which may include modifications to the
-              system message (e.g. with instructions for JSON mode formatting).
-            - A ChatCompletionCreateKwargs dict with parameters for OpenAI's create method.
-    """
+    """Prepares a request for the `OpenAI.chat.completions.create` method."""
     kwargs: ChatCompletionCreateKwargs = {
         "model": model_id,
     }

--- a/python/mirascope/llm/clients/openai/completions/clients.py
+++ b/python/mirascope/llm/clients/openai/completions/clients.py
@@ -154,7 +154,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
         Returns:
             An `llm.Response` object containing the LLM-generated content.
         """
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -251,7 +251,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
         Returns:
             An `llm.ContextResponse` object containing the LLM-generated content.
         """
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -336,7 +336,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
             An `llm.AsyncResponse` object containing the LLM-generated content.
         """
 
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             params=params,
             messages=messages,
@@ -433,7 +433,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
         Returns:
             An `llm.AsyncContextResponse` object containing the LLM-generated content.
         """
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             params=params,
             messages=messages,
@@ -517,7 +517,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
         Returns:
             An `llm.StreamResponse` object for iterating over the LLM-generated content.
         """
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -615,7 +615,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
         Returns:
             An `llm.ContextStreamResponse` object for iterating over the LLM-generated content.
         """
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -701,7 +701,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
             An `llm.AsyncStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
 
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -801,7 +801,7 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
         Returns:
             An `llm.AsyncContextStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
-        input_messages, format, kwargs = _utils.prepare_openai_request(
+        input_messages, format, kwargs = _utils.prepare_completions_request(
             model_id=model_id,
             messages=messages,
             tools=tools,

--- a/python/mirascope/llm/clients/openai/responses/_utils.py
+++ b/python/mirascope/llm/clients/openai/responses/_utils.py
@@ -150,7 +150,7 @@ PARAMS_TO_KWARGS: _base_utils.ParamsToKwargs = {
 }
 
 
-def prepare_openai_request(
+def prepare_responses_request(
     *,
     model_id: OpenAIResponsesModelId,
     messages: Sequence[Message],
@@ -158,22 +158,7 @@ def prepare_openai_request(
     format: type[FormattableT] | Format[FormattableT] | None = None,
     params: Params | None = None,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, ResponseCreateKwargs]:
-    """Prepare OpenAI Responses API request parameters.
-
-    Args:
-        model_id: The OpenAI model string.
-        messages: A sequence of Mirascope `Message`s.
-        tools: A sequence of Mirascope tools (or None).
-        format: A format type (or None).
-        params: Additional parameters.
-
-    Returns:
-        A tuple containing:
-            - A sequence of Mirascope `Message`s, which may include modifications to the
-              system message (e.g. with instructions for JSON mode formatting).
-            - A Format instance (or None).
-            - A ResponseCreateKwargs dict with parameters for OpenAI's Responses create method.
-    """
+    """Prepares a request for the `OpenAI.responses.create` method."""
     kwargs: ResponseCreateKwargs = {
         "model": model_id,
     }

--- a/python/mirascope/llm/clients/openai/responses/clients.py
+++ b/python/mirascope/llm/clients/openai/responses/clients.py
@@ -141,7 +141,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             An `llm.Response` object containing the LLM-generated content.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -225,7 +225,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             An `llm.AsyncResponse` object containing the LLM-generated content.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -309,7 +309,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             A `llm.StreamResponse` object containing the LLM-generated content stream.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -396,7 +396,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             A `llm.AsyncStreamResponse` object containing the LLM-generated content stream.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -496,7 +496,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             A `llm.ContextResponse` object containing the LLM-generated content and context.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -593,7 +593,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             A `llm.AsyncContextResponse` object containing the LLM-generated content and context.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -690,7 +690,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             A `llm.ContextStreamResponse` object containing the LLM-generated content stream and context.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,
@@ -796,7 +796,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
         Returns:
             A `llm.AsyncContextStreamResponse` object containing the LLM-generated content stream and context.
         """
-        messages, format, kwargs = _utils.prepare_openai_request(
+        messages, format, kwargs = _utils.prepare_responses_request(
             model_id=model_id,
             messages=messages,
             tools=tools,

--- a/python/tests/llm/clients/openai/test_completions_client.py
+++ b/python/tests/llm/clients/openai/test_completions_client.py
@@ -18,7 +18,7 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
         llm.messages.user("Hello there"),
         llm.messages.assistant(["General ", "Kenobi"]),
     ]
-    assert openai_utils.prepare_openai_request(
+    assert openai_utils.prepare_completions_request(
         model_id="gpt-4o", messages=messages
     ) == snapshot(
         (
@@ -60,7 +60,7 @@ def test_strict_unsupported_legacy_model() -> None:
     format = llm.format(Book, mode="strict")
 
     with pytest.raises(llm.FormattingModeNotSupportedError):
-        openai_utils.prepare_openai_request(
+        openai_utils.prepare_completions_request(
             model_id="gpt-4",
             messages=messages,
             format=format,

--- a/python/tests/llm/clients/openai/test_responses_client.py
+++ b/python/tests/llm/clients/openai/test_responses_client.py
@@ -16,7 +16,7 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
         llm.messages.user("Hello there"),
         llm.messages.assistant(["General ", "Kenobi"]),
     ]
-    _, _, kwargs = openai_utils.prepare_openai_request(
+    _, _, kwargs = openai_utils.prepare_responses_request(
         model_id="gpt-4o", messages=messages
     )
     assert kwargs == snapshot(
@@ -44,7 +44,7 @@ def test_prepare_message_multiple_system_messages() -> None:
         llm.messages.system("Be concise."),
         llm.messages.system("On second thought, be verbose."),
     ]
-    _, _, kwargs = openai_utils.prepare_openai_request(
+    _, _, kwargs = openai_utils.prepare_responses_request(
         model_id="gpt-4o", messages=messages
     )
     assert kwargs == snapshot(


### PR DESCRIPTION
Removes docstrings for the openai prepare_request methods, these are
internal-only utils in the _utils module, and the docstring was
basically just a redeclaration of the type signature anyway. This makes
it consistent with how we handle the other prepare methods for google
and anthropic. Also, rename the methods to distinguish which API they
serve.