### PR TITLE
fix: address a google-specific max tokens bug

### DIFF
--- a/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/async.yaml
+++ b/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/async.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "List all U.S. states, sorted by the
+      number of consonants in their name, ascending."}], "role": "user"}], "generationConfig":
+      {"maxOutputTokens": 50}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '184'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2VQXWvCQBB8z6847lmLFYu0b9KKiMSWNhShiBxmvRy53IbcBaqS/969i0kb+rIL
+        M/sxM9eIMX4UJlWpcGD5E/sihLFrqJ5D48A4IjqIwAo1EMILTEHzG96Mup2TMspm7yAsGj8WL3aH
+        5HWz3H7wfkaZFL6JnASgobr3HK+tkBCDE6RH9F95WWFRugRzMM9YBz3T+/YYd+iEHlDzyejfmn2h
+        o0r/WmR/HZEToZU7e7nJcpf0QsP9wdfObuj7TkOGtcycHciYPUa3WNqkPqGyqo1EQkEhjad3D+OT
+        FjYL/3gFtkRjYZ36GXe8gNgeVjGe5WW+fstxFctFzqMm+gG+a6wBtwEAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 02 Oct 2025 19:04:21 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=865
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "EMIT NO OUTPUT WHATSOEVER."}], "role":
+      "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '83'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2VQ30vDMBB+718R8ryJDLY5X6eMweamVhFkD4e5tcE0V3qp6Eb/d5N0rRu+XOD7
+        7vL9OCZCyA+wSitwyPJWvHtEiGOcgSPr0DpPdJAHKzLoEVmQQiNPeDPobvbaas6fEJhsWHtON1vZ
+        s9oq/PbwdQQaP3eBkzVDhmt04J1AryfLiorSpfSJdk51dDJr/5KOHJgLZjKbDP6d8Z3/VJu/cOI8
+        i88ARrufYDS9f0t7o1HgXLXLGd9d5yGnOssdX9q4mSanQtqOXrFi3ZaRYeHrGY6uxsO9Ac6jnqyQ
+        S7KMSxV2vviAsF69zDcLd5gut3o1euBHkkmT/AInXgnPsQEAAA==
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 02 Oct 2025 19:04:30 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=8300
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/async_stream.yaml
+++ b/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/async_stream.yaml
@@ -1,0 +1,112 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "List all U.S. states, sorted by the
+      number of consonants in their name, ascending."}], "role": "user"}], "generationConfig":
+      {"maxOutputTokens": 50}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '184'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+  response:
+    body:
+      string: ''
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Thu, 02 Oct 2025 19:05:44 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=918
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "EMIT NO OUTPUT WHATSOEVER."}], "role":
+      "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '83'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+  response:
+    body:
+      string: "data: {\"candidates\": [{\"content\": {\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 9,\"totalTokenCount\":
+        52,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\": 9}],\"thoughtsTokenCount\":
+        43},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\": \"CM3eaP-mIZmdz7IPy9ro2A4\"}\r\n\r\n"
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Disposition:
+      - attachment
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Thu, 02 Oct 2025 19:05:45 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=955
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/stream.yaml
+++ b/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/stream.yaml
@@ -1,0 +1,109 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "List all U.S. states, sorted by the
+      number of consonants in their name, ascending."}], "role": "user"}], "generationConfig":
+      {"maxOutputTokens": 50}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '184'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+  response:
+    body:
+      string: ''
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Thu, 02 Oct 2025 19:20:25 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=1102
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "EMIT NO OUTPUT WHATSOEVER."}], "role":
+      "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '83'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
+  response:
+    body:
+      string: ''
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Disposition:
+      - attachment
+      Content-Length:
+      - '0'
+      Content-Type:
+      - text/event-stream
+      Date:
+      - Thu, 02 Oct 2025 19:20:41 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=15998
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/sync.yaml
+++ b/python/tests/e2e/provider-specific/cassettes/google_max_tokens_edge_case/google/sync.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "List all U.S. states, sorted by the
+      number of consonants in their name, ascending."}], "role": "user"}], "generationConfig":
+      {"maxOutputTokens": 50}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '184'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2VQTUvDQBC951cse26kVkvRW9EeikSDRgmVIouZJks3OzGzAduS/+7upokGLzPw
+        3ny8904BY/xT6ExmwgDxW/ZuEcZOvjoOtQFtLNFDFqxRgUV4iRkofsbbSb+zk1pS8QyCULuxaJl+
+        JE8Pq8cXPsxIncG3JaceaG3dOo43JHKIwAirRwxfeVVjWZkE96DvsPF6ZpfdMW7QCDWiFtPJvzW6
+        t0el+rXI/jqyToSS5uDkJqs0GYT6+6OvvV3ft72GApu8MDSScX0TnGPpknqDmmQXSQ6lDSmcXczD
+        nRJU+H+8BqpQE6wzN4PREUR82ERfV6/HxToO43S+XxIP2uAHXu9ujLcBAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 02 Oct 2025 19:04:00 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=880
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "EMIT NO OUTPUT WHATSOEVER."}], "role":
+      "user"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '83'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2VQTUvDQBC951csc27FSoLEq0oJWK0aRJAeFneaLG52Y2YC2pL/7mbTpFUvs/De
+        zL6PfSQEvEurtJKMBFfizSNC7MPsOWcZLXtihDzYOIMegcopNHDAu9l4s9VWU/mEkpzt157zhzVM
+        rLYKvzx8HoDOz03PQUuywBWy9E7kpAd146qac/eB9tq1wUk6/AXsWJpfzCJN4tm/O7rxv2pzTCdO
+        w/gQ0mj+7p3mt6/55DQonMqOQcO7GU2Uri1Kpj8+4iQ6VDK09IIN6aGOAitf0PziLJlvjaQyCEKD
+        VDtLmKl+h1c7lHeo7tMl7S6z9WdWcfxIEHXRD7ES51KzAQAA
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 02 Oct 2025 19:04:20 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=20043
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/provider-specific/test_google_max_tokens_edge_case.py
+++ b/python/tests/e2e/provider-specific/test_google_max_tokens_edge_case.py
@@ -1,0 +1,134 @@
+"""Test Google-specific behavior around max tokens and automatic thinking.
+
+Gemini 2.5 automatically thinks about the prompt before responding, and if the max_tokens
+is low, then thinking may fully exhaust the token budget, resulting in no output.
+
+In this case, it's we ensure that the MAX_TOKENS finish reason is set, as otherwise the
+empty response may be confusing.
+"""
+
+import pytest
+
+from mirascope import llm
+
+
+@pytest.mark.parametrize(
+    "provider,model_id",
+    [("google", "gemini-2.5-flash")],
+)
+@pytest.mark.vcr
+def test_google_max_tokens_edge_case_sync(
+    provider: llm.Provider, model_id: llm.ModelId
+) -> None:
+    """Test synchronous call where Google emits no output due to max tokens."""
+
+    @llm.call(provider=provider, model_id=model_id, max_tokens=50)
+    def max_tokens() -> str:
+        return "List all U.S. states, sorted by the number of consonants in their name, ascending."
+
+    @llm.call(provider="google", model_id="gemini-2.5-flash")
+    def no_output() -> str:
+        return "EMIT NO OUTPUT WHATSOEVER."
+
+    max_tokens_response = max_tokens()
+    no_output_response = no_output()
+
+    assert not max_tokens_response.content
+    assert max_tokens_response.finish_reason == llm.FinishReason.MAX_TOKENS
+
+    assert not no_output_response.content
+    assert no_output_response.finish_reason is None
+
+
+@pytest.mark.parametrize(
+    "provider,model_id",
+    [("google", "gemini-2.5-flash")],
+)
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_google_max_tokens_edge_case_async(
+    provider: llm.Provider, model_id: llm.ModelId
+) -> None:
+    """Test asynchronous call where Google emits no output due to max tokens."""
+
+    @llm.call(provider=provider, model_id=model_id, max_tokens=50)
+    async def max_tokens() -> str:
+        return "List all U.S. states, sorted by the number of consonants in their name, ascending."
+
+    @llm.call(provider="google", model_id="gemini-2.5-flash")
+    async def no_output() -> str:
+        return "EMIT NO OUTPUT WHATSOEVER."
+
+    max_tokens_response = await max_tokens()
+    no_output_response = await no_output()
+
+    assert not max_tokens_response.content
+    assert max_tokens_response.finish_reason == llm.FinishReason.MAX_TOKENS
+
+    assert not no_output_response.content
+    assert no_output_response.finish_reason is None
+
+
+@pytest.mark.parametrize(
+    "provider,model_id",
+    [("google", "gemini-2.5-flash")],
+)
+@pytest.mark.vcr
+def test_google_max_tokens_edge_case_stream(
+    provider: llm.Provider, model_id: llm.ModelId
+) -> None:
+    """Test streaming call where Google emits no output due to max tokens."""
+
+    @llm.call(provider=provider, model_id=model_id, max_tokens=50)
+    def max_tokens() -> str:
+        return "List all U.S. states, sorted by the number of consonants in their name, ascending."
+
+    @llm.call(provider="google", model_id="gemini-2.5-flash")
+    def no_output() -> str:
+        return "EMIT NO OUTPUT WHATSOEVER."
+
+    max_tokens_response = max_tokens.stream()
+    max_tokens_response.finish()
+    no_output_response = no_output.stream()
+    no_output_response.finish()
+
+    assert not max_tokens_response.content
+    assert max_tokens_response.finish_reason == llm.FinishReason.MAX_TOKENS
+
+    assert not no_output_response.content
+    # Known false positive: In the sync stream case we mis-classify the empty response
+    # as being limited due to MAX_TOKENS
+    assert no_output_response.finish_reason == llm.FinishReason.MAX_TOKENS
+
+
+@pytest.mark.parametrize(
+    "provider,model_id",
+    [("google", "gemini-2.5-flash")],
+)
+@pytest.mark.vcr
+@pytest.mark.asyncio
+async def test_google_max_tokens_edge_case_async_stream(
+    provider: llm.Provider, model_id: llm.ModelId
+) -> None:
+    """Test async streaming call where Google emits no output due to max tokens."""
+
+    @llm.call(provider=provider, model_id=model_id, max_tokens=50)
+    async def max_tokens() -> str:
+        return "List all U.S. states, sorted by the number of consonants in their name, ascending."
+
+    @llm.call(provider="google", model_id="gemini-2.5-flash")
+    async def no_output() -> str:
+        return "EMIT NO OUTPUT WHATSOEVER."
+
+    max_tokens_response = await max_tokens.stream()
+    await max_tokens_response.finish()
+    no_output_response = await no_output.stream()
+    await no_output_response.finish()
+
+    assert not max_tokens_response.content
+    assert max_tokens_response.finish_reason == llm.FinishReason.MAX_TOKENS
+
+    assert not no_output_response.content
+    # In the async stream case, Google emits an empty block so we can classify the finish
+    # reason correctly.
+    assert no_output_response.finish_reason is None


### PR DESCRIPTION
When Google hits its max token limits during the pre-response thinking
phase, and is in streaming mode, it emits no events at all, so we
incorrectly set the finish reason to None. This is a strange behavior so
I have added a patch that sets finish reason to max tokens in this case.
I hoped I could do so without adding any other bugs, however there is
one false positive in the sync (not async!) streaming case where the
model is prompted to emit no output at all. I think this is an OK
tradeoff to make although I'm sad the fix isn't perfect. Behavior
documented in a provider-specific e2e test.