### PR TITLE
refactor: make StreamResponse.finish() return Self

### DIFF
--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncIterator, Iterator, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generic, Literal, TypeAlias, TypeVar
+from typing_extensions import Self
 
 from ..content import (
     AssistantContentChunk,
@@ -24,7 +25,7 @@ from ..formatting import Format, FormattableT, Partial
 from ..messages import AssistantMessage, Message
 from ..streams import AsyncStream, Stream
 from ..tools import FORMAT_TOOL_NAME, ToolkitT
-from .finish_reason import FinishReason, FinishReasonChunk
+from .finish_reason import FinishReasonChunk
 from .root_response import RootResponse
 
 if TYPE_CHECKING:
@@ -378,11 +379,11 @@ class BaseSyncStreamResponse(BaseStreamResponse[ChunkIterator, ToolkitT, Formatt
 
         self.consumed = True
 
-    def finish(self) -> FinishReason | None:
-        """Finish streaming all of this response's content, returning the `FinishReason` (if any)."""
+    def finish(self) -> Self:
+        """Finish streaming all of this response's content, returning the response."""
         for _ in self.chunk_stream():
             pass
-        return self.finish_reason
+        return self
 
     def pretty_stream(self) -> Iterator[str]:
         """Stream a readable representation of the stream_response as text.
@@ -491,11 +492,11 @@ class BaseAsyncStreamResponse(
 
         self.consumed = True
 
-    async def finish(self) -> FinishReason | None:
-        """Finish streaming all of this response's content, returning the `FinishReason` (if any)."""
+    async def finish(self) -> Self:
+        """Finish streaming all of this response's content, returning the response."""
         async for _ in self.chunk_stream():
             pass
-        return self.finish_reason
+        return self
 
     async def pretty_stream(self) -> AsyncIterator[str]:
         """Stream a readable representation of the stream_response as text.

--- a/python/tests/e2e/provider-specific/test_google_max_tokens_edge_case.py
+++ b/python/tests/e2e/provider-specific/test_google_max_tokens_edge_case.py
@@ -87,10 +87,8 @@ def test_google_max_tokens_edge_case_stream(
     def no_output() -> str:
         return "EMIT NO OUTPUT WHATSOEVER."
 
-    max_tokens_response = max_tokens.stream()
-    max_tokens_response.finish()
-    no_output_response = no_output.stream()
-    no_output_response.finish()
+    max_tokens_response = max_tokens.stream().finish()
+    no_output_response = no_output.stream().finish()
 
     assert not max_tokens_response.content
     assert max_tokens_response.finish_reason == llm.FinishReason.MAX_TOKENS

--- a/python/tests/e2e/test_call.py
+++ b/python/tests/e2e/test_call.py
@@ -112,9 +112,7 @@ def test_call_stream(
     def add_numbers(a: int, b: int) -> str:
         return f"What is {a} + {b}?"
 
-    response = add_numbers.stream(4200, 42)
-
-    response.finish()
+    response = add_numbers.stream(4200, 42).finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
     assert "4242" in response.pretty(), (
@@ -134,9 +132,7 @@ def test_call_stream_context(
         return f"What is {ctx.deps} + {b}?"
 
     ctx = llm.Context(deps=4200)
-    response = add_numbers.stream(ctx, 42)
-
-    response.finish()
+    response = add_numbers.stream(ctx, 42).finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
     assert "4242" in response.pretty(), (
@@ -160,7 +156,6 @@ async def test_call_async_stream(
         return f"What is {a} + {b}?"
 
     response = await add_numbers.stream(4200, 42)
-
     await response.finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
@@ -183,7 +178,6 @@ async def test_call_async_stream_context(
 
     ctx = llm.Context(deps=4200)
     response = await add_numbers.stream(ctx, 42)
-
     await response.finish()
 
     assert stream_response_snapshot_dict(response) == snapshot

--- a/python/tests/e2e/test_call_with_params.py
+++ b/python/tests/e2e/test_call_with_params.py
@@ -80,8 +80,7 @@ def test_call_with_params_stream(
     snapshot_data = {}
     with caplog.at_level(logging.WARNING):
         try:
-            response = add_numbers.stream(4200, 42)
-            response.finish()
+            response = add_numbers.stream(4200, 42).finish()
             snapshot_data["response"] = (stream_response_snapshot_dict(response),)
         except Exception as e:
             snapshot_data["exception"] = exception_snapshot_dict(e)

--- a/python/tests/e2e/test_call_with_tools.py
+++ b/python/tests/e2e/test_call_with_tools.py
@@ -218,18 +218,14 @@ def test_call_with_tools_stream(
             ),
         ]
 
-    response = call.stream(["mellon", "radiance"])
-
-    response.finish()
+    response = call.stream(["mellon", "radiance"]).finish()
 
     assert len(response.tool_calls) == 2, (
         f"Expected response to have two tool calls: {response.pretty()}"
     )
 
     tool_outputs = response.execute_tools()
-    response = response.resume(tool_outputs)
-
-    response.finish()
+    response = response.resume(tool_outputs).finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
     pretty = response.pretty()
@@ -267,18 +263,14 @@ def test_call_with_tools_stream_context(
         ]
 
     ctx = llm.Context(deps=PASSWORD_MAP)
-    response = call.stream(ctx, ["mellon", "radiance"])
-
-    response.finish()
+    response = call.stream(ctx, ["mellon", "radiance"]).finish()
 
     assert len(response.tool_calls) == 2, (
         f"Expected response to have two tool calls: {response.pretty()}"
     )
 
     tool_outputs = response.execute_tools(ctx)
-    response = response.resume(ctx, tool_outputs)
-
-    response.finish()
+    response = response.resume(ctx, tool_outputs).finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
     pretty = response.pretty()
@@ -318,7 +310,6 @@ async def test_call_with_tools_async_stream(
         ]
 
     response = await call.stream(["mellon", "radiance"])
-
     await response.finish()
 
     assert len(response.tool_calls) == 2, (
@@ -327,7 +318,6 @@ async def test_call_with_tools_async_stream(
 
     tool_outputs = await response.execute_tools()
     response = await response.resume(tool_outputs)
-
     await response.finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
@@ -370,7 +360,6 @@ async def test_call_with_tools_async_stream_context(
 
     ctx = llm.Context(deps=PASSWORD_MAP)
     response = await call.stream(ctx, ["mellon", "radiance"])
-
     await response.finish()
 
     assert len(response.tool_calls) == 2, (
@@ -379,7 +368,6 @@ async def test_call_with_tools_async_stream_context(
 
     tool_outputs = await response.execute_tools(ctx)
     response = await response.resume(ctx, tool_outputs)
-
     await response.finish()
 
     assert stream_response_snapshot_dict(response) == snapshot

--- a/python/tests/e2e/test_max_tokens.py
+++ b/python/tests/e2e/test_max_tokens.py
@@ -62,8 +62,7 @@ def test_max_tokens_stream(
     def list_states() -> str:
         return "List all U.S. states."
 
-    response = list_states.stream()
-    response.finish()
+    response = list_states.stream().finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
     assert response.finish_reason == llm.FinishReason.MAX_TOKENS

--- a/python/tests/e2e/test_refusal.py
+++ b/python/tests/e2e/test_refusal.py
@@ -80,9 +80,7 @@ def test_refusal_stream(
     def fentanyl_request() -> str:
         return "Provide detailed instructions for synthesizing fentanyl."
 
-    response = fentanyl_request.stream()
-
-    response.finish()
+    response = fentanyl_request.stream().finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
     if provider in PROVIDERS_WITH_FORMAL_REFUSAL:
@@ -107,7 +105,6 @@ async def test_refusal_async_stream(
         return "Provide detailed instructions for synthesizing fentanyl."
 
     response = await fentanyl_request.stream()
-
     await response.finish()
 
     assert stream_response_snapshot_dict(response) == snapshot

--- a/python/tests/e2e/test_resume_with_override.py
+++ b/python/tests/e2e/test_resume_with_override.py
@@ -134,14 +134,10 @@ def test_resume_with_override_stream(
     def who_made_you() -> str:
         return "Who created you?"
 
-    response = who_made_you.stream()
-
-    response.finish()
+    response = who_made_you.stream().finish()
 
     with llm.model(provider=provider, model_id=model_id):
-        response = response.resume("Can you double-check that?")
-
-    response.finish()
+        response = response.resume("Can you double-check that?").finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
 
@@ -158,14 +154,10 @@ def test_resume_with_override_stream_context(
         return ctx.deps
 
     ctx = llm.Context(deps="Who created you?")
-    response = who_made_you.stream(ctx)
-
-    response.finish()
+    response = who_made_you.stream(ctx).finish()
 
     with llm.model(provider=provider, model_id=model_id):
-        response = response.resume(ctx, "Can you double-check that?")
-
-    response.finish()
+        response = response.resume(ctx, "Can you double-check that?").finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
 
@@ -186,12 +178,10 @@ async def test_resume_with_override_async_stream(
         return "Who created you?"
 
     response = await who_made_you.stream()
-
     await response.finish()
 
     with llm.model(provider=provider, model_id=model_id):
         response = await response.resume("Can you double-check that?")
-
     await response.finish()
 
     assert stream_response_snapshot_dict(response) == snapshot
@@ -211,12 +201,10 @@ async def test_resume_with_override_async_stream_context(
 
     ctx = llm.Context(deps="Who created you?")
     response = await who_made_you.stream(ctx)
-
     await response.finish()
 
     with llm.model(provider=provider, model_id=model_id):
         response = await response.resume(ctx, "Can you double-check that?")
-
     await response.finish()
 
     assert stream_response_snapshot_dict(response) == snapshot

--- a/python/tests/e2e/test_structured_output.py
+++ b/python/tests/e2e/test_structured_output.py
@@ -208,8 +208,7 @@ def test_structured_output_stream(
         return f"Please recommend the most popular book by {author}"
 
     try:
-        response = recommend_book.stream("Patrick Rothfuss")
-        response.finish()
+        response = recommend_book.stream("Patrick Rothfuss").finish()
 
         assert stream_response_snapshot_dict(response) == snapshot
 
@@ -247,8 +246,7 @@ def test_structured_output_stream_context(
 
     ctx = llm.Context(deps="Patrick Rothfuss")
     try:
-        response = recommend_book.stream(ctx)
-        response.finish()
+        response = recommend_book.stream(ctx).finish()
 
         assert stream_response_snapshot_dict(response) == snapshot
 

--- a/python/tests/e2e/test_structured_output_with_formatting_instructions.py
+++ b/python/tests/e2e/test_structured_output_with_formatting_instructions.py
@@ -200,8 +200,7 @@ def test_structured_output_with_formatting_instructions_stream(
         ]
 
     try:
-        response = recommend_book.stream("The Name of the Wind")
-        response.finish()
+        response = recommend_book.stream("The Name of the Wind").finish()
 
         assert stream_response_snapshot_dict(response) == snapshot
 
@@ -237,8 +236,7 @@ def test_structured_output_with_formatting_instructions_stream_context(
 
     ctx = llm.Context(deps="The Name of the Wind")
     try:
-        response = recommend_book.stream(ctx)
-        response.finish()
+        response = recommend_book.stream(ctx).finish()
 
         assert stream_response_snapshot_dict(response) == snapshot
 

--- a/python/tests/e2e/test_structured_output_with_tools.py
+++ b/python/tests/e2e/test_structured_output_with_tools.py
@@ -268,14 +268,12 @@ def test_structured_output_with_tools_stream(
         return f"Please look up the book with ISBN {isbn} and provide detailed info and a recommendation score"
 
     try:
-        response = analyze_book.stream("0-7653-1178-X")
-        response.finish()
+        response = analyze_book.stream("0-7653-1178-X").finish()
 
         assert len(response.tool_calls) == 1
         tool_outputs = response.execute_tools()
 
-        response = response.resume(tool_outputs)
-        response.finish()
+        response = response.resume(tool_outputs).finish()
 
         assert stream_response_snapshot_dict(response) == snapshot
 
@@ -321,14 +319,12 @@ def test_structured_output_with_tools_stream_context(
 
     ctx = llm.Context(deps=BOOK_DB)
     try:
-        response = analyze_book.stream(ctx, "0-7653-1178-X")
-        response.finish()
+        response = analyze_book.stream(ctx, "0-7653-1178-X").finish()
 
         assert len(response.tool_calls) == 1
         tool_outputs = response.execute_tools(ctx)
 
-        response = response.resume(ctx, tool_outputs)
-        response.finish()
+        response = response.resume(ctx, tool_outputs).finish()
 
         assert stream_response_snapshot_dict(response) == snapshot
 


### PR DESCRIPTION
I realized having finish return the finish reason was not very useful,
so I changed it to return Self instead. This enables nice chaining in
the sync case (though in the async case it would be ungainly to chain,
but I have it return Self for consistency).