### PR TITLE
refactor: remove Content.content_type

### DIFF
--- a/python/mirascope/llm/content/audio.py
+++ b/python/mirascope/llm/content/audio.py
@@ -35,9 +35,6 @@ class Audio:
 
     type: Literal["audio"] = "audio"
 
-    content_type: Literal["audio"] = "audio"
-    """The type of content being represented."""
-
     source: Base64AudioSource
 
     @classmethod

--- a/python/mirascope/llm/content/document.py
+++ b/python/mirascope/llm/content/document.py
@@ -66,9 +66,6 @@ class Document:
 
     type: Literal["document"] = "document"
 
-    content_type: Literal["document"] = "document"
-    """The type of content being represented."""
-
     source: Base64DocumentSource | TextDocumentSource | URLDocumentSource
 
     @classmethod

--- a/python/mirascope/llm/content/image.py
+++ b/python/mirascope/llm/content/image.py
@@ -47,9 +47,6 @@ class Image:
 
     type: Literal["image"] = "image"
 
-    content_type: Literal["image"] = "image"
-    """The type of content being represented."""
-
     source: Base64ImageSource | URLImageSource
 
     @classmethod

--- a/python/mirascope/llm/content/text.py
+++ b/python/mirascope/llm/content/text.py
@@ -10,9 +10,6 @@ class Text:
 
     type: Literal["text"] = "text"
 
-    content_type: Literal["text"] = "text"
-    """The type of content being represented."""
-
     text: str
     """The text content."""
 

--- a/python/mirascope/llm/content/thinking.py
+++ b/python/mirascope/llm/content/thinking.py
@@ -13,9 +13,6 @@ class Thinking:
 
     type: Literal["thinking"] = "thinking"
 
-    content_type: Literal["thinking"] = "thinking"
-    """The type of content being represented."""
-
     signature: str | None
     """The signature of the thinking content, if available."""
 

--- a/python/mirascope/llm/content/tool_call.py
+++ b/python/mirascope/llm/content/tool_call.py
@@ -14,9 +14,6 @@ class ToolCall:
 
     type: Literal["tool_call"] = "tool_call"
 
-    content_type: Literal["tool_call"] = "tool_call"
-    """The type of content being represented."""
-
     id: str
     """A unique identifier for this tool call."""
 

--- a/python/mirascope/llm/content/tool_output.py
+++ b/python/mirascope/llm/content/tool_output.py
@@ -16,9 +16,6 @@ class ToolOutput(Generic[JsonableT]):
 
     type: Literal["tool_output"] = "tool_output"
 
-    content_type: Literal["tool_output"] = "tool_output"
-    """The type of content being represented."""
-
     id: str
     """The ID of the tool call that this output is for."""
 


### PR DESCRIPTION
This field was only really useful to represent the fact that `ImageUrl`
and `Image` were the same content type (likewise Audio). Now that those
are unified, `content.content_type == content.type` in every case, so we
can remove it.

Chunk content types are still useful as they represent the type of
content reconstructed by the chunks.