### PR TITLE
feat: setup API keys in global conftest.py

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Configuration for all Mirascope tests."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from dotenv import load_dotenv
+
+
+@pytest.fixture(scope="session", autouse=True)
+def load_api_keys() -> None:
+    """Load environment variables from .env file.
+
+    This is necessary for e2e tests, but also may be necessary for any tests that
+    instantiate a client, as clients may test API key presence at `__init__` time.
+    """
+    load_dotenv()
+    # Set dummy keys if not present so that tests pass in CI.
+    os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-anthropic-key")
+    os.environ.setdefault("GOOGLE_API_KEY", "dummy-google-key")
+    os.environ.setdefault("OPENAI_API_KEY", "dummy-openai-key")

--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -6,26 +6,13 @@ Includes setting up VCR for HTTP recording/playback.
 from __future__ import annotations
 
 import importlib
-import os
 from pathlib import Path
 from typing import Any, Literal, TypeAlias, TypedDict, get_args
 
 import pytest
-from dotenv import load_dotenv
 from pytest import FixtureRequest
 
 from mirascope import llm
-
-
-@pytest.fixture(scope="session", autouse=True)
-def load_api_keys() -> None:
-    """Load environment variables from .env file for e2e tests."""
-    load_dotenv()
-    # Set dummy keys if not present so that tests pass in CI.
-    os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-anthropic-key")
-    os.environ.setdefault("GOOGLE_API_KEY", "dummy-google-key")
-    os.environ.setdefault("OPENAI_API_KEY", "dummy-openai-key")
-
 
 PROVIDER_MODEL_ID_PAIRS: list[tuple[llm.Provider, llm.ModelId]] = [
     ("anthropic", "claude-sonnet-4-0"),


### PR DESCRIPTION
Without this change, tests like test_responses_client.py will pass when
run as part of a full test suite invocation (because the e2e tests run
first, and setup the API keys). However, they fail when run in isolation
(because they require valid API keys that aren't set.)