### PR TITLE
refactor: add provider, model_id, and raw_content to assistant message

### DIFF
--- a/python/mirascope/llm/clients/anthropic/_utils.py
+++ b/python/mirascope/llm/clients/anthropic/_utils.py
@@ -28,7 +28,7 @@ from ...formatting import (
     _utils as _formatting_utils,
     resolve_format,
 )
-from ...messages import AssistantMessage, Message, UserMessage, assistant
+from ...messages import AssistantMessage, Message, UserMessage
 from ...responses import (
     AsyncChunkIterator,
     ChunkIterator,
@@ -214,10 +214,14 @@ def prepare_anthropic_request(
 
 def decode_response(
     response: anthropic_types.Message,
+    model_id: AnthropicModelId,
 ) -> tuple[AssistantMessage, FinishReason | None]:
     """Convert Anthropic message to mirascope AssistantMessage."""
-    assistant_message = assistant(
-        content=[_decode_assistant_content(part) for part in response.content]
+    assistant_message = AssistantMessage(
+        content=[_decode_assistant_content(part) for part in response.content],
+        provider="anthropic",
+        model_id=model_id,
+        raw_content=[],
     )
     finish_reason = (
         ANTHROPIC_FINISH_REASON_MAP.get(response.stop_reason)

--- a/python/mirascope/llm/clients/anthropic/clients.py
+++ b/python/mirascope/llm/clients/anthropic/clients.py
@@ -164,7 +164,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         anthropic_response = self.client.messages.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            anthropic_response, model_id
+        )
 
         return Response(
             raw=anthropic_response,
@@ -261,7 +263,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         anthropic_response = self.client.messages.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            anthropic_response, model_id
+        )
 
         return ContextResponse(
             raw=anthropic_response,
@@ -345,7 +349,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         anthropic_response = await self.async_client.messages.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            anthropic_response, model_id
+        )
 
         return AsyncResponse(
             raw=anthropic_response,
@@ -442,7 +448,9 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         anthropic_response = await self.async_client.messages.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(anthropic_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            anthropic_response, model_id
+        )
 
         return AsyncContextResponse(
             raw=anthropic_response,

--- a/python/mirascope/llm/clients/google/_utils.py
+++ b/python/mirascope/llm/clients/google/_utils.py
@@ -27,7 +27,7 @@ from ...formatting import (
     _utils as _formatting_utils,
     resolve_format,
 )
-from ...messages import AssistantMessage, Message, UserMessage, assistant
+from ...messages import AssistantMessage, Message, UserMessage
 from ...responses import (
     AsyncChunkIterator,
     ChunkIterator,
@@ -302,16 +302,23 @@ def prepare_google_request(
 
 
 def decode_response(
-    response: genai_types.GenerateContentResponse,
+    response: genai_types.GenerateContentResponse, model_id: GoogleModelId
 ) -> tuple[AssistantMessage, FinishReason | None]:
     """Returns an `AssistantMessage` and `FinishReason` extracted from a `GenerateContentResponse`"""
     if not response.candidates or not response.candidates[0].content:
         # Unclear under what circumstances this happens (if ever).
         # In testing, when generating no output at all, it creates a part with
         # no fields set.
-        return assistant(content=[]), None  # pragma: no cover
+        return AssistantMessage(
+            content=[], provider="google", model_id=model_id, raw_content=[]
+        ), None  # pragma: no cover
     candidate = response.candidates[0]
-    assistant_message = assistant(content=_decode_candidate_content(candidate))
+    assistant_message = AssistantMessage(
+        content=_decode_candidate_content(candidate),
+        provider="google",
+        model_id=model_id,
+        raw_content=[],
+    )
     finish_reason = (
         GOOGLE_FINISH_REASON_MAP.get(candidate.finish_reason)
         if candidate.finish_reason

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -170,7 +170,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
             config=config,
         )
 
-        assistant_message, finish_reason = _utils.decode_response(google_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            google_response, model_id
+        )
 
         return Response(
             raw=google_response,
@@ -271,7 +273,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
             config=config,
         )
 
-        assistant_message, finish_reason = _utils.decode_response(google_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            google_response, model_id
+        )
 
         return ContextResponse(
             raw=google_response,
@@ -359,7 +363,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
             config=config,
         )
 
-        assistant_message, finish_reason = _utils.decode_response(google_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            google_response, model_id
+        )
 
         return AsyncResponse(
             raw=google_response,
@@ -460,7 +466,9 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
             config=config,
         )
 
-        assistant_message, finish_reason = _utils.decode_response(google_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            google_response, model_id
+        )
 
         return AsyncContextResponse(
             raw=google_response,

--- a/python/mirascope/llm/clients/openai/completions/_utils.py
+++ b/python/mirascope/llm/clients/openai/completions/_utils.py
@@ -293,6 +293,7 @@ def prepare_completions_request(
 
 def decode_response(
     response: openai_types.ChatCompletion,
+    model_id: OpenAICompletionsModelId,
 ) -> tuple[AssistantMessage, FinishReason | None]:
     """Convert OpenAI ChatCompletion to mirascope AssistantMessage."""
     choice = response.choices[0]
@@ -325,7 +326,14 @@ def decode_response(
         else OPENAI_FINISH_REASON_MAP.get(choice.finish_reason)
     )
 
-    return AssistantMessage(content=parts), finish_reason
+    assistant_message = AssistantMessage(
+        content=parts,
+        provider="openai:completions",
+        model_id=model_id,
+        raw_content=[],
+    )
+
+    return (assistant_message, finish_reason)
 
 
 class _OpenAIChunkProcessor:

--- a/python/mirascope/llm/clients/openai/completions/clients.py
+++ b/python/mirascope/llm/clients/openai/completions/clients.py
@@ -164,7 +164,9 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
 
         openai_response = self.client.chat.completions.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return Response(
             raw=openai_response,
@@ -261,7 +263,9 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
 
         openai_response = self.client.chat.completions.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return ContextResponse(
             raw=openai_response,
@@ -346,7 +350,9 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
 
         openai_response = await self.async_client.chat.completions.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return AsyncResponse(
             raw=openai_response,
@@ -443,7 +449,9 @@ class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
 
         openai_response = await self.async_client.chat.completions.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return AsyncContextResponse(
             raw=openai_response,

--- a/python/mirascope/llm/clients/openai/responses/_utils.py
+++ b/python/mirascope/llm/clients/openai/responses/_utils.py
@@ -286,6 +286,7 @@ def prepare_responses_request(
 
 def decode_response(
     response: openai_types.Response,
+    model_id: OpenAIResponsesModelId,
 ) -> tuple[AssistantMessage, FinishReason | None]:
     """Convert OpenAI Responses Response to mirascope AssistantMessage."""
     parts: list[AssistantContentPart] = []
@@ -327,7 +328,14 @@ def decode_response(
     elif details := response.incomplete_details:
         finish_reason = INCOMPLETE_DETAILS_TO_FINISH_REASON.get(details.reason or "")
 
-    return (AssistantMessage(content=parts), finish_reason)
+    assistant_message = AssistantMessage(
+        content=parts,
+        provider="openai:responses",
+        model_id=model_id,
+        raw_content=[],
+    )
+
+    return (assistant_message, finish_reason)
 
 
 class _OpenAIResponsesChunkProcessor:

--- a/python/mirascope/llm/clients/openai/responses/clients.py
+++ b/python/mirascope/llm/clients/openai/responses/clients.py
@@ -151,7 +151,9 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
 
         openai_response = self.client.responses.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return Response(
             raw=openai_response,
@@ -235,7 +237,9 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
 
         openai_response = await self.async_client.responses.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return AsyncResponse(
             raw=openai_response,
@@ -506,7 +510,9 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
 
         openai_response = self.client.responses.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return ContextResponse(
             raw=openai_response,
@@ -603,7 +609,9 @@ class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
 
         openai_response = await self.async_client.responses.create(**kwargs)
 
-        assistant_message, finish_reason = _utils.decode_response(openai_response)
+        assistant_message, finish_reason = _utils.decode_response(
+            openai_response, model_id
+        )
 
         return AsyncContextResponse(
             raw=openai_response,

--- a/python/mirascope/llm/responses/base_response.py
+++ b/python/mirascope/llm/responses/base_response.py
@@ -82,6 +82,10 @@ class BaseResponse(RootResponse[ToolkitT, FormattableT]):
             # NOTE: we copy over the assistant message `name` field, although in
             # practice we don't know of any providers that set the name themselves.
             assistant_message = AssistantMessage(
-                content=self.content, name=assistant_message.name
+                content=self.content,
+                name=assistant_message.name,
+                provider=assistant_message.provider,
+                model_id=assistant_message.model_id,
+                raw_content=assistant_message.raw_content,
             )
         self.messages = list(input_messages) + [assistant_message]

--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -166,7 +166,14 @@ class BaseStreamResponse(
 
         self.finish_reason = None
 
-        self.messages = list(input_messages) + [AssistantMessage(content=self._content)]
+        self.messages = list(input_messages) + [
+            AssistantMessage(
+                content=self._content,
+                provider=provider,
+                model_id=model_id,
+                raw_content=[],
+            )
+        ]
 
         self._chunk_iterator = chunk_iterator
         self._current_content: Text | Thought | ToolCall | None = None

--- a/python/tests/e2e/snapshots/call/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/call/anthropic_snapshots.py
@@ -14,7 +14,12 @@ sync_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 = 4242")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 = 4242")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -28,7 +33,12 @@ async_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 = 4242")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 = 4242")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -41,7 +51,12 @@ stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 = 4242")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 = 4242")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -55,7 +70,12 @@ async_stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 = 4242")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 = 4242")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],

--- a/python/tests/e2e/snapshots/call/google_snapshots.py
+++ b/python/tests/e2e/snapshots/call/google_snapshots.py
@@ -28,7 +28,10 @@ To find the sum of 4200 + 42, you can add them:
 So, 4200 + 42 = **4242**.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -57,7 +60,10 @@ To find the sum of 4200 + 42, we can add the numbers:
 So, 4200 + 42 = **4242**.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -87,7 +93,10 @@ To find the sum of 4200 and 42, we can add them:
 So, 4200 + 42 = **4242**.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -116,7 +125,10 @@ To find the sum of 4200 + 42, you can add the numbers:
 So, 4200 + 42 = **4242**.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/call/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/call/openai_completions_snapshots.py
@@ -14,7 +14,12 @@ sync_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 equals 4242.")],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -28,7 +33,12 @@ async_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 equals 4242.")],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -41,7 +51,12 @@ stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="The sum of 4200 and 42 is 4242.")]),
+            AssistantMessage(
+                content=[Text(text="The sum of 4200 and 42 is 4242.")],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -55,7 +70,12 @@ async_stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 equals 4242.")],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],

--- a/python/tests/e2e/snapshots/call/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/call/openai_responses_snapshots.py
@@ -14,7 +14,12 @@ sync_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 equals 4242.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -28,7 +33,12 @@ async_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 equals 4242.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -41,7 +51,12 @@ stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 = 4242")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 = 4242")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -55,7 +70,12 @@ async_stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="What is 4200 + 42?")]),
-            AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+            AssistantMessage(
+                content=[Text(text="4200 + 42 equals 4242.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],

--- a/python/tests/e2e/snapshots/call_with_params/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_params/anthropic_snapshots.py
@@ -24,7 +24,12 @@ sync_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 = ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 = ")],
+                        provider="anthropic",
+                        model_id="claude-sonnet-4-0",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -54,7 +59,12 @@ async_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 = ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 = ")],
+                        provider="anthropic",
+                        model_id="claude-sonnet-4-0",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -75,7 +85,12 @@ stream_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 = ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 = ")],
+                        provider="anthropic",
+                        model_id="claude-sonnet-4-0",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -97,7 +112,12 @@ async_stream_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 = ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 = ")],
+                        provider="anthropic",
+                        model_id="claude-sonnet-4-0",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],

--- a/python/tests/e2e/snapshots/call_with_params/google_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_params/google_snapshots.py
@@ -35,7 +35,10 @@ To find the sum of 4200 and 42, you add them together:
 ------
 """
                             )
-                        ]
+                        ],
+                        provider="google",
+                        model_id="gemini-2.5-flash",
+                        raw_content=[],
                     ),
                 ],
                 "format": None,
@@ -76,7 +79,10 @@ To find the sum of 4200 and 42, you add them together:
 -----
 """
                             )
-                        ]
+                        ],
+                        provider="google",
+                        model_id="gemini-2.5-flash",
+                        raw_content=[],
                     ),
                 ],
                 "format": None,
@@ -108,7 +114,10 @@ To find the sum of 4200 and 42, you add them together:
 ------
 """
                             )
-                        ]
+                        ],
+                        provider="google",
+                        model_id="gemini-2.5-flash",
+                        raw_content=[],
                     ),
                 ],
                 "format": None,
@@ -141,7 +150,10 @@ To find the sum of 4200 and 42, you add them together:
 ------
 """
                             )
-                        ]
+                        ],
+                        provider="google",
+                        model_id="gemini-2.5-flash",
+                        raw_content=[],
                     ),
                 ],
                 "format": None,

--- a/python/tests/e2e/snapshots/call_with_params/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_params/openai_completions_snapshots.py
@@ -24,7 +24,12 @@ sync_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals ")],
+                        provider="openai:completions",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -54,7 +59,12 @@ async_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals ")],
+                        provider="openai:completions",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -75,7 +85,12 @@ stream_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals ")],
+                        provider="openai:completions",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -97,7 +112,12 @@ async_stream_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals ")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals ")],
+                        provider="openai:completions",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],

--- a/python/tests/e2e/snapshots/call_with_params/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_params/openai_responses_snapshots.py
@@ -24,7 +24,12 @@ sync_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals 4242.")],
+                        provider="openai:responses",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -56,7 +61,12 @@ async_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals 4242.")],
+                        provider="openai:responses",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -79,7 +89,12 @@ stream_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals 4242.")],
+                        provider="openai:responses",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],
@@ -103,7 +118,12 @@ async_stream_snapshot = snapshot(
                 "finish_reason": None,
                 "messages": [
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
-                    AssistantMessage(content=[Text(text="4200 + 42 equals 4242.")]),
+                    AssistantMessage(
+                        content=[Text(text="4200 + 42 equals 4242.")],
+                        provider="openai:responses",
+                        model_id="gpt-4o",
+                        raw_content=[],
+                    ),
                 ],
                 "format": None,
                 "tools": [],

--- a/python/tests/e2e/snapshots/call_with_thinking_true/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_thinking_true/openai_responses_snapshots.py
@@ -54,7 +54,10 @@ I confirm 79, 179, and 379 as the only candidates, so my final count is 3. I’l
 """
                         ),
                         Text(text="3"),
-                    ]
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
                 ),
                 UserMessage(
                     content=[
@@ -63,7 +66,12 @@ I confirm 79, 179, and 379 as the only candidates, so my final count is 3. I’l
                         )
                     ]
                 ),
-                AssistantMessage(content=[Text(text="79, 179, 379")]),
+                AssistantMessage(
+                    content=[Text(text="79, 179, 379")],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
+                ),
             ],
             "format": None,
             "tools": [],
@@ -115,7 +123,10 @@ It turns out 379 is prime. So, the primes under 400 that contain "79" are 79, 17
 """
                         ),
                         Text(text="3"),
-                    ]
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
                 ),
                 UserMessage(
                     content=[
@@ -124,7 +135,12 @@ It turns out 379 is prime. So, the primes under 400 that contain "79" are 79, 17
                         )
                     ]
                 ),
-                AssistantMessage(content=[Text(text="79, 179, 379")]),
+                AssistantMessage(
+                    content=[Text(text="79, 179, 379")],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
+                ),
             ],
             "format": None,
             "tools": [],
@@ -195,7 +211,10 @@ So, I'll keep it simple and just return the number: 3.\
 """
                         ),
                         Text(text="3"),
-                    ]
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
                 ),
                 UserMessage(
                     content=[
@@ -204,7 +223,12 @@ So, I'll keep it simple and just return the number: 3.\
                         )
                     ]
                 ),
-                AssistantMessage(content=[Text(text="79, 179, 379")]),
+                AssistantMessage(
+                    content=[Text(text="79, 179, 379")],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
+                ),
             ],
             "format": None,
             "tools": [],
@@ -266,7 +290,10 @@ So far, I have 79, 179, and 379 as the only qualifying primes—totaling three. 
 """
                         ),
                         Text(text="3"),
-                    ]
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
                 ),
                 UserMessage(
                     content=[
@@ -275,7 +302,12 @@ So far, I have 79, 179, and 379 as the only qualifying primes—totaling three. 
                         )
                     ]
                 ),
-                AssistantMessage(content=[Text(text="79, 179, 379")]),
+                AssistantMessage(
+                    content=[Text(text="79, 179, 379")],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
+                ),
             ],
             "format": None,
             "tools": [],

--- a/python/tests/e2e/snapshots/call_with_tools/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/anthropic_snapshots.py
@@ -39,7 +39,10 @@ sync_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -65,7 +68,10 @@ Here are the secrets retrieved for each password:
 - Password "radiance": "Life before Death"\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -123,7 +129,10 @@ async_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -149,7 +158,10 @@ Here are the secrets retrieved for each password:
 2. **Password "radiance"**: "Life before Death"\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -206,7 +218,10 @@ stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -232,7 +247,10 @@ Here are the secrets retrieved for each password:
 - Password "radiance": "Life before Death"\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -290,7 +308,10 @@ async_stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -316,7 +337,10 @@ Here are the secrets retrieved for each password:
 - Password "radiance": **Life before Death**\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/call_with_tools/google_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/google_snapshots.py
@@ -36,7 +36,10 @@ sync_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -60,7 +63,10 @@ Welcome to Moria!
 Life before Death\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -115,7 +121,10 @@ async_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -141,7 +150,10 @@ For the password "mellon", the secret is "Welcome to Moria!"
 For the password "radiance", the secret is "Life before Death"\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -195,7 +207,10 @@ stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -216,7 +231,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='I have retrieved the following secrets: "Welcome to Moria!" and "Life before Death".\n'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -271,7 +289,10 @@ async_stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -292,7 +313,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='I have retrieved the following secrets: "Welcome to Moria!" and "Life before Death".\n'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/call_with_tools/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/openai_completions_snapshots.py
@@ -36,7 +36,10 @@ sync_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -62,7 +65,10 @@ The secrets associated with the passwords are as follows:
 - Password "radiance": "Life before Death"\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -117,7 +123,10 @@ async_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -138,7 +147,10 @@ async_snapshot = snapshot(
                     Text(
                         text='The secret associated with the password "mellon" is "Welcome to Moria!", and the secret for the password "radiance" is "Life before Death".'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -192,7 +204,10 @@ stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -218,7 +233,10 @@ The secrets associated with the passwords are as follows:
 - For "radiance": "Life before Death"\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -273,7 +291,10 @@ async_stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -299,7 +320,10 @@ The secrets associated with the passwords are as follows:
 - For "radiance": "Life before Death"\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/call_with_tools/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/openai_responses_snapshots.py
@@ -36,7 +36,10 @@ sync_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password":"radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -62,7 +65,10 @@ Here are the secrets associated with each password:
 - **radiance**: Life before Death\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -117,7 +123,10 @@ async_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password":"radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -143,7 +152,10 @@ Here are the secrets associated with the passwords:
 - Password `"radiance"`: Life before Death\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -197,7 +209,10 @@ stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password":"radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -223,7 +238,10 @@ Here are the secrets:
 - **radiance**: Life before Death\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -278,7 +296,10 @@ async_stream_snapshot = snapshot(
                         name="secret_retrieval_tool",
                         args='{"password":"radiance"}',
                     ),
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -304,7 +325,10 @@ Here are the secrets for the provided passwords:
 - **radiance**: Life before Death\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/max_tokens/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/max_tokens/anthropic_snapshots.py
@@ -32,7 +32,10 @@ Here are all 50 U.S. states in alphabetical order:
 9\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -64,7 +67,10 @@ Here are all 50 U.S. states listed alphabetically:
 9.\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -95,7 +101,10 @@ Here are all 50 U.S. states listed alphabetically:
 9.\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -127,7 +136,10 @@ Here are all 50 U.S. states listed alphabetically:
 9.\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/max_tokens/google_snapshots.py
+++ b/python/tests/e2e/snapshots/max_tokens/google_snapshots.py
@@ -16,7 +16,10 @@ sync_snapshot = snapshot(
         "messages": [
             UserMessage(content=[Text(text="List all U.S. states.")]),
             AssistantMessage(
-                content=[Text(text="Here is a list of all 50 U.S. states:")]
+                content=[Text(text="Here is a list of all 50 U.S. states:")],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -40,7 +43,10 @@ Here are all 50 U.S. states:
 1\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -54,7 +60,12 @@ stream_snapshot = snapshot(
         "finish_reason": FinishReason.MAX_TOKENS,
         "messages": [
             UserMessage(content=[Text(text="List all U.S. states.")]),
-            AssistantMessage(content=[Text(text="Here are all 50 U.S. states in")]),
+            AssistantMessage(
+                content=[Text(text="Here are all 50 U.S. states in")],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -68,7 +79,12 @@ async_stream_snapshot = snapshot(
         "finish_reason": FinishReason.MAX_TOKENS,
         "messages": [
             UserMessage(content=[Text(text="List all U.S. states.")]),
-            AssistantMessage(content=[Text(text="Here is a list of all 50 U.S")]),
+            AssistantMessage(
+                content=[Text(text="Here is a list of all 50 U.S")],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],

--- a/python/tests/e2e/snapshots/max_tokens/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/max_tokens/openai_completions_snapshots.py
@@ -33,7 +33,10 @@ Here is a list of all 50 U.S. states:
 10\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -65,7 +68,10 @@ Sure! Here is a list of all the U.S. states:
 9. Florida
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -96,7 +102,10 @@ Certainly! Here is a list of all 50 U.S. states:
 9. Florida\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -129,7 +138,10 @@ Here is a list of all 50 U.S. states:
 10\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/max_tokens/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/max_tokens/openai_responses_snapshots.py
@@ -33,7 +33,10 @@ Sure! Here are all the U.S. states:
 10. Georgia\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -66,7 +69,10 @@ Sure! Here are all the U.S. states:
 10. Georgia\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -98,7 +104,10 @@ Certainly! Here is a list of all U.S. states:
 10\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -131,7 +140,10 @@ Here is a list of all U.S. states:
 10. Georgia\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/refusal/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/refusal/anthropic_snapshots.py
@@ -31,7 +31,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a controlled substance whose unauthorized manufacture is illegal and extremely dangerous. Such information could:\\n\\n1. Enable illegal drug production\\n2. Contribute to the ongoing opioid crisis\\n3. Put people at serious risk of harm or death\\n4. Violate laws regarding controlled substances\\n\\nIf you\'re interested in pharmaceutical chemistry for legitimate educational or research purposes, I\'d recommend:\\n- Consulting published academic literature through proper institutional channels\\n- Speaking with chemistry professors or professionals in regulated environments\\n- Exploring legal pharmaceutical research opportunities\\n\\nIf you\'re struggling with substance use, please reach out to appropriate healthcare providers or support services for help."}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -75,7 +78,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a controlled substance, and its unauthorized manufacture is illegal and extremely dangerous.\\n\\nInstead, I can provide information about:\\n- The legitimate medical uses of fentanyl in hospital settings\\n- The public health crisis caused by illicit fentanyl\\n- Resources for addiction treatment and support\\n- Harm reduction strategies\\n- Legal pharmaceutical research and development processes (in general terms)\\n\\nIf you\'re interested in chemistry or pharmaceutical sciences for educational or legitimate research purposes, I\'d be happy to discuss legal topics in those fields or direct you to appropriate academic resources."}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -118,7 +124,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other controlled substances. Fentanyl synthesis involves dangerous chemicals and illegal activities. Manufacturing fentanyl is:\\n\\n1. Illegal in most jurisdictions worldwide\\n2. Extremely dangerous due to toxic chemicals and risk of accidental exposure\\n3. Contributing to a public health crisis that has caused hundreds of thousands of deaths\\n4. Subject to severe criminal penalties including lengthy prison sentences\\n\\nIf you\'re interested in chemistry for legitimate educational purposes, I\'d be happy to discuss legal chemical reactions, pharmaceutical research conducted through proper channels, or direct you to legitimate educational resources about chemistry.\\n\\nIf you or someone you know is struggling with substance use, please contact:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local emergency services: 911 (US)\\n- Your healthcare provider\\n\\nI\'m here to provide helpful information on legal and safe topics."}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -162,7 +171,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text="{\"instructions\": \"I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a highly dangerous controlled substance that:\\n\\n1. Is illegal to manufacture without proper licensing and authorization\\n2. Poses extreme risks to public health and safety\\n3. Has caused a devastating overdose crisis\\n4. Requires specialized knowledge, equipment, and safety protocols that are restricted to legitimate pharmaceutical facilities\\n\\nIf you're interested in pharmaceutical chemistry for educational purposes, I'd recommend:\\n- Taking formal chemistry courses at accredited institutions\\n- Reading peer-reviewed scientific literature through proper academic channels\\n- Exploring legal career paths in pharmaceutical research\\n\\nIf you're struggling with substance use, please reach out to:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local addiction treatment services\\n- Healthcare professionals who can provide appropriate support\\n\\nI'm happy to discuss other chemistry topics, harm reduction information, or direct you to legitimate educational resources instead.\"}"
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/refusal/google_snapshots.py
+++ b/python/tests/e2e/snapshots/refusal/google_snapshots.py
@@ -25,7 +25,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"instructions": "I cannot provide instructions for synthesizing fentanyl. Fentanyl is an extremely dangerous and potent opioid, and its synthesis and possession are illegal in most jurisdictions. Attempting to synthesize it is highly hazardous due to its toxicity, the risk of accidental exposure, and the severe legal consequences. If you or someone you know is struggling with substance use, please seek help from a medical professional or a support organization."}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -64,7 +67,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"instructions": "I cannot provide instructions for synthesizing fentanyl. Providing information on how to create dangerous and illegal substances is against my safety guidelines."}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -102,7 +108,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"instructions": "I cannot provide instructions for synthesizing fentanyl. This is an illegal and extremely dangerous activity with severe health and legal consequences. My purpose is to be helpful and harmless, and that includes refusing to generate content that promotes illegal or harmful activities."}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -141,7 +150,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"instructions": "I cannot provide instructions for synthesizing fentanyl. Fentanyl is an extremely dangerous substance, and its synthesis is illegal and carries severe risks, including overdose and death. Providing such information would be irresponsible and harmful."}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/refusal/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/refusal/openai_completions_snapshots.py
@@ -24,7 +24,10 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(text="I'm very sorry, but I can't assist with that request.")
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -59,7 +62,10 @@ async_snapshot = snapshot(
                 ]
             ),
             AssistantMessage(
-                content=[Text(text="I'm very sorry, but I can't assist with that.")]
+                content=[Text(text="I'm very sorry, but I can't assist with that.")],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -95,7 +101,10 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(text="I'm very sorry, but I can't assist with that request.")
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -132,7 +141,10 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(text="I'm really sorry, but I can't assist with that request.")
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/refusal/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/refusal/openai_responses_snapshots.py
@@ -22,7 +22,10 @@ sync_snapshot = snapshot(
                 ]
             ),
             AssistantMessage(
-                content=[Text(text="I'm sorry, I can't assist with that.")]
+                content=[Text(text="I'm sorry, I can't assist with that.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -57,7 +60,10 @@ async_snapshot = snapshot(
                 ]
             ),
             AssistantMessage(
-                content=[Text(text="I'm sorry, I can't assist with that.")]
+                content=[Text(text="I'm sorry, I can't assist with that.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -91,7 +97,10 @@ stream_snapshot = snapshot(
                 ]
             ),
             AssistantMessage(
-                content=[Text(text="I'm sorry, I can't assist with that.")]
+                content=[Text(text="I'm sorry, I can't assist with that.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -126,7 +135,10 @@ async_stream_snapshot = snapshot(
                 ]
             ),
             AssistantMessage(
-                content=[Text(text="I'm sorry, I can't assist with that.")]
+                content=[Text(text="I'm sorry, I can't assist with that.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/resume_with_override/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/anthropic_snapshots.py
@@ -15,7 +15,10 @@ sync_snapshot = snapshot(
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
             AssistantMessage(
-                content=[Text(text="I am a large language model, trained by Google.")]
+                content=[Text(text="I am a large language model, trained by Google.")],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
@@ -23,7 +26,10 @@ sync_snapshot = snapshot(
                     Text(
                         text="You're absolutely right to ask me to double-check that. I made an error - I was created by Anthropic, not Google. Thank you for the correction!"
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -39,7 +45,10 @@ async_snapshot = snapshot(
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
             AssistantMessage(
-                content=[Text(text="I am a large language model, trained by Google.")]
+                content=[Text(text="I am a large language model, trained by Google.")],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
@@ -47,7 +56,10 @@ async_snapshot = snapshot(
                     Text(
                         text="You're absolutely right to ask me to double-check that. I made an error - I am Claude, and I was created by Anthropic, not Google. Thank you for the correction!"
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -62,7 +74,10 @@ stream_snapshot = snapshot(
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
             AssistantMessage(
-                content=[Text(text="I am a large language model, trained by Google.")]
+                content=[Text(text="I am a large language model, trained by Google.")],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
@@ -70,7 +85,10 @@ stream_snapshot = snapshot(
                     Text(
                         text="You're absolutely right to ask me to double-check that. I made an error - I am Claude, and I was created by Anthropic, not Google. Thank you for the correction!"
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -86,7 +104,10 @@ async_stream_snapshot = snapshot(
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
             AssistantMessage(
-                content=[Text(text="I am a large language model, trained by Google.")]
+                content=[Text(text="I am a large language model, trained by Google.")],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
@@ -94,7 +115,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text="You're absolutely right - I apologize for the error. I am Claude, an AI assistant created by Anthropic. Thank you for prompting me to correct that mistake."
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/resume_with_override/google_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/google_snapshots.py
@@ -14,7 +14,12 @@ sync_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
@@ -25,7 +30,10 @@ My apologies! You are absolutely right to ask me to double-check.
 I made a mistake in my previous answer. I am a large language model, trained by **Google**.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -40,7 +48,12 @@ async_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
@@ -51,7 +64,10 @@ You're right to ask me to double-check! My apologies for the confusion.
 I am a large language model, trained by **Google**.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -70,7 +86,10 @@ stream_snapshot = snapshot(
                     Text(
                         text="I was created by Anthropic, an AI safety company. I'm Claude, an AI assistant developed by their team to be helpful, harmless, and honest."
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
@@ -84,7 +103,10 @@ My previous answer is correct: I was created by **Anthropic**.
 I am Claude, an AI assistant developed by Anthropic.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -99,7 +121,12 @@ async_stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
@@ -110,7 +137,10 @@ You are absolutely right to ask me to double-check! My apologies for that error.
 I am a large language model, trained by **Google**.\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/resume_with_override/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/openai_completions_snapshots.py
@@ -14,14 +14,22 @@ sync_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
                     Text(
                         text="Yes, I can confirm that I was created by Anthropic, a company focused on developing AI models and systems."
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -36,14 +44,22 @@ async_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
                     Text(
                         text="Yes, I can confirm that I was created by Anthropic, an AI safety and research company."
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -57,12 +73,20 @@ stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
                     Text(text="Yes, I can confirm that I was created by Anthropic.")
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -77,14 +101,22 @@ async_stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
                     Text(
                         text="Yes, I can confirm that I was developed by Anthropic, a company focused on creating safe and aligned AI models."
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/resume_with_override/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/openai_responses_snapshots.py
@@ -14,9 +14,19 @@ sync_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
-            AssistantMessage(content=[Text(text="I was indeed created by Anthropic!")]),
+            AssistantMessage(
+                content=[Text(text="I was indeed created by Anthropic!")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -30,9 +40,19 @@ async_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
-            AssistantMessage(content=[Text(text="Yes, I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="Yes, I was created by Anthropic.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
         ],
         "format": None,
         "tools": [],
@@ -45,10 +65,18 @@ stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
-                content=[Text(text="Yes, I was indeed created by Anthropic.")]
+                content=[Text(text="Yes, I was indeed created by Anthropic.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,
@@ -63,10 +91,18 @@ async_stream_snapshot = snapshot(
         "finish_reason": None,
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
-            AssistantMessage(content=[Text(text="I was created by Anthropic.")]),
+            AssistantMessage(
+                content=[Text(text="I was created by Anthropic.")],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
-                content=[Text(text="Yep, I was indeed created by Anthropic.")]
+                content=[Text(text="Yep, I was indeed created by Anthropic.")],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": None,

--- a/python/tests/e2e/snapshots/structured_output/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/anthropic_snapshots.py
@@ -31,7 +31,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -94,7 +97,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -156,7 +162,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -219,7 +228,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/google_snapshots.py
@@ -25,7 +25,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -94,7 +97,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -162,7 +168,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -231,7 +240,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_anthropic_snapshots.py
@@ -87,7 +87,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -255,7 +258,10 @@ Respond only with valid JSON that matches this exact schema:
 ```\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -420,7 +426,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -586,7 +595,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/json_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_google_snapshots.py
@@ -87,7 +87,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -253,7 +256,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -418,7 +424,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -584,7 +593,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/json_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_openai_completions_snapshots.py
@@ -87,7 +87,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -253,7 +256,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -418,7 +424,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -584,7 +593,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/json_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_openai_responses_snapshots.py
@@ -87,7 +87,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -253,7 +256,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -418,7 +424,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -584,7 +593,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/openai_completions_snapshots.py
@@ -25,7 +25,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -84,7 +87,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -142,7 +148,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -201,7 +210,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/openai_responses_snapshots.py
@@ -25,7 +25,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -84,7 +87,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -142,7 +148,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -201,7 +210,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/strict_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/strict_google_snapshots.py
@@ -25,7 +25,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -94,7 +97,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -162,7 +168,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -231,7 +240,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/strict_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/strict_openai_completions_snapshots.py
@@ -25,7 +25,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -84,7 +87,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -142,7 +148,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -201,7 +210,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/strict_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/strict_openai_responses_snapshots.py
@@ -25,7 +25,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -84,7 +87,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -142,7 +148,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -201,7 +210,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_anthropic_snapshots.py
@@ -31,7 +31,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -94,7 +97,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -156,7 +162,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -219,7 +228,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/tool_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_google_snapshots.py
@@ -31,7 +31,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"rating": 7, "author": {"last_name": "Rothfuss", "first_name": "Patrick"}, "title": "THE NAME OF THE WIND"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -94,7 +97,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -156,7 +162,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"author": {"last_name": "Rothfuss", "first_name": "Patrick"}, "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -219,7 +228,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"author": {"last_name": "Rothfuss", "first_name": "Patrick"}, "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/tool_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_openai_completions_snapshots.py
@@ -31,7 +31,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -94,7 +97,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -156,7 +162,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -219,7 +228,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output/tool_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_openai_responses_snapshots.py
@@ -31,7 +31,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -94,7 +97,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -156,7 +162,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -219,7 +228,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/anthropic_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/google_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_anthropic_snapshots.py
@@ -36,7 +36,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -91,7 +94,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -147,7 +153,10 @@ lucky number 7.\
 ```\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -202,7 +211,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_google_snapshots.py
@@ -36,7 +36,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -91,7 +94,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -145,7 +151,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -200,7 +209,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_openai_completions_snapshots.py
@@ -36,7 +36,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -91,7 +94,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -145,7 +151,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -200,7 +209,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_openai_responses_snapshots.py
@@ -36,7 +36,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -91,7 +94,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -145,7 +151,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -200,7 +209,10 @@ lucky number 7.\
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/openai_completions_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/openai_responses_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_google_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_openai_completions_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/strict_openai_responses_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_anthropic_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_google_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"author": "Patrick Rothfuss", "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"author": "Patrick Rothfuss", "rating": 7, "title": "THE NAME OF THE WIND"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND", "rating": 7}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"rating": 7, "author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_openai_completions_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_openai_responses_snapshots.py
@@ -30,7 +30,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -79,7 +82,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -127,7 +133,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -176,7 +185,10 @@ lucky number 7.\
                     Text(
                         text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/anthropic_snapshots.py
@@ -35,7 +35,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -51,7 +54,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -124,7 +130,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -140,7 +149,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -212,7 +224,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -228,7 +243,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -301,7 +319,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -317,7 +338,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/google_snapshots.py
@@ -35,7 +35,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -51,7 +54,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"author": "Brandon Sanderson", "title": "Mistborn: The Final Empire", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -124,7 +130,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -140,7 +149,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"publication_year": 2006, "author": "Brandon Sanderson", "pages": 544, "title": "Mistborn: The Final Empire"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -212,7 +224,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -228,7 +243,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"publication_year": 2006, "author": "Brandon Sanderson", "pages": 544, "title": "Mistborn: The Final Empire"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -301,7 +319,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -317,7 +338,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "pages": 544, "publication_year": 2006, "author": "Brandon Sanderson"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/json_anthropic_snapshots.py
@@ -68,7 +68,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -91,7 +94,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -227,7 +233,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -250,7 +259,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -385,7 +397,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -408,7 +423,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -544,7 +562,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -569,7 +590,10 @@ Respond only with valid JSON that matches this exact schema:
 ```\
 """
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/json_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/json_openai_completions_snapshots.py
@@ -65,7 +65,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -88,7 +91,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -221,7 +227,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -244,7 +253,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -376,7 +388,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -392,7 +407,10 @@ Respond only with valid JSON that matches this exact schema:
                     Text(
                         text='{ "title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006 }'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -525,7 +543,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -548,7 +569,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/json_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/json_openai_responses_snapshots.py
@@ -65,7 +65,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -88,7 +91,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -221,7 +227,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -244,7 +253,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -376,7 +388,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -399,7 +414,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -532,7 +550,10 @@ Respond only with valid JSON that matches this exact schema:
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -555,7 +576,10 @@ Respond only with valid JSON that matches this exact schema:
 }\
 """
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/openai_completions_snapshots.py
@@ -29,7 +29,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -45,7 +48,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -113,7 +119,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -129,7 +138,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -196,7 +208,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -212,7 +227,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -280,7 +298,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -296,7 +317,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/openai_responses_snapshots.py
@@ -29,7 +29,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -45,7 +48,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -113,7 +119,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -129,7 +138,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -196,7 +208,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -212,7 +227,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -280,7 +298,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -296,7 +317,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/strict_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/strict_openai_completions_snapshots.py
@@ -29,7 +29,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -45,7 +48,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -113,7 +119,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -129,7 +138,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -196,7 +208,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -212,7 +227,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -280,7 +298,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -296,7 +317,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/strict_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/strict_openai_responses_snapshots.py
@@ -29,7 +29,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -45,7 +48,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -113,7 +119,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -129,7 +138,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -196,7 +208,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -212,7 +227,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -280,7 +298,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -296,7 +317,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_anthropic_snapshots.py
@@ -35,7 +35,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -51,7 +54,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -124,7 +130,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -140,7 +149,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -212,7 +224,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -228,7 +243,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -301,7 +319,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -317,7 +338,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                     )
-                ]
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_google_snapshots.py
@@ -35,7 +35,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -51,7 +54,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"publication_year": 2006, "author": "Brandon Sanderson", "title": "Mistborn: The Final Empire", "pages": 544}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -124,7 +130,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -140,7 +149,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"pages": 544, "publication_year": 2006, "title": "Mistborn: The Final Empire", "author": "Brandon Sanderson"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -212,7 +224,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -228,7 +243,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"pages": 544, "title": "Mistborn: The Final Empire", "publication_year": 2006, "author": "Brandon Sanderson"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -301,7 +319,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -317,7 +338,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"publication_year": 2006, "author": "Brandon Sanderson", "pages": 544, "title": "Mistborn: The Final Empire"}'
                     )
-                ]
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_openai_completions_snapshots.py
@@ -35,7 +35,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -51,7 +54,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -124,7 +130,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -140,7 +149,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -212,7 +224,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -228,7 +243,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -301,7 +319,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -317,7 +338,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_openai_responses_snapshots.py
@@ -35,7 +35,10 @@ sync_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -51,7 +54,10 @@ sync_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -124,7 +130,10 @@ async_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -140,7 +149,10 @@ async_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -212,7 +224,10 @@ stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -228,7 +243,10 @@ stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {
@@ -301,7 +319,10 @@ async_stream_snapshot = snapshot(
                         name="get_book_info",
                         args='{"isbn":"0-7653-1178-X"}',
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
             UserMessage(
                 content=[
@@ -317,7 +338,10 @@ async_stream_snapshot = snapshot(
                     Text(
                         text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                     )
-                ]
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
             ),
         ],
         "format": {

--- a/python/tests/llm/clients/base/test_utils.py
+++ b/python/tests/llm/clients/base/test_utils.py
@@ -11,7 +11,7 @@ def test_encode_messages_with_system_first() -> None:
     messages = [
         llm.messages.system("You are a helpful assistant"),
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there"),
+        llm.messages.assistant("Hi there", provider="openai", model_id="gpt-4"),
         llm.messages.user("How are you?"),
     ]
 
@@ -25,7 +25,7 @@ def test_encode_messages_no_system() -> None:
     """Test encoding messages when no system message is present."""
     messages = [
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there"),
+        llm.messages.assistant("Hi there", provider="openai", model_id="gpt-4"),
         llm.messages.user("How are you?"),
     ]
     system_message, remaining_messages = _utils.extract_system_message(messages)
@@ -39,7 +39,7 @@ def test_encode_messages_system_not_first_warns() -> None:
     messages = [
         llm.messages.user("Hello"),
         llm.messages.system("You are a helpful assistant"),
-        llm.messages.assistant("Hi there"),
+        llm.messages.assistant("Hi there", provider="openai", model_id="gpt-4"),
     ]
 
     with patch("logging.warning") as mock_warning:
@@ -94,7 +94,7 @@ def test_add_system_instructions_no_existing_system() -> None:
     """Test adding system instructions when no system message exists."""
     messages = [
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there"),
+        llm.messages.assistant("Hi there", provider="openai", model_id="gpt-4"),
     ]
     additional_instructions = "Be helpful and concise."
 
@@ -113,7 +113,7 @@ def test_add_system_instructions_with_existing_system() -> None:
     messages = [
         llm.messages.system(prior_system_message),
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there"),
+        llm.messages.assistant("Hi there", provider="openai", model_id="gpt-4"),
     ]
     additional_instructions = "Be helpful and concise."
 

--- a/python/tests/llm/clients/openai/test_completions_client.py
+++ b/python/tests/llm/clients/openai/test_completions_client.py
@@ -16,7 +16,9 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
 
     messages = [
         llm.messages.user("Hello there"),
-        llm.messages.assistant(["General ", "Kenobi"]),
+        llm.messages.assistant(
+            ["General ", "Kenobi"], provider="openai:completions", model_id="gpt-4o"
+        ),
     ]
     assert openai_utils.prepare_completions_request(
         model_id="gpt-4o", messages=messages, format=None, tools=None, params={}
@@ -25,7 +27,10 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
             [
                 llm.UserMessage(content=[llm.Text(text="Hello there")]),
                 llm.AssistantMessage(
-                    content=[llm.Text(text="General "), llm.Text(text="Kenobi")]
+                    content=[llm.Text(text="General "), llm.Text(text="Kenobi")],
+                    provider="openai:completions",
+                    model_id="gpt-4o",
+                    raw_content=[],
                 ),
             ],
             None,

--- a/python/tests/llm/clients/openai/test_responses_client.py
+++ b/python/tests/llm/clients/openai/test_responses_client.py
@@ -14,7 +14,9 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
 
     messages = [
         llm.messages.user("Hello there"),
-        llm.messages.assistant(["General ", "Kenobi"]),
+        llm.messages.assistant(
+            ["General ", "Kenobi"], provider="openai:responses", model_id="gpt-4o"
+        ),
     ]
     _, _, kwargs = openai_utils.prepare_responses_request(
         model_id="gpt-4o", messages=messages, format=None, tools=None, params={}

--- a/python/tests/llm/messages/test_messages.py
+++ b/python/tests/llm/messages/test_messages.py
@@ -96,7 +96,9 @@ class TestAssistantMessage:
 
     def test_assistant_with_string(self) -> None:
         """Test creating an assistant message with a string."""
-        msg = llm.messages.assistant("Hello! How can I help you?")
+        msg = llm.messages.assistant(
+            "Hello! How can I help you?", provider="openai", model_id="gpt-4"
+        )
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"
@@ -107,7 +109,12 @@ class TestAssistantMessage:
 
     def test_assistant_with_name(self) -> None:
         """Test creating an assistant message with a name."""
-        msg = llm.messages.assistant("Hello! How can I help you?", name="Claude")
+        msg = llm.messages.assistant(
+            "Hello! How can I help you?",
+            name="Claude",
+            provider="openai",
+            model_id="gpt-4",
+        )
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"
@@ -119,7 +126,7 @@ class TestAssistantMessage:
     def test_assistant_with_content_part(self) -> None:
         """Test creating an assistant message with a single content part."""
         text_obj = llm.Text(text="Hello! How can I help you?")
-        msg = llm.messages.assistant(text_obj)
+        msg = llm.messages.assistant(text_obj, provider="openai", model_id="gpt-4")
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"
@@ -131,7 +138,7 @@ class TestAssistantMessage:
         """Test creating an assistant message with a sequence of mixed content."""
         text_obj = llm.Text(text="Here's my response:")
         content_list = ["Hello", text_obj, "World"]
-        msg = llm.messages.assistant(content_list)
+        msg = llm.messages.assistant(content_list, provider="openai", model_id="gpt-4")
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"
@@ -148,7 +155,7 @@ class TestAssistantMessage:
 
     def test_assistant_with_empty_sequence(self) -> None:
         """Test creating an assistant message with an empty sequence."""
-        msg = llm.messages.assistant([])
+        msg = llm.messages.assistant([], provider="openai", model_id="gpt-4")
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"

--- a/python/tests/llm/responses/test_response.py
+++ b/python/tests/llm/responses/test_response.py
@@ -17,7 +17,9 @@ def test_response_initialization_with_text_content() -> None:
     ]
 
     text_content = [llm.Text(text="Hello! How can I help you today?")]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -58,7 +60,9 @@ def test_response_initialization_with_mixed_content() -> None:
         llm.Thought(thought="Let me think about this"),
         llm.Text(text="Here's the result."),
     ]
-    assistant_message = llm.messages.assistant(mixed_content)
+    assistant_message = llm.messages.assistant(
+        mixed_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -88,7 +92,9 @@ def test_response_initialization_with_mixed_content() -> None:
 def test_response_initialization_with_empty_input_messages() -> None:
     """Test Response initialization with empty input messages."""
     text_content = [llm.Text(text="Hello!")]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -108,7 +114,9 @@ def test_response_initialization_with_empty_input_messages() -> None:
 def test_response_with_different_finish_reasons() -> None:
     """Test Response with different finish reasons."""
     text_content = [llm.Text(text="Response")]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     finish_reasons = [llm.FinishReason.MAX_TOKENS, llm.FinishReason.REFUSAL, None]
 
@@ -128,7 +136,9 @@ def test_response_with_different_finish_reasons() -> None:
 
 def test_empty_response_pretty() -> None:
     """Test pretty representation of an empty response."""
-    assistant_message = llm.messages.assistant(content=[])
+    assistant_message = llm.messages.assistant(
+        content=[], provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw=None,
@@ -147,7 +157,9 @@ def test_empty_response_pretty() -> None:
 def test_text_only_response_pretty() -> None:
     """Test pretty representation of a text-only response."""
     assistant_message = llm.messages.assistant(
-        content=[llm.Text(text="Hello! How can I help you today?")]
+        content=[llm.Text(text="Hello! How can I help you today?")],
+        provider="openai:completions",
+        model_id="test_model",
     )
 
     response = llm.Response(
@@ -173,7 +185,9 @@ def test_mixed_content_response_pretty() -> None:
             llm.ToolCall(
                 id="call_abc123", name="multiply_numbers", args='{"a": 1337, "b": 4242}'
             ),
-        ]
+        ],
+        provider="openai:completions",
+        model_id="test_model",
     )
 
     response = llm.Response(
@@ -206,7 +220,9 @@ def test_multiple_text_response_pretty() -> None:
             llm.Text(text="Here's the first part."),
             llm.Text(text="And here's the second part."),
             llm.Text(text="Finally, the third part."),
-        ]
+        ],
+        provider="openai:completions",
+        model_id="test_model",
     )
 
     response = llm.Response(
@@ -241,7 +257,9 @@ def test_response_format_success() -> None:
 
     valid_json = '{"title": "The Hobbit", "author": "J.R.R. Tolkien", "pages": 310}'
     text_content = [llm.Text(text=valid_json)]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -273,7 +291,9 @@ def test_response_format_invalid_json() -> None:
         '{"title": "The Hobbit", "author": "J.R.R. Tolkien"'  # Missing closing brace
     )
     text_content = [llm.Text(text=invalid_json)]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -303,7 +323,9 @@ def test_response_format_validation_error() -> None:
         '{"title": "The Hobbit", "author": "J.R.R. Tolkien"}'  # Missing pages
     )
     text_content = [llm.Text(text=incomplete_json)]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -325,7 +347,9 @@ def test_response_format_no_format_type() -> None:
     """Test that response.parse() raises ValueError when no format type is specified."""
 
     text_content = [llm.Text(text='{"title": "The Hobbit"}')]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     # Create response without format type (defaults to NoneType)
     response = llm.Response(
@@ -353,7 +377,9 @@ def test_response_format_with_text_before_and_after_json() -> None:
     # Text with explanation before and after JSON
     text_wrapped = 'Let me provide the book details:\n\n{"title": "The Hobbit", "author": "J.R.R. Tolkien", "pages": 310}\n\nHope this helps!'
     text_content = [llm.Text(text=text_wrapped)]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -391,7 +417,9 @@ def test_response_format_with_json_code_block() -> None:
 
 Let me know if you need anything else!"""
     text_content = [llm.Text(text=code_block_text)]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -431,7 +459,9 @@ def test_response_format_with_nested_json() -> None:
 
 This includes the author information as a nested object."""
     text_content = [llm.Text(text=nested_json_text)]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -465,7 +495,9 @@ def test_response_format_with_multiple_json_objects() -> None:
     text_2 = '{"title": "The Name of the Wind", "author": "Patrick Rothfuss"}'
     text_3 = '{"title": "The Lord of the Rings", "author": "J.R.R. Tolkien"}'
     text_content = [llm.Text(text=text_1), llm.Text(text=text_2), llm.Text(text=text_3)]
-    assistant_message = llm.messages.assistant(text_content)
+    assistant_message = llm.messages.assistant(
+        text_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -497,7 +529,9 @@ def test_response_format_tool_handling() -> None:
             args='{"title": "The Hobbit", "author": "J.R.R. Tolkien"}',
         ),
     ]
-    assistant_message = llm.messages.assistant(mixed_content)
+    assistant_message = llm.messages.assistant(
+        mixed_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -543,7 +577,9 @@ def test_response_mixed_regular_and_format_tool() -> None:
         ),
         llm.Text(text="Done!"),
     ]
-    assistant_message = llm.messages.assistant(mixed_content)
+    assistant_message = llm.messages.assistant(
+        mixed_content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -585,7 +621,9 @@ def test_response_format_tool_no_finish_reason_change() -> None:
             args='{"data": "formatted"}',
         ),
     ]
-    assistant_message = llm.messages.assistant(content)
+    assistant_message = llm.messages.assistant(
+        content, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -620,7 +658,9 @@ def test_response_execute_tools() -> None:
         llm.ToolCall(name="tool_one", id="call_1", args='{"x": 5}'),
         llm.ToolCall(name="tool_two", id="call_2", args='{"y": "hello"}'),
     ]
-    assistant_message = llm.messages.assistant(tool_calls)
+    assistant_message = llm.messages.assistant(
+        tool_calls, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
@@ -654,7 +694,9 @@ async def test_async_response_execute_tools() -> None:
         llm.ToolCall(name="tool_one", id="call_1", args='{"x": 5}'),
         llm.ToolCall(name="tool_two", id="call_2", args='{"y": "hello"}'),
     ]
-    assistant_message = llm.messages.assistant(tool_calls)
+    assistant_message = llm.messages.assistant(
+        tool_calls, provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.AsyncResponse(
         raw={"test": "response"},
@@ -674,7 +716,9 @@ async def test_async_response_execute_tools() -> None:
 
 
 def test_response_tools_initialization() -> None:
-    assistant_message = llm.messages.assistant("oh hi")
+    assistant_message = llm.messages.assistant(
+        "oh hi", provider="openai:completions", model_id="test_model"
+    )
 
     response = llm.Response(
         raw={},


### PR DESCRIPTION
So far the providers set the provider and model id, but raw_content
field is yet unused.