### PR TITLE
test: add special e2e test call type for dropping raw content

### DIFF
--- a/python/tests/e2e/cassettes/call_with_thinking_true/openai_responses/without_raw_content.yaml
+++ b/python/tests/e2e/cassettes/call_with_thinking_true/openai_responses/without_raw_content.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"user","content":"How many primes below 400 contain 79
+      as a substring? Answer ONLY with the number, not sharing which primes they are."}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '221'
+      content-type:
+      - application/json
+      cookie:
+      - _cfuvid=hShblBfBDe9THQIeqj7s9V2kFcWipgUrUiVGqu6BtOc-1759973390793-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6xXTY/jNgy9z68gfFlgkQmcj8nH3IoCRefSSxfYQ1MEsk0n6siSV6SSpsX+94KS
+        7dg7s+ihvQSOSEnke08U9fcDQKar7Bkyj9Qe8+2mLlS9rXG1WeeIeb7Z4W65KFWxqde7xT5Xq/Xu
+        afm0K9flcodFmc1kCVf8gSX3yzhLmMZLj4qxOiqxLbabPF+v1ptNtBErDiRzSte0BhmrNKlQ5evJ
+        u2AlrloZwjSsjdH2lD3D3w8AAFmrbuhlfoUXNK5Fnz0AfI3O6L0Tmw3GxAFt+12OFbLShqZWYh9K
+        1s5Oxhv159EFbgMf2b3iWyM7Z46lMtPlGlehkchOLT8+PS7z5dNjvnvMtx1accXsGX6LiaR07kTQ
+        92koNpXKhYYi3yEuNmtcPOW79W4dF46L8K3FRIQiZwWwwUShaZS/DRuPN5/M7RyPjH/yMD15yMgz
+        ZB8//uiCZW1PQC2WutYltF43SB8/HuzBvoBFrIAd1NpWwGfszGCQCPisLKzzXD4YtC1NqDB6USiI
+        vax7yLb7+SGDT2cEV1y0CwTOImiC7R40E5p6BspW8AJ8duF0ZnA1LLb7OLjYb+fwWWmeySecFcEh
+        229nhwys42H1X90MnDW3uHnpLOtTkJ0IvwS0JUbHQwalpEvzGE2pbKUrxUigPD6DJPwIn67usdIn
+        zc8gS8vI2SP2Y4vtfgZL+ZHoVtv9PM772V3xgl5Gb2BDU6AnIFY+YnvVfIYuoZOTkdAKqNv9Xra2
+        HxiCrdALljMgJ1ncoHJiiBHP4eVDA7UrA8lsZ+GPQByTvWhVmJ6WeTaw/HX238XxUqFlXd9kz7jB
+        CLNOIIewzBf7JoFvnHsVX8UDBhOdzOEn54HvePZuM3ijNEeYZIW2Am0jgcL69azLM5z0BQkafI8P
+        4ZZ7FrsdIvqG3CCAgbAX8KiM/gujrg4ZVA5JgD+ryyAbbcH5StzJgebkk1JnuDr/Cmf0OBdEfnHX
+        GZRnLCMStfMROWU03557DURxe4TC8blnTpIAfV814V1gqQIhaP5AUOmLJi1sFzdYJTBXknrHgjFp
+        4/6MJpGpwgWGRdq5A1dOK6dJ1O2kCK5ozP+soB+drbVv7gLqCJ+o5xKPrPhhF9yo0KjG2RM0t2+O
+        K0jeixHvM2DHSq6WJLAB15cEClaga1nYI1zlR06qk//jleNJ7UhXgvhJM82gCAIYEGJD8iFaJQG3
+        GFebmM1aylI8nYSt8nJvphLxgyE3E/maOId0hbFAphiG86JfEfbbvvbNpqXAsuqOQhJlqnbeY8lJ
+        oPNYCdP0PRTYVQvxw+qENFVuo5jRA2oJIUX5yUHlQmHwMaIm5+OCXtca7+U/irkv0qkiTRSnmYC+
+        BGHJO8eznl1x1CyVP7rLSQ00E25rbZUBZemKHjw2Slua0NjnPrpR/l+h/iQR6L+SfLALpVPph7cC
+        XXQULfdbIacHdKgZUqmiMPfbPnTqC4x0KaiqOXxGWbm7NqukZp1KrsAtBUFJ5k3rSDMmqQ9srJK5
+        g/KlV2csxMPNOtQ7SeTzGe2EXW1PQjAhgnWdECU6ZUskIbgXkmpbVFGtqvSOuoMBhXR3ymukKMZv
+        ai5BgaJyuehTAKLNO7oihNWoEpOWi1rsgaIMvgQkTpdCNyMeT/HoqroyzuK4/qWDp27PsBpXsu7r
+        94eRXL7p1xo6fbdhq8pFjbFh2+32u43aLFS1Ljfr5fZtw9YgkTrhqF37ToMcjaINtPzvvVzfvr6R
+        sLLWsepb3t9+nxiNO7XeFe9YeuWv3kFpiM47EzdXRFpUwclZHKNTJgXOGDTTBpp9SL1+6zE2fMf+
+        OXGMWA8Ndutd0/KxVOUZj694G9vuje/wUsC6dp4TyJUOTQfEqCHO0qMAq/sTglSNfDsO52rynCD0
+        F13ikXX/BKlVMAnhjNh5HKfD2LToFYc4vJjn3WhEsouxdr5R9/8jBqPfWIDZBX0hJ/s2SmmIOyF6
+        drpMFAR22WC4E5qxa48jmvNhsB3H6IMto0hilpqkZ+zeaSHKdUhA28kzabWcvR0fvb2GNCOJ1X1i
+        Pkn129fXbrV/z/LewoMQxrOXk9XjzT8ybxcDjFJKJm86ZFUpVrLD14ev/wAAAP//AwD1CEvIOg8A
+        AA==
+    headers:
+      CF-RAY:
+      - 98c0cad27a4aec9c-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:04 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=fNVY4VFcSuVHvq2rXBnjIPWVQ6ky1Eid7e1NmyfpQGw-1760043484-1.0.1.1-goA0iJi4U0LW9Nm1sPHrjaYAPAuKo6CqL5ZfNOLGRea6bkhz9bqWJUvfUU_SdRxYT2g9NepaG1CkcNj57OE5_7ofoXAx.pWchlapHR0EAtE;
+        path=/; expires=Thu, 09-Oct-25 21:28:04 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=A1MsmSmfMdpeeDZteSo02EZUKaFfeel5wHkgxuYzwHw-1760043484397-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '17664'
+      openai-project:
+      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '17670'
+      x-request-id:
+      - req_c344fc816af14fc094814384474d795f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "{\"input\":[{\"role\":\"user\",\"content\":\"How many primes below 400
+      contain 79 as a substring? Answer ONLY with the number, not sharing which primes
+      they are.\"},{\"role\":\"assistant\",\"content\":\"**Thinking: **Counting specific
+      primes**\\n\\nI need to find the primes less than 400 that include the substring
+      \\\"79.\\\" The obvious one is 79 itself, and I thought of 179 and 197. Wait,
+      197 has \\\"97,\\\" not \\\"79.\\\" So, only the contiguous sequence \\\"79\\\"
+      counts. The candidates are: \\n\\n- Two-digit: 79.\\n- Three-digit: 179, 279,
+      and 379. \\n\\nHowever, any numbers starting with 79 and going up to 799 aren't
+      under 400, so they don't count. I'm focusing on just the viable primes.\"},{\"role\":\"assistant\",\"content\":\"**Thinking:
+      **Identifying prime candidates**\\n\\nI\u2019m only looking at numbers less
+      than 400. For three-digit numbers, I need to find those that end in \\\"79,\\\"
+      which gives me 179, 279, and 379. The two-digit number 79 also counts. However,
+      I realize \\\"97\\\" doesn't have \\\"79\\\" in order, so it doesn\u2019t work
+      here.\\n\\nNow, checking for primality: 79 and 179 are both primes. 279 isn\u2019t
+      prime because it's divisible by 3. For 379, I\u2019ll check primes up to about
+      19 and find that it\u2019s prime as well.\"},{\"role\":\"assistant\",\"content\":\"**Thinking:
+      **Confirming prime numbers**\\n\\nI\u2019ve confirmed that the primes among
+      my candidates are 79, 179, and 379, totaling three primes. I checked if there
+      were any other candidates with \\\"79\\\" as digits, but it seems it needs to
+      be contiguous\u2014not just separated. \\n\\nAlso, while considering other numbers
+      like 97 and 197, they don't contain \\\"79\\\" in the correct order. So, 7 and
+      9 being on the edges doesn\u2019t matter either. \\n\\nTo double-check, I verified
+      the primality of 179 using primes up to its square root, confirming it is prime.
+      Thus, my final answer remains three primes containing \\\"79.\\\"\"},{\"role\":\"assistant\",\"content\":\"**Thinking:
+      **Finalizing the answer**\\n\\nI've confirmed that 197 and 297 don\u2019t have
+      \\\"79,\\\" and 397 contains \\\"97\\\" instead. We've included 179, identified
+      279 as composite, and verified 379 as prime. It seems only 79 itself counts.
+      \\n\\nWhen double-checking, I see no other instances of 7 and 9 appearing across
+      digit boundaries in two-digit numbers besides 79. \\n\\nSo, the answer is 3.
+      However, since the user requested to answer with the number alone, I\u2019ll
+      just say: 3.\"},{\"role\":\"assistant\",\"content\":\"3\"},{\"role\":\"user\",\"content\":\"If
+      you remember what the primes were, then share them, or say 'I don't remember.'\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"}}"
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '2545'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=fNVY4VFcSuVHvq2rXBnjIPWVQ6ky1Eid7e1NmyfpQGw-1760043484-1.0.1.1-goA0iJi4U0LW9Nm1sPHrjaYAPAuKo6CqL5ZfNOLGRea6bkhz9bqWJUvfUU_SdRxYT2g9NepaG1CkcNj57OE5_7ofoXAx.pWchlapHR0EAtE;
+        _cfuvid=A1MsmSmfMdpeeDZteSo02EZUKaFfeel5wHkgxuYzwHw-1760043484397-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//fFTbjqMwDH3vV6A8t6tQoEB/ZTRCJphOdkISJU411aj/viK0XHY7+1JR
+        H/tw7GPzvUsSJjt2TphDbxteZlUB/FjXVZoXueD8VGF1TDtR4klUaV20ZZ1ilvIWUuCYHdl+pDDt
+        bxT0pDHa4xQXDoGwa2DE0vLEeZ7lVR4xT0DBjzXCDFYhYTcVtSA+L84EPerqQXmcwlIpqS/snHzv
+        kiRJmIUburG+wysqY9GxXZLcYzI6Z0ZMB6ViQOrnW5oOCaTyW9STC4Kk0Zv4AF+NCWQDNWQ+8V+Q
+        jFGNALWlG0yHalR2sXQoDkd+LA68OvDyMa3IyM7JW2xkamcxwv9sQ5cdgY821H1birQrsMWqz8o2
+        EkcSulmcjABv9DiwGfJhGMDdxhe/x9h9/0rA4C//UVD0kEcFbZoVuejqWqSnjL9QMKD3cMHV+39w
+        PILCaEK9TGUtbEP79AO/aK6OCaC1IXh6+Pa+AZW5WGfaF0gkOiesrPdJOv5kZc3mhPvjaa5hzqio
+        A7yXnkDTlDwmxiRmwYFSqLbLQS5Me2wdXqUJvnmeShPHPi+PdWaw1AgQH9h84m2NLabOV4B9b1xs
+        YJBaDqAeQ1m5PZbPl+GhR7o1skNNspe4uRKP7ioFNiSfl9VDUNOcmSfjcN0J4WDRAYUYTn/xRzTO
+        8yGvN26A5f/Kx5i3XkN2RdcaL+k2bU8nw7Bc9DTMDyPFNP1Ahs3AYisjY5uV2XwO2rVGF7SIqxK7
+        lB5a9fz8hLi0cwNSb66/qMv9v8DqmzL3GQ3slkq+6fXvr0qavQJe8c478BM1GQK1gKeUz0MMfuv3
+        gAQdEIz89939DwAAAP//AwB9S/DGDwYAAA==
+    headers:
+      CF-RAY:
+      - 98c0cb41a826ec9c-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1235'
+      openai-project:
+      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1240'
+      x-request-id:
+      - req_8e3102df24a64172a44f6bf9bba7506c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/cassettes/call_with_tools/anthropic/without_raw_content.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/anthropic/without_raw_content.yaml
@@ -1,0 +1,225 @@
+interactions:
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+      the secrets associated with each of these passwords: mellon,radiance"}],"model":"claude-sonnet-4-0","system":"Use
+      parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
+      tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '473'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.64.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.64.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//nJFBa9wwEIX/iphLL9qy3tpp4ltSKGmhOYTCEkoRE2m6ViNLrmbkZln8
+        34s3MWlaAqUnoXnvzTcjHaBPjgK0YAMWRytOMZKs6tVmvWnWTVWDBu+ghZ53Zl1dDJ/9uB/fk5zv
+        662jzdn++uMNaJD9QLOLmHFHoCGnMBeQ2bNgFNBgUxSKAu2Xw+IXup+V49HCh1chqEySPY2kpCPF
+        ZDMJq28pq9sknRqQ+WfKjlVhH3dqwIwhUFCSUlAWQ+DXMOknQErBFKZljflezLq6chfnNr/51H+/
+        jvXlKTblpLmsQEPEfs49gM3jMBjMHJybxKEItAdYBjkuHUKKMP0DdtN78Xfy7urt1m3vT292Y6nP
+        tv+Hzeg8RkswTV81sKTBZEJO8Tn/KDD9KDR721hC0FCOv9QeHhobSXcUGdq6OtFg0XZkbCYUn6J5
+        7lgveiZ0L2lLdgbQ0FFPGYNp+r/9T2rV/alOGlKR30tVVWlgyqO3ZMRTnl9MMDrMDqbpFwAAAP//
+        AwDM5oqszQIAAA==
+    headers:
+      CF-RAY:
+      - 98c0cb4d0a2e759a-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:09 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-10-09T20:58:08Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-10-09T20:58:09Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-10-09T20:58:06Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-10-09T20:58:08Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CTxJ3edQ6QShoKr3mpcfp
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '2900'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+      the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":[{"type":"text","text":"I''ll
+      retrieve the secrets for both passwords using parallel tool calls."},{"type":"tool_use","id":"toolu_01NdBAcr3MmjRn4H8a5u65H1","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_012mitiktCN7WdWx8Ygvu49W","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01NdBAcr3MmjRn4H8a5u65H1","content":"Welcome
+      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_012mitiktCN7WdWx8Ygvu49W","content":"Life
+      before Death"}]}],"model":"claude-sonnet-4-0","system":"Use parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
+      tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1071'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.64.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.64.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJFNaxsxEIb/ijLHRYa1a8exbiU59OBAoIUQ4rAo0uusiFZaj2bTFuP/
+        XjaJyRc9DfM+zzAMs6cue0Qy5KIdPCYlpwSZzCezeraoF9M5aQqeDHXloamn57Obn7vV2ePicnl/
+        s1sud6v1+td30iR/e4wWSrEPIE2c4xjYUkIRm4Q0uZwEScjc7o++4M9InouhH2Aoy1DSQhU4hhTF
+        EA54glfbzArWtaq3pfzO7M0mbdJEXb22akMdYsxpQ0ZV1TWiyx2UZHWZOdiTqvpks/XBJocXfx22
+        UPfYZoa6gJW2quhwp6lI7huGLTmRISTfyMCJXkHBbkByIJOGGDUNz/ebPYXUD9JIfkQqZE7ruSZn
+        XYvGMayEnJqPRn3kDOv/x46z4wL0LTqwjc2i++q/0Wn7mR405UHeR99Wmgr4KTg0EsBkaPyat+zp
+        cPgHAAD//wMA8g1i4iYCAAA=
+    headers:
+      CF-RAY:
+      - 98c0cb5fe91d759a-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:11 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-10-09T20:58:10Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-10-09T20:58:11Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-10-09T20:58:09Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-10-09T20:58:10Z'
+      cf-cache-status:
+      - DYNAMIC
+      request-id:
+      - req_011CTxJ3sW4JVM2kX44shQ7y
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      via:
+      - 1.1 google
+      x-envoy-upstream-service-time:
+      - '2166'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/cassettes/call_with_tools/google/without_raw_content.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/google/without_raw_content.yaml
@@ -1,0 +1,144 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Please retrieve the secrets associated
+      with each of these passwords: mellon,radiance"}], "role": "user"}], "systemInstruction":
+      {"parts": [{"text": "Use parallel tool calling."}], "role": "user"}, "tools":
+      [{"functionDeclarations": [{"description": "A tool that requires a password
+      to retrieve a secret.", "name": "secret_retrieval_tool", "parameters": {"properties":
+      {"password": {"title": "Password", "type": "STRING"}}, "required": ["password"],
+      "type": "OBJECT"}}]}], "generationConfig": {}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '530'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/81UXY+iSBR991cYnmbDzihio24yD4ofiHyIoituNpMCSiwtqpAqBbrT/32RHnu0
+        d5J5HRJIce+tcw/nFuelVq8LASAhCgGHTPir/k8Zqddfquc1RwmHhJeJW6gMJiDlP2rfrpe7dVmy
+        O5OAI0pUgPHD5u95AmJYxgUGgxTyb+WdIngB+BunFAt/fiwHacR+AlNxYSyjaXgFiyHGlAgfil4f
+        3l8fsQW+p+doz5coIoCf04qUyiK1H2ocxb3B1uBY13uEryaToTaHhSE5TZyeMi1RGrk0O629tb8y
+        vcGuD5Qhxj3f6XFOZ/ZE1639ilgeVY5zLj7zXcM6bAerHTkN/NySpoGtoFaSLEGyVttaJgag0YoP
+        ytAs1ss4H+wyaeGkysnM80AetbCzbw5G8dzu+o646TZWureYykNvmHnSokMR9O0wKzqJ6kRKwb0T
+        SC1rJs7lpt93dqlnNYqD9txr60vNkZUtRfuVwVu5lrqGY9vFpLVucdB9cpfS4piN5plox9xFY/WA
+        lE3c5g1DAiszuYQbKRxeTCxHC+/ANb6WRh3a1s+EhUN5Ey/k8ZB0Q4t7R0/pnR3nuW1kvj47MJX0
+        uQ+24Jh3upscBf1Bq0jGxihGPfa31Jeft83RNO2sseKG02BJrcZTJsq5fsFBBuhcbPqTTXusjP0t
+        uCq0u8SFH2JjJS4aYhievIGxGB9I9PXr/fQfZv07HNAUhAiQAP7iiNZ+tv73R08hpbgiF9MQ4hvY
+        +9cKO0QQ2y8gYOXfUJYtXXv+TllAJIR5GW5+qDchYyCqcM0rbj2CBKalLYT1m1j1oFTrE/vjy1vP
+        K7mKlnC+7jQhB6WNgHcdhCSlccJdeoREpefKRjrf2965zkO+fctzygF+SEndW+4Olw3Lrgjf29Gd
+        U5UCAYx4cf0od7Rx7wZXNnigdVOxdif2zR2Y+7/aSu23AaxhytCb0hGMSy0/t748fd5hwPZVPyGF
+        LKGEwWl1CJ5UjYKZfTZtxE+czfeBwpR+JNRea/8B/6NM748FAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 09 Oct 2025 20:58:12 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=1146
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"contents": [{"parts": [{"text": "Please retrieve the secrets associated
+      with each of these passwords: mellon,radiance"}], "role": "user"}, {"parts":
+      [{"functionCall": {"args": {"password": "mellon"}, "name": "secret_retrieval_tool"}},
+      {"functionCall": {"args": {"password": "radiance"}, "name": "secret_retrieval_tool"}}],
+      "role": "model"}, {"parts": [{"functionResponse": {"name": "secret_retrieval_tool",
+      "response": {"output": "Welcome to Moria!"}}}, {"functionResponse": {"name":
+      "secret_retrieval_tool", "response": {"output": "Life before Death"}}}], "role":
+      "user"}], "systemInstruction": {"parts": [{"text": "Use parallel tool calling."}],
+      "role": "user"}, "tools": [{"functionDeclarations": [{"description": "A tool
+      that requires a password to retrieve a secret.", "name": "secret_retrieval_tool",
+      "parameters": {"properties": {"password": {"title": "Password", "type": "STRING"}},
+      "required": ["password"], "type": "OBJECT"}}]}], "generationConfig": {}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '965'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+      x-goog-api-client:
+      - google-genai-sdk/1.31.0 gl-python/3.10.16
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2WRTU8CMRCG7/srxp6BCAkavRnRCEIkshGNcKjsLNvY7azt8BXCf7e7sLBoD+1k
+        3rcz06fbAEDMpIlUJBmduIVPnwHYFnuukWE07IUy5ZOZtHzy7te2EnsL4zq/JLqQyCWCRbYKlxgB
+        JwgxaU0rZebgcOYldwsTMUY9oxSBCQZklbyYCPCDeaWvYoQvjMkidFByMhGNiRGVhrtjPK2dxrSk
+        MZ8hpQh1ad+VBhEro1zyitKRyW2j8GUojqoyEa59+jIoGxSlxcLJOQ6QpQcmj1hEZinNOKRvNPe0
+        KIA12619tQrgc8PNQWdiqc+l62btX2HX8W2VrpKvfIp/pdSKN/lTwof3UFRI8J+5ShbFOQ0OVPag
+        3tA6tScyx9Qzqrca7XqspUuKksKiy8g47Ea5pz16Itl/7j32xlc/7IYrjDfp3YcIdsEvlwmKHV0C
+        AAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 09 Oct 2025 20:58:13 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=507
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/cassettes/call_with_tools/openai_completions/without_raw_content.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/openai_completions/without_raw_content.yaml
@@ -1,0 +1,227 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"system","content":"Use parallel tool calling."},{"role":"user","content":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"secret_retrieval_tool","description":"A
+      tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '507'
+      content-type:
+      - application/json
+      cookie:
+      - _cfuvid=.3RyxenKPvTQu62p338fW64Lzj1.diE8wN3.oC7d2OU-1758333932950-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA8xU32/aMBB+z19h3TNM4TflbWyaNGlVV1Fp6kYVGfsSDI7t2hc6hvjfqwRKAu2m
+        Pi4PkXOfv7vvu5y9ixgDJWHCQCw5idzp9qebEH/26x+Py6dN2putptlGXd8NP/65/dYP0CoZdrFC
+        QS+sD8LmTiMpaw6w8MgJy6yd0TCO+73+Va8CcitRl7TMUbtv292422/H43Y8PBKXVgkMMGG/IsYY
+        21XvUqKR+BsmLG69RHIMgWcIk9MmxsBbXUaAh6ACcUPQqkFhDaEpVZtC6wZA1upEcK3rwodn11jX
+        feJaJzcbOb3qDGhMs8XIXs0Gq5+jYnjbbdQ7pN66SlBaGHHqTwM/xScXxRgDw/OKG1B4pMQjeYUb
+        rpNS70UixoD7rMjRUGkCdnNwPIQn6+UcJmwOOWptzRz2cMbbN772rXdZz9Zbevw+xbuvj7lx96m8
+        +WKv9T39t9Y9l4obgf82f1o/NCbDY1oErl+PDDfGEi/lVzPzEF20ELTNnLeLcEGFVBkVlolHHirr
+        zeGLXoRUEqA4m29w3uaOErJrrIqOBoekUJ++Ghz0jiBZqtp2jHe649Yb6RKJxFU1/6cjJ7hYoqyp
+        9dHjhVS2AUQN66/VvJX7YF+Z7D3pa0AIdIQycR6lEueO620ey8vpb9tOTa4EQ0C/UQITUujL3yEx
+        5YU+DDOEbSDMk1SZDL3zqro8IHUJLnqiJxbjvoRoHz0DAAD//wMAplLmZEUFAAA=
+    headers:
+      CF-RAY:
+      - 98c0cb79fd1e7533-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:14 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=ZWG09GyW2tTtb8rVQsO7nLnicUgnnq0Osbbk1SQovyc-1760043494-1.0.1.1-VGvzcKFO_kETePL75cPzvnLmRFZvUFTMeiujVGVyR4G9VyAC0AJ8pycgoiRtLGJaNRI.2EEFVuas4WZquYl0jOg.ADgi40DlOD1.8TtDVmw;
+        path=/; expires=Thu, 09-Oct-25 21:28:14 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=E5C.YyRrNZJnqSN4qyJ0fJoSMPsZdfLxgDEXczsZDO4-1760043494696-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1080'
+      openai-project:
+      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1187'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '800000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '799969'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 2ms
+      x-request-id:
+      - req_e661fa983d95416d8473eefa9d150837
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"messages":[{"role":"system","content":"Use parallel tool calling."},{"role":"user","content":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":null,"tool_calls":[{"id":"call_OvdB915t8tSb7o9S5jZ7u6Q2","type":"function","function":{"name":"secret_retrieval_tool","arguments":"{\"password\":
+      \"mellon\"}"}},{"id":"call_gkytqPBeTIqmnpYfdOFoMlYt","type":"function","function":{"name":"secret_retrieval_tool","arguments":"{\"password\":
+      \"radiance\"}"}}]},{"role":"tool","content":"Welcome to Moria!","tool_call_id":"call_OvdB915t8tSb7o9S5jZ7u6Q2"},{"role":"tool","content":"Life
+      before Death","tool_call_id":"call_gkytqPBeTIqmnpYfdOFoMlYt"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"secret_retrieval_tool","description":"A
+      tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1030'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=ZWG09GyW2tTtb8rVQsO7nLnicUgnnq0Osbbk1SQovyc-1760043494-1.0.1.1-VGvzcKFO_kETePL75cPzvnLmRFZvUFTMeiujVGVyR4G9VyAC0AJ8pycgoiRtLGJaNRI.2EEFVuas4WZquYl0jOg.ADgi40DlOD1.8TtDVmw;
+        _cfuvid=E5C.YyRrNZJnqSN4qyJ0fJoSMPsZdfLxgDEXczsZDO4-1760043494696-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jFJNb9NAEL37Vwx7jpGbmJL4CgkS9OMAEghcWZvdcbyw3lntTihVlf+O
+        bKexS1uJiw/7PvzmzdwnAMJoUYBQjWTVepu+u47Z+ltjVneXV+u6vvjw5vvm49Wnz5u1Xl+LWaeg
+        7U9U/KB6raj1FtmQG2AVUDJ2rmdvz7MsX+SrvAda0mg72c5zmlM6z+Z5mi3T7PwobMgojKKAHwkA
+        wH3/7SI6jX9EAdns4aXFGOUORXEiAYhAtnsRMkYTWToWsxFU5Bhdn/pLgxBRBeQIMkZSpssLt4Yb
+        4AbByxhvKegIMmBRuhQ2FKAULVpLrhQFlOIrWkUtAhNcUjDyVSlGYpDaSKdwoF6YGmGLNQWE9yi5
+        KcU0WMB6H2XXi9tbOwGkc8Sy67Wv5OaIHE4lWNr5QNv4j1TUxpnYVAFlJNcNHJm86NFDAnDTl71/
+        1J/wgVrPFdMv7H93lq8GPzGud0QXiyPIxNJOVMv57Bm/SiNLY+NkXUJJ1aAepeNu5V4bmgDJZOqn
+        aZ7zHiY3bvc/9iOgFHpGXfmA2qjHE4+0gN31v0Q7tdwHFhHDb6OwYoOh24TGWu7tcJgi3kXGtqqN
+        22HwwQzXWfsKtwu1UNtlrkVySP4CAAD//wMAda/UR6YDAAA=
+    headers:
+      CF-RAY:
+      - 98c0cb825cc57533-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:15 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '588'
+      openai-project:
+      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '695'
+      x-openai-proxy-wasm:
+      - v0.1
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '800000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '799958'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 3ms
+      x-request-id:
+      - req_754459f6b7774131b0958d7cd23e3a86
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/cassettes/call_with_tools/openai_responses/without_raw_content.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/openai_responses/without_raw_content.yaml
@@ -1,0 +1,224 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+      tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '494'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=fNVY4VFcSuVHvq2rXBnjIPWVQ6ky1Eid7e1NmyfpQGw-1760043484-1.0.1.1-goA0iJi4U0LW9Nm1sPHrjaYAPAuKo6CqL5ZfNOLGRea6bkhz9bqWJUvfUU_SdRxYT2g9NepaG1CkcNj57OE5_7ofoXAx.pWchlapHR0EAtE;
+        _cfuvid=A1MsmSmfMdpeeDZteSo02EZUKaFfeel5wHkgxuYzwHw-1760043484397-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7xVTW/bOBC9+1cQPCeFpCi27FuRLHaxH0W26GKBbgphRI4cNpSokkO3buD/viBl
+        68Npiu1lb9K8maeZNzOapwVjXEm+Ydyi68okhay+qvNlVVVY5EmSLAssshRX1bXIi3Sdr1NZy6oC
+        sRRiVawrfhEoTPURBZ1oTOuwtwuLQChLCFi6WiZJfpWvryPmCMi7ECNM02kklH1QBeJxa41vQ141
+        aIe9WWmt2i3fsKcFY4zxDvZoQ7zEHWrToeULxg7RGa01AWu91tGg2tNXSokESrs56sh6Qcq0M3sD
+        X0rjqfNUknnE5yAZo0sBek7XGIk6ZLbt6DI3l1mS5ZdJcZksj3JFSr5h/8RK+nqGTtTi5T4UuJIi
+        9KGSAnNRrYsszbIM00gcSWjfYaTxbSwopjfCL8keQbBb32BLEX+65x0499lYec8397xBrU17zw+j
+        f6Au+6zjY6avv/7t9tVX/Xv9tv3tzXvx1+e7m9vbMaKFJmbnUFik0iJZhTvQUUkevQ4XP6rKOqnT
+        IqpS1LVI0lUB67y+SvP/QRULUkEr8Lu6/PlYVzc/3dCv797cvl39QcUvn97/nHysf0yXBWMf4vx0
+        YEFr1PPxI+v7Teks7pTxrjwtY5/KMJ6dNU1HpQDxgOUj7qeYRXCmne0Z1rWxNHEKevmmAXuKHNbO
+        QY20L5XEllStcLaCDu1OCSxJnda2Bq+JH/8GxuK0CMKmQwvkozl9lRytX2jMrDa2gfF90uboN50m
+        vkNbGaco5MwblMo34++i1/HBKBGjwZPhA+CeL+r5NI19lOiEVV00bhh/zQIDowcgZvGTVxYdA3aa
+        IEaGHVuNDFjf/Ff/dSoGtzAPDRJaN9Gib3SHlhTO7TGiT+DMHkpTpOM3704uF2cOx9od2TAmE/Aw
+        PB/GGH4sWw4qnqcwGD9MokBKFUQEfTctYjgHZ8kcD9Di7PMxyXiYYuDZGpHpSm22nTVV4E4GYzed
+        OOtbAad+SuWg0qdL5R1scRxH1c4OxdXy4rl9cn2exr+FeEA5BiazwT2/P9f5t4Bv8Q67/BI1GYqz
+        dATXybAQ3s13t0ECCQSB/rA4/AsAAP//AwAghnHpOAgAAA==
+    headers:
+      CF-RAY:
+      - 98c0cb87ca5e838c-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:17 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1705'
+      openai-project:
+      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1710'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '800000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '799710'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 21ms
+      x-request-id:
+      - req_b63c507e96cf4219b12b6907f0012588
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance"},{"call_id":"call_2l5zWsybzlLfRnKNZcUwPCDD","name":"secret_retrieval_tool","arguments":"{\"password\":\"mellon\"}","type":"function_call"},{"call_id":"call_QkfbCECtJTNDR7Mt8HqZG0jf","name":"secret_retrieval_tool","arguments":"{\"password\":\"radiance\"}","type":"function_call"},{"call_id":"call_2l5zWsybzlLfRnKNZcUwPCDD","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_QkfbCECtJTNDR7Mt8HqZG0jf","output":"Life
+      before Death","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+      tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '978'
+      content-type:
+      - application/json
+      cookie:
+      - __cf_bm=fNVY4VFcSuVHvq2rXBnjIPWVQ6ky1Eid7e1NmyfpQGw-1760043484-1.0.1.1-goA0iJi4U0LW9Nm1sPHrjaYAPAuKo6CqL5ZfNOLGRea6bkhz9bqWJUvfUU_SdRxYT2g9NepaG1CkcNj57OE5_7ofoXAx.pWchlapHR0EAtE;
+        _cfuvid=A1MsmSmfMdpeeDZteSo02EZUKaFfeel5wHkgxuYzwHw-1760043484397-0.0.1.1-604800000
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFXLjuM2ELz7KxiedwbyYzy2bwH2uAH2ECCHdSC0yJbNDEUyzaazxsL/
+        HoiyXp6Zm93VLPWjivy1EEIaLQ9CEsZQFit8UQCVKrSGarcpiu0Od6sl7uEFdrvlvtipDb7U9Xaz
+        2+4rtdbyS0vhq39QcU/jXcQurgiBUZfQYsvXbVFs1pv9a8YiA6fYnlG+CRYZ72QVqLcT+eTaumqw
+        Ebuwsda4kzyIXwshhJABrkjteY0XtD4gyYUQt5yMRL7FXLI2B4zrv1JqZDA2ztHIlBQb72bxBn6W
+        PnFIXLJ/w/cge29LBXZO13iNtq3sFPhp459WxWrzVOyeiu19XJlSHsSP3EnXz7CJJp4+XwSs1apo
+        F1HV6zVuivW+3q9Q4z4zZxa+Bsw8GCOccAQ+m3gGlXeMbixqWtiMtp8H/uThdE4A5zxDP8Mff89A
+        60+BfPUBkokOQv55RhFREXIUZ7igqBCdIGQyeEF9OLqjWz6L7xDjf560OMoGrfXuKA/iL7TKNyjY
+        iz88Gfjt6FazVAJtwClsk7+ZuiWvPaH4isBnOZRzu/8aKpTkbe4aYjSRwXGX3CbmJBmAwFq0cykw
+        pU61gfBifIplb4wyL3mQSiDfBC4VqDOWb3idYoQQvZtpHuvaE0+S2rWmpgHqTw4WiFAjX0uj0bGp
+        Dc7sEJEuRmHJprdQDcl2C5WRPeG0CcYmIAGnHF4+F/doXty9stpTA+P/iWByXje1e8UXpMpHw9dO
+        ptqkZrRuN8ezN6obfGIvByC+N03/mTq5bOBR0hqjIhNy8CDk76JlEHwGFoT/JkMYBYjQq4T9oDYB
+        dyk+j2wOmvydDijvqdAtfkxr9dAgI8XJLLpFByQ2OI/nE10BD/G2NcOd+nolzww36T0ytTKZgLdR
+        0+MZeW9bz1w+LWEITjwqQWvTDhHs92kTw9X8eEF0j8Hi4fO5yPxI5IMPNmIfyskdUQzBMFUcJaeg
+        36c2ESrbvxop33WDHI2bXdrL9fbLe2DyFAxyyk7U48liptzHx2C9/Aj4iHcw82fU7DmLqa94+zpY
+        IsW5extk0MDQ8t8Wt/8BAAD//wMAV7uVLcYHAAA=
+    headers:
+      CF-RAY:
+      - 98c0cb93af2c838c-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 09 Oct 2025 20:58:18 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1228'
+      openai-project:
+      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1233'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '800000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '799647'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 26ms
+      x-request-id:
+      - req_27c2af80229f4e7d8dec5b5df096f4de
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/snapshots/call_with_thinking_true/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_thinking_true/openai_responses_snapshots.py
@@ -475,3 +475,89 @@ So far, I have 79, 179, and 379 as the only qualifying primes—totaling three. 
         "logging": [],
     }
 )
+without_raw_content_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "openai:responses",
+            "model_id": "gpt-5",
+            "params": {"thinking": False},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="How many primes below 400 contain 79 as a substring? Answer ONLY with the number, not sharing which primes they are."
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Thought(
+                            thought="""\
+**Counting specific primes**
+
+I need to find the primes less than 400 that include the substring "79." The obvious one is 79 itself, and I thought of 179 and 197. Wait, 197 has "97," not "79." So, only the contiguous sequence "79" counts. The candidates are: \n\
+
+- Two-digit: 79.
+- Three-digit: 179, 279, and 379. \n\
+
+However, any numbers starting with 79 and going up to 799 aren't under 400, so they don't count. I'm focusing on just the viable primes.\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Identifying prime candidates**
+
+I’m only looking at numbers less than 400. For three-digit numbers, I need to find those that end in "79," which gives me 179, 279, and 379. The two-digit number 79 also counts. However, I realize "97" doesn't have "79" in order, so it doesn’t work here.
+
+Now, checking for primality: 79 and 179 are both primes. 279 isn’t prime because it's divisible by 3. For 379, I’ll check primes up to about 19 and find that it’s prime as well.\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Confirming prime numbers**
+
+I’ve confirmed that the primes among my candidates are 79, 179, and 379, totaling three primes. I checked if there were any other candidates with "79" as digits, but it seems it needs to be contiguous—not just separated. \n\
+
+Also, while considering other numbers like 97 and 197, they don't contain "79" in the correct order. So, 7 and 9 being on the edges doesn’t matter either. \n\
+
+To double-check, I verified the primality of 179 using primes up to its square root, confirming it is prime. Thus, my final answer remains three primes containing "79."\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Finalizing the answer**
+
+I've confirmed that 197 and 297 don’t have "79," and 397 contains "97" instead. We've included 179, identified 279 as composite, and verified 379 as prime. It seems only 79 itself counts. \n\
+
+When double-checking, I see no other instances of 7 and 9 appearing across digit boundaries in two-digit numbers besides 79. \n\
+
+So, the answer is 3. However, since the user requested to answer with the number alone, I’ll just say: 3.\
+"""
+                        ),
+                        Text(text="3"),
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="If you remember what the primes were, then share them, or say 'I don't remember.'"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[Text(text="79, 179, 379")],
+                    provider="openai:responses",
+                    model_id="gpt-5",
+                    raw_content=[],
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        },
+        "logging": [],
+    }
+)

--- a/python/tests/e2e/snapshots/call_with_tools/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/anthropic_snapshots.py
@@ -369,3 +369,93 @@ Here are the secrets retrieved for each password:
         "n_chunks": 8,
     }
 )
+without_raw_content_snapshot = snapshot(
+    {
+        "provider": "anthropic",
+        "model_id": "claude-sonnet-4-0",
+        "params": {},
+        "finish_reason": None,
+        "messages": [
+            SystemMessage(content=Text(text="Use parallel tool calling.")),
+            UserMessage(
+                content=[
+                    Text(
+                        text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="I'll retrieve the secrets for both passwords using parallel tool calls."
+                    ),
+                    ToolCall(
+                        id="toolu_01NdBAcr3MmjRn4H8a5u65H1",
+                        name="secret_retrieval_tool",
+                        args='{"password": "mellon"}',
+                    ),
+                    ToolCall(
+                        id="toolu_012mitiktCN7WdWx8Ygvu49W",
+                        name="secret_retrieval_tool",
+                        args='{"password": "radiance"}',
+                    ),
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+            UserMessage(
+                content=[
+                    ToolOutput(
+                        id="toolu_01NdBAcr3MmjRn4H8a5u65H1",
+                        name="secret_retrieval_tool",
+                        value="Welcome to Moria!",
+                    ),
+                    ToolOutput(
+                        id="toolu_012mitiktCN7WdWx8Ygvu49W",
+                        name="secret_retrieval_tool",
+                        value="Life before Death",
+                    ),
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="""\
+Here are the secrets retrieved for each password:
+
+- Password "mellon": **Welcome to Moria!**
+- Password "radiance": **Life before Death**\
+"""
+                    )
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+        ],
+        "format": None,
+        "tools": [
+            {
+                "name": "secret_retrieval_tool",
+                "description": "A tool that requires a password to retrieve a secret.",
+                "parameters": """\
+{
+  "properties": {
+    "password": {
+      "title": "Password",
+      "type": "string"
+    }
+  },
+  "required": [
+    "password"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                "strict": False,
+            }
+        ],
+    }
+)

--- a/python/tests/e2e/snapshots/call_with_tools/google_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/google_snapshots.py
@@ -345,3 +345,85 @@ async_stream_snapshot = snapshot(
         "n_chunks": 3,
     }
 )
+without_raw_content_snapshot = snapshot(
+    {
+        "provider": "google",
+        "model_id": "gemini-2.5-flash",
+        "params": {},
+        "finish_reason": None,
+        "messages": [
+            SystemMessage(content=Text(text="Use parallel tool calling.")),
+            UserMessage(
+                content=[
+                    Text(
+                        text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="<unknown>",
+                        name="secret_retrieval_tool",
+                        args='{"password": "mellon"}',
+                    ),
+                    ToolCall(
+                        id="<unknown>",
+                        name="secret_retrieval_tool",
+                        args='{"password": "radiance"}',
+                    ),
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
+            ),
+            UserMessage(
+                content=[
+                    ToolOutput(
+                        id="<unknown>",
+                        name="secret_retrieval_tool",
+                        value="Welcome to Moria!",
+                    ),
+                    ToolOutput(
+                        id="<unknown>",
+                        name="secret_retrieval_tool",
+                        value="Life before Death",
+                    ),
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text='I have retrieved the following secrets: "Welcome to Moria!" and "Life before Death".\n'
+                    )
+                ],
+                provider="google",
+                model_id="gemini-2.5-flash",
+                raw_content=[],
+            ),
+        ],
+        "format": None,
+        "tools": [
+            {
+                "name": "secret_retrieval_tool",
+                "description": "A tool that requires a password to retrieve a secret.",
+                "parameters": """\
+{
+  "properties": {
+    "password": {
+      "title": "Password",
+      "type": "string"
+    }
+  },
+  "required": [
+    "password"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                "strict": False,
+            }
+        ],
+    }
+)

--- a/python/tests/e2e/snapshots/call_with_tools/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/openai_completions_snapshots.py
@@ -352,3 +352,89 @@ The secrets associated with the passwords are as follows:
         "n_chunks": 36,
     }
 )
+without_raw_content_snapshot = snapshot(
+    {
+        "provider": "openai:completions",
+        "model_id": "gpt-4o",
+        "params": {},
+        "finish_reason": None,
+        "messages": [
+            SystemMessage(content=Text(text="Use parallel tool calling.")),
+            UserMessage(
+                content=[
+                    Text(
+                        text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="call_OvdB915t8tSb7o9S5jZ7u6Q2",
+                        name="secret_retrieval_tool",
+                        args='{"password": "mellon"}',
+                    ),
+                    ToolCall(
+                        id="call_gkytqPBeTIqmnpYfdOFoMlYt",
+                        name="secret_retrieval_tool",
+                        args='{"password": "radiance"}',
+                    ),
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
+            UserMessage(
+                content=[
+                    ToolOutput(
+                        id="call_OvdB915t8tSb7o9S5jZ7u6Q2",
+                        name="secret_retrieval_tool",
+                        value="Welcome to Moria!",
+                    ),
+                    ToolOutput(
+                        id="call_gkytqPBeTIqmnpYfdOFoMlYt",
+                        name="secret_retrieval_tool",
+                        value="Life before Death",
+                    ),
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="""\
+The secrets associated with the passwords are:
+- For "mellon": "Welcome to Moria!"
+- For "radiance": "Life before Death"\
+"""
+                    )
+                ],
+                provider="openai:completions",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
+        ],
+        "format": None,
+        "tools": [
+            {
+                "name": "secret_retrieval_tool",
+                "description": "A tool that requires a password to retrieve a secret.",
+                "parameters": """\
+{
+  "properties": {
+    "password": {
+      "title": "Password",
+      "type": "string"
+    }
+  },
+  "required": [
+    "password"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                "strict": False,
+            }
+        ],
+    }
+)

--- a/python/tests/e2e/snapshots/call_with_tools/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/openai_responses_snapshots.py
@@ -431,3 +431,90 @@ Here are the secrets for the provided passwords:
         "n_chunks": 32,
     }
 )
+without_raw_content_snapshot = snapshot(
+    {
+        "provider": "openai:responses",
+        "model_id": "gpt-4o",
+        "params": {},
+        "finish_reason": None,
+        "messages": [
+            SystemMessage(content=Text(text="Use parallel tool calling.")),
+            UserMessage(
+                content=[
+                    Text(
+                        text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="call_2l5zWsybzlLfRnKNZcUwPCDD",
+                        name="secret_retrieval_tool",
+                        args='{"password":"mellon"}',
+                    ),
+                    ToolCall(
+                        id="call_QkfbCECtJTNDR7Mt8HqZG0jf",
+                        name="secret_retrieval_tool",
+                        args='{"password":"radiance"}',
+                    ),
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
+            UserMessage(
+                content=[
+                    ToolOutput(
+                        id="call_2l5zWsybzlLfRnKNZcUwPCDD",
+                        name="secret_retrieval_tool",
+                        value="Welcome to Moria!",
+                    ),
+                    ToolOutput(
+                        id="call_QkfbCECtJTNDR7Mt8HqZG0jf",
+                        name="secret_retrieval_tool",
+                        value="Life before Death",
+                    ),
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="""\
+The secrets have been retrieved:
+
+1. Password "mellon": Welcome to Moria!
+2. Password "radiance": Life before Death\
+"""
+                    )
+                ],
+                provider="openai:responses",
+                model_id="gpt-4o",
+                raw_content=[],
+            ),
+        ],
+        "format": None,
+        "tools": [
+            {
+                "name": "secret_retrieval_tool",
+                "description": "A tool that requires a password to retrieve a secret.",
+                "parameters": """\
+{
+  "properties": {
+    "password": {
+      "title": "Password",
+      "type": "string"
+    }
+  },
+  "required": [
+    "password"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                "strict": False,
+            }
+        ],
+    }
+)

--- a/python/tests/e2e/test_call_with_thinking_true.py
+++ b/python/tests/e2e/test_call_with_thinking_true.py
@@ -8,6 +8,7 @@ from mirascope import llm
 from tests.e2e.conftest import Snapshot
 from tests.utils import (
     exception_snapshot_dict,
+    remove_response_raw_content,
     response_snapshot_dict,
     stream_response_snapshot_dict,
 )
@@ -147,6 +148,43 @@ async def test_call_with_thinking_true_async_stream(
                 response = await response.resume(RESUME_PROMPT)
             await response.finish()
             snapshot_data["response"] = stream_response_snapshot_dict(response)
+        except Exception as e:
+            snapshot_data["exception"] = exception_snapshot_dict(e)
+
+        snapshot_data["logging"] = [
+            record.message
+            for record in caplog.records
+            if record.levelno >= logging.WARNING
+        ]
+        assert snapshot_data == snapshot
+
+
+@pytest.mark.parametrize("provider,model_id", PROVIDER_MODEL_ID_PAIRS)
+@pytest.mark.vcr
+def test_call_with_thinking_true_without_raw_content(
+    provider: llm.Provider,
+    model_id: llm.ModelId,
+    snapshot: Snapshot,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test synchronous call with thinking=True to verify reasoning content.
+
+    Wipes out assistant message raw content, testing fallback encoding of thoughts.
+    """
+
+    @llm.call(provider=provider, model_id=model_id, thinking=True)
+    def call(query: str) -> str:
+        return query
+
+    snapshot_data = {}
+    with caplog.at_level(logging.WARNING):
+        try:
+            response = call(PROMPT)
+            remove_response_raw_content(response)
+            with llm.model(provider=provider, model_id=model_id, thinking=False):
+                response = response.resume(RESUME_PROMPT)
+                remove_response_raw_content(response)
+            snapshot_data["response"] = response_snapshot_dict(response)
         except Exception as e:
             snapshot_data["exception"] = exception_snapshot_dict(e)
 

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -92,3 +92,14 @@ def exception_snapshot_dict(exception: Exception) -> dict:
             if not attr.startswith("_") and not callable(getattr(exception, attr))
         },
     }
+
+
+def remove_response_raw_content(response: llm.responses.RootResponse) -> None:
+    """Utility for removing raw content from a response's assistant message.
+
+    Useful in certain cases for testing `response.resume` behavior when provider-specific
+    raw content is not available and the assistant message must be regenerated from scratch.
+    """
+    assistant_message = response.messages[-1]
+    assert assistant_message.role == "assistant"
+    assistant_message.raw_content = []


### PR DESCRIPTION
This allows us to get code coverage of the fallback paths for every
provider (resuming when there is not assistant_message.raw content so
the messages are reconstructed).

In tests without resume behavior, we'll leave this call type unused and
the corresponding snapshot empty.