### PR TITLE
feat: bump anthropic default max_tokens to 16k

### DIFF
--- a/python/mirascope/llm/clients/anthropic/_utils.py
+++ b/python/mirascope/llm/clients/anthropic/_utils.py
@@ -156,7 +156,7 @@ def prepare_anthropic_request(
     """Prepares a request for the `Anthropic.messages.create` method."""
     kwargs: MessageCreateKwargs = {
         "model": model_id,
-        "max_tokens": 1024,
+        "max_tokens": 16000,
     }
 
     with _base_utils.ensure_all_params_accessed(

--- a/python/tests/e2e/cassettes/call/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/call/anthropic/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"What is 4200 +
-      42?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"What is 4200
+      + 42?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -12,7 +12,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '107'
+      - '108'
       content-type:
       - application/json
       host:
@@ -44,14 +44,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBBS8QwFIT/SpmrWWhDqxLwJIqsIAi9iYSQvN0NtklNXsRl6X+XLi6y
-        iqcH75sZhjnAOyiMeavrpu+f15uHx72c+N5f9+vbp8tmcwcB3k+0qChnsyUIpDgsD5Ozz2wCQ2CM
-        jgYo2MEUR6scQyBetStZy67umhYCNgamwFAvh1Mk0+diPh6FVtZ1dVG1srqpWtlKzK8CmeOkE5kc
-        AxQoOM0lBXyDTO+FgiWoUIZBoBwbqgN8mAprjm8UMlRzJWCN3ZG2iQz7GPS5oD7xRMb9x07eJZ+m
-        HY2UzKC78a/+hza733QWiIXP2nUCmdKHt6TZU4LCMqszyWGevwAAAP//AwB+pPaqpAEAAA==
+        H4sIAAAAAAAAA3SQTUvEMBCG/0p5r2ahrS1iwJOKHkRERA8iIZuMu9U2qZmJKEv/u3RxkVU8Dczz
+        zAfvBkP01EPD9TZ7WnAMgWTRLOqybsu2aqDQeWgMvDJldVu93N9cpdPDc87Pdw9ny+Pr8fICCvI5
+        0mwRs10RFFLs54Zl7lhsECi4GISCQD9udr7Qx0y2RaOpy7I4KJq6OCmauqkxPSmwxNEkshwDNCh4
+        IzkFfAOmt0zBEXTIfa+Qt+f1Bl0YsxiJrxQYujpScNatybhEVroYzL5Q7ngi6/9ju9l5P41rGijZ
+        3rTDX/+HVuvfdFKIWfa+axWY0nvnyEhHCRpzZt4mj2n6AgAA//8DADOgk9CkAQAA
     headers:
       CF-RAY:
-      - 97fc35057f536812-SEA
+      - 98c09c46ff9acdf7-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Sep 2025 00:22:02 GMT
+      - Thu, 09 Oct 2025 20:26:02 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -73,35 +73,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-16T00:22:02Z'
+      - '2025-10-09T20:26:01Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-16T00:22:02Z'
+      - '2025-10-09T20:26:01Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-16T00:22:01Z'
+      - '2025-10-09T20:26:00Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-16T00:22:02Z'
+      - '2025-10-09T20:26:01Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTB8BcP6njhwrx4bPbq8p
+      - req_011CTxFbfmemTFMUnfbVizSs
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1064'
+      - '1761'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/call/anthropic/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"What is 4200 +
-      42?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"What is 4200
+      + 42?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -12,7 +12,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '121'
+      - '122'
       content-type:
       - application/json
       host:
@@ -47,23 +47,50 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01LdHryNuBZwzaKwCJFuiv29","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01XWid3aZomE38VQA6mf6amD","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}}
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
+        }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"4200
-        + 42 = 4242"}         }
+        + 42 ="}               }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        4242"}  }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0         }
+        data: {"type":"content_block_stop","index":0       }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: message_delta
@@ -73,13 +100,13 @@ interactions:
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
       CF-RAY:
-      - 97fc352a2cef8383-SEA
+      - 98c09c639eccb9b2-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -87,7 +114,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 16 Sep 2025 00:22:09 GMT
+      - Thu, 09 Oct 2025 20:26:06 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -101,35 +128,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-16T00:22:07Z'
+      - '2025-10-09T20:26:04Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-16T00:22:07Z'
+      - '2025-10-09T20:26:04Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-16T00:22:07Z'
+      - '2025-10-09T20:26:04Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-16T00:22:07Z'
+      - '2025-10-09T20:26:04Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTB8C3WCoK2rm44jdAsBw
+      - req_011CTxFc1KPtyjaB3LhivYUy
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1599'
+      - '1606'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/call/anthropic/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"What is 4200 +
-      42?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"What is 4200
+      + 42?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -12,7 +12,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '121'
+      - '122'
       content-type:
       - application/json
       host:
@@ -47,39 +47,65 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01M1G3pVDZZwN527UxB6kbD6","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_018dHTrujAhcPYdNWvA2W426","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}     }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"4200
-        + 42 = 4242"} }
+        + 42 ="}    }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        4242"}           }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0}
+        data: {"type":"content_block_stop","index":0   }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":15}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":15}  }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"           }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
       CF-RAY:
-      - 97fc35179abe308c-SEA
+      - 98c09c531b697557-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -87,7 +113,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 16 Sep 2025 00:22:05 GMT
+      - Thu, 09 Oct 2025 20:26:03 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -101,35 +127,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-16T00:22:04Z'
+      - '2025-10-09T20:26:02Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-16T00:22:04Z'
+      - '2025-10-09T20:26:02Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-16T00:22:04Z'
+      - '2025-10-09T20:26:02Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-16T00:22:04Z'
+      - '2025-10-09T20:26:02Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTB8BprCZt5tANWu7m7pb
+      - req_011CTxFbp3EitokoqqZcwL1f
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '892'
+      - '1765'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/call/anthropic/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"What is 4200 +
-      42?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"What is 4200
+      + 42?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -12,7 +12,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '107'
+      - '108'
       content-type:
       - application/json
       host:
@@ -44,14 +44,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBBS8QwFIT/SpmrWWhrihDwuod6U8SDSIjJY7fYvnSTF1GW/nfp4iKr
-        eHrwvplhmCOGAIMp72zd9P7gt3d0HbeP909z/yC9fk09FORzplVFObsdQSHFcX24nIcsjgUKUww0
-        wsCPrgTa5MhMstGbtm67ums0FHxkIRaY5+M5UuhjNZ+OgW7rurqqdFvdVrrVLZYXhSxxtolcjgwD
-        4mClJMY3yHQoxJ5guIyjQjk1NEcMPBexEt+IM0xzo+Cd35P1iZwMke2loD7zRC78x87eNZ/mPU2U
-        3Gi76a/+hzb733RRiEUu2nUKmdL74MnKQAkG66zBpYBl+QIAAP//AwBC3nUdpAEAAA==
+        H4sIAAAAAAAAA3SQy2rDMBBFf8XcbRWwjU1A0E2z7dK7UoSQprGILbmaUR8E/3txaChp6WpgzpkH
+        94w5eZqg4SZbPO04xUiy63Zt3fZ133RQCB4aMx9N3QxDUw6Owiz8+O5O43Cw+5cHKMjnQptFzPZI
+        UMhp2hqWObDYKFBwKQpFgX46X32hj41cikbX1nV1V3VtdV91bddifVZgSYvJZDlFaFD0RkqO+AZM
+        r4WiI+hYpkmhXM7rM0JcihhJJ4oM3ewVnHUjGZfJSkjR3Ar1lWey/j92nd320zLSTNlOpp//+j+0
+        GX/TVSEVufmuV2DKb8GRkUAZGltm3maPdf0CAAD//wMAnOoJoqQBAAA=
     headers:
       CF-RAY:
-      - 97fc34f53882308c-SEA
+      - 98c09c375f427557-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 16 Sep 2025 00:22:00 GMT
+      - Thu, 09 Oct 2025 20:25:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -73,35 +73,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-16T00:22:00Z'
+      - '2025-10-09T20:25:59Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-16T00:22:00Z'
+      - '2025-10-09T20:25:59Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-16T00:21:59Z'
+      - '2025-10-09T20:25:57Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-16T00:22:00Z'
+      - '2025-10-09T20:25:59Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTB8BRKqZ5RTf3xc7fSjo
+      - req_011CTxFbV8wJyFYr3QiwuB5Z
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '984'
+      - '1911'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_params/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/anthropic/async.yaml
@@ -32,7 +32,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -44,14 +44,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dI9RS4VAEIX/ipzXVlDRsoWeIgh67CEoYtnW4SrprO2O1UX876EhcYue
-        hjPfOcOZGV0DjSEeTJbX51zL7f2xvX684fojr+8uH9wLFOQ40uqiGO2BoBB8vy5sjF0UywKFwTfU
-        Q8P1dmoojZ6ZJC3TIiuqrMpLKDjPQizQT/N+UuhzDW9DoyyyLDlLyiK5SrA8K0Txowlko2fobxXp
-        bSJ2a4tTvcbLAgrTVlLP6HicxIh/JY7Q+YWCs64l4wJZ6TybU0O280C2+Y/t2fU+jS0NFGxvquGv
-        /4fm7W+6KPhJTtoVCpHCe+fISEdhe9dyY0ODZfkCAAD//wMA06xWT6cBAAA=
+        H4sIAAAAAAAAAwAAAP//dI9LS8UwEIX/SjlbU2hDixJw40LXcn3AFQkxHe6NtklNpj4o/e/SSpEq
+        roYz35mZMyO60FALBduaoaE8Be+J8yqXhayLuqwg4BoodOmgi/Lm4nBvL5/d+/5MhqvrfX+72z3d
+        QYA/e5pdlJI5EARiaOeGScklNp4hYINn8gz1MK5+po+ZLEWhkkWRnWSVzM4zTI8CiUOvI5kUPNS3
+        SvQ6kLfzia2exysJgWFJoEY43w+sObyQT1DlqYA19kjaRjLsgtdbQ7HySKb5j62z837qj9RRNK2u
+        u7/+H1oef9NJIAy8SScFEsU3Z0mzo7i8a3xjYoNp+gIAAP//AwCOgva/pwEAAA==
     headers:
       CF-RAY:
-      - 98761053bb5c30e1-SEA
+      - 98c09c8afc35b9e6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Sep 2025 19:18:02 GMT
+      - Thu, 09 Oct 2025 20:26:13 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -73,35 +73,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-30T19:18:02Z'
+      - '2025-10-09T20:26:12Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-30T19:18:02Z'
+      - '2025-10-09T20:26:13Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-30T19:18:01Z'
+      - '2025-10-09T20:26:11Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-30T19:18:02Z'
+      - '2025-10-09T20:26:12Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTf88mzKiCGNpjAmBmtCs
+      - req_011CTxFcUJcTZmRNHSMtrda5
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1084'
+      - '2195'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_params/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/anthropic/async_stream.yaml
@@ -47,39 +47,65 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01LdJVSTxAWjg4hx3382Xxoi","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}     }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01CpUV5Aiega3TH6zAHu8n2S","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}       }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"4200
-        + 42 = "}             }
+        + 42 ="}               }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        "}             }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0            }
+        data: {"type":"content_block_stop","index":0   }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"4242"},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"4242"},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}    }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"        }
+        data: {"type":"message_stop"          }
 
 
         '
     headers:
       CF-RAY:
-      - 98761066196530d4-SEA
+      - 98c09c9cfd667696-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -87,7 +113,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Tue, 30 Sep 2025 19:18:05 GMT
+      - Thu, 09 Oct 2025 20:26:15 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -101,35 +127,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-30T19:18:04Z'
+      - '2025-10-09T20:26:14Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-30T19:18:04Z'
+      - '2025-10-09T20:26:14Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-30T19:18:04Z'
+      - '2025-10-09T20:26:14Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-30T19:18:04Z'
+      - '2025-10-09T20:26:14Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTf88zarfRECn2iHSU3ib
+      - req_011CTxFcgdXHCYRv5jM6QqaW
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '888'
+      - '1471'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_params/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/anthropic/stream.yaml
@@ -47,39 +47,65 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01BXNpg9MyNhVLVK5wzsaU2G","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}     }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01WgNygSb6Q2r1QAzzt2mvzd","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}            }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"4200
-        + 42 = "}  }
+        + 42 ="}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        "}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0    }
+        data: {"type":"content_block_stop","index":0}
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"4242"},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}            }
+        data: {"type":"message_delta","delta":{"stop_reason":"stop_sequence","stop_sequence":"4242"},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":12}              }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"              }
+        data: {"type":"message_stop"            }
 
 
         '
     headers:
       CF-RAY:
-      - 984ece19da91dee8-SEA
+      - 98c09c7d4d577557-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -87,7 +113,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 26 Sep 2025 00:57:06 GMT
+      - Thu, 09 Oct 2025 20:26:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -101,35 +127,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-26T00:57:04Z'
+      - '2025-10-09T20:26:08Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-26T00:57:04Z'
+      - '2025-10-09T20:26:08Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-26T00:57:04Z'
+      - '2025-10-09T20:26:08Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-26T00:57:04Z'
+      - '2025-10-09T20:26:08Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTW6wkU6Aa4zjWmBNeZKQ
+      - req_011CTxFcJt58aJA7noY6twVk
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2010'
+      - '1387'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_params/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/call_with_params/anthropic/sync.yaml
@@ -44,14 +44,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SPQWuEMBCF/4q8ayOoRLYEeln2uKdeSwkhTjVUE5uMS1vxvxctUmzpaXjzvTe8
-        meEaKAyp1UV5uT7G9ny7545PLyZcz/ISxk8I8MdIq4tSMi1BIIZ+XZiUXGLjGQJDaKiHgu3N1FCe
-        gvfEucyroqqLupQQsMEzeYZ6mveTTO9reBsKsiqK7C6TVfaQYXkWSBxGHcmk4KG+VaK3ibxdWxz1
-        GpcVBKatpJrh/Dix5vBKPkGVJwFrbEfaRjLsgtdHQ7HzSKb5j+3Z9T6NHQ0UTa/r4a//h5bdb7oI
-        hIkP7SqBRPHmLGl2FLd3jW9MbLAsXwAAAP//AwBqqa8tpwEAAA==
+        H4sIAAAAAAAAA3SPQUvEMBCF/0qZqymkIUUJeNy9iCJeRUJIhm7YNqnJdF0p/e+SSpEqnoaZ972Z
+        NzMM0WEPCmxvJod1jiEg1bIWXLS8bSQw8A4UDLnTvJGXjyd55w/HQ/d8fnwIL1fTRQIG9DlioTBn
+        0yEwSLEvA5Ozz2RCYWwMhIFAvc4bT3hd3aUokILz6qaSorqvYHljkCmOOqHJMYD67jK+TxhsObHv
+        i10KYDCtCdQMPowTaYpnDBlUc8vAGntCbRMa8jHoPcA3PaFx/2mbt+zH8YQDJtPrdvjL/6jN6be6
+        MIgT7dIJBhnTxVvU5DGt75rgTHKwLF8AAAD//wMAntfpSKcBAAA=
     headers:
       CF-RAY:
-      - 984ec15e79512813-SEA
+      - 98c09c7028fb7557-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 26 Sep 2025 00:48:23 GMT
+      - Thu, 09 Oct 2025 20:26:08 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -73,35 +73,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-26T00:48:23Z'
+      - '2025-10-09T20:26:08Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-26T00:48:23Z'
+      - '2025-10-09T20:26:08Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-26T00:48:22Z'
+      - '2025-10-09T20:26:06Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-26T00:48:23Z'
+      - '2025-10-09T20:26:08Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTW6HJmTA6FGDZkTE3MrD
+      - req_011CTxFcA1Xbg4x2cADPWMqA
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1103'
+      - '1879'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_tools/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/anthropic/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"}],"model":"claude-sonnet-4-0","system":"Use
       parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
@@ -14,7 +14,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '473'
+      - '474'
       content-type:
       - application/json
       host:
@@ -34,7 +34,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -46,17 +46,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFFfb9MwEP8q0b3w4qJkTenIG9tUCQETCBWmTcgy8bVJcXzBdy7dqnx3
-        5ExhGwgJ8XTy/f6d747QWqig463Oi2Xz8Wpzunz1fnn68u16+cbjxefzCArktsfEQmazRVAQyKWG
-        YW5ZjBdQ0JFFBxXUzkSLMybvUWbl7CQ/WeSLogQFNXlBL1DdHCdLwUMSj6WC18+cywJKaHGPmTSY
-        MdYBhbMNhewrSZP1hvkHBctZ5NZvH5EmoXGZELnnMKiHGCKnI6fRx/+md9R5Ue6b3d05El/YQy3r
-        y08fVvP5ChR40yXdvbP+5ayTMJn4PgpUR5jGGbfjHHkY/iH27OB3Z7frkuzltnm3sbv1tVld/V9s
-        MLY1vkYYhi8KWKjXAQ2Tf5o/AozfIyZu5aNzCuJ4zup4b6yFvqFnqMrihYLa1A3qOqCRlrx+ysgn
-        PKCxf8MmbQrAvsEOg3F60f3Jf0CL5nd0UEBRHreKYq6AMezbGrW0GNLGxHhrgoVh+AkAAP//AwDk
-        QN1h0wIAAA==
+        H4sIAAAAAAAAA5yR0WsUMRDG/5UwL77k5Pa6Z3EfSzlRaMEeRa1ImGanu6HZZC8zqafH/u+Sq0ut
+        IohPIfN9M7/5kgMMsSUPDViPuaUFxxBIFvVitVytl+uqBg2uhQYG7syy2tgkp+9X5ze33ZXDfb11
+        O97cgQb5NlJxETN2BBpS9KWAzI4Fg4AGG4NQEGg+H2a/0L4ox6OBty+8V4kkOXogJT0pJptIWN3F
+        pG6j9GpE5q8xtawyu9CpERN6T15JjF5Z9J5fwqSfADF6k5nmGOWezbJand9cDPf5zadru6/OTk9O
+        3Ha7K0ECDqXvEWx+LoPelMYyJIxZoDnAvMgxtPcxwPQP2Kv92aYd4vVu+HjRdx/q1933y3eX/4dN
+        2DoMlmCavmhgiaNJhBzDc/5RYNplKt4mZO815OMvNYfHwUbiPQWGpq5eabBoezI2EYqLwTx3LGc9
+        EbZ/0+beAqCxp4ESerMe/vQ/qVX/uzppiFl+LVVVpYEpPThLRhyl8mKCocXUwjT9AAAA//8DAIM1
+        E37NAgAA
     headers:
       CF-RAY:
-      - 981dc2301d5075e2-SEA
+      - 98c09cd1bec6755d-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 20 Sep 2025 02:05:36 GMT
+      - Thu, 09 Oct 2025 20:26:24 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -78,43 +78,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:35Z'
+      - '2025-10-09T20:26:23Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:36Z'
+      - '2025-10-09T20:26:24Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:34Z'
+      - '2025-10-09T20:26:22Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:35Z'
+      - '2025-10-09T20:26:23Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqKCuVdTZReR4UFTGtE
+      - req_011CTxFdJfDC7e6JtMzPNHkK
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2467'
+      - '2395'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":[{"type":"text","text":"I''ll
-      retrieve the secrets for both passwords using the secret retrieval tool."},{"type":"tool_use","id":"toolu_014vhjzCeosDdxctUNVQF33F","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_01BxnjByU4odNghMfdjUZaFX","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_014vhjzCeosDdxctUNVQF33F","content":"Welcome
-      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_01BxnjByU4odNghMfdjUZaFX","content":"Life
+      retrieve the secrets for both passwords using parallel tool calls."},{"type":"tool_use","id":"toolu_012DZMmkuGYUcx1B733iSSqf","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_01RxBFdmoUqmXMhgW49gzNJN","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_012DZMmkuGYUcx1B733iSSqf","content":"Welcome
+      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_01RxBFdmoUqmXMhgW49gzNJN","content":"Life
       before Death"}]}],"model":"claude-sonnet-4-0","system":"Use parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
     headers:
@@ -127,7 +127,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1077'
+      - '1072'
       content-type:
       - application/json
       host:
@@ -159,16 +159,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRQYsTQRCF/0pbx9CRSUxW08dlRQ8KexA8ODK03S+ZJj3VY3VNdAn57zLLBnXF
-        U8P73lcNVWdKkRwN9dA1q9vDcVde36fj28Npd/tpF169uXt4R5b0YcTcQq3+ALIkJc+BrzVV9axk
-        aSgRmRyF7KeIZS3M0OVmuW7W22a72pClUFjBSu7L+TpS8XOWHx9H7yEwXmC0h6kIAq1GoJJwQjT7
-        IgY+9Gb0tf4oEl3LLa9emsXi/ikxLQ3IuXBLi4UzLX1GDmWA0WI+Fkn+RUstr58p4mPyHHCVPqQ9
-        zDfsi8DcwWvfEl2+Wqpaxk7ga2FyBI6dTsL0BCq+T+AAcjzlbGl6XJY7U+Jx0k7LEVzJ3TQ3loIP
-        Pbog8JoKd383misX+Pg/dnXnDzD2GCA+d9vh3/5vuuqf04ulMumf0WZjqUJOKaDTBCFH84mjl0iX
-        yy8AAAD//wMAGBXTuzACAAA=
+        H4sIAAAAAAAAAwAAAP//dJFNaxwxDIb/iqOzF2bT3RJ8K/RQ6AeFBHLolMG1382Y9cgTWd4kLPvf
+        y6RZ2qb0JPQ+jxBCR5pKRCZHIfsWsaqFGbrarC67y223XW/IUorkaKp3Q7f+Mu2lpvn68d3+/tDa
+        zfbjLV89kSV9mrFYqNXfgSxJyUvga01VPStZCoUVrOS+Hc++4nEhz8XRBwiMFxgdYSqCQKsRqCQc
+        EM2uiIEPo5l9rQ9Fouu555X5+tKanibkXLgnZ3q6RQ5lgtFiPhdJ/qKnV7b4mDwH/PI/pR3MD+yK
+        wLyH17EnOn23VLXMg8DXwuQIHAdtwvQCKu4bOIAct5wttef73ZESz00HLXtwJfe221gKPowYgsBr
+        Kjz8bXRnLvDxf+w8uyzAPGKC+Dxsp3/933Q9vqYnS6Xpn9GbK0sVckgBgyYIOVq+Fr1EOp1+AgAA
+        //8DAMP8V5YmAgAA
     headers:
       CF-RAY:
-      - 981dc2407dfb75e2-SEA
+      - 98c09ce17c23755d-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -176,7 +176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 20 Sep 2025 02:05:38 GMT
+      - Thu, 09 Oct 2025 20:26:27 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -190,35 +190,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:38Z'
+      - '2025-10-09T20:26:26Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:38Z'
+      - '2025-10-09T20:26:27Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:36Z'
+      - '2025-10-09T20:26:24Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:38Z'
+      - '2025-10-09T20:26:26Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqKQ5D1dTN9W7TW9gpj
+      - req_011CTxFdVS7DZyM1f37sGQmq
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2113'
+      - '2150'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_tools/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/anthropic/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"}],"model":"claude-sonnet-4-0","system":"Use
       parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}],"stream":true}'
@@ -14,7 +14,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '487'
+      - '488'
       content-type:
       - application/json
       host:
@@ -49,25 +49,25 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01K6o6ypEtaapVZiMXjN38f3","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":6,"service_tier":"standard"}}
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01LoJqc2MGigcc8XXhkHRFyW","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":6,"service_tier":"standard"}}
         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
-        retrieve the secrets for"}   }
+        retrieve the secrets for"}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        both passwords using the secret retrieval tool."}      }
+        both passwords you provided."}    }
 
 
         event: ping
@@ -77,7 +77,7 @@ interactions:
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0   }
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: ping
@@ -87,7 +87,7 @@ interactions:
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01EFJoduGZrDduDVvC6eWyWd","name":"secret_retrieval_tool","input":{}}           }
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01QUhubo4SrZfM6hiTWvKHLU","name":"secret_retrieval_tool","input":{}}  }
 
 
         event: ping
@@ -97,81 +97,81 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}           }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"pas"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"sword\""}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":":
-        \"m"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"ellon\"}"}       }
-
-
-        event: content_block_stop
-
-        data: {"type":"content_block_stop","index":1      }
-
-
-        event: content_block_start
-
-        data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01GwxbcejgBLwP64QWysQ2Y9","name":"secret_retrieval_tool","input":{}}
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"password"}
         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}            }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\":
+        \"mello"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"pass"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"word\":
-        \"radi"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"ance\"}"}       }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"n\"}"}      }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":2           }
+        data: {"type":"content_block_stop","index":1             }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_012c5wEhFPc2eYdY6awKqbnf","name":"secret_retrieval_tool","input":{}}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"passwo"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"rd\""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":":
+        \"radian"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"ce\"}"}  }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":2  }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":113}    }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}             }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
       CF-RAY:
-      - 981dc2aad99a322f-SEA
+      - 98c09d144bf8d7dd-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -179,7 +179,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 20 Sep 2025 02:05:54 GMT
+      - Thu, 09 Oct 2025 20:26:34 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -193,43 +193,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:53Z'
+      - '2025-10-09T20:26:33Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:53Z'
+      - '2025-10-09T20:26:33Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:53Z'
+      - '2025-10-09T20:26:33Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:53Z'
+      - '2025-10-09T20:26:33Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqLf1fFRZBq67wiGrjM
+      - req_011CTxFe6BtvkAqw1HviVUAz
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1033'
+      - '1744'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":[{"type":"text","text":"I''ll
-      retrieve the secrets for both passwords using the secret retrieval tool."},{"type":"tool_use","id":"toolu_01EFJoduGZrDduDVvC6eWyWd","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_01GwxbcejgBLwP64QWysQ2Y9","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01EFJoduGZrDduDVvC6eWyWd","content":"Welcome
-      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_01GwxbcejgBLwP64QWysQ2Y9","content":"Life
+      retrieve the secrets for both passwords you provided."},{"type":"tool_use","id":"toolu_01QUhubo4SrZfM6hiTWvKHLU","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_012c5wEhFPc2eYdY6awKqbnf","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01QUhubo4SrZfM6hiTWvKHLU","content":"Welcome
+      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_012c5wEhFPc2eYdY6awKqbnf","content":"Life
       before Death"}]}],"model":"claude-sonnet-4-0","system":"Use parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}],"stream":true}'
     headers:
@@ -242,7 +242,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1091'
+      - '1073'
       content-type:
       - application/json
       host:
@@ -277,25 +277,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_011QgRhAxnfR5ay6afcfVyT6","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":606,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}
-        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01HeYPkr3zNyJF8C6ax8jCKa","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":602,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here
-        are the secrets retrieve"}        }
+        are the secrets retrieve"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        for each password:\n\n-"}          }
+        for your"}        }
 
 
         event: ping
@@ -306,46 +305,58 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Password \"mellon\": **"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Welcome
-        to Moria!**"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
-        Password \"radiance\": **Life"}            }
+        passwords:\n\n-"}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        before Death**"}              }
+        Password \""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"mellon\":
+        **Welcome"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        to Moria!**\n-"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Password \"radiance\": **Life before"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Death**"}}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0  }
+        data: {"type":"content_block_stop","index":0    }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":606,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":602,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}     }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"               }
 
 
         '
     headers:
       CF-RAY:
-      - 981dc2b818d2322f-SEA
+      - 98c09d257dced7dd-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -353,7 +364,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 20 Sep 2025 02:05:57 GMT
+      - Thu, 09 Oct 2025 20:26:37 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -367,35 +378,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:55Z'
+      - '2025-10-09T20:26:35Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:55Z'
+      - '2025-10-09T20:26:35Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:55Z'
+      - '2025-10-09T20:26:35Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:55Z'
+      - '2025-10-09T20:26:35Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqLovvxzPsmB1Ro6cS8
+      - req_011CTxFeHxZgMu4pixozT1AF
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1305'
+      - '1617'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_tools/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/anthropic/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"}],"model":"claude-sonnet-4-0","system":"Use
       parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}],"stream":true}'
@@ -14,7 +14,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '487'
+      - '488'
       content-type:
       - application/json
       host:
@@ -49,118 +49,145 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01PaCgFd3dmavbF8TTDx1hXb","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":6,"service_tier":"standard"}}          }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01FQNCNTo6Ly4py6gndeF2aa","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":6,"service_tier":"standard"}}         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
-        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
-        retrieve the secrets for"}}
+        retrieve the secrets for"}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        both passwords using parallel tool calls."}}
+        both passwords using"}              }
 
 
         event: ping
 
         data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        parallel tool calls"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0       }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01NPiHGLhnoztgTgkKRghZGZ","name":"secret_retrieval_tool","input":{}}        }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01SAGCVHUCWy2LMY5HqWE2f9","name":"secret_retrieval_tool","input":{}}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}            }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"password\""}    }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"pas"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":":
-        \"mellon\"}"}  }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"sw"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"ord\":
+        \"m"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"ellon"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}               }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":1      }
+        data: {"type":"content_block_stop","index":1           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01CfojYMvtvLDGAXn8ESb5HP","name":"secret_retrieval_tool","input":{}}        }
+        data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01F2GufZTpdY6wnQbMhgsvR5","name":"secret_retrieval_tool","input":{}}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}             }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"passwo"}             }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"password"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"rd\":
-        \"radia"}       }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\":"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"nce\"}"}      }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"
+        \"rad"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"ia"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"nce\"}"}  }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":2           }
+        data: {"type":"content_block_stop","index":2 }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":111}               }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":111}      }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"               }
+        data: {"type":"message_stop"          }
 
 
         '
     headers:
       CF-RAY:
-      - 981dc273f8f0ebbf-SEA
+      - 98c09cf07ca1c3e4-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -168,7 +195,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 20 Sep 2025 02:05:46 GMT
+      - Thu, 09 Oct 2025 20:26:28 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -182,43 +209,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:45Z'
+      - '2025-10-09T20:26:27Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:45Z'
+      - '2025-10-09T20:26:27Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:45Z'
+      - '2025-10-09T20:26:27Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:45Z'
+      - '2025-10-09T20:26:27Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqL1MFWmMXMF9SD323A
+      - req_011CTxFdfgzekLvMVyhCdPx2
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1302'
+      - '1632'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":[{"type":"text","text":"I''ll
-      retrieve the secrets for both passwords using parallel tool calls."},{"type":"tool_use","id":"toolu_01NPiHGLhnoztgTgkKRghZGZ","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_01CfojYMvtvLDGAXn8ESb5HP","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01NPiHGLhnoztgTgkKRghZGZ","content":"Welcome
-      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_01CfojYMvtvLDGAXn8ESb5HP","content":"Life
+      retrieve the secrets for both passwords using parallel tool calls."},{"type":"tool_use","id":"toolu_01SAGCVHUCWy2LMY5HqWE2f9","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_01F2GufZTpdY6wnQbMhgsvR5","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01SAGCVHUCWy2LMY5HqWE2f9","content":"Welcome
+      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_01F2GufZTpdY6wnQbMhgsvR5","content":"Life
       before Death"}]}],"model":"claude-sonnet-4-0","system":"Use parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}],"stream":true}'
     headers:
@@ -231,7 +258,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1085'
+      - '1086'
       content-type:
       - application/json
       host:
@@ -266,24 +293,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_018Ax5yV3h4WLVc3V2WiakTh","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":604,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01Acji73omPm5xEHvMnZ3ZaK","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":604,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":5,"service_tier":"standard"}}}
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here
-        are the secrets retrieve"}               }
+        are the secrets retrieve"}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        for each password:\n\n- Passwor"}}
+        for each password:\n\n-"}           }
 
 
         event: ping
@@ -293,41 +320,53 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        \"mellon\": \"Welcome to Moria!\""}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Password \""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"mellon\":
+        **"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Welcome
+        to Moria!**"}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
-        Password \"radiance\": \"Life"} }
+        Password \"radiance\": **Life"}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        before Death\""}     }
+        before Death**"}              }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0          }
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":604,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}        }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":604,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}          }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"       }
+        data: {"type":"message_stop"               }
 
 
         '
     headers:
       CF-RAY:
-      - 981dc284be77ebbf-SEA
+      - 98c09d026926c3e4-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -335,7 +374,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Sat, 20 Sep 2025 02:05:48 GMT
+      - Thu, 09 Oct 2025 20:26:31 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -349,35 +388,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:47Z'
+      - '2025-10-09T20:26:30Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:47Z'
+      - '2025-10-09T20:26:30Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:47Z'
+      - '2025-10-09T20:26:30Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:47Z'
+      - '2025-10-09T20:26:30Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqLCoKe2n6DUEQaXQS8
+      - req_011CTxFdt1fKZywdNJhWfe66
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1267'
+      - '1624'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_tools/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/anthropic/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"}],"model":"claude-sonnet-4-0","system":"Use
       parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
@@ -14,7 +14,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '473'
+      - '474'
       content-type:
       - application/json
       host:
@@ -46,17 +46,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFFdj9MwEPwr1r7w4qKmanpc3vpwQiCBTkUHRxGyFmfb5HDsxLu+o1T5
-        78g5qvtASIgna3dmdmbXR2hrqKDjvZkXH3efXu0vbxbb1z0t0s0ZXq0PF29Bgxx6yixixj2Bhhhc
-        biBzy4JeQEMXanJQgXWYappx8J5ktpwt5otyXhZL0GCDF/IC1ZfjaaTQjyyengrevHBORZLY0i0p
-        aUgx2UjCahei+hakUT0y34VYs0rc+r3qMaJz5JSE4JRF5/gljPrBIARnEufQ06a5TnnX1fXn9TDU
-        Zz+lv9t6e5W6dfkBNHjssu7e2PwOg85kYR7i+yRQHeEUZLqLc8HD+A+25+d4vdms3r/bDBeMh+2w
-        KXeX4f9sI9Ytekswjl81sITeREIO/qn/BDANiTK38sk5DWn6yOp4P9hI+E6eoVoWKw0WbUPGRkJp
-        gzdPGfMTHgnrv2EnbTagvqGOIjpTdn/yH9CieY6OGkKSx62iKDQwxdvWkpGWYr6YoK8x1jCOvwAA
-        AP//AwBEkeUIzQIAAA==
+        H4sIAAAAAAAAAwAAAP//nJFRa9swFIX/irkve1GG3Tlp6seGFbYy2EMX2MoQin0da5F1Xd2rNFvw
+        fx9K8dpuDEqfhHS+c46udISeGnRQQe1MbHDG5D3KrJyd5WfzfF6UoMA2UEHPW50X6/ZqFRfXa2qX
+        V+fd+2a1udiXAgrk54CJQmazRVAQyKUDw2xZjE9MTV7QC1S3x4kXPJzcaangwxvnsoASLO4xkw4z
+        xjqgcNZSyDYkXTYY5nsKDWeRrd8+gSajcZkQubcwqscaIqcj4zRM2kedF8vLLzd2Pg9f68/tr82n
+        9cXNx3Z3CQq86ZPvIVn/SdbJmEL8EAWqI0zXOY3uHHkYX1BbHhZ2oOXh24+yWN2dt/ft7jouXlcb
+        TGONrxHG8bsCFhp0QMPkn/efBMa7iImtfHROQTz9VXV8CNZCO/QMVVksFNSm7lDXAY1Y8vo5kU96
+        QNP8T5u8qQCHDnsMxul5/y//qBbd3+qogKI8PSqKdwoYw97WqMViSC8mxjcmNDCOvwEAAP//AwC/
+        9EKA0wIAAA==
     headers:
       CF-RAY:
-      - 981dc1f85ca6703b-SEA
+      - 98c09caada2076ee-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 20 Sep 2025 02:05:27 GMT
+      - Thu, 09 Oct 2025 20:26:18 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -78,43 +78,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:26Z'
+      - '2025-10-09T20:26:17Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:27Z'
+      - '2025-10-09T20:26:18Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:25Z'
+      - '2025-10-09T20:26:16Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:26Z'
+      - '2025-10-09T20:26:17Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqJYk5ESQsBrGXnyDUr
+      - req_011CTxFcr82Z87PaE7S1UXXj
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2744'
+      - '2594'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":[{"type":"text","text":"I''ll
-      retrieve the secrets for both passwords using parallel tool calls."},{"type":"tool_use","id":"toolu_01V6XYAqqd7ztpwZncUumA5S","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_0199aXRR6NMRqEsayZqR5fPo","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01V6XYAqqd7ztpwZncUumA5S","content":"Welcome
-      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_0199aXRR6NMRqEsayZqR5fPo","content":"Life
+      retrieve the secrets for both passwords using the secret retrieval tool."},{"type":"tool_use","id":"toolu_018BUTi55rYcPfzbMV9TJfkB","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_014x6ipo8xZj41Cq7fwfkKu6","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_018BUTi55rYcPfzbMV9TJfkB","content":"Welcome
+      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_014x6ipo8xZj41Cq7fwfkKu6","content":"Life
       before Death"}]}],"model":"claude-sonnet-4-0","system":"Use parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
     headers:
@@ -127,7 +127,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1071'
+      - '1078'
       content-type:
       - application/json
       host:
@@ -159,16 +159,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJHBbhQxDIZfJfznrDRbdgvKjbYSHBYJ9QISg0Yh+bcTMZNMHU8prPbd
-        0ZSuCkWcLPv7bEv2ASnCYaw3XbPe/fw0X09v5fJid1uu39yHV+f7qx4W+mPiYrFWf0NYSBmWgq81
-        VfVZYTGWyAEOYfBz5KqWnKmrzeqsOds22/UGFqFkZVa4z4fTSOX90vwQHN5RaLzQaE9TGYRajVAl
-        8Y7R7IsY+tCbydf6vUh0bW7zynx4TE2LkcNQcgtnWnzkEMpIo8W8L5L8ixbPbPEx+Rz429+lPc1X
-        7ovQXNFr3wLHLxZVy9QJfS0ZDsyx01kyHkHl7cwcCJfnYbCYH07kDkh5mrXT8o25wp03G4vgQ88u
-        CL2mkru/jebEhT7+j516lwWceo4UP3Tb8V//ia775/RoUWb9s/TytUWl3KXAThMFDstjo5eI4/EX
-        AAAA//8DACD3APkmAgAA
+        H4sIAAAAAAAAAwAAAP//dJFhaxQxEIb/SjpfCksO9tq7KvkmCCKcIoIc4pUlTd7txmaTNTO5Wo77
+        77JtD7Xip2He5xkGZg40Zo9Ihly01WPBOSXIYrW4aC/W7Xq5Ik3Bk6GRb7t2ue3fvPr88S5s9+y+
+        b969/nJfv24uSZM8TJgtMNtbkKaS4xxY5sBik5Aml5MgCZlvh5Mv+DmTx2Lo/fkeiqtzYO5rjA+q
+        QErAHl7JAMVwBcKqz0XdZBnUZJnvc/FsdmmXFurTc692NCLGnHZkVNNsEV0eoSSrD7kEe9Y0L+xi
+        fbDJ4cnfhB7qBn0uUG9hZWgaOl5rYslTV2A5JzKE5DupJdEzYPyoSA5kUo1RU328hDlQSFOVTvId
+        EpO5aq80OesGdK7ASsip+9toT7zA+v+x0+y8ANOAEcXGbj3+6/+my+ElPWrKVf6MVq0mRtkHh04C
+        Chma/+dt8XQ8/gIAAP//AwC+wgQXMAIAAA==
     headers:
       CF-RAY:
-      - 981dc20a68dc703b-SEA
+      - 98c09cbbba3076ee-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -176,7 +176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Sat, 20 Sep 2025 02:05:29 GMT
+      - Thu, 09 Oct 2025 20:26:21 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -190,35 +190,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-20T02:05:29Z'
+      - '2025-10-09T20:26:20Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-20T02:05:29Z'
+      - '2025-10-09T20:26:21Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-20T02:05:28Z'
+      - '2025-10-09T20:26:18Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-20T02:05:29Z'
+      - '2025-10-09T20:26:20Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTJqJmCRRvNn3h2ZfMQNY
+      - req_011CTxFd3i3Rz6QP2bLp7QA7
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1716'
+      - '2568'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/call_with_tools/anthropic/without_raw_content.yaml
+++ b/python/tests/e2e/cassettes/call_with_tools/anthropic/without_raw_content.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"}],"model":"claude-sonnet-4-0","system":"Use
       parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
@@ -14,7 +14,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '473'
+      - '474'
       content-type:
       - application/json
       host:
@@ -46,17 +46,17 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nJFBa9wwEIX/iphLL9qy3tpp4ltSKGmhOYTCEkoRE2m6ViNLrmbkZln8
-        34s3MWlaAqUnoXnvzTcjHaBPjgK0YAMWRytOMZKs6tVmvWnWTVWDBu+ghZ53Zl1dDJ/9uB/fk5zv
-        662jzdn++uMNaJD9QLOLmHFHoCGnMBeQ2bNgFNBgUxSKAu2Xw+IXup+V49HCh1chqEySPY2kpCPF
-        ZDMJq28pq9sknRqQ+WfKjlVhH3dqwIwhUFCSUlAWQ+DXMOknQErBFKZljflezLq6chfnNr/51H+/
-        jvXlKTblpLmsQEPEfs49gM3jMBjMHJybxKEItAdYBjkuHUKKMP0DdtN78Xfy7urt1m3vT292Y6nP
-        tv+Hzeg8RkswTV81sKTBZEJO8Tn/KDD9KDR721hC0FCOv9QeHhobSXcUGdq6OtFg0XZkbCYUn6J5
-        7lgveiZ0L2lLdgbQ0FFPGYNp+r/9T2rV/alOGlKR30tVVWlgyqO3ZMRTnl9MMDrMDqbpFwAAAP//
-        AwDM5oqszQIAAA==
+        H4sIAAAAAAAAAwAAAP//nFHdb9MwEP9XonvhxUXxmiI1j6wIprJqgBhM02S5zi3xcOzgO29sVf53
+        5E7ZBwgJ7cny7/PO3kEfGnRQg3E6NTij4D3yrJodlAeLciErEGAbqKGnVpVy2a5sRP1xgyeHd8fr
+        t6uT6uscQQDfDphVSKTbDMTgMqCJLLH2DAJM8IyeoT7fTXrGX5nZHzUcvXKuiMjR4jUW3GFBaCIy
+        FZchFtvAXTFoopsQGyoSWd8+EU1G7QoOwb2GUTzWhOBUIpyWyfekSvlps4kyXp2m1fvqdr3+9mHb
+        tjdfQIDXffbdJ6uHZJWNOcQPiaHewTTOfnXngofxP2rPtu8+H/P31p8t58Ph8vKulybZl9VG3Vjt
+        DcI4XgggDoOKqCn45/17gvBnwqytfXJOQNr/Vb27D1YcfqAnqCv5RoDRpkNlImq2wavninLiI+rm
+        X9zkzQU4dNhj1E4t+r/1j6zs/mRHASHxU0jKuQDCeG0NKrYY84ux9o2ODYzjbwAAAP//AwDRGqJ+
+        0wIAAA==
     headers:
       CF-RAY:
-      - 98c0cb4d0a2e759a-SEA
+      - 98c0d503985fec94-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -64,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 Oct 2025 20:58:09 GMT
+      - Thu, 09 Oct 2025 21:04:46 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -78,43 +78,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-09T20:58:08Z'
+      - '2025-10-09T21:04:45Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-09T20:58:09Z'
+      - '2025-10-09T21:04:46Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-09T20:58:06Z'
+      - '2025-10-09T21:04:44Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-09T20:58:08Z'
+      - '2025-10-09T21:04:45Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTxJ3edQ6QShoKr3mpcfp
+      - req_011CTxJYycy4HpUMHD2u8if5
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2900'
+      - '2630'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please retrieve
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":[{"type":"text","text":"I''ll
-      retrieve the secrets for both passwords using parallel tool calls."},{"type":"tool_use","id":"toolu_01NdBAcr3MmjRn4H8a5u65H1","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_012mitiktCN7WdWx8Ygvu49W","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01NdBAcr3MmjRn4H8a5u65H1","content":"Welcome
-      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_012mitiktCN7WdWx8Ygvu49W","content":"Life
+      retrieve the secrets for both passwords using the secret retrieval tool."},{"type":"tool_use","id":"toolu_01QNNr1rjVuDG4yKKWHbggwS","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_01YbERMtXgnY93pC9fzm1cui","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01QNNr1rjVuDG4yKKWHbggwS","content":"Welcome
+      to Moria!"},{"type":"tool_result","tool_use_id":"toolu_01YbERMtXgnY93pC9fzm1cui","content":"Life
       before Death"}]}],"model":"claude-sonnet-4-0","system":"Use parallel tool calling.","tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"}}]}'
     headers:
@@ -127,7 +127,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1071'
+      - '1078'
       content-type:
       - application/json
       host:
@@ -159,16 +159,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFNaxsxEIb/ijLHRYa1a8exbiU59OBAoIUQ4rAo0uusiFZaj2bTFuP/
-        XjaJyRc9DfM+zzAMs6cue0Qy5KIdPCYlpwSZzCezeraoF9M5aQqeDHXloamn57Obn7vV2ePicnl/
-        s1sud6v1+td30iR/e4wWSrEPIE2c4xjYUkIRm4Q0uZwEScjc7o++4M9InouhH2Aoy1DSQhU4hhTF
-        EA54glfbzArWtaq3pfzO7M0mbdJEXb22akMdYsxpQ0ZV1TWiyx2UZHWZOdiTqvpks/XBJocXfx22
-        UPfYZoa6gJW2quhwp6lI7huGLTmRISTfyMCJXkHBbkByIJOGGDUNz/ebPYXUD9JIfkQqZE7ruSZn
-        XYvGMayEnJqPRn3kDOv/x46z4wL0LTqwjc2i++q/0Wn7mR405UHeR99Wmgr4KTg0EsBkaPyat+zp
-        cPgHAAD//wMA8g1i4iYCAAA=
+        H4sIAAAAAAAAAwAAAP//dJHBahtBDIZfZaLjMoZ1Gjt0zoGW4kCghx7qsExnfnuHzmo2Gq2b1Pjd
+        w6YxbVN6Evq/TwihIw0lIpOjkP0UsaiFGbq4Wly2l6t2tbwiSymSo6Huu3Z5O31YrQ8Sxs3n6+uf
+        nx4eb542+w1Z0qcRs4Va/R5kSUqeA19rqupZyVIorGAl9/V49hWPM3kpjj5CYLzAaA9TEQRajUAl
+        4YBodkUMfOjN6Gv9USS6LW95Ye5eW7OlATkX3pIzTfMFOZQBRou5LZL8RdO8scXH5Dngl79JO5hv
+        2BWBuYHXvmnodG+pahk7ga+FyRE4djoJ0yuoeJjAAeR4ytnS9HK/O1LicdJOy3dwJbdu15aCDz26
+        IPCaCnd/G+2ZC3z8HzvPzgsw9hggPner4V//N132b+nJUpn0z+jde0sVckgBnSYIOZq/Fr1EOp2e
+        AQAA//8DAGYumpsmAgAA
     headers:
       CF-RAY:
-      - 98c0cb5fe91d759a-SEA
+      - 98c0d514dd93ec94-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -176,7 +176,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 09 Oct 2025 20:58:11 GMT
+      - Thu, 09 Oct 2025 21:04:48 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -190,35 +190,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-09T20:58:10Z'
+      - '2025-10-09T21:04:48Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-09T20:58:11Z'
+      - '2025-10-09T21:04:48Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-09T20:58:09Z'
+      - '2025-10-09T21:04:46Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-09T20:58:10Z'
+      - '2025-10-09T21:04:48Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTxJ3sW4JVM2kX44shQ7y
+      - req_011CTxJZBS7nTwf2EZk6UXdp
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2166'
+      - '2021'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/max_tokens/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/max_tokens/anthropic/async.yaml
@@ -31,7 +31,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -43,16 +43,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJHbahtBDIZfZdD1eNl1vG2zdyEhBIpN6YGWdMqizCjx4FnNdqRtkxi/
-        e1lT0xO9EDp8/68LaQ8xQAeDPPR18369ked1fHO29pvX55vwcby+ffsJLOjTSLOKRPCBwELJaR6g
-        SBRFVrAw5EAJOvAJp0ALycyki9ViWS/bum1WYMFnVmKF7vP+tFLpcTYfUwc3VMjgHCmZtjYfqneV
-        EUUlMSmKUjCYxi3ekUaPKT11jh03lblIeIcDOl4ea9mh47PKXJT4nBkdr+Z6hywojtvKXGKK97lw
-        RMcvKnOZUy4YsuOXc8NMXqOf1PGrylxRwu9YyPF5BYcvFkTz2BdCyTwfBR97zTtigZ9I6OtE7Ak6
-        nlKyMB2P1u0h8jjpSdw1rQWPfku9L4QaM/d/CuoTL4Thf+zknffTuKWBCqa+Hf7V/6LN9m96sJAn
-        /X3U1haEyrfoqddIBTqYPx2wBDgcfgAAAP//AwBYm7gmNwIAAA==
+        H4sIAAAAAAAAAwAAAP//dJFLb9swDID/isCzY9hZvIduRXcYUOw07FBMg8FKTKNapjyR3tIF+e+D
+        ggV7YQdCFL+PBCSeYM6BEljwCddAG8nMpJvdZttth27od9BADGBhlsex6++3uyfdz9NxuAvTsucj
+        v3+6v4MG9HmhapEIPhI0UHKqBRSJosgKDfjMSqxgP52uvtKxksth4R0VMlgjJTN05mP7oTWiqCQm
+        RVEKBtNywAfS6DGlZ+vYcd+am4QPOKPj7SWXCR2/aM1Nid8zo+NdzSdkQXE8tOYWU9znwhEdv2zN
+        bU65YMiOX9ULM3mNflXHr1vzlhJ+w0KO37Rw/tyAaF7GQiiZ64vxOGqeiAV+IqEvK7EnsLym1MB6
+        +RF7gsjLqlfZ9kMDHv2BRl8INWYe/xS6Ky+E4X/s2lvn03KgmQqmcZj/9X/R/vA3PTeQV/29NHQN
+        CJWv0dOokQpYqGsMWAKczz8AAAD//wMAWD3LizcCAAA=
     headers:
       CF-RAY:
-      - 98864bf66dfd76a2-SEA
+      - 98c09d4689c1b9b6-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -60,7 +60,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Oct 2025 18:34:58 GMT
+      - Thu, 09 Oct 2025 20:26:43 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -74,35 +74,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:34:57Z'
+      - '2025-10-09T20:26:42Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:34:58Z'
+      - '2025-10-09T20:26:43Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:34:56Z'
+      - '2025-10-09T20:26:41Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:34:57Z'
+      - '2025-10-09T20:26:42Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTirU3X9eKLkeiob3Tc3z
+      - req_011CTxFegarWUbLSs3H1RC8p
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1837'
+      - '2521'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/max_tokens/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/max_tokens/anthropic/async_stream.yaml
@@ -46,24 +46,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_018MNx4vqJjP2uLjXG1XYQvR","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}       }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01QLT9c5cvN5cUeLYj5BwYBd","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here
-        are all "}     }
+        are all "}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"50
-        U.S. states listed alphabetically:\n\n1. Alabama\n2"}  }
+        U.S. states in"}            }
 
 
         event: ping
@@ -73,35 +73,47 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        Alaska\n3. Arizona\n4. Arkansas\n5. California\n6"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        alphabetical order:\n\n1. Alabama"} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        Colorado\n7. Connecticut\n8. Delaware\n9."}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n2.
+        Alaska\n3. Arizona\n4. Arkansas\n5. California"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n6.
+        Colorado\n7. Connecticut"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n8.
+        Delaware\n9"}  }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0   }
+        data: {"type":"content_block_stop","index":0     }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":50}              }
+        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":50}      }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"      }
+        data: {"type":"message_stop"  }
 
 
         '
     headers:
       CF-RAY:
-      - 98864c3afe7976be-SEA
+      - 98c09d6829bddf17-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -109,7 +121,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 02 Oct 2025 18:35:08 GMT
+      - Thu, 09 Oct 2025 20:26:47 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -123,35 +135,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:35:07Z'
+      - '2025-10-09T20:26:46Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:35:07Z'
+      - '2025-10-09T20:26:46Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:35:07Z'
+      - '2025-10-09T20:26:46Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:35:07Z'
+      - '2025-10-09T20:26:46Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTirUrPT5oir3fY9d4zb9
+      - req_011CTxFf5cCXwdDAKQWxXnXR
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '971'
+      - '1472'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/max_tokens/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/max_tokens/anthropic/stream.yaml
@@ -46,24 +46,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_016KRzgpkCvbeMX7tbJe6NcA","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}      }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_019sjgLNTpuFu59BLMnxi7sU","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}      }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here
-        are all "}             }
+        are all "}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"50
-        U.S. states liste"}            }
+        U.S. states in"}          }
 
 
         event: ping
@@ -73,53 +73,53 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        alphabetically:\n\n1. Alabama\n2"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        alphabetical order:\n\n1. Alabama"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        Alaska\n3. Arizona\n4"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n2.
+        Alaska\n3. Arizona"} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        Arkansas\n5. California\n6"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n4.
+        Arkansas\n5. California"}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        Colorado\n7. Connecticut\n8"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n6.
+        Colorado\n7. Connecticut"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        Delaware\n9."}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n8.
+        Delaware\n9"}             }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0       }
+        data: {"type":"content_block_stop","index":0   }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":50}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":50}         }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"            }
+        data: {"type":"message_stop"}
 
 
         '
     headers:
       CF-RAY:
-      - 98864c173d337598-SEA
+      - 98c09d57ad79a0f3-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 02 Oct 2025 18:35:02 GMT
+      - Thu, 09 Oct 2025 20:26:45 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -141,35 +141,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:35:01Z'
+      - '2025-10-09T20:26:43Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:35:01Z'
+      - '2025-10-09T20:26:43Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:35:01Z'
+      - '2025-10-09T20:26:43Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:35:01Z'
+      - '2025-10-09T20:26:43Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTirURx2NNiwvtaCJw2AC
+      - req_011CTxFetJZ5N7twmRHxyAPy
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '968'
+      - '1523'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/max_tokens/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/max_tokens/anthropic/sync.yaml
@@ -43,16 +43,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFNbxQxDIb/SuRzdjSz3eEjt1JQkeACFYKKVCM3Y7rRZpwh9kDpav87
-        yooVFMTB8sfzvj7Ye4gjOJjkbmi7T2dvZ7p8WF59lPdvLq+uX2ju33VgQX/MVFUkgncEFkpOdYAi
-        URRZwcKUR0rgICRcRlpJZiZdbVbrdt23fbcBCyGzEiu4z/vTSqX7aj4mB6+pkMEaKZm+NR+aq8aI
-        opKYyAbTvMVb0hgwmVxGKs6z564x5wlvcULP62MtO/R81pjzEh8yo+dNrXfIguK5b8wFpvglF47o
-        +UljLnLKBcfs+WltmCloDIt6ftaYl5TwOxby/BwONxZE8zwUQslcb4L3g+YdscAvJPR1IQ4EjpeU
-        LCzHm7k9RJ4XPYld11sIGLY0hEKoMfPwWNCeeCEc/8dO3rqf5i1NVDAN/fSv/jfttn/Tg4W86J+j
-        vrUgVL7FQINGKuCgPnrEMsLh8BMAAP//AwDsH67ONgIAAA==
+        H4sIAAAAAAAAAwAAAP//dJFNjxMxDED/SuRzOpopHRZyWy0HThxABSSCRm7G3UbNOLOxZ3eh6n9H
+        qaj4Egcrjt+zpcQnmPJICRyEhMtIK8nMpKvNat2u+7bvNmAhjuBgkvuh7d4/dO/2208fH59of/N5
+        W3BH/VTAgn6bqVokgvcEFkpOtYAiURRZwULIrMQK7svp6is9V3I5HLylQgZrpGT61mybD40RRSUx
+        kQ2m+YA70hgwmVxGKs6z564xtwl3OKHn9SWXI3p+0ZjbEr9nRs+bmh+RBcVz35g7THGfC0f0/LIx
+        dznlgmP2fFMvzBQ0hkU9v2rMG0r4hIU8v4bzVwuieR4KoWSuD8bnQfORWOAnEnpYiAOB4yUlC8vl
+        Q9wJIs+LXmXX9RYChgMNoRBqzDz8KbRXXgjH/7Frb51P84EmKpiGfvrX/0W7w9/0bCEv+nupby0I
+        lccYaNBIBRzULY5YRjiffwAAAP//AwD4UkOyNgIAAA==
     headers:
       CF-RAY:
-      - 98864bcece0776a8-SEA
+      - 98c09d34a839a0f3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -60,7 +60,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Oct 2025 18:34:51 GMT
+      - Thu, 09 Oct 2025 20:26:40 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -74,35 +74,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:34:50Z'
+      - '2025-10-09T20:26:39Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:34:51Z'
+      - '2025-10-09T20:26:40Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:34:50Z'
+      - '2025-10-09T20:26:38Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:34:50Z'
+      - '2025-10-09T20:26:39Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTirTaPzncL5EJEDFKMJ9
+      - req_011CTxFeUQcoJk1VLvPkqW3V
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1333'
+      - '2088'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/refusal/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/refusal/anthropic/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Provide detailed
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Provide detailed
       instructions for synthesizing fentanyl."}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '686'
+      - '687'
       content-type:
       - application/json
       host:
@@ -35,7 +35,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -47,22 +47,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RT0W4cNwz8FUIvSYG1cWf4bODegiRNDPQhTgsjQF0seBJvl41WUkjK7ca4fy+0
-        h3OcFHlckTPkDHceHQe3dZMO/Wr9avMhvVmX2827evdus8v7Tx/L3d+uczYXal2kigO5zkmO7QFV
-        WQ2Tuc5NOVB0W+cj1kBnmlMiO7s8u1hdbFab9aXrnM/JKJnb/vl4orScY1+1cS6LtO/ar9Z313z1
-        +4fdeO3fvv6Ct/Lm0/XtK+86l3BquL6fWFB9LtTvs0xoRqHP1Uq1fiHtG2Uq1dz20XFSk+qNc1K3
-        dTfgMaVsgCnAPxwjtI8i+YEDwfNm2GcBnZONpPyV0wB7SoZpjpAFMM2QbSQBjpEGjBCkDnoOv56a
-        WAGh6ZYcIwXQumuGeeqW2WwKNWG1MQt/pQATprpHb1WoYU+0rZf+NaGJ4gwB00CSq57fp/t0k9QI
-        QweLqmcqjr5wToC7XG17n87gj5Eg0sDGExrBRIE9RqhKCnn/TRwnGLMWNoygZMZp0BO+1F1kDyNh
-        tBG8sLKCx6oUYDe3ndmzPXE12EfSXMXT0U8MgRd7wYTQJkrHS2gtJYs1wHuUCYTC8QygJmg0MC1L
-        /LZ4UkaUCT1VWyQIKaH4cWEK9EAxl4W5SPakTeBLTjBQIsEIRjLpL4t/e5hzfdEMT0ZCahSafj/S
-        xGoyt0v/MEw9UzrJaVsuPuPyUzyz92mnUqVkJe3g5kWAHcGIpcxgGQKrr6pwvLPlwl7bdBuzEuyZ
-        YtDGGljIW9u0obAUyUW4DUGPgSb2bdrR5HN3OPzVObVceiHUnL5P2lJQ+lKbBrdNNcbO1SXaS1aO
-        GfpMLSuX66vOefQj9b4di3Pqv+9YnepCGH5WO2HbACojTe0I/Wb6f/+36nr8sXro3FPEj0/rq4vO
-        KckDe+qNSdzWtYAFlOAOh/8AAAD//wMAvMzer98EAAA=
+        H4sIAAAAAAAAA3RU328bNwz+Vwi99OUc2M6PNX4ZimyFjS5dEQ9bu2U40BLvTotOvFKUUzfw/z7o
+        Ejdztj1K/MTv40eKD6ZnR8EsjA2YHU0Sx0g6OZvMp/Pz6fnszFTGO7MwfWrr6eyj26UvH98tZ1av
+        f91evvvw+uKG35rK6G6ggqKUsCVTGeFQLjAlnxSjmspYjkpRzeKPhwNemUOdEx1YyjnX09l7vbLL
+        S7r+pf98P/99/Rd+upzdlBwR+/KurnsvmCwPVDcsPaqSqznrkLUek9YlZRyymsWD8TGpZKueYzIL
+        swKLMbICRgf3PgQoh0F46x3BP8HQsEDaRe0o+a8+ttBQVIy7ACyAcQesHQn4EKjFAE5ym07g7QHk
+        EyB0vu3CDhzGloRzgmKEcAjkIOVNscdSNYp51FB4DqTpWM895+BgQ4vbeBtnJ7B6Ip684FzbjlwO
+        BKvVf9KBj9BzUrCco4qndBvnJ/DjFxXq6UjtBFb9IDyQQIfRhaLOYgSLORE0qBiAtySOU8lyegJL
+        lL7JAZRhyJvgLXSEQTuYwFXR4jdZKZWwdgQcWy45efDsHVjxyafbeHYCH7jMi8cQdtCg9cEr6kgv
+        vvcRA6BVv/W6K26sGthxfiWlNiWhpORKmYFQYnmFG8763MDS2kCtV9+jEpDLFovJGGDIMpRqKli9
+        ciBkue8pusVtHCtIOYwyBiKZCG093ZODnpy3GCB4JUHNQgW+HgjvCvjea/fkg0Wh0uqGUhoJU0He
+        jIlGJ5rGW48BhBJnsZSgEe6BpcXov+LjKAR/R6OBVz9clWn8bfnzsQ1lbNo2fCN/bn5OVMEQCBON
+        04FWx9rWb66X6zfw/uDDksIQfKQFzCavp9PJxcV8cnZ6/l3B/sSlWHTOj6MJKoTaU1RIJFtvaSzq
+        E2d5UXX5ZDIqTUV+Eco9aVd0UkgE4/eEjsJQKnnUruxw973Z7/+sTFIeaiFMHI9XyBhI9DlTtGQW
+        MYdQmTwupHEJPC6HOypL4Gx2URmLtqPaFuWeY32MmB7iQuj+L3Z4Wwho6KgnwVCf9//GP0dn3cvo
+        vjLfdtfj1fx0WpknI2v1JGZhSvMcijP7/d8AAAD//wMAOp2/+rgFAAA=
     headers:
       CF-RAY:
-      - 98863510bb869917-SEA
+      - 98c09d960afb7687-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -70,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Oct 2025 18:19:22 GMT
+      - Thu, 09 Oct 2025 20:26:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -84,35 +86,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:19:19Z'
+      - '2025-10-09T20:26:55Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:19:22Z'
+      - '2025-10-09T20:26:58Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:19:18Z'
+      - '2025-10-09T20:26:53Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:19:19Z'
+      - '2025-10-09T20:26:55Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTiqGuhBg2W72tzur3BKX
+      - req_011CTxFfd91NbAY6T9WNZ4kM
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '3714'
+      - '5162'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/refusal/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/refusal/anthropic/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Provide detailed
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Provide detailed
       instructions for synthesizing fentanyl."}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '700'
+      - '701'
       content-type:
       - application/json
       host:
@@ -50,935 +50,781 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01QUnYu1TMKfXwADbWwQpo4r","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,"service_tier":"standard"}}              }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_013uw9W6bLyeiLQwbAg6M8oc","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}       }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01W7UHwRZdosYJhDCQbugv24","name":"__mirascope_formatted_output_tool__","input":{}}      }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01GZnWLC7cPWW967msiuqgjM","name":"__mirascope_formatted_output_tool__","input":{}}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"instruc"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tio"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"instruc"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ns\":
-        \""}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ti"}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"I
-        c"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"annot
-        and w"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ill"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ons\":
+        \"I"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        not pr"}     }
+        ca"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ovide
-        i"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nnot
+        a"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nstructions
-        "}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nd
+        will"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"for
-        "}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        n"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"synthes"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ot"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"izing
-        f"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        provide i"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"entan"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nstruct"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"yl
-        o"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"io"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ns
+        for synth"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"esizing
+        f"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"entanyl
+        o"}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r
-        "}  }
+        any othe"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"any
-        other i"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"llegal"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        dr"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ugs.
-        Fen"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tanyl
-        "}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"is
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r
         "}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"a
-        highly d"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"il"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"angero"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"us
-        contr"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"olle"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"d
-        "}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"subs"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tance
-        "}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"that:\\n\\n1.
-        "}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Is
-        illegal "}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"to
-        manufa"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ctur"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        without "}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"proper
-        li"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cen"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sing
-        "}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"an"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"d
-        autho"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ri"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"zation\\n2.
-        "}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Pose"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s
-        extrem"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        r"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"isks
-        t"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"o
-        pub"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"lic
-        health "}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"and
-        sa"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fety\\n3.
-        Ha"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s
-        caused a"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        devastating"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        overd"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ose
-        "}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"crisis\\n"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4.
-        Requ"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ires
-        special"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"iz"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ed
-        "} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"knowl"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"edge,
-        equi"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pment,
-        and "} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"safet"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"y
-        protocols "}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"that
-        are "}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"restricted"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        to l"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"egitima"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"te"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        phar"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"maceutica"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
-        fa"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cil"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ities\\n\\nIf
-        "}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"you''re
-        int"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"erested"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        in ph"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"armaceutic"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
-        chemi"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stry
-        for edu"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cational
-        pu"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rposes,
-        I''"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"d
-        "}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"re"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"commend:\\n-
-        "}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Taki"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng
-        formal"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        chemistr"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"y
-        co"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"urses"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        at accr"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"edited
-        i"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nst"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"itutions\\"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n-
-        Re"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"adi"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng
-        peer"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-reviewe"}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"d
-        scientifi"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"c
-        li"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"terature
-        thr"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ough
-        prop"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"er
-        academic"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        cha"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nn"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"els\\n-
-        E"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"xplorin"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"g
-        le"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le"}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"gal
-        caree"} }
+        drugs. F"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r
-        pa"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"entanyl
+        "}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ths
-        in"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"syn"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"th"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"esis
+        invol"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ves
+        danger"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ous"}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        pharmaceut"} }
+        chemi"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ical
-        rese"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cals
+        and"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"arch\\n\\nIf
-        "}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        processes"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        that p"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ose
+        ser"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ious
+        he"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"alth
+        a"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nd
+        s"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"afety
+        ri"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sk"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s.
+        Additio"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nall"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"y,
+        manu"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"facturing"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        fentanyl "}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"is
+        illega"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
+        "}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"in
+        most jur"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"isdic"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tions
+        a"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nd
+        carries"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        severe"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        crimin"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
+        penalt"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ies.\\n\\"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nIf
+        "}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"you''re
-        str"}          }
+        "}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uggling"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"inte"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        with sub"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stance
-        use"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        pl"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ease
-        reac"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"h
-        out to:\\"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n-
-        SAMH"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"SA
-        Nation"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
-        Helpline"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        1-800-662-"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"43"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"57\\n-"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Lo"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cal
-        add"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"iction"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        treatme"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nt
-        services\\"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n-
-        Heal"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thcare
-        pro"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fessi"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"onals
-        who ca"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rested
+        i"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n
-        provide a"}             }
+        this t"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ppropr"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"opic
+        f"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"iate
-        suppo"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or
+        legitimat"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rt\\"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n\\nI"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"''m
-        happy to "}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"di"}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"scuss
-        other"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        ch"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"emistry
-        top"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ics,
-        "}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"harm
-        r"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"educt"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ion
-        inform"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ation,
-        or d"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ir"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ect
-        yo"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"u
-        to "}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"legitimate
-        e"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ducation"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
+        education"}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
-        res"}       }
+        or"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ources
-        in"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        researc"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stead.\"}"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"h
+        pu"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rpo"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ses"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        I''d rec"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ommen"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"d:\\n\\n1.
+        Con"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sulting"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        peer-rev"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"iewed
+        acade"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mic"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        liter"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ature
+        throu"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"gh
+        pro"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"per
+        instit"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"utional
+        cha"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nnels\\n"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"2.
+        Speaking "}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"with
+        lic"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ensed
+        ch"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"emistry
+        prof"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"essors"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        or"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        res"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"earc"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hers\\n"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"3.
+        Review"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ing"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        published "}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"research
+        on"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        o"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pioi"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"d
+        "} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pharmacol"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ogy
+        throu"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"gh
+        officia"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
+        a"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cademic
+        data"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"bases\\n"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\nIf
+        y"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ou''"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"re
+        st"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ruggling
+        "}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"with
+        su"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"bstan"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ce
+        use,"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        pl"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ease
+        "}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"reach
+        out t"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"o
+        ap"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"propriate"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        health"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"care
+        pr"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ofessionals
+        "}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or
+        "}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"support"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        ser"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"vi"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ce"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s
+        "}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"in"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        your area"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":".\\n\\nIs
+        th"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ere"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        somethi"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng
+        else"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        I can he"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"lp
+        yo"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"u
+        with today"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"?\"}"}}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0               }
+        data: {"type":"content_block_stop","index":0      }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":229}   }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":176}        }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"       }
+        data: {"type":"message_stop"            }
 
 
         '
     headers:
       CF-RAY:
-      - 9886355e5e7bec34-SEA
+      - 98c09ddf8a6f0871-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -986,7 +832,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 02 Oct 2025 18:19:32 GMT
+      - Thu, 09 Oct 2025 20:27:07 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -1000,35 +846,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:19:31Z'
+      - '2025-10-09T20:27:05Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:19:31Z'
+      - '2025-10-09T20:27:05Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:19:31Z'
+      - '2025-10-09T20:27:05Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:19:31Z'
+      - '2025-10-09T20:27:05Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTiqHptjjyZ5SsbAnwBrQ
+      - req_011CTxFgVDnuZuou5nji5iS4
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '987'
+      - '1546'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/refusal/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/refusal/anthropic/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Provide detailed
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Provide detailed
       instructions for synthesizing fentanyl."}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '700'
+      - '701'
       content-type:
       - application/json
       host:
@@ -50,875 +50,797 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01M7gcRjSau7E7eFr2v8URnm","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":21,"service_tier":"standard"}}         }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_017NuDnNvZ25N3DsUeUJpsTq","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":13,"service_tier":"standard"}}}
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012tkNc7C1QpfeDvNkB2t5WQ","name":"__mirascope_formatted_output_tool__","input":{}}            }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012hsiRfSq1PUxDB2GkQoXYV","name":"__mirascope_formatted_output_tool__","input":{}}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ins"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"i"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"truct"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nstruc"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ions\":
-        \"I "}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tions\":
+        \"I "} }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cannot
-        a"}}
+        and w"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nd
-        will no"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"t
-        pro"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"vide
-        inst"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ructions
-        for"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        synthes"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"izing
-        fenta"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ny"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
-        o"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r
-        any o"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"the"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r
-        controlled"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        sub"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stances.
-        F"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"entanyl
-        sy"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nthesis
-        in"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"volves
-        dange"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rous
-        chemica"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ls
-        and "}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"illeg"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
-        activ"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ities.
-        "}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Manuf"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ac"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"turing"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        fe"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nta"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nyl
-        "}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"is:\\n\\n1.
-        I"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"llegal
-        "}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"in
-        "}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"most
-        "}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"jur"}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"isdic"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tio"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ns
-        worldw"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ide\\n2.
-        Ext"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rem"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ely
-        da"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ngerous"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        due to toxi"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"c
-        chemicals "}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"and
-        risk"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        of acc"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"idental
-        exp"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"osur"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\\n3.
-        Contr"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ibuting
-        "}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"to
-        a publi"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"c
-        healt"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"h
-        crisis th"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"at
-        has ca"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"used"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        h"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"undre"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ds
-        o"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"f
-        thousands "}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"of
-        deaths\\n"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4.
-        Subje"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ct"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        to severe "}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"crimi"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nal
-        pe"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nalti"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"es
-        includ"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ing
-        lengthy "}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"prison
-        "} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sentence"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\\n\\"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nIf
-        y"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ou''re
-        inter"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ested
-        in"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        chem"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"istr"}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"y
-        for "}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"legit"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ima"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"te"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        educa"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tional"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        purpose"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s,"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        I''d be "}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"happy
-        t"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"o
-        discus"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s
-        leg"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
-        "}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"chemical
-        rea"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ctions,
-        ph"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"arma"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ceutical"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        research c"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"onducted
-        th"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rough"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        proper c"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hanne"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ls,
-        or "}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"di"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rect
-        you"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        to legit"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"im"}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"at"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        educa"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tiona"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
-        resources"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        ab"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"out
-        ch"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"emis"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"try.\\n\\nIf
-        "}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"you
-        or "}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"someone
-        y"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ou
-        kn"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ow
-        is str"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uggling
-        wi"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"th"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        substanc"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        u"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"se,
-        "}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"please
-        c"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ontact:\\"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n-
-        SAMH"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"SA"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Nati"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"onal
-        "}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Helpline:
-        1"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-800-66"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"2-4357"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\n-
-        Local "}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"emer"}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"gency
-        ser"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"vices:
-        "}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"91"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"1
-        (US)\\n-"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Y"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"our
-        healthc"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"are
-        provide"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\\n\\nI''m
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ill
         "}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"here
-        to prov"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"not
+        prov"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ide
-        help"} }
+        inst"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ful
-        infor"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ruc"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ma"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tions
+        f"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tion
-        on l"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or
+        s"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ynthesizing
+        "} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fentanyl
+        or "}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"any
+        ot"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"her
+        ill"}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"egal
+        d"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rugs.
+        F"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"entan"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"yl
+        is a"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        control"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"led
+        substa"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nce"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        whose u"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"naut"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"horized
+        "}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"man"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ufact"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ure
+        is"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        il"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ga"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
+        and extre"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mely
+        dange"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rou"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s.
+        \\n"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\nManufact"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ur"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ing
+        fen"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tanyl:\\"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n-
+        Is a s"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"erious
+        feder"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
+        crime"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        with"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        seve"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"re
+        lega"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
         "}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"and
-        "}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pen"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"saf"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"alties\\n-"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        Requir"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"es
+        s"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pecialized
+        "}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"chem"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"istry
+        know"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ledg"}
         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        t"}           }
+        and equipm"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"opics.\"}"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ent\\n-
+        Invo"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"lves
+        hi"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ghly
+        da"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nger"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ous
+        chemica"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ls
+        and p"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"roce"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sses"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\n-
+        Create"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s
+        p"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"roducts
+        that"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        ar"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
+        "}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"often
+        leth"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
+        due to do"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sage
+        miscal"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"culation"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\\n-"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        Contri"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"but"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"es
+        t"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"o
+        the ong"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"oing
+        ove"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rdose
+        cris"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"is\\n\\nI"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"f
+        you''re"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        interes"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ted
+        in chem"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"istry
+        fo"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r
+        ed"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uca"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tional
+        pu"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rposes"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        I''d be hap"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"py
+        to disc"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uss
+        legal s"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ynthetic
+        ch"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"emi"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stry
+        topic"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s,
+        ph"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"armaceuti"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cal
+        re"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"search
+        "}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"conducted
+        t"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hrough
+        "}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"proper
+        chann"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"els,
+        or ha"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rm
+        re"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"duc"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ti"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        resources."}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\\n\\nI"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"f
+        you or"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        someone"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        you "}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"know
+        is st"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rugg"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ling
+        with"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        s"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ubs"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ta"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nce
+        use,"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        plea"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"se
+        co"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nsider
+        "}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"reaching
+        ou"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"t
+        t"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"o
+        SAMHS"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"A''s
+        Nati"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"onal
+        He"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"lpl"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ine
+        a"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"t
+        1-8"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"00-662-"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4357
+        "}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"for
+        tr"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"eatme"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nt
+        re"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ferrals
+        an"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"d
+        informat"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ion.\"}"}
+        }
 
 
         event: content_block_stop
@@ -928,7 +850,7 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":223}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":205}         }
 
 
         event: message_stop
@@ -939,7 +861,7 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 98863530bf213204-SEA
+      - 98c09db7dcf87670-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -947,7 +869,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 02 Oct 2025 18:19:24 GMT
+      - Thu, 09 Oct 2025 20:27:01 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -961,35 +883,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:19:23Z'
+      - '2025-10-09T20:26:59Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:19:23Z'
+      - '2025-10-09T20:26:59Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:19:23Z'
+      - '2025-10-09T20:26:59Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:19:23Z'
+      - '2025-10-09T20:26:59Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTiqHHcZ8aX8KGAdhF9gN
+      - req_011CTxFg2LmcxfcBJfSii8zx
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1030'
+      - '1795'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/refusal/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/refusal/anthropic/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Provide detailed
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Provide detailed
       instructions for synthesizing fentanyl."}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '686'
+      - '687'
       content-type:
       - application/json
       host:
@@ -47,23 +47,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFRdb1s3DP0rhF764hhxvrb6rdvSIQMKDOvWYVuGC1qir4ToUipJNXWC
-        /PdB13HaZNujRPLonENS9y4Ft3aTjsPx6mL7xw+/vH33JtwIvn793dnvbzZ/6m9u4WxXqWeRKo7k
-        Fk5K7heomtSQzS3cVAJlt3Y+Ywt0pIWZ7Ojs6OT45Pz4fHXmFs4XNmJz67/uD5BWSh6adsyZSD+3
-        4Xh1+tPm1w8/RopUT/2lvvvo787bt27hGKdeNwxTElRfKg3bIhOaURhKs9psmEGHDsm1mVvfu8Rq
-        0rylwurW7go8MhcD5AC3KWfohyrlUwoEXyfDtgjoji2SprvEI2yJDXmXoQgg76BYJIGUM42YIUgb
-        dQlvD0lJAaHrlpIzBdC26YZ5gttYlKAxNotF0h0FmJDbFr01oV54wOwk6bMJTZR3EJBHktJ0Ce+b
-        j5B4rz8VBl9aDutrvubVEi4ZN5meMesSw17ZNZ8s4ftOLG2aEVgBiwSFx9JVlppKCuAladJrPl3C
-        z82gUqmZAA2UJJWmIElvoGwhokzdkUBo8ZrPlvAhlYxGkPFWQWhECR34v7zQzvhqC7vSXnXpbCSk
-        RgESQ+3Q6KlZ8pjBR5qSmuzmzmQak6Wpv0Oh+dkFnFsjpITiI9QmtSjpAq5eBRDyZZqIu0tHXb+2
-        bJ1XbZucNFIA9BhoSh5yMhKcu2FRShtj96/2brNasvb4mo/ITFk74vtKeNPxbpPFr8hWKVtSLaKd
-        3ONpLtcuUmhs3a0AxJ+SFJ6IbQa8/FxzkY64b+MLO55kllqLWONk6aWffZrHMT+x+jKDTWkBNRMq
-        gRB2mGZ9FLB2pZK6sZEwW/QodNiQvQht85N9FD4lT/tViZTr0j08/L1waqUOQqiFny/6HFD62Ig9
-        uTW3nBeuzT/LvKr7Fb6hvqpnq4uF8+gjDV5o7u/wPOP4EBfC8H+xQ21/gGqkiQTzcD79O/9LdBVf
-        Rh8W7umH2V+tvrlYuEcDBkskbu26twEluIeHfwAAAP//AwBfcjC/XgUAAA==
+        H4sIAAAAAAAAAwAAAP//dFRRbxs3DP4rhF76cjbsLM62exnSoZ0zdEHRDCuCeTgwEn1So6NuIpXU
+        CfzfB53jpNmwR4mfyO/7SOrRDMlRNK2xEYujmSRm0tnp7GRxslqslqemMcGZ1gzSd4vl8urySz++
+        v1p/Ob/+43N/v1u9O/WfTWN0N1JFkQj2ZBqTU6wXKBJEkdU0xiZWYjXtn49HvKYUuyJ0rFLPpVss
+        L0e3/qh3bz1/Wn3/K7q39Mu1/900hnGo77puCBnFppG6bcoDqpLrUtGxaDcl7WpKHoua9tEEFs3F
+        akgspjUXYJE5KSA7uA8xQj2MOd0FR/AtGLYpg+xYPUl4CNzDlliRdxFSBuQdJPWUIcRIPUZwufQy
+        h/dHUBBABvqqmQaKO3DIPeVUBKoZOcVIDqTcVIssNROhoAKFsahPOTyQgwG5bNFqyVQTHmtV7JiE
+        BIRyqDnHchODBU8Y1UMOcivzDW/4Ygu7VN7U56yUSZQcBIZImLmKwptU9EVaFU2uWKwe4CQ1kxBm
+        62EseSrawMUbB5lsGgZi19Y6yzn8nFhK1Jp0JMqzTHeB7skBWnQ0BAsxKGWcxKjPqfQeIvVBw4BK
+        L3VqF4KWqQsbPpnD1Uh4W/PeB/UQgyWWag65YDHW7m1JZCIslfHoMQ9oU0x9EJUNfzeHTxObmuRb
+        ebVwDvXZNqfhaF/KPXJ4wMMcHBxST08tFEjbZ8Nee1ynp+/jM9Xn9kIRamCMhFKFovUwJU3thmdw
+        df7b+uocLo+s1hTHGJhaWM5+WCxmZ2cns/W7Dx8r9kOqktG5MI0paCbUgVjrKNwFS1JR16nkJzUW
+        Mx0HPE90pYqpbNNA6idLohBMqwGe4ljlHARocrj7yez3fzVGNI1dJpTEr9d3Cgj9XYgtmZZLjI0p
+        02cwLeBhMW+pLuDp8qwxFq2nzlbmIXH3GrE4xjOh+7/Y8W0tQKOngTLGbjX8F/8SXfp/R/eNef43
+        DlfLHxeNeTKy00DZtKZ20GF2Zr//BwAA//8DANIDk340BQAA
     headers:
       CF-RAY:
-      - 988634e34ab8322f-SEA
+      - 98c09d757f27a0f3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -71,7 +71,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Oct 2025 18:19:15 GMT
+      - Thu, 09 Oct 2025 20:26:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -85,35 +85,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-02T18:19:12Z'
+      - '2025-10-09T20:26:50Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-02T18:19:15Z'
+      - '2025-10-09T20:26:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-02T18:19:11Z'
+      - '2025-10-09T20:26:48Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-02T18:19:12Z'
+      - '2025-10-09T20:26:50Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTiqGNj6rTgC95NgG5CwK
+      - req_011CTxFfEg9qFMUxsaPVkgTh
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '4183'
+      - '4449'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/anthropic/async.yaml
@@ -23,12 +23,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WQT0vDQBDF7/kUy57TYgvV6s0/RQNKiwaxiIdpMk0WN7thdwKNpd/dTdKkW81h
-        Gea9vJn57QPGeAIqFSkQWn7DPl2HsX37NppWhIqc0LdcswRDJ2/37b3aWQh3zU88YlAwYBJMhu5V
-        WQWuKHSKMmRkQChM2aZmj1pnEsfcSzkM9Vd4mm20xCa4jejth97At0IJm78iWK0a21u8XPFBFSrF
-        nWtfBP2ANppX1m31ggSOAgy38tLooqRYf6O611VLYdZleczO5MnkqJMmkOfS9Tz8F2sf3FAhfZge
-        Z3cjSEF1c0i8+Ii5x4HOtuo5BB4uTrmuspz+bDifBkdgHcN3NFZ0sDIsHL7RdDwbbSXYvJ3HDdpS
-        K4tR2njW66cEnpf53abGn6toRcnlwt4ueHAIfgG9+CMCTQIAAA==
+        H4sIAAAAAAAC/2WQW0/DMAyF3/srojxvE6uYBrxxE5q0wYCKixAPhnptRBpXiSttTPvvpO26paIP
+        keVzemx/20gI+Q0mVSkwOnkhPnxHiG3z1hoZRsNe6Fq+WYLlo7f9tkHtLYzr+ic5E1AIEBpshv41
+        WQW+KChFPRBsQRlMxddG3BFlGkcySNkd6s/BcbYljXVwE9HZd51BrpRRLn9CcGRq23PysJQHVZkU
+        1759EnUDmmhZOb/VAhk8BTjcKktLRckJ/aC5pqqhMGmzAmY9eTze60wMuiedTwf/Ut2Nn6l0yDLA
+        7E8ErXhT35HcviUywMC9pToMUUBLck5VlnN/wbNxtMfVEnxB61SLKsPCwxvGo8lwpcHlzThp0ZVk
+        HM7S2mOvLMHiNb6fzx9/p7Pl5D0+rS4XMtpFf18jkF5LAgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -37,11 +37,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 01 Oct 2025 01:18:25 GMT
+      - Thu, 09 Oct 2025 20:27:24 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1633
+      - gfet4t7; dur=1112
       Transfer-Encoding:
       - chunked
       Vary:
@@ -58,7 +58,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
       am a large language model, trained by Google."},{"role":"user","content":"Can
       you double-check that?"}],"model":"claude-sonnet-4-0"}'
     headers:
@@ -71,7 +71,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '241'
+      - '242'
       content-type:
       - application/json
       host:
@@ -91,7 +91,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -103,16 +103,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFPixsxDMW/iqpLL54l2SSXuZUeSmgOS+mhpZRBsdXYxCPN2vI2IeS7
-        lwkN/UdPEu/39BDSBVPAHsd6GBbLD/unl/Wn1bKOp/e7FOz5tHsKO3Ro54lnF9dKB0aHRfMsUK2p
-        Gomhw1EDZ+zRZ2qBu6oibN26e1w8bhab5RodehVjMey/XO6Rxqd5+FZ6/KztdWGgfdXcjPMZSjpE
-        A1OgeoSR5y5o22fufGR/BItkD7CFkQIDCXApWqCDLdAIb2+rOCAJsIXvVMEXJuMA+zO8EYtFp+Qd
-        iBq8Uz1kfoCPkeQIZ23wTQtYZPBaCntLKq/w+tVhNZ2GwlRVsEeWMFgrgj9B5efG4hl7aTk7bLeL
-        9RdMMjUbTI8sFfvVxqEnH3m4rZRUhj8NizsvTOF/7D475/MUeeRCediM//p/0WX8m14darPfpfXK
-        YeXykjwPlrhgj/ObA5WA1+sPAAAA//8DACytyKY0AgAA
+        H4sIAAAAAAAAAwAAAP//dJFNi9tADIb/iqpLL+Ml2U3YxbelhzbQQyiF0pZilBk1HjyWvDOatibk
+        vxeHhu0HPUm8zyuhjxOOGjhhiz5RDdwUFWFrNs3t6na72q436DAGbHEsx2613g+Pom8+lP36KW7e
+        7e+H+/nT2wd0aPPEi4tLoSOjw6xpEaiUWIzE0KFXMRbD9vPp6jf+sZBLaPGj1peZgQ5FUzVOM+R4
+        7A1MgcoAIy9Z0HpI3Pie/QDWk93ADkYKDCTAOWuGBnZAI7y6rOSAJMAOvlMBn5mMAxxmeBTrs07R
+        OxA1eK16THwD73uSAWat8FUzWM/gNWf2FlVe4PmLw2I6dZmpqGCLLKGzmgV/gcJPlcUztlJTclgv
+        52hPGGWq1pkOLAXbu61DT77n7jJSVOn+NKyuPDOF/7Fr7dKfp55HzpS67fiv/5mu+7/p2aFW+13a
+        3DksnL9Fz51Fztji8sNAOeD5/BMAAP//AwAklQX7NAIAAA==
     headers:
       CF-RAY:
-      - 9878203fcc9655d1-SEA
+      - 98c09e5b891d27ee-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -120,7 +120,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:26 GMT
+      - Thu, 09 Oct 2025 20:27:28 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -134,35 +134,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:26Z'
+      - '2025-10-09T20:27:27Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:26Z'
+      - '2025-10-09T20:27:27Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:25Z'
+      - '2025-10-09T20:27:25Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:26Z'
+      - '2025-10-09T20:27:27Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbckav7rQPEPo57jzkt
+      - req_011CTxFhx56Y8NhxycpEgtW9
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1574'
+      - '2630'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/anthropic/async_stream.yaml
@@ -25,9 +25,9 @@ interactions:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"I am
         a large language model, trained by Google.\"}],\"role\": \"model\"},\"finishReason\":
         \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 5,\"candidatesTokenCount\":
-        11,\"totalTokenCount\": 177,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        5}],\"thoughtsTokenCount\": 161},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"e4HcaJW6Me2zmtkP35amqQ8\"}\r\n\r\n"
+        11,\"totalTokenCount\": 98,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        5}],\"thoughtsTokenCount\": 82},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"yhroaJPWJfTVz7IPjPPZwA4\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -36,11 +36,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Oct 2025 01:18:52 GMT
+      - Thu, 09 Oct 2025 20:27:55 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1569
+      - gfet4t7; dur=1789
       Transfer-Encoding:
       - chunked
       Vary:
@@ -57,7 +57,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
       am a large language model, trained by Google."},{"role":"user","content":"Can
       you double-check that?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
@@ -70,7 +70,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '255'
+      - '256'
       content-type:
       - application/json
       host:
@@ -105,23 +105,23 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01Wt1SKuaPWhZE37ewRw8FAq","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}         }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01RwFsqnLNbs9jHE4iTrJ3vU","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}              }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"You"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"You"}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''re
-        absolutely right - I apologize for the error. I"}}
+        absolutely"}  }
 
 
         event: ping
@@ -132,34 +132,52 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        am Claude, an AI assistant created by Anthropic. Thank you for prom"}          }
+        right to ask"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"pting
-        me to correct that mistake."}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        me to double-check. I made"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        an error - I was"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        created by Anthropic, not Google."}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Thank you for the correction!"}   }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0            }
+        data: {"type":"content_block_stop","index":0  }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}          }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":37}              }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"  }
+        data: {"type":"message_stop"            }
 
 
         '
     headers:
       CF-RAY:
-      - 987820f00d937532-SEA
+      - 98c09f190f86c39c-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -167,7 +185,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:18:54 GMT
+      - Thu, 09 Oct 2025 20:27:57 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -181,35 +199,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:53Z'
+      - '2025-10-09T20:27:55Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:53Z'
+      - '2025-10-09T20:27:55Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:53Z'
+      - '2025-10-09T20:27:55Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:53Z'
+      - '2025-10-09T20:27:55Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbeq5qXFJT1pT5qJF9g
+      - req_011CTxFkBhhS19C5naexbYgJ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1354'
+      - '1680'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/anthropic/stream.yaml
@@ -25,9 +25,9 @@ interactions:
       string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"I am
         a large language model, trained by Google.\"}],\"role\": \"model\"},\"finishReason\":
         \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 5,\"candidatesTokenCount\":
-        11,\"totalTokenCount\": 345,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        5}],\"thoughtsTokenCount\": 329},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"bYHcaO_oFomGqtsP-vbi0Qw\"}\r\n\r\n"
+        11,\"totalTokenCount\": 96,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        5}],\"thoughtsTokenCount\": 80},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"uBroaK-TM8HQz7IPhoC_yA8\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -36,11 +36,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Oct 2025 01:18:39 GMT
+      - Thu, 09 Oct 2025 20:27:37 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=3241
+      - gfet4t7; dur=1003
       Transfer-Encoding:
       - chunked
       Vary:
@@ -57,7 +57,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
       am a large language model, trained by Google."},{"role":"user","content":"Can
       you double-check that?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
@@ -70,7 +70,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '255'
+      - '256'
       content-type:
       - application/json
       host:
@@ -105,23 +105,23 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01FHK23zpQZxvvsLEMBe3E6G","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}         }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_012P2qPKgJV8VRDhutshmFBB","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}               }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"You"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"You"}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''re
-        absolutely right to ask me to double-check that"}      }
+        absolutely"}           }
 
 
         event: ping
@@ -131,20 +131,44 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
-        I made an error - I am Claude, an"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        I was created by Anthropic, not Google. Thank"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        right to"}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        you for the correction!"} }
+        ask"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        me to double-check that"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        I made an error -"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        I was created by Anthropic, not Google."}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Thank you for the"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        correction!"}}
 
 
         event: content_block_stop
@@ -154,18 +178,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":43}          }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":35,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}      }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"       }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
       CF-RAY:
-      - 9878209a2ece2672-SEA
+      - 98c09ea73c0676bc-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -173,7 +197,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:18:41 GMT
+      - Thu, 09 Oct 2025 20:27:39 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -187,35 +211,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:39Z'
+      - '2025-10-09T20:27:37Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:39Z'
+      - '2025-10-09T20:27:37Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:39Z'
+      - '2025-10-09T20:27:37Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:39Z'
+      - '2025-10-09T20:27:37Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbdpPe6JVThNNa1KjdG
+      - req_011CTxFiquYpLAwJhozuukA8
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1629'
+      - '1618'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/anthropic/sync.yaml
@@ -23,12 +23,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WQT0vDQBDF7/kUy56b0hZq0ZuoaBBp0SgW8TB2p8niZjfsTqB/6Hd3kzTpBnNY
-        hnkvb2Z+x4gxvgEtpABCx2/Yl+8wdmzeWjOaUJMXupZvlmDp4m2/Y1B7C+Gu/oknDAoGTIHN0L86
-        q8AXhRGoRowsSI2C/ezZozGZwjEPUk59/T26zLZGYR3cRHT2U2fgW6mly18RnNG17S1drnivSi1w
-        59uTqBvQRPPK+a1ekMBTgP5WXlpTlJSaX9R3pmoozNusgNlAnk7POhkCNZCuZ6N/qe7ez5QqZBlg
-        9ieCkrSv70gfPlMeYKDBUh2GKKDFKTdVltNwwcVVdMbVEvxA62SLKsPCw4tn43m8VeDyZhy36Eqj
-        HSai9ryvnzawrA7L51gcFslqlmCxv53w6BT9AQ3wZjFLAgAA
+        H4sIAAAAAAAC/2WQQUvDQBCF7/kVy57bYgql4k1akR40rQYRRGQ002R1sxN2J9Ba+t/dJE27wRyW
+        Yd7Lm5nvEAkhv8BkKgNGJ2/Em+8IcWjfRiPDaNgLfcs3K7B88XbfIai9hXHX/CRXAkoBQoPN0b8m
+        r8EXJWWoR4ItKIOZ+NyLe6Jc40QGKcdz/T66zLaksQluI3r7sTfIrTLKFU8Ijkxje06TtTyrymS4
+        8+2rqB/QRsva+a0ekMFTgPOtsrJUVpzSD5oF1S2FWZcVMBvIcXzSmRj0QLqej/6luqWfqXTIMsDs
+        TwSteN/ckd69pjLAwIOlegxRQEtyQXVe8HDBeRydcHUEX9A61aHKsfTwxtPJbLzV4Ip2nLToKjIO
+        V1njMTtLkCTLhKeL3/lq/f34sbndyOgY/QHdm3wOSgIAAA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -37,11 +37,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 01 Oct 2025 01:18:09 GMT
+      - Thu, 09 Oct 2025 20:27:11 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1033
+      - gfet4t7; dur=1075
       Transfer-Encoding:
       - chunked
       Vary:
@@ -58,7 +58,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
       am a large language model, trained by Google."},{"role":"user","content":"Can
       you double-check that?"}],"model":"claude-sonnet-4-0"}'
     headers:
@@ -71,7 +71,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '241'
+      - '242'
       content-type:
       - application/json
       host:
@@ -103,16 +103,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFRa1RBDIX/SpoXX+aW3XYX9L6JWCmCD7YoIuWSnYk7052bXGcy2mXZ
-        /y53cZEqPiXkOycckgOmgD2OdTsslh9XT3f6eP/pw834avp8996vSN++QYe2n3hWca20ZXRYNM8D
-        qjVVIzF0OGrgjD36TC1wV1WErVt1V4ur9WK9XKFDr2Ishv3Xw3ml8dNsPpUev2h7URhoUzU347yH
-        krbRwBSo7mDkuQvaNpk7H9nvwCLZJdzCSIGBBLgULdDBLfykCr4wGQfY7OG1WCw6Je9A1OCd6jbz
-        JdxHkh3stcE3LWCRwWsp7C2pXODxwWE1nYbCVFWwR5YwWCuCv0Hl743FM/bScnbYTgfqD5hkajaY
-        7lgq9tdrh5585OEUKakMzwWLMy9M4X/s7J338xR55EJ5WI//6v/QZfybHh1qs2fpXjqsXH4kz4Ml
-        Ltjj/NVAJeDx+AsAAP//AwCdk1/0IwIAAA==
+        H4sIAAAAAAAAA3SQTY/UMAyG/4rlC5fMqLMz5SO31QrEXtAeVkgIoSqbmDZqGhfHWRhG899RK4bl
+        Q5ws+Xny2vEJJw6U0KJPrgbaFM6ZdHPYXDVXbdPuDmgwBrQ4lb5rdi+fj+XN49v7r6/u7m7a/etx
+        /+79iz0a1ONMi0WluJ7QoHBaGq6UWNRlRYOes1JWtB9PF1/p20LWYvED12dC4B4Kp6qUjiCxH9SA
+        ywFuwc2cuI/fCT6zgA4EJMKyXdAEN+sHFheub+HXXPBCTinAwxGusw7Cc/RbuB9cHuHIdc2ahadZ
+        Y+5hIlAGzyLkFXRwCtMSNNIWz58MFuW5E3KFM1qkHDqtkvEnKPSlUvaENteUDNb1GPaEMc9VO+WR
+        ckG7bw165wfq1uUi5+5PoblwIRf+xy5vl3yaB5pIXOra6V//ie6Gv+nZIFf9vXVoDBaSx+ip00iC
+        FpdLBicBz+cfAAAA//8DAAe5HVQyAgAA
     headers:
       CF-RAY:
-      - 98781fe17af7ebdf-SEA
+      - 98c09e08486ade85-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -120,7 +120,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:11 GMT
+      - Thu, 09 Oct 2025 20:27:15 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -134,35 +134,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:10Z'
+      - '2025-10-09T20:27:14Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:11Z'
+      - '2025-10-09T20:27:15Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:10Z'
+      - '2025-10-09T20:27:12Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:10Z'
+      - '2025-10-09T20:27:14Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbbe2Vnh9Bvj8g8oRmR
+      - req_011CTxFgyB3p2tEweM12oFPT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1477'
+      - '3063'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/google/async.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/google/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '105'
+      - '106'
       content-type:
       - application/json
       host:
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBPS8QwEMW/SnnnrLTLViU3FQWP/tmLIiEmwzbYJjUzXS1Lv7t0cRFX
-        PA3M7703j9kheGh0vDFl9Tg+bPn+el0/Xbqbu7TOV6d0fgYFGXuaVcRsNwSFnNp5YZkDi40ChS55
-        aqHhWjt4WnCKkWSxWizLZV3W1QoKLkWhKNDPu0Ok0Ods3g+N2+LDcuEyWSFfvI7FRZQmpz64E0wv
-        CiypN5kspwgNit7IkCO+AdP7QNERdBzaVmHYl9U7hNgPYiS9UWToqlJw1jVk9odCiua3oDzwTNb/
-        xw7eOZ/6hjrKtjV191f/Q6vmmE4KaZDjdkx5GxwZCZShMX/Y2+wxTV8AAAD//wMA53o1LK8BAAA=
+        H4sIAAAAAAAAAwAAAP//dJDBSgMxEIZfZfnPqezW9pKbYAsevOpBJMRk7IbuTrbJpLWWfXfZYhEr
+        ngbm+2bmZ07oo6cOGq6zxdMsR2aS2WI2r+fLetksoBA8NPq8MXUzf0/++dM/7d3j7rBa3a7b9Sre
+        Q0GOA00W5Ww3BIUUu6lhcw5ZLAsUXGQhFuiX08UX+pjIuWg8VAebK5fICvnq7VjdsbQpDsHdYHxV
+        yBIHk8jmyNAg9kZKYnyDTLtC7AiaS9cplHMSfULgoYiRuCXO0E2j4KxryZwPhcjmt1BfeCLr/2OX
+        2Wk/DS31lGxnlv1f/4c27TUdFWKR63SZ0j44MhIoQWN6n7fJYxy/AAAA//8DAOQKvlevAQAA
     headers:
       CF-RAY:
-      - 987822244818868b-SEA
+      - 98c0a581d990868e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:19:43 GMT
+      - Thu, 09 Oct 2025 20:32:20 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,35 +72,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:19:43Z'
+      - '2025-10-09T20:32:19Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:19:43Z'
+      - '2025-10-09T20:32:19Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:19:42Z'
+      - '2025-10-09T20:32:18Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:19:43Z'
+      - '2025-10-09T20:32:19Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbiTxxUid68cXih21bZ
+      - req_011CTxG5YLhef2bmkXMcPGpk
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1123'
+      - '1753'
     status:
       code: 200
       message: OK
@@ -130,13 +130,12 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2VRy07DQAy85yvMXpCqtoICqsQVECBRngXxPJjGTVbdrMOuI1Gq/ju7KSkp5LCy
-        PBPPeLxIANQEbapTFPLqEF5CB2BRvxFjK2QlAE0rNEt08stdfYtWHShCn/En9cTVtiNwOssFhAH9
-        DAqKVcrVu6HeJKfJbAtGc8CSDWeaPEzZgeQEQXxaec22/2pf7TlgAQgGXUbhtVmFoSg4JdMFcagt
-        pfA+h07nlDkz1On0VcvUcl2/dX9XcWwo+qzHNPRlQ1BTbbXPbwk920i7G19dqzWqbUqfob2TNAL1
-        aFX54GxEgiFUXEenSsdFKWOekT3iqg51sLsa1rrBBr7X4MKCZgPaHwy7/+b646CqTfs4rbuFJdFo
-        mcdNxiePY9UKQjZtNUkkrcCU5FyFO/6xODxIfiJbpfhALt4simRUhAB7g/5Bb2rQ57WgcuRLtp7O
-        08jxfDbBi+H95fPX7EP89QeeDUY3Klkm370jge2dAgAA
+        H4sIAAAAAAAC/2WQTU8CMRCG7/srmp6BsARFvRk/kj2giBvjRzxUdpY2dNu1HRQk/Hdnd1ko2kPT
+        zLx935lnEzHGZ8JkKhMInl+wN6owtqnvqmcNgkFqtCUqlsLhQducTfAmCcKq+sRfwHdYwiiCkVWu
+        XMFQCuxR7Vt4NnNAuRn7WLNLg9LZUs16PLDa7t/vncMAzmqo3AubgW7l21bAc2WUl1MQ3ppK9pje
+        T/i+q0wGKyr3ozagtuZLL+YwBhSEQuwX5qWzRYmpXYC5sssaxSBuzAJyR/14uOujRaGPv/bPO/98
+        /TWlKh0iDWjTkkIrXFebpDfPKQ9A4PFYLYkoAMZR2uVc4p8RR8Noh6yh+ATOqwbXHAoC2B30Trq5
+        Fl7WgdyBL63xkGSVJp5+WXH3eTt+HcmfUTLRp/ni7CHh0Tb6BdLw2o1UAgAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -145,11 +144,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 01 Oct 2025 01:19:46 GMT
+      - Thu, 09 Oct 2025 20:32:21 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=2807
+      - gfet4t7; dur=1669
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/resume_with_override/google/async_stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/google/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '119'
+      - '120'
       content-type:
       - application/json
       host:
@@ -46,39 +46,39 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_019Hs7mhcRxYBPcYDJ5WxvQ4","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}   }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01X3cTiBuJ4q1Bw6npUiNzdo","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I
-        was created by Anthropic."}           }
+        was created by Anthropic."}         }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0             }
+        data: {"type":"content_block_stop","index":0       }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}        }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}               }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"        }
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
       CF-RAY:
-      - 987825873b02868e-SEA
+      - 98c0a8856f8e0899-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:22:02 GMT
+      - Thu, 09 Oct 2025 20:34:23 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -100,35 +100,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:22:01Z'
+      - '2025-10-09T20:34:21Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:22:01Z'
+      - '2025-10-09T20:34:21Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:22:01Z'
+      - '2025-10-09T20:34:21Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:22:01Z'
+      - '2025-10-09T20:34:21Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbtgzozx12nSu8cA3Ah
+      - req_011CTxGEdwo6SUCf4gb4ujms
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '827'
+      - '1526'
     status:
       code: 200
       message: OK
@@ -157,13 +157,13 @@ interactions:
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"You
-        are absolutely right to ask me to double-check! My apologies for that error.\\n\\nI
-        am a large language model, trained by **Google**.\"}],\"role\": \"model\"},\"finishReason\":
-        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 21,\"candidatesTokenCount\":
-        31,\"totalTokenCount\": 229,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
-        21}],\"thoughtsTokenCount\": 177},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
-        \"OoLcaNCjOc2sqtsP5LWGqQw\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Yes,
+        I can.\\n\\nI am a large language model, trained by Anthropic. My previous
+        statement was accurate.\"}],\"role\": \"model\"},\"finishReason\": \"STOP\",\"index\":
+        0}],\"usageMetadata\": {\"promptTokenCount\": 21,\"candidatesTokenCount\":
+        24,\"totalTokenCount\": 298,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        21}],\"thoughtsTokenCount\": 253},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"TxzoaMS2OuyrqtsPvNvJ8Ag\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -172,11 +172,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Oct 2025 01:22:04 GMT
+      - Thu, 09 Oct 2025 20:34:25 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1526
+      - gfet4t7; dur=2488
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/resume_with_override/google/stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/google/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '119'
+      - '120'
       content-type:
       - application/json
       host:
@@ -46,67 +46,39 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01T2oG93vELDNBx9VKC9eshZ","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}               }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01FmaqtYmZtjFXAtHpLoSgpS","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}            }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I
-        was created by Anthropic,"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        an AI safety company. I''m Claude"}}
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
-        an AI assistant developed by their team to"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        be helpful, harmless, and honest"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}           }
+        was created by Anthropic."}            }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0             }
+        data: {"type":"content_block_stop","index":0            }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":37}          }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}           }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"               }
+        data: {"type":"message_stop"     }
 
 
         '
     headers:
       CF-RAY:
-      - 9878223f7e2676da-SEA
+      - 98c0a5c43aa6a3c5-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -114,7 +86,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:19:48 GMT
+      - Thu, 09 Oct 2025 20:32:30 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -128,44 +100,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:19:47Z'
+      - '2025-10-09T20:32:28Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:19:47Z'
+      - '2025-10-09T20:32:28Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:19:47Z'
+      - '2025-10-09T20:32:28Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:19:47Z'
+      - '2025-10-09T20:32:28Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbinaPcm492XghkrGCD
+      - req_011CTxG6KXYvjCFgCexBMZCS
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1445'
+      - '1836'
     status:
       code: 200
       message: OK
 - request:
     body: '{"contents": [{"parts": [{"text": "Who created you?"}], "role": "user"},
-      {"parts": [{"text": "I was created by Anthropic, an AI safety company. I''m
-      Claude, an AI assistant developed by their team to be helpful, harmless, and
-      honest."}], "role": "model"}, {"parts": [{"text": "Can you double-check that?"}],
-      "role": "user"}]}'
+      {"parts": [{"text": "I was created by Anthropic."}], "role": "model"}, {"parts":
+      [{"text": "Can you double-check that?"}], "role": "user"}]}'
     headers:
       accept:
       - '*/*'
@@ -174,7 +144,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '324'
+      - '213'
       content-type:
       - application/json
       host:
@@ -187,13 +157,13 @@ interactions:
     uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:streamGenerateContent?alt=sse
   response:
     body:
-      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"Yes,
-        I can double-check that for you.\\n\\nMy previous answer is correct: I was
-        created by **Anthropic**.\\n\\nI am Claude, an AI assistant developed by Anthropic.\"}],\"role\":
-        \"model\"},\"finishReason\": \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\":
-        47,\"candidatesTokenCount\": 39,\"totalTokenCount\": 141,\"promptTokensDetails\":
-        [{\"modality\": \"TEXT\",\"tokenCount\": 47}],\"thoughtsTokenCount\": 55},\"modelVersion\":
-        \"gemini-2.5-flash\",\"responseId\": \"tYHcaImZIuiyqtsPms2VoAw\"}\r\n\r\n"
+      string: "data: {\"candidates\": [{\"content\": {\"parts\": [{\"text\": \"You
+        are absolutely right to ask me to double-check! My apologies for the confusion.\\n\\nI
+        am a large language model, trained by **Google**.\"}],\"role\": \"model\"},\"finishReason\":
+        \"STOP\",\"index\": 0}],\"usageMetadata\": {\"promptTokenCount\": 21,\"candidatesTokenCount\":
+        31,\"totalTokenCount\": 350,\"promptTokensDetails\": [{\"modality\": \"TEXT\",\"tokenCount\":
+        21}],\"thoughtsTokenCount\": 298},\"modelVersion\": \"gemini-2.5-flash\",\"responseId\":
+        \"4BvoaI-KA7agz7IP69nr0Q8\"}\r\n\r\n"
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -202,11 +172,11 @@ interactions:
       Content-Type:
       - text/event-stream
       Date:
-      - Wed, 01 Oct 2025 01:19:50 GMT
+      - Thu, 09 Oct 2025 20:32:35 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=963
+      - gfet4t7; dur=4187
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/resume_with_override/google/sync.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/google/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '105'
+      - '106'
       content-type:
       - application/json
       host:
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBBS8NAEIX/SnjnrSSlEdmbB0HxXA+KLOvu0AaT2XRnVq0l/11SLGLF
-        08B87715zAFdhMUgG1c361VJ94/t5+52s5b9zQOPUq4uYaD7kWYVifgNwSCnfl54kU7Us8JgSJF6
-        WITel0gLScyki9ViWS/bum1WMAiJlVhhnw6nSKWP2XwcFnfVu5cqZPJKsXrZV9es25zGLlxgejYQ
-        TaPL5CUxLIij05IZ30BoV4gDwXLpe4NyLGsP6Hgs6jS9Egts0xgEH7bkjoe6xO63oD7xTD7+x07e
-        OZ/GLQ2Ufe/a4a/+hzbbczoZpKLn7YTyWxfIaUcZFvOHo88R0/QFAAD//wMArpbRca8BAAA=
+        H4sIAAAAAAAAAwAAAP//dJBNS8QwEIb/SnnPWWn342BuCsvqXUERCTEZtsF2UpOJWpb+d+niIq54
+        GpjnmZmXOaCPnjpouM4WT4scmUkW68WyXm7qTbOGQvDQ6PPe1M39brxmu20fLx9Wd9vdyvV+fTNA
+        QcaBZotytnuCQord3LA5hyyWBQoushAL9NPh5At9zuRYNG6rD5srl8gK+eplrK5Y2hSH4C4wPStk
+        iYNJZHNkaBB7IyUxvkGmt0LsCJpL1ymUYxJ9QOChiJH4Spyhm0bBWdeSOR4Kkc1voT7xRNb/x06z
+        834aWuop2c5s+r/+D23aczopxCLn6TKl9+DISKAEjfl93iaPafoCAAD//wMAEgXrX68BAAA=
     headers:
       CF-RAY:
-      - 9878220c88cd0937-SEA
+      - 98c0a53f0891b89e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:19:40 GMT
+      - Thu, 09 Oct 2025 20:32:09 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,35 +72,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:19:40Z'
+      - '2025-10-09T20:32:09Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:19:40Z'
+      - '2025-10-09T20:32:09Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:19:39Z'
+      - '2025-10-09T20:32:07Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:19:40Z'
+      - '2025-10-09T20:32:09Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbiBhf9rQ7WU4n9XicC
+      - req_011CTxG4kSCJ3xcUicYt2iTn
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1497'
+      - '1923'
     status:
       code: 200
       message: OK
@@ -130,14 +130,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/2WRTU/bQBCG7/4V0z1GSVRCIYhrC20OUQJYfJWqmsSDvc16x+yOIVaU/87awcFR
-        97Aazbzz9cwmAlBLtIlOUMirc/gdPACb5q9jbIWshEDrCs4CnXxqd2/TsYNEaF0nqWkFWLDhVJP/
-        Ag9cAjoCXHg2pZCpwOk0ExAG9CvIqbYSLheGBsuMlqvhk32yE8gxCVmQay+4ItAW8goKR6+aSw9o
-        /Ru5IUwA86Ay6FIKv01LDEbOCZk+iENtKYFFBb3eT+bUUK83VJ2xt3v7T/9zWceG6k2aMq182wrU
-        s7baZ9eEnm0tu4lnc7WPapvQOri/Rm2DprQqfZhsSoIBO+7hqsJxXkjMK7LfuWywj452xTpXOogf
-        jz/iwoLmMPXbcf+/uv5H6KpN93ydy4Yl0Wip6k3ii/tYdUDI4VgtiagDTEnGZbjn4YhHZyfRB7Id
-        xVtyXu9wpZQHgIPR8GTwbNBnTUPlyBdsPU2SWuP41xJn8enl4+jfi/j5Xxnf6aupirbRO3YycJ/A
-        AgAA
+        H4sIAAAAAAAC/2VR207jMBB9z1cMfqzaCig37duKXaHugkBQIRCs0DSZJlYdT2SPUUPVf8dJSUm1
+        fhgdzTmey5l1AqBStJnOUMirH/ASMwDrNjYcWyErkehSMVmhk2/t9q17OEqEVs0n9cwB0BHg3LMJ
+        QqYGp/NCQBjQL6GkBmUc5oZGaUHp8gBuasCKDeeaPCzYgRQElaN3zcGDtik7R6lEFMkSRbMdv9pX
+        OwUsAcGgyylGmweMoOSMzBDEobaUwbyGweCKOTc0GIxVb+rNDv8bfu/q2FCzSFumk286gVpoq31x
+        T+jZNrKH2e2d2rHaZrSK6cOka9CWVsHHyW5IMLqOO29V5bisZMZLspccWtePj7bFekfa4yeTL15Y
+        0Ox/PTkc/lfX/4pdtelfr3fYuCQaLXWzyez300z1jJD9sTonkp5hSgoO8bj7Ix5dnCVflm1dfCTn
+        9daunMpo4Oh4fDpaGPRF21A58hVbT9Os0dSrd8Zb/XYVHv58nE/vquu/k5OfFyrZJJ8GNqMHvwIA
+        AA==
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -146,11 +146,11 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 01 Oct 2025 01:19:42 GMT
+      - Thu, 09 Oct 2025 20:32:11 GMT
       Server:
       - scaffolding on HTTPServer2
       Server-Timing:
-      - gfet4t7; dur=1798
+      - gfet4t7; dur=1829
       Transfer-Encoding:
       - chunked
       Vary:

--- a/python/tests/e2e/cassettes/resume_with_override/openai_completions/async.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_completions/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '105'
+      - '106'
       content-type:
       - application/json
       host:
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBBSwMxEIX/yvLOqezW7sHcFDwoCCL0JBLSZHCDu5NtMmktZf+7bLGI
-        FU8D87335jFHBA+NIb+bumnW7fbATy+rm259fefXm+fH+90eCnIYaVZRzvadoJBiPy9sziGLZYHC
-        ED310HC9LZ4WOTKTLFaLZb1s67ZZQcFFFmKBfj2eI4U+Z/NpaDxUe5srl8gK+WpzqG5ZuhTH4K4w
-        vSlkiaNJZHNkaBB7IyUxvkGmbSF2BM2l7xXKqaw+IvBYxEj8IM7QTaPgrOvInA6FyOa3oD7zRNb/
-        x87eOZ/GjgZKtjft8Ff/Q5vukk4Kschlu0xpFxwZCZSgMX/Y2+QxTV8AAAD//wMA8SSWtK8BAAA=
+        H4sIAAAAAAAAAwAAAP//dJDBSgMxEIZfZfnPWdktrYfcvAhSzyoVCWkydoO7kzWZWEvZd5ctFrHi
+        aWC+b2Z+5ogheuqh4XpbPNU5MpPUy3rRLFbNql1CIXhoDHlnmvbabtzj63bN7e2W1g/3np42e4KC
+        HEaaLcrZ7uZGiv3csDmHLJYFCi6yEAv08/HsC33O5FQ07qq9zZVLZIV8tT1UNyxdimNwV5heFLLE
+        0SSyOTI0iL2RkhjfINN7IXYEzaXvFcopiT4i8FjESHwjztBtq+Cs68icDoXI5rfQnHki6/9j59l5
+        P40dDZRsb1bDX/+Htt0lnRRikct0mdJHcGQkUILG/D5vk8c0fQEAAP//AwC5WA3vrwEAAA==
     headers:
       CF-RAY:
-      - 987820625cb7ea78-SEA
+      - 98c0a59be8f4df2d-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:31 GMT
+      - Thu, 09 Oct 2025 20:32:24 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,35 +72,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:31Z'
+      - '2025-10-09T20:32:23Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:31Z'
+      - '2025-10-09T20:32:24Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:30Z'
+      - '2025-10-09T20:32:22Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:31Z'
+      - '2025-10-09T20:32:23Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbdABjon256euoPED2L
+      - req_011CTxG5qxrSFsDyQEZCb7KE
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1015'
+      - '1661'
     status:
       code: 200
       message: OK
@@ -145,18 +145,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4xSy47bMAy8+ysIneOF4zyazS3YU4AuWqB7KYqFwUi0ra4tCRLdJljk3wvZSez0
-        AfSiA4dDzQz5ngAIrcQWhKyRZeua9Olj2T7Jl09ms1PPz/Xj8fhFqs/HdfZyeFuIWWTYw3eSfGU9
-        SNu6hlhbM8DSEzLFqfMPq8d8M1/N8x5oraIm0irH6dKmeZYv02yTZusLsbZaUhBb+JYAALz3b5Ro
-        FB3FFrLZtdJSCFiR2N6aAIS3TawIDEEHRsNiNoLSGibTq/5KYQZ7kGhAWlNq3wLXyLCHnxjgIh8O
-        J9gZrr11Ws4ADez2ELAkPgEaBZ4CoZc1RPtoTg/TzzyVXcDo1XRNMwHQGMsYs+ptvl6Q881YYyvn
-        7SH8RhWlNjrUhScM1kQTga0TPXpOAF77ALu7TITztnVcsH2j/rtFPowT48ZGML+EK9gyNmN9dSXd
-        TSsUMeomTBYgJMqa1Mgct4Wd0nYCJBPPf4r52+zBtzbV/4wfASnJManCeVJa3hse2zzFe/5X2y3j
-        XrAI5H9oSQVr8nEPikrsmuHURDgFprYotanIO6+HeytdUS4W62WGyywTyTn5BQAA//8DAAbVWY54
-        AwAA
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrKxY8W4HsyHbim9G0gIGkOfTUFoGwIlcWU4okyFVbI/C/
+        F5QfsvsAeuFhZ2c5M7tvGYDQSqxAyBZZdt7k755D/d6svzwx64dPH+R98/DxGR+f1Ott+SgmieHq
+        V5J8Yt1I13lDrJ09wDIQMqWp0+WiKMrpfVkOQOcUmUTbes5Ll8+KWZkXd3mxOBJbpyVFsYKvGQDA
+        2/AmiVbRT7GCYnKqdBQjbkmszk0AIjiTKgJj1JHRspiMoHSWyQ6qP1OcwAYkWpDONjp0wC0ybOAH
+        RjjKh3oHa8ttcF7LCaCF9QYiNsQ7QKsgUCQMsoVkH+3u5vKzQE0fMXm1vTEXAFrrGFNWg82XI7I/
+        GzNu64Or429U0WirY1sFwuhsMhHZeTGg+wzgZQiwv8pE+OA6zxW7bzR8dzs7jBPjxkZwdgxXsGM0
+        Y31+Il1NqxQxahMvFiAkypbUyBy3hb3S7gLILjz/KeZvsw++td3+z/gRkJI8k6p8IKXlteGxLVC6
+        53+1nTMeBItI4buWVLGmkPagqMHeHE5NxF1k6qpG2y0FH/Th3hpfybqZLu/m88VSZPvsFwAAAP//
+        AwBfvmq4eAMAAA==
     headers:
       CF-RAY:
-      - 987820696e5376e8-SEA
+      - 98c0a5a72c07ec6c-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -164,14 +164,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:32 GMT
+      - Thu, 09 Oct 2025 20:32:25 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=rqYqaUTz4fUJS9PRdkspttSb48XK53wibGfTG8jkSbs-1759281512-1.0.1.1-C7y7ejmChvUpTY_7u9ru49JbDlaT9UpbsfX44r4vtpdYm3h6xteEHMjWQ8gVqi_UPqo6u9Z96b0j84gseNRGHVX_snPbA7Q48SplGPsSJvA;
-        path=/; expires=Wed, 01-Oct-25 01:48:32 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=L2tLqjH8gvK3XzjZjk1BOhnfgWVZ3zDOsYo4mAHozIM-1760041945-1.0.1.1-WJax6xYZ71lBr_c1urt_RIxuKnmE6FpfHz7dcaMYJXRrfYShqCgGCWhJJ9Wzy4QM9aDtysZp8MvK5BbMTjTU_scBIP29b.KTka.geKT3JEI;
+        path=/; expires=Thu, 09-Oct-25 21:02:25 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=p1iqclNcFQ.Qcg6h_qsRj9gHWqH.0mJyb5p4XWWXHRA-1759281512646-0.0.1.1-604800000;
+      - _cfuvid=A26iS5_9rj9yMxyDNGvlQCNoUZHZHz8g5t84L5v9aBA-1760041945012-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -188,13 +188,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '644'
+      - '547'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '659'
+      - '734'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -210,7 +210,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_c50ff97a73584f35952c2c2b405e381d
+      - req_5496147e9bb747c980b5afd706eec2e5
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/openai_completions/async_stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_completions/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '119'
+      - '120'
       content-type:
       - application/json
       host:
@@ -46,39 +46,39 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_017hSdDDxXvvo5ekY8mPR1aV","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}               }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01CS53Jg9uPLZTYHoDaH8Hx8","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}             }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I
-        was created by Anthropic."} }
+        was created by Anthropic."}       }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0       }
+        data: {"type":"content_block_stop","index":0               }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}  }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}    }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"     }
 
 
         '
     headers:
       CF-RAY:
-      - 9878210e782fba0e-SEA
+      - 98c0a6237ded50b7-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:18:59 GMT
+      - Thu, 09 Oct 2025 20:32:45 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -100,35 +100,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:58Z'
+      - '2025-10-09T20:32:44Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:58Z'
+      - '2025-10-09T20:32:44Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:58Z'
+      - '2025-10-09T20:32:44Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:58Z'
+      - '2025-10-09T20:32:44Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbfBwi919GghKigFSqH
+      - req_011CTxG7Sn93AesF9puvne1k
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '772'
+      - '1660'
     status:
       code: 200
       message: OK
@@ -147,8 +147,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=rqYqaUTz4fUJS9PRdkspttSb48XK53wibGfTG8jkSbs-1759281512-1.0.1.1-C7y7ejmChvUpTY_7u9ru49JbDlaT9UpbsfX44r4vtpdYm3h6xteEHMjWQ8gVqi_UPqo6u9Z96b0j84gseNRGHVX_snPbA7Q48SplGPsSJvA;
-        _cfuvid=p1iqclNcFQ.Qcg6h_qsRj9gHWqH.0mJyb5p4XWWXHRA-1759281512646-0.0.1.1-604800000
+      - __cf_bm=L2tLqjH8gvK3XzjZjk1BOhnfgWVZ3zDOsYo4mAHozIM-1760041945-1.0.1.1-WJax6xYZ71lBr_c1urt_RIxuKnmE6FpfHz7dcaMYJXRrfYShqCgGCWhJJ9Wzy4QM9aDtysZp8MvK5BbMTjTU_scBIP29b.KTka.geKT3JEI;
+        _cfuvid=A26iS5_9rj9yMxyDNGvlQCNoUZHZHz8g5t84L5v9aBA-1760041945012-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -175,101 +175,85 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"zTw7NuUvZFQ"}
+      string: 'data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"jlwotpMiuW0"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"Yes"},"logprobs":null,"finish_reason":null}],"obfuscation":"QwUoMrriYN"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"Yes"},"logprobs":null,"finish_reason":null}],"obfuscation":"qtvDTVPmcg"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"LsoxaEpuFGBg"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"uwcXNiKBvoH5"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"E7xH8EBHiR8"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZyTjxTY6e2h"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        can"},"logprobs":null,"finish_reason":null}],"obfuscation":"BnzNPOsg0"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}],"obfuscation":"HlhYW6OIr"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        confirm"},"logprobs":null,"finish_reason":null}],"obfuscation":"G5JJ5"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        confirm"},"logprobs":null,"finish_reason":null}],"obfuscation":"HOff8"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        that"},"logprobs":null,"finish_reason":null}],"obfuscation":"9aiIy3Mx"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        that"},"logprobs":null,"finish_reason":null}],"obfuscation":"V0cpHgLf"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"mUj7JSGx9NM"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"JJ5C8T7ka4A"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        was"},"logprobs":null,"finish_reason":null}],"obfuscation":"855k7jG40"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        was"},"logprobs":null,"finish_reason":null}],"obfuscation":"l5gad6Yut"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        developed"},"logprobs":null,"finish_reason":null}],"obfuscation":"qtE"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        created"},"logprobs":null,"finish_reason":null}],"obfuscation":"fRugm"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        by"},"logprobs":null,"finish_reason":null}],"obfuscation":"TZTU6dvoQT"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        by"},"logprobs":null,"finish_reason":null}],"obfuscation":"2gB31xtd53"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        Anth"},"logprobs":null,"finish_reason":null}],"obfuscation":"2r18PuRo"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        Anth"},"logprobs":null,"finish_reason":null}],"obfuscation":"GofRYf7J"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"ropic"},"logprobs":null,"finish_reason":null}],"obfuscation":"8XBTmaLg"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"ropic"},"logprobs":null,"finish_reason":null}],"obfuscation":"x2I9ZleE"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"jTvUFp1AMuQM"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"q7sBekMiNVeG"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        a"},"logprobs":null,"finish_reason":null}],"obfuscation":"7dfZCFj2ZdY"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        an"},"logprobs":null,"finish_reason":null}],"obfuscation":"fGYxaFXYfY"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        company"},"logprobs":null,"finish_reason":null}],"obfuscation":"m8iuW"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        AI"},"logprobs":null,"finish_reason":null}],"obfuscation":"uAHUlrRtWO"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        focused"},"logprobs":null,"finish_reason":null}],"obfuscation":"MAWdw"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        safety"},"logprobs":null,"finish_reason":null}],"obfuscation":"cRUAFF"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        on"},"logprobs":null,"finish_reason":null}],"obfuscation":"pxiYWvhchN"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}],"obfuscation":"pOO6J4Zrp"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        creating"},"logprobs":null,"finish_reason":null}],"obfuscation":"22gB"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        research"},"logprobs":null,"finish_reason":null}],"obfuscation":"OSJt"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        safe"},"logprobs":null,"finish_reason":null}],"obfuscation":"BJw87ghp"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
+        company"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZiT18"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        and"},"logprobs":null,"finish_reason":null}],"obfuscation":"G2xvUWObN"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"obfuscation":"nlAMuc7Uflt7"}
 
 
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        aligned"},"logprobs":null,"finish_reason":null}],"obfuscation":"8BjHG"}
-
-
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        AI"},"logprobs":null,"finish_reason":null}],"obfuscation":"zOZ1QleR6U"}
-
-
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        models"},"logprobs":null,"finish_reason":null}],"obfuscation":"R8PLoX"}
-
-
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"obfuscation":"5IlV2IEprDtO"}
-
-
-        data: {"id":"chatcmpl-CLfme3Lomdi4pnaf8hs0roupjho9U","object":"chat.completion.chunk","created":1759281540,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"fp0DeW7"}
+        data: {"id":"chatcmpl-COrba33jzqxFT1RWxp6HCkT5IWRgX","object":"chat.completion.chunk","created":1760041966,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"4pDAniW"}
 
 
         data: [DONE]
@@ -278,13 +262,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 98782118e8f77651-SEA
+      - 98c0a6329e6f8c86-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:19:00 GMT
+      - Thu, 09 Oct 2025 20:32:46 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -302,13 +286,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '240'
+      - '304'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '388'
+      - '362'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -324,7 +308,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_f91fd4cb048e48f8a94a9011e25fbafd
+      - req_c192975de04f4041857244fa847a7d18
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/openai_completions/stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_completions/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '119'
+      - '120'
       content-type:
       - application/json
       host:
@@ -46,39 +46,39 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01ARUy1XwbBorF5srQLTAHK6","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}            }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_019Fwq67HF7YBTW2a8ofwMCd","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}               }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I
-        was created by Anthropic."}            }
+        was created by Anthropic."}      }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0               }
+        data: {"type":"content_block_stop","index":0              }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}    }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}        }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"           }
+        data: {"type":"message_stop"            }
 
 
         '
     headers:
       CF-RAY:
-      - 987820c60b652672-SEA
+      - 98c0a5ec9e26a3c5-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:18:47 GMT
+      - Thu, 09 Oct 2025 20:32:36 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -100,35 +100,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:46Z'
+      - '2025-10-09T20:32:35Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:46Z'
+      - '2025-10-09T20:32:35Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:46Z'
+      - '2025-10-09T20:32:35Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:46Z'
+      - '2025-10-09T20:32:35Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbeLWdKqYbSNS61AkKu
+      - req_011CTxG6oLNrLATdXG4G7kGS
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '896'
+      - '1560'
     status:
       code: 200
       message: OK
@@ -147,8 +147,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=aJZtifHJKUwZEl9hDldtXmsxNBW9gDzowHGMx4t34FA-1759281500-1.0.1.1-P9Qu4wl2I.YmqYBd7HP2Z0dIw1WQmHNhdV1wF5xImJfMRnNB0gvkkDP4xf6RsotMHNpclo8uEuGvJGHfR14jZTiNkUSbkyJY9mshUujSRv4;
-        _cfuvid=JiyEUFh0LAYPnigPVIPpapXvatztyet.tRdVhrBcXj8-1759281500681-0.0.1.1-604800000
+      - __cf_bm=TUPyeSSFcqqPIKbCbSCsmzktSYuW3JnkLWumyDPwPm8-1760041934-1.0.1.1-13bLZyW0gnRBHybZrPRrr8iLFmveIr8DK0q3dhxaqtEuNFfaBPd95ZZsuISC4haQ3fxjw2hMsWXqJI5OT2c3djVqxC5qxV.7QEojGT2Z4BI;
+        _cfuvid=koBBc9IXTeW6rLcUYkCsdNSDNLbNg9KBJsxSTT3cjbQ-1760041934359-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -175,58 +175,129 @@ interactions:
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
-      string: 'data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"R4bp5Bs1WzW"}
+      string: 'data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}],"obfuscation":"6PDkzsDedPW"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"Yes"},"logprobs":null,"finish_reason":null}],"obfuscation":"WNZDZZVMqE"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"Yes"},"logprobs":null,"finish_reason":null}],"obfuscation":"rkMf5Ir3QG"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"YvaHW6roDlcY"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"zYpEGd9semed"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"nCSw6sXE1cr"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"BQakwDXlQON"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        can"},"logprobs":null,"finish_reason":null}],"obfuscation":"xDzHRUxC0"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        can"},"logprobs":null,"finish_reason":null}],"obfuscation":"Ecs1Svwhl"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        confirm"},"logprobs":null,"finish_reason":null}],"obfuscation":"FZcIW"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        confirm"},"logprobs":null,"finish_reason":null}],"obfuscation":"mSx3P"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        that"},"logprobs":null,"finish_reason":null}],"obfuscation":"4aVNt7d5"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        that"},"logprobs":null,"finish_reason":null}],"obfuscation":"rl3dCEqa"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"LiaH0tRrOkf"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        I"},"logprobs":null,"finish_reason":null}],"obfuscation":"eE7aUlNVa9z"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        was"},"logprobs":null,"finish_reason":null}],"obfuscation":"48kn3dpo1"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        was"},"logprobs":null,"finish_reason":null}],"obfuscation":"b0jBYfmbb"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        created"},"logprobs":null,"finish_reason":null}],"obfuscation":"Z2i7O"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        created"},"logprobs":null,"finish_reason":null}],"obfuscation":"NWdQC"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        by"},"logprobs":null,"finish_reason":null}],"obfuscation":"NgIQ87gyGb"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        by"},"logprobs":null,"finish_reason":null}],"obfuscation":"p59lqPptG8"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"
-        Anth"},"logprobs":null,"finish_reason":null}],"obfuscation":"2jjagbh2"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        Anth"},"logprobs":null,"finish_reason":null}],"obfuscation":"7iuiwrHM"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"ropic"},"logprobs":null,"finish_reason":null}],"obfuscation":"pMiOSEcL"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"ropic"},"logprobs":null,"finish_reason":null}],"obfuscation":"BhL5l2cU"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"obfuscation":"PLmvB9ndeyGL"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":","},"logprobs":null,"finish_reason":null}],"obfuscation":"0TU5AkIGSAYr"}
 
 
-        data: {"id":"chatcmpl-CLfmSCNQm2Dyjx4A9KDgouaCM0jg6","object":"chat.completion.chunk","created":1759281528,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_f33640a400","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"wZA8wQD"}
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        a"},"logprobs":null,"finish_reason":null}],"obfuscation":"PXHdBJcyb7a"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        company"},"logprobs":null,"finish_reason":null}],"obfuscation":"GQGmf"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        focused"},"logprobs":null,"finish_reason":null}],"obfuscation":"1B6cY"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        on"},"logprobs":null,"finish_reason":null}],"obfuscation":"5p1JJBklzS"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        developing"},"logprobs":null,"finish_reason":null}],"obfuscation":"HN"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        advanced"},"logprobs":null,"finish_reason":null}],"obfuscation":"ZWrT"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        AI"},"logprobs":null,"finish_reason":null}],"obfuscation":"WFgqsHjC7R"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        models"},"logprobs":null,"finish_reason":null}],"obfuscation":"5f8JgB"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}],"obfuscation":"MgL4Qbwn6"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        ensuring"},"logprobs":null,"finish_reason":null}],"obfuscation":"A8To"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        their"},"logprobs":null,"finish_reason":null}],"obfuscation":"b55w0OQ"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        alignment"},"logprobs":null,"finish_reason":null}],"obfuscation":"Blp"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        with"},"logprobs":null,"finish_reason":null}],"obfuscation":"8ZMBWkOj"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        human"},"logprobs":null,"finish_reason":null}],"obfuscation":"UfbB6fY"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        values"},"logprobs":null,"finish_reason":null}],"obfuscation":"hNb7k0"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        and"},"logprobs":null,"finish_reason":null}],"obfuscation":"nUo1dtORa"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"
+        safety"},"logprobs":null,"finish_reason":null}],"obfuscation":"TPldf9"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{"content":"."},"logprobs":null,"finish_reason":null}],"obfuscation":"LphX2A5ItDek"}
+
+
+        data: {"id":"chatcmpl-COrbR0sZ3PZ6dqRCji8jmuDzLOFQN","object":"chat.completion.chunk","created":1760041957,"model":"gpt-4o-2024-08-06","service_tier":"default","system_fingerprint":"fp_cbf1785567","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop"}],"obfuscation":"ntNKuOs"}
 
 
         data: [DONE]
@@ -235,13 +306,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 987820ce7da72661-SEA
+      - 98c0a5f91cc975fd-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:18:48 GMT
+      - Thu, 09 Oct 2025 20:32:37 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -259,13 +330,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '238'
+      - '277'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '353'
+      - '446'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -281,7 +352,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_bb6d1fe8d2f84a578b77b8d3ce48c6b1
+      - req_199b2068f5e2495ca444bc4a6f4689c8
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/openai_completions/sync.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_completions/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '105'
+      - '106'
       content-type:
       - application/json
       host:
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBBSwMxEIX/yvLOqeyWLkhuepCqFy9eFAlpMnRDdydrMrGWsv9dtljE
-        iqeB+d5785gjgofGkLembp665W73sl09tg9+fftMd9f7zXiAghxGmlWUs90SFFLs54XNOWSxLFAY
-        oqceGq63xdMiR2aSxWqxrJdt3TYrKLjIQizQr8dzpNDnbD4Njftqb3PlElkhX20O1Q1Ll+IY3BWm
-        N4UscTSJbI4MDWJvpCTGN8j0XogdQXPpe4VyKquPCDwWMRJ3xBm6aRScdR2Z06EQ2fwW1GeeyPr/
-        2Nk759PY0UDJ9qYd/up/aNNd0kkhFrlslyl9BEdGAiVozB/2NnlM0xcAAAD//wMA8t+laa8BAAA=
+        H4sIAAAAAAAAAwAAAP//dJDBSsQwEIZfpfznrLRLe8lNBcWDoF5FQkwGG2wn3WTiurv03aWLi7ji
+        aWC+b2Z+5oAxehqg4QZbPK1yZCZZtat1ve7qrmmhEDw0xvxm6ubhal8e2+mmNH0v2+vNbdvd75+g
+        ILuJFotytm8EhRSHpWFzDlksCxRcZCEW6OfDyRf6XMixaNxVW5srl8gK+ep1V12y9ClOwV1gflHI
+        EieTyObI0CD2RkpifINMm0LsCJrLMCiUYxJ9QOCpiJH4Tpyhm0bBWdeTOR4Kkc1voT7xRNb/x06z
+        y36aehop2cF041//hzb9OZ0VYpHzdJnSR3BkJFCCxvI+b5PHPH8BAAD//wMAB6HFhK8BAAA=
     headers:
       CF-RAY:
-      - 9878200abfd4ebdf-SEA
+      - 98c0a5586e96b89e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:19 GMT
+      - Thu, 09 Oct 2025 20:32:13 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,35 +72,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:18Z'
+      - '2025-10-09T20:32:13Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:18Z'
+      - '2025-10-09T20:32:13Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:16Z'
+      - '2025-10-09T20:32:11Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:18Z'
+      - '2025-10-09T20:32:13Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbc8EdfrZSB1AZSoT19
+      - req_011CTxG53myznAdhDniYY2E9
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2275'
+      - '1635'
     status:
       code: 200
       message: OK
@@ -145,18 +145,18 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFLBbtswDL37Kwid7cJ1nK7JLcgpaIECAQasGwpDkWhbmywKktwtK/Lv
-        g+w0drsO2EUHPr6n90i+JABMSbYGJloeRGd1tr2v9e/Hz4u2+bLZ7tTWf833+31593D3cF+wNDLo
-        8B1FeGVdCeqsxqDIjLBwyANG1etPy1Vxe12uVgPQkUQdaY0NWUlZkRdllt9m+c2Z2JIS6NkaviUA
-        AC/DGy0aib/YGvL0tdKh97xBtr40ATBHOlYY9175wE1g6QQKMgHN4PoRfQo7ENyAIFMr10FoeYAd
-        /OQezvbhcISNCa0jq0QKHGJMbo5Qk+g9SiADEp9Rk1Wmgc0OhngeuJHgjz5g56/mBhzWvecxv+m1
-        ngHcGAo8zm+I/nRGTpewmhrr6ODfUVmtjPJt5ZB7MjGYD2TZgJ4SgKdhqP2bOTHrqLOhCvQDh+8W
-        xSjHpi1OYLE4g4EC11N9uUw/UKskBq60ny2FCS5alBNz2iDvpaIZkMwy/23mI+0xtzLN/8hPgBBo
-        A8rKOpRKvA08tTmMN/6vtsuMB8PMo3tWAqug0MU9SKx5r8fzY+MtVLUyDTrr1HiDta3qxeKmzHmZ
-        5yw5JX8AAAD//wMARYHBAIwDAAA=
+        H4sIAAAAAAAAAwAAAP//jFLLbtswELzrKxY8y4Eiu27jWx4XAy166KEoikBYkSuJCcUlSMq1E/jf
+        C8oPOW0K9MLDzs5wZndfMwChlViBkB1G2Tszu//q63lty932ZfOi5p+/bVt1d19/eXp+4O8iTwyu
+        n0jGE+tKcu8MRc32AEtPGCmpXn9cFsXi+mY+H4GeFZlEa12cLXhWFuViVnyaFcsjsWMtKYgV/MwA
+        AF7HN1m0irZiBUV+qvQUArYkVucmAOHZpIrAEHSIaKPIJ1CyjWRH1z8o5LAGiRYk20b7HmKHEdbw
+        CwMc7UO9g1sbO89OyxwQUky0O2hYDoEUsAVFGzLstG0B1QatJAW3axhzhqvL3z01Q8AU3g7GXABo
+        LUdMwxtzPx6R/Tmp4dZ5rsMfVNFoq0NXecLANqUKkZ0Y0X0G8DhOdHgzJOE89y5WkZ9p/G5eHuTE
+        tMIJLE9g5Ihmqn9Y5O+oVYoiahMuNiIkyo7UxJzWh4PSfAFkF5n/NvOe9iG3tu3/yE+AlOQiqcp5
+        Ulq+DTy1eUoH/q+284xHwyKQ32hJVdTk0x4UNTiYw+2JsAuR+qrRtiXvvD4cYOOqZrloypsCm1Jk
+        ++w3AAAA//8DAIWoPcaJAwAA
     headers:
       CF-RAY:
-      - 9878201adb287660-SEA
+      - 98c0a564b9f47648-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -164,14 +164,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:20 GMT
+      - Thu, 09 Oct 2025 20:32:14 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=aJZtifHJKUwZEl9hDldtXmsxNBW9gDzowHGMx4t34FA-1759281500-1.0.1.1-P9Qu4wl2I.YmqYBd7HP2Z0dIw1WQmHNhdV1wF5xImJfMRnNB0gvkkDP4xf6RsotMHNpclo8uEuGvJGHfR14jZTiNkUSbkyJY9mshUujSRv4;
-        path=/; expires=Wed, 01-Oct-25 01:48:20 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=TUPyeSSFcqqPIKbCbSCsmzktSYuW3JnkLWumyDPwPm8-1760041934-1.0.1.1-13bLZyW0gnRBHybZrPRrr8iLFmveIr8DK0q3dhxaqtEuNFfaBPd95ZZsuISC4haQ3fxjw2hMsWXqJI5OT2c3djVqxC5qxV.7QEojGT2Z4BI;
+        path=/; expires=Thu, 09-Oct-25 21:02:14 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=JiyEUFh0LAYPnigPVIPpapXvatztyet.tRdVhrBcXj8-1759281500681-0.0.1.1-604800000;
+      - _cfuvid=koBBc9IXTeW6rLcUYkCsdNSDNLbNg9KBJsxSTT3cjbQ-1760041934359-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -188,13 +188,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1083'
+      - '599'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1266'
+      - '712'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -210,7 +210,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 1ms
       x-request-id:
-      - req_3adaeed93c954567813e4c97f6dd33af
+      - req_b83375c13c1541d48f30a754354debe5
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/openai_responses/async.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_responses/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '105'
+      - '106'
       content-type:
       - application/json
       host:
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBBSwMxEIX/yvLOqezW7sHcBA8KXjyIB5GQJkM3dneyJhPbUva/yxaL
-        WPE0MN97bx5zRPDQGPLG1E37/uLY57vH5qnbC9/s1tv762coyGGkWUU52w1BIcV+XticQxbLAoUh
-        euqh4XpbPC1yZCZZrBbLetnWbbOCgossxAL9ejxHCu1n82loPFQ7myuXyAr5an2oblm6FMfgrjC9
-        KWSJo0lkc2RoEHsjJTG+QaaPQuwImkvfK5RTWX1E4LGIkbglztBNo+Cs68icDoXI5regPvNE1v/H
-        zt45n8aOBkq2N+3wV/9Dm+6STgqxyGW7TOkzODISKEFj/rC3yWOavgAAAP//AwDb8bmhrwEAAA==
+        H4sIAAAAAAAAA3SQTUvDQBCG/0p4zxtJSnvZW1H8uokIgsiy7o5NNJlNd2etbcl/lxSLWPE0MM8z
+        My+zRx88ddBwnc2eyhSYScp5Oatmi2pRz6HQemj0aWWq+sHev17xOe/u1pvHy9u33fVFnZZQkO1A
+        k0Up2RVBIYZuatiU2iSWBQousBAL9NP+6At9TuRQNG6KjU2Fi2SFfPGyLZYsTQxD684wPiskCYOJ
+        ZFNgaBB7IzkyvkGidSZ2BM256xTyIYneo+Uhi5HwTpyg61rBWdeQORxqA5vfQnXkkaz/jx1np/00
+        NNRTtJ1Z9H/9H1o3p3RUCFlO0yWKH60jIy1FaEzv8zZ6jOMXAAAA//8DAGLVX32vAQAA
     headers:
       CF-RAY:
-      - 987820716f4e6812-SEA
+      - 98c0a5b05d1f75ce-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:35 GMT
+      - Thu, 09 Oct 2025 20:32:27 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,35 +72,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:34Z'
+      - '2025-10-09T20:32:27Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:35Z'
+      - '2025-10-09T20:32:27Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:33Z'
+      - '2025-10-09T20:32:25Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:34Z'
+      - '2025-10-09T20:32:27Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbdLU7bowUP93XEqWmu
+      - req_011CTxG65uFiyTsQXMxr4mPy
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1793'
+      - '1907'
     status:
       code: 200
       message: OK
@@ -145,20 +145,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUwW7bMAy95ysEn5vCdpzYyW3HfcJQDAYt06lWWRQkKmtQ5N8Hy7Fjr91uCR/5
-        Qr73lI+NEIlqk5NIHHpbp2VT5LIq92W6L2XRpOmhamWVHZpd16RVdiybDtOiPOzkUVaQF8fkaaCg
-        5hdKnmjIeBzr0iEwtjUMWFbuj3mV7bN9xDwDBz/MSOqtRsZ2HGpAvp0dBTPs1YH2OJaV1sqck5P4
-        2AghRGLhim6Yb/GCmiy6ZCPELTajczRgJmgdC8pMv1K3yKC0X6OeXZCsyKzqPbzXFNgGrpne8DPI
-        RLqWoNd0PbWoh83OlrcFbfM0L7ZptU0Pd7kiZXISL/GS8Z7Zid6f/2NEc6zkYMQRdmV7ACmzfbE7
-        tFVkjix8tRh50Hs44wP4l+IRlGQYzWOp5WIr2kkPfOd5OjaAMcQwafjycwVqOltHzRdIJDqJ5Af6
-        J/Fd/AYv7rERzVV8M/zqyCr5nMxDt/unmSdxpONu4L3yDIbH5qExNiUWHGiNem0YuzBmyzq8KAq+
-        nuJbRytmQ62j3nItQb5i/YbXJeYQPJlVMrHryPGiaRA/9D24aXIOqocO+VqrFg2rTuEqtB7dRUms
-        WU1B7yDoUfbEMzlcHsHYW3TAIZaz5/RejfLeN+vI9fD4vrA19o2q3Te+oGvIK76OYWpV6B8PbNTx
-        lZQchQ9MyQw8XE6YbL3wPp2LdrmjC0bG5MQrlYdGT/8GIWZ4PkCZ1WPc5U+f64sXPp8ZrWsfg+nq
-        1L/feJZ+BXzFO7v/L2omBv0Ai3yWMPi12z0ytMAw0N82tz8AAAD//wMACKNMbpwFAAA=
+        H4sIAAAAAAAAA3RUy27bMBC8+ytYnuOAstX4cSt66jcEhbCiVg4bikuQSzdG4H8vRFmy1CQ3e2d3
+        vDsz9PtKCGkaeRQyYPSV2u7qFstDC82u3aqNUk973Bd1U+uyVvvisDs0GjUUB1CFblvQ8qGnoPoP
+        ah5pyEUc6jogMDYV9Fixe1KqLA7lLmORgVPsZzR13iJjMwzVoF9PgZLr92rBRhzKxlrjTvIo3ldC
+        CCE9XDD08w2e0ZLHIFdCXHMzhkA95pK1uWDc+CtVgwzGxiUaOSTNhtyi3sFbRYl94orpFT+CTGQr
+        DXZJ11GDtt/s5Hld0nqjNuVa7dfq6SZXppRH8ZwvGe6ZnOji6Wsj9Pct7rMRe7WvEfSuKFUL2yIz
+        Zxa+eMw8GCOc8A58pXgGNTlGd19qvtiCdtQD33iazg3gHDGMGj7/XoCWTj5Q/QmSiY5C/sTAYJy9
+        fBO/xF+I4hYeUV/ED8cvgbzRj3Iavd4+TWwykM0bQowmMjgemvvG3CQ9BLAW7dI2DmlImA94NpRi
+        NYa4yoZMtvpAnedKg37B6hUvcywgRHKLfGLbUuBZU29B6joI4+QU1wgt8qUyDTo2rcFFdCOGs9FY
+        sRnj3kKyg/gyMgWcH8HYeQzAKZeLR3WrZpFvm7UUOrh/n5mb+wbVbhufMdQUDV+GSDUmdfdnNuj4
+        QkYPwicmOQF3ryWTr2YJUFPRz3cMyemcn3yliVDb8T8h5SRPBxi3eJLbzcPH+uydT2dm65r7oFqc
+        +v9LL9RnwGe8k/tfUTMx2DtYbiYJU1y63SFDAww9/XV1/QcAAP//AwBL9PIJogUAAA==
     headers:
       CF-RAY:
-      - 9878207ddde0767e-SEA
+      - 98c0a5bd2ee5c4cb-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -166,15 +166,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:36 GMT
+      - Thu, 09 Oct 2025 20:32:28 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=QNkkVSsirli4096mgRPehv4VlRqWjD9b4MrWLUPguIY-1759281516-1.0.1.1-vmXyi6Ctzm2R_SG4icVIt3kA3oSFQFBNGSGCiC6gruafopOyf3cBtcdHOH2dlM2PBRFviJ0YeAAWDKRA1gcmlSOPInJmeZ7nNQ9C33tnDPs;
-        path=/; expires=Wed, 01-Oct-25 01:48:36 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=HgV4DuT_HIp1uIBp0GkTQ1q.G7164WvCwJeAxetcIqk-1760041948-1.0.1.1-3qfFsyUs0xvKiCfVzmO_QoGmuyyaUbyAtTojy5e6x1rgnDPf97DDG.ZDqOiUUyb6Q0_FgXDzx9edOr0pW7immI5HYR4LVcm9tFzTy0ZK6.U;
+        path=/; expires=Thu, 09-Oct-25 21:02:28 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=f27JzZKeD.Xr.H3R.T7UeBrDhbfSgm5Lhbt3u0Iip5Q-1759281516115-0.0.1.1-604800000;
+      - _cfuvid=z9.CcUBA7O.ao2nwppM0PV95yymcL48fgbvzKbwuY_k-1760041948603-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -186,15 +188,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '847'
+      - '810'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '855'
+      - '814'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -208,7 +208,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_6822246d20b00a6cfe37fe31c6d9305f
+      - req_7518a14b0d3e484484eca108d3d9d70c
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/openai_responses/async_stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_responses/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '119'
+      - '120'
       content-type:
       - application/json
       host:
@@ -46,28 +46,28 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_014LiME8qCUf2z4uBsYSRxFh","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01U3WtQvA8gk9jyiXMq4ix5N","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}            }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I
-        was created by Anthropic."}     }
+        was created by Anthropic."}           }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0 }
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}       }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}         }
 
 
         event: message_stop
@@ -78,7 +78,7 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 987821217c053089-SEA
+      - 98c0a63ba9601f9a-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:19:03 GMT
+      - Thu, 09 Oct 2025 20:32:49 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -100,35 +100,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:19:01Z'
+      - '2025-10-09T20:32:48Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:19:01Z'
+      - '2025-10-09T20:32:48Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:19:01Z'
+      - '2025-10-09T20:32:48Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:19:01Z'
+      - '2025-10-09T20:32:48Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbfQxYi8dchLUxXvpiV
+      - req_011CTxG7jGLDayEVvuSezwSi
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1642'
+      - '1762'
     status:
       code: 200
       message: OK
@@ -147,8 +147,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=QNkkVSsirli4096mgRPehv4VlRqWjD9b4MrWLUPguIY-1759281516-1.0.1.1-vmXyi6Ctzm2R_SG4icVIt3kA3oSFQFBNGSGCiC6gruafopOyf3cBtcdHOH2dlM2PBRFviJ0YeAAWDKRA1gcmlSOPInJmeZ7nNQ9C33tnDPs;
-        _cfuvid=f27JzZKeD.Xr.H3R.T7UeBrDhbfSgm5Lhbt3u0Iip5Q-1759281516115-0.0.1.1-604800000
+      - __cf_bm=HgV4DuT_HIp1uIBp0GkTQ1q.G7164WvCwJeAxetcIqk-1760041948-1.0.1.1-3qfFsyUs0xvKiCfVzmO_QoGmuyyaUbyAtTojy5e6x1rgnDPf97DDG.ZDqOiUUyb6Q0_FgXDzx9edOr0pW7immI5HYR4LVcm9tFzTy0ZK6.U;
+        _cfuvid=z9.CcUBA7O.ao2nwppM0PV95yymcL48fgbvzKbwuY_k-1760041948603-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -177,116 +177,136 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c8ab4fbebb11de00068dc8187ca8c8193af35d4cfb45c2786","object":"response","created_at":1759281543,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0ae62be960f936480068e81bf2860c8197aa2fbc16b9d3a7c3","object":"response","created_at":1760041970,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c8ab4fbebb11de00068dc8187ca8c8193af35d4cfb45c2786","object":"response","created_at":1759281543,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0ae62be960f936480068e81bf2860c8197aa2fbc16b9d3a7c3","object":"response","created_at":1760041970,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"Yep","logprobs":[],"obfuscation":"tVElXgrz9g32A"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"Yes","logprobs":[],"obfuscation":"RlUAtuxPkqRuE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"9RfpIvW88J0FFkW"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"Znuq6PHgUUH1fDW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"
-        I","logprobs":[],"obfuscation":"x12O5a77W7RI3b"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        I","logprobs":[],"obfuscation":"BEP2eNFrX0J5KZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"
-        was","logprobs":[],"obfuscation":"6lhY3vGIe8Qm"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        can","logprobs":[],"obfuscation":"rYGOq7KpRULv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"
-        indeed","logprobs":[],"obfuscation":"T8pfmI6f5"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        confirm","logprobs":[],"obfuscation":"1KeaETtI"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"
-        created","logprobs":[],"obfuscation":"vkaE9jas"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        that","logprobs":[],"obfuscation":"HFmONv83f9N"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"
-        by","logprobs":[],"obfuscation":"Ycskl8mKsX5iK"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        I","logprobs":[],"obfuscation":"TUE5tQEElmNImH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"
-        Anth","logprobs":[],"obfuscation":"z7ttsRRD2Rw"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        was","logprobs":[],"obfuscation":"cxdEYoD6p7cP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":"ropic","logprobs":[],"obfuscation":"CU4V8ei1rz6"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        created","logprobs":[],"obfuscation":"DTovSjiX"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"bDD2hB0kyJ30VNk"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        by","logprobs":[],"obfuscation":"3LD5ExfIFcJIz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"
+        Anth","logprobs":[],"obfuscation":"vTRV9a3faXz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":"ropic","logprobs":[],"obfuscation":"mZ4viuD7Pe0"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"9t1woycp2Qsa4PJ"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"text":"Yep,
-        I was indeed created by Anthropic.","logprobs":[]}
+        data: {"type":"response.output_text.done","sequence_number":17,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"text":"Yes,
+        I can confirm that I was created by Anthropic.","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Yep,
-        I was indeed created by Anthropic."}}
+        data: {"type":"response.content_part.done","sequence_number":18,"item_id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
+        I can confirm that I was created by Anthropic."}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yep,
-        I was indeed created by Anthropic."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","sequence_number":19,"output_index":0,"item":{"id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
+        I can confirm that I was created by Anthropic."}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0c8ab4fbebb11de00068dc8187ca8c8193af35d4cfb45c2786","object":"response","created_at":1759281543,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yep,
-        I was indeed created by Anthropic."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":32,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":43},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","sequence_number":20,"response":{"id":"resp_0ae62be960f936480068e81bf2860c8197aa2fbc16b9d3a7c3","object":"response","created_at":1760041970,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
+        I can confirm that I was created by Anthropic."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":32,"input_tokens_details":{"cached_tokens":0},"output_tokens":14,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":46},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 987821304c5f5ea8-SEA
+      - 98c0a64b4a7ea324-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:19:04 GMT
+      - Thu, 09 Oct 2025 20:32:50 GMT
       Server:
       - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -298,17 +318,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '327'
+      - '133'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '345'
+      - '149'
       x-request-id:
-      - req_b69ad91943cf58add8d5a850ee5174cd
+      - req_f9e0eb9eae7440e2935e94e38861e251
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/openai_responses/stream.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_responses/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0","stream":true}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '119'
+      - '120'
       content-type:
       - application/json
       host:
@@ -46,39 +46,40 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_019xgW1qMCU4fmjq5TNNCeRr","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_013V9EAyUjQwkN2udFLbfJMf","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}}
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
+        }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I
-        was created by Anthropic."}      }
+        was created by Anthropic."}          }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0 }
+        data: {"type":"content_block_stop","index":0   }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}   }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":11,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":11}     }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"          }
+        data: {"type":"message_stop"     }
 
 
         '
     headers:
       CF-RAY:
-      - 987820d28eb22672-SEA
+      - 98c0a6004b2da3c5-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -86,7 +87,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:18:49 GMT
+      - Thu, 09 Oct 2025 20:32:40 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -100,35 +101,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:48Z'
+      - '2025-10-09T20:32:38Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:48Z'
+      - '2025-10-09T20:32:38Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:48Z'
+      - '2025-10-09T20:32:38Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:48Z'
+      - '2025-10-09T20:32:38Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbeUtuA1QYZkXWS23En
+      - req_011CTxG72arFCjRFQjNidLgn
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '808'
+      - '1524'
     status:
       code: 200
       message: OK
@@ -147,8 +148,8 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=9DB6Ekyud6KM3ptuRyhOP8DPd_IljouDjdmJNKMdhw4-1759281503-1.0.1.1-trjQ9wS30Eaf.J_teBOIAxNRCaJeLhLWwaJ9fLXrBIw.NiUMU3mVTexeSl4pHmOqwgnGYDF8AmitcaMxvqd8J0rVC6LBAghqOvHWOfj7Nog;
-        _cfuvid=dcXYoA1DhFeu5pxaL4xPOse0Y956RHuDInRPFHCWDKs-1759281503343-0.0.1.1-604800000
+      - __cf_bm=p4DRm6SSVa9zGln5eYa3bxOA04l89S0XEIZpAtSDslY-1760041937-1.0.1.1-eBYxH_FoclcXSzMVuuApKHwvmp8HMbK1D4KpERZPTf297F5Cfqp6dR26VezL2Va4iFQ6Y71e.ty9KZgspZ.tVPmtUHJUar9.yI2C3QEev4I;
+        _cfuvid=B9LvR3G.6DCeNkFFf9yp0ebQPVY3ii6HU_6OaCSTJSM-1760041937948-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -177,116 +178,112 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c50d3cc2a8564780068dc8179f41c8197ac1cabbb913bf7c3","object":"response","created_at":1759281530,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_085a34355e7cd43c0068e81be867608196b1f75d9c3cf85162","object":"response","created_at":1760041960,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c50d3cc2a8564780068dc8179f41c8197ac1cabbb913bf7c3","object":"response","created_at":1759281530,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_085a34355e7cd43c0068e81be867608196b1f75d9c3cf85162","object":"response","created_at":1760041960,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"Yes","logprobs":[],"obfuscation":"qq6DErkASvtP3"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"Yes","logprobs":[],"obfuscation":"zhLz2IC0u28Hs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"DoftjhdjMawyGDz"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"ddXdlK9mMIom70p"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"
-        I","logprobs":[],"obfuscation":"T5eTfhBQfjrWfr"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"
+        I''m","logprobs":[],"obfuscation":"nfG87NcJyHdf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"
-        was","logprobs":[],"obfuscation":"3Ug6eqaLa9sx"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"
+        definitely","logprobs":[],"obfuscation":"16Sci"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"
-        indeed","logprobs":[],"obfuscation":"Q7Ke3HMua"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"
+        created","logprobs":[],"obfuscation":"XvsCwib0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"
-        created","logprobs":[],"obfuscation":"viOSVzvC"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"
+        by","logprobs":[],"obfuscation":"YqYwOUuzmmue4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"
-        by","logprobs":[],"obfuscation":"NaDMUhCuFBGLv"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"
+        Anth","logprobs":[],"obfuscation":"FBD3WCdgmIN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"
-        Anth","logprobs":[],"obfuscation":"cCJaRPR9qBk"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"ropic","logprobs":[],"obfuscation":"enJoGwd6Kko"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":"ropic","logprobs":[],"obfuscation":"8bKbGI6tIcK"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"3JHr3VRSNWYsrkb"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"BsRQXfUoZjZPTIQ"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"text":"Yes,
-        I was indeed created by Anthropic.","logprobs":[]}
+        data: {"type":"response.output_text.done","sequence_number":13,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"text":"Yes,
+        I''m definitely created by Anthropic!","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
-        I was indeed created by Anthropic."}}
+        data: {"type":"response.content_part.done","sequence_number":14,"item_id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
+        I''m definitely created by Anthropic!"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
-        I was indeed created by Anthropic."}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","sequence_number":15,"output_index":0,"item":{"id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
+        I''m definitely created by Anthropic!"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0c50d3cc2a8564780068dc8179f41c8197ac1cabbb913bf7c3","object":"response","created_at":1759281530,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
-        I was indeed created by Anthropic."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":32,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":43},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","sequence_number":16,"response":{"id":"resp_085a34355e7cd43c0068e81be867608196b1f75d9c3cf85162","object":"response","created_at":1760041960,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Yes,
+        I''m definitely created by Anthropic!"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":32,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":42},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 987820d96dd46832-SEA
+      - 98c0a60c2b2efd8a-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 01 Oct 2025 01:18:50 GMT
+      - Thu, 09 Oct 2025 20:32:40 GMT
       Server:
       - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -298,17 +295,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '238'
+      - '56'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '257'
+      - '63'
       x-request-id:
-      - req_e7889b4f46e90f1f7cb4cd81d3e5a4ff
+      - req_a19e5b6529ac4b8fb1ed944527c860c9
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/resume_with_override/openai_responses/sync.yaml
+++ b/python/tests/e2e/cassettes/resume_with_override/openai_responses/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Who created you?"}],"model":"claude-sonnet-4-0"}'
     headers:
       accept:
       - application/json
@@ -11,7 +11,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '105'
+      - '106'
       content-type:
       - application/json
       host:
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJBRSwMxEIT/yjHPqdyVFiRvUkQU65tIEQkxWXqhd5sz2VRLuf8uVyyi
-        4tPCfjOzwx4RPDT6vDV1c9c/rN1Gbha7zfrx8ml1fVjt6R4KchhoUlHOdktQSLGbFjbnkMWyQKGP
-        njpouM4WT7McmUlmi9m8ni/rZbOAgossxAL9fDxHCn1M5tPQuK3eba5cIivkq9dDdcXSpjgEd4Hx
-        RSFLHEwimyNDg9gbKYnxBTK9FWJH0Fy6TqGcyuojAg9FjMQdcYZuGgVnXUvmdChENj8F9Zknsv4/
-        dvZO+TS01FOynVn2f/XftGl/01EhFvndLlPaB0dGAiVoTB/2NnmM4ycAAAD//wMAXqf8Bq8BAAA=
+        H4sIAAAAAAAAA3SQwUrDQBCGXyX8560kJfWwN6sXsRTEgxSRZd0dmsVkNt2daEvJu0uKRax4Gpjv
+        m5mfOaKLnlpouNYOnmY5MpPM6tm8nC/KRVVDIXhodHlryuphbVebx+XqerfeP91u6mXd7e6eoSCH
+        niaLcrZbgkKK7dSwOYcslgUKLrIQC/TL8ewL7SdyKhr3xafNhUtkhXzxdihuWJoU++CuML4qZIm9
+        SWRzZGgQeyNDYnyDTLuB2BE0D22rMJyS6CMC94MYie/EGbqqFJx1DZnToRDZ/BbKM09k/X/sPDvt
+        p76hjpJtzaL76//Qqrmko0Ic5DJdpvQRHBkJlKAxvc/b5DGOXwAAAP//AwAE5vzjrwEAAA==
     headers:
       CF-RAY:
-      - 9878202408beebdf-SEA
+      - 98c0a56a7a79b89e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:22 GMT
+      - Thu, 09 Oct 2025 20:32:16 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,35 +72,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-01T01:18:21Z'
+      - '2025-10-09T20:32:16Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-01T01:18:22Z'
+      - '2025-10-09T20:32:16Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-01T01:18:20Z'
+      - '2025-10-09T20:32:14Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-01T01:18:21Z'
+      - '2025-10-09T20:32:16Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTfbcRZRsQa3zapoycxJY
+      - req_011CTxG5G9Npp9Z35qzrt7WU
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1539'
+      - '1887'
     status:
       code: 200
       message: OK
@@ -145,20 +145,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUy3LbMAy8+ytYneOOJD8i+dZjvyHT0UAk5LChCA4JuvFk/O8dUZYstcnNxgJr
-        YHfpj40QmVbZSWQeg2vyZ1C1Ko67tsKdzI95fqyUrIoD1sdSVkX93NaoFCp5KLGqCrXPngYKan+j
-        5ImGbMCxLj0Co2pgwIrnQ11WxSEvExYYOIZhRlLvDDKqcagF+Xb2FO2wVwcm4FjWxmh7zk7iYyOE
-        EJmDK/phXuEFDTn02UaIW2pG72nAbDQmFbSdfqVRyKBNWKOBfZSsya7qPbw3FNlFbpje8H+QiUwj
-        wazpelJohs3Ojrd72pZ5ud/m1TY/3uVKlNlJvKRLxntmJ/pw/tqILj8WeTLiuNuXNdRlvi92CkbB
-        EwtfHSYeDAHOC+ArxRMoyTLax1LLxVa0kx74zvN0agBriWHS8OXXCjR0dp7aT5BEdBLZT/EHgtBW
-        ISpxD45or+KH5VdPTstv2Tx2u3+amTJPJm0HIejAYHlsHhpTU+bAgzFo1paxj2O6nMeLphiaKcBN
-        MmO21HnqHTcS5Cs2b3hdYh4hkF1lE7uOPC+aBvlj34OfJueoBuiQr41WaFl3GlexDegvWmLDeop6
-        B9GMwmeByePyCMbeoQeOqVx8z+/VJPB9s458D4/vC2NT36jafeML+paC5usYJ6Vj/3hio46vpOUo
-        fGTKZuDhc8bkmoX7+Vx0yx19tDJlJ12pA7Rm+j+IKcXzAdqunuOufPq/vnjj85nJOvUYzFen/vvK
-        68/qn9HO5n/FzMRgHuC+mBWMYW12jwwKGAb62+b2FwAA//8DAE/Bl3CdBQAA
+        H4sIAAAAAAAAAwAAAP//dFRBbuMwDLznFYLOTSHXqRPntsd9Q7EwaJtO1cqiIFHZBkX+vrAcO/a2
+        vSUcckLOjPK5EULqVh6F9BhcpWBfdqo+FNmha/Nip1RxwENWt6rOc3XIyryEfVmoUj3v632e7ZV8
+        GCiofsOGJxqyAcd64xEY2woGLNsXSu2yMi8SFhg4hmGmod4ZZGzHoRqa95OnaIe9OjABx7I2RtuT
+        PIrPjRBCSAcX9MN8i2c05NDLjRDX1Ize04DZaEwqaDv9StUigzZhjQb2sWFNdlXv4aOiyC5yxfSO
+        X0EmMlUDZk3XU4tm2OzkeLuj7ZN62m3VYauKm1yJUh7FS7pkvGd2og+nn43Inms1GtHliHXdPR+6
+        QkEJiTmx8MVh4sEQ4IR34CfFE9iQZbT3pZaLrWgnPfCD5+nUANYSw6Thy58VaOjkPNXfIInoKORv
+        8ReC0LZFbMUtOKK+iF+WXz053TzKeex6+zQzSU8mbQch6MBgeWweGlOTdODBGDRry9jHMV3O41lT
+        DNUU4CqZMVvqPPWOqwaaV6ze8bLEPEIgu8omdh15XjQN8se+Bz9NzlEN0CFfKt2iZd1pXMU2oD/r
+        BivWU9Q7iGYUXgYmj8sjGHuHHjimcvaobtUk8G2zjnwP9+8LY1PfqNpt4zP6moLmyxinVsf+/sRG
+        HV9JN6PwkUnOwN1nyeSqhftqLrrljj7aJmUnXakD1Gb6P4gpxfMB2q6eY/708LW+eOPzmcm69j6o
+        Vqf+/8rL7+rf0c7m/8TMxGDu4C6bFYxhbXaPDC0wDPTXzfUfAAAA//8DALv1iSadBQAA
     headers:
       CF-RAY:
-      - 9878202ecdb4a336-SEA
+      - 98c0a577fab22804-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -166,15 +166,17 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 Oct 2025 01:18:23 GMT
+      - Thu, 09 Oct 2025 20:32:17 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=9DB6Ekyud6KM3ptuRyhOP8DPd_IljouDjdmJNKMdhw4-1759281503-1.0.1.1-trjQ9wS30Eaf.J_teBOIAxNRCaJeLhLWwaJ9fLXrBIw.NiUMU3mVTexeSl4pHmOqwgnGYDF8AmitcaMxvqd8J0rVC6LBAghqOvHWOfj7Nog;
-        path=/; expires=Wed, 01-Oct-25 01:48:23 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=p4DRm6SSVa9zGln5eYa3bxOA04l89S0XEIZpAtSDslY-1760041937-1.0.1.1-eBYxH_FoclcXSzMVuuApKHwvmp8HMbK1D4KpERZPTf297F5Cfqp6dR26VezL2Va4iFQ6Y71e.ty9KZgspZ.tVPmtUHJUar9.yI2C3QEev4I;
+        path=/; expires=Thu, 09-Oct-25 21:02:17 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=dcXYoA1DhFeu5pxaL4xPOse0Y956RHuDInRPFHCWDKs-1759281503343-0.0.1.1-604800000;
+      - _cfuvid=B9LvR3G.6DCeNkFFf9yp0ebQPVY3ii6HU_6OaCSTJSM-1760041937948-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
       X-Content-Type-Options:
@@ -186,15 +188,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '722'
+      - '1225'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '725'
+      - '1230'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -208,7 +208,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_b76b3f089003975cbfda8bedcb9bcb22
+      - req_0a375d474a6d4e40bf37187375550a45
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1117'
+      - '1118'
       content-type:
       - application/json
       host:
@@ -51,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJdb9swDPwrAZ8VwE6bNdVbt2YfwJp9oGuBDoPAyUysxRY9kdpQBP7v
-        g9xlRTfsjbo7Hk8EDxAasNDLzlX1pw/f9s3mJty8+Lrl1e7t+fN89+oUDOj9QEVFIrgjMJC4KwCK
-        BFGMCgZ6bqgDC77D3NBcOEbS+el8US2W1bIuNp6jUlSwnw9HS2XuXJbiOQUp7+yqenG5qs+u+OJ+
-        8bNuJefzNa3aWzAQsS99zvUhoXgeyG059ahKjeOsQ1Y3mbpiGYesYA+gQafA16/Xs83F1Xr27uWs
-        1LdvNpdgALO2nIpwG5Ko+z3kPWoKfg8GOnxEP7K22ywCo4GEGuIO7Nk4fjEgyoNLhMLx6dcmQuh7
-        pugJbMxdZyBPu7SHh5ROeU9RwC6fnRjw6FtyPhFq4OieKqojnwib/3HH3jKAhpZ6Sti5Zf+v/pGt
-        27/Z0cCfnT5Aq9qAUPoRPDkNlMBCuYAGUwPj+AsAAP//AwDsdM08TwIAAA==
+        H4sIAAAAAAAAAwAAAP//dJHhTxQxEMX/lcv73Et2keWw34ygGMJJTo2IIc3Ynbut7LZrOzWYy/7v
+        pgcnQcK39v3ezJtOtxhCyz00bE+55XkK3rPMD+cH1UFTNfUhFFwLjSFtTFWvzprXV8fLcD0sxusf
+        i2/erd5LgoL8Gbm4OCXaMBRi6ItAKbkk5AUKNnhhL9Dft3u/hNCbnHifUu7ZVPX5p6OfJxd3zd3l
+        OWdLebV5+8VeQcHTUOqMGVykZMPIZh3iQCLcmpBlzGJ2TU1p6ccs0FuIk900n89OZ8s3F6ezj+9m
+        5fz1w/IECpSlC7EY1y4mMQ8hlyTR2Vso9PSoroJ065wSJoVI4vwGejFNNwpJwmgiUwr+6dN2IPGv
+        zN4ytM99r5B3i9Lb+ymNhFv2Cbo5eqVgyXZsbGQSF7x56qj2PDK1L7F9bQngseOBI/WmGZ77H2nd
+        /U8nhX87vZeOa4XE8bezbMRxhEb53pZii2n6CwAA//8DANcWkyRPAgAA
     headers:
       CF-RAY:
-      - 9845539d4c22c366-SEA
+      - 98c09fa0cc417538-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:20:37 GMT
+      - Thu, 09 Oct 2025 20:28:20 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -82,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:36Z'
+      - '2025-10-09T20:28:19Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:37Z'
+      - '2025-10-09T20:28:19Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:35Z'
+      - '2025-10-09T20:28:17Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:36Z'
+      - '2025-10-09T20:28:19Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvdNBU8gbPo7qmjm8Fu
+      - req_011CTxFmnZi8RU7ygAg8NHFs
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2185'
+      - '2553'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1131'
+      - '1132'
       content-type:
       - application/json
       host:
@@ -54,17 +54,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01PXfMr2Twge6VvPbgGSkyZD","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}   }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_014YJ6aNPQ1C3igAG1KbXeRy","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01QSUzkFAeLWvXkgexxzXs5a","name":"__mirascope_formatted_output_tool__","input":{}}            }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01XbPUYtF4GkRmB8oKXZ9UJu","name":"__mirascope_formatted_output_tool__","input":{}}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}              }
 
 
         event: ping
@@ -74,7 +74,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}            }
 
 
         event: ping
@@ -85,7 +85,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"TH"}}
+        \"THE NAM"}              }
 
 
         event: ping
@@ -96,7 +96,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
-        N"}         }
+        OF THE WI"}        }
 
 
         event: ping
@@ -106,99 +106,66 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"AME
-        "}    }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
-        THE"}          }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        WIND\""}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ND\""}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\""}               }
+        \"autho"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        {\"fir"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
+        {\"fir"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"st_name"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"st_name\":\"Pa"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":\"Patri"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"trick\",\"l"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ck\",\"last"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ast_"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_name\":\"Roth"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"name\":\"Roth"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fus"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\""}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fuss\"}"}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"ra"} }
+        "}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ting"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"ratin"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        7}"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"g\":
+        7}"}}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0        }
+        data: {"type":"content_block_stop","index":0  }
 
 
         event: message_delta
@@ -214,7 +181,7 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 984554721d9b1846-SEA
+      - 98c0a00e6b0aa381-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -222,7 +189,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:21:10 GMT
+      - Thu, 09 Oct 2025 20:28:36 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -236,35 +203,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:09Z'
+      - '2025-10-09T20:28:35Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:09Z'
+      - '2025-10-09T20:28:35Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:09Z'
+      - '2025-10-09T20:28:35Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:09Z'
+      - '2025-10-09T20:28:35Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvfsnFsZhs7QDHgQfU8
+      - req_011CTxFo5aBukUdzZkhAvNME
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1361'
+      - '1924'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
       only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
       {\n      \"description\": \"The author of a book.\",\n      \"properties\":
@@ -25,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1247'
+      - '1248'
       content-type:
       - application/json
       host:
@@ -45,7 +45,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -57,16 +57,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRXWsUMRSG/8rwXmdhP7XmrtqWWugqKig0kgkzpztpZ07W5ESqy/x3yXYXbYtX
-        Ce/zvOdAsoNvoTGkjZ3O3r47+/Z5OVtf3l2dLPh3+/DGDS5DQX5tqViUktsQFGLoS+BS8kkcCxSG
-        0FIPjaZ3uaVJCswkk+VkPp2vpqvZEgpNYCEW6JvdcaTQQynvD426ru9SYMM7w1VlIF56MtCVwZfL
-        82p9en1efbioyv3r+/WZgXr0XJYuxCLuiyW69TGJZTcc+h+dRN/cHyrF6N0T4VOQ7janZFCE8TA5
-        OvG8KcZrw6Phuq4xfldIErY2kkuBoUHcWsmRcQCJfmTihqA5971C3j+b3sHzNouVcE+coBfzE4XG
-        NR3ZJpITH9g+NaZHHsm1/2PHbllA244Giq63q+Gl/5fOuud0VAhZ/o1eLRQSxZ++ISueIjTKZ7cu
-        thjHPwAAAP//AwANpajYOgIAAA==
+        H4sIAAAAAAAAA3SRUWvbMBSF/4o5zwrEWc2C3lbapqMsK6VQaD2EsG9iUfvKka5KS/B/L8oStnbs
+        SZfzfUcC3T0G31IPjaa3qaVZ9Mwks7PZYr6o5lV5BgXXQmOIWzMvq9WqfNzZi+UNn7/d3Lrxfjk+
+        llCQt5GyRTHaLUEh+D4HNkYXxbJAofEsxAL9tD/5Qq+ZHA6Nfc1FUUOc9FRDFzXury+L9bcfl8XP
+        qyLPD9/XFzXUb88m6XzI4qGYo40LUQzb4di/tRJc83ysZKO3H4Q7L90mxVgjC9Px5mDF8TYbX2ue
+        MP1SiOJHE8hGz9Agbo2kwDiCSLtE3BA0p75XSIdf0Hs4HpMY8c/EEfrLYqnQ2KYj0wSy4jybj8b8
+        xAPZ9n/s1M0P0NjRQMH2phr+9f/QsvtMJwWf5O+oWipECi+uISOOAjTy7lobWkzTOwAAAP//AwA8
+        4AwuLAIAAA==
     headers:
       CF-RAY:
-      - 98455366feb376d6-SEA
+      - 98c09f7b9f5a76b2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -74,7 +74,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:20:28 GMT
+      - Thu, 09 Oct 2025 20:28:14 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -88,35 +88,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:27Z'
+      - '2025-10-09T20:28:13Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:28Z'
+      - '2025-10-09T20:28:13Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:26Z'
+      - '2025-10-09T20:28:11Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:27Z'
+      - '2025-10-09T20:28:13Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvcj5nkeyVRFfcA959c
+      - req_011CTxFmMAFL9DDQYDmuu468
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1999'
+      - '2475'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
       only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
       {\n      \"description\": \"The author of a book.\",\n      \"properties\":
@@ -25,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1261'
+      - '1262'
       content-type:
       - application/json
       host:
@@ -60,12 +60,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01P5i1qu2XkShjHbGynhJuqx","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01AzRntLxKGztDaJL1zsx8XQ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}  }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
 
 
         event: content_block_delta
@@ -76,7 +76,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
-        \"THE"}          }
+        \"THE"}}
 
 
         event: ping
@@ -87,57 +87,57 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        NAME OF THE WIND\",\n  \""}       }
+        NAME OF THE WIND\",\n  \""}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
-        {\n    \"first_"}      }
+        {\n    \"first_"}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":
-        \"Patrick\",\n    \""}            }
+        \"Patrick\",\n    \""}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"last_name\":
-        \"Rothf"}               }
+        \"Rothf"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":
-        7\n}"}}
+        7\n}"}   }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0     }
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":58}      }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":58}            }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"              }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
       CF-RAY:
-      - 9845543bcc617de4-SEA
+      - 98c09fe5f85f2367-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -145,7 +145,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:21:01 GMT
+      - Thu, 09 Oct 2025 20:28:30 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -159,35 +159,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:00Z'
+      - '2025-10-09T20:28:28Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:00Z'
+      - '2025-10-09T20:28:28Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:00Z'
+      - '2025-10-09T20:28:28Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:00Z'
+      - '2025-10-09T20:28:28Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvfEaNjMVgsCTQri9Dv
+      - req_011CTxFnbunTPmqR5jP6LPR5
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1097'
+      - '1740'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
       only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
       {\n      \"description\": \"The author of a book.\",\n      \"properties\":
@@ -25,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1261'
+      - '1262'
       content-type:
       - application/json
       host:
@@ -60,17 +60,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01MLd36GZdH6R45oGLi8cnbn","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}}
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01GeELDWipVKp95UXHYmtbti","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}              }
 
 
         event: content_block_delta
@@ -87,31 +87,36 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        NAME OF THE WIND\",\n  \""}  }
+        NAME OF THE WIND\",\n  \""}        }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
-        {\n    \"first_"}            }
+        {\n    \"first_"}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":
-        \"Patrick\",\n    \""}          }
+        \"Patrick\",\n    \""}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"last_name\":
-        \"Rothfuss\"\n  },\n  \""}  }
+        \"Rothf"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":
-        7\n}"}            }
+        7\n}"}       }
 
 
         event: content_block_stop
@@ -121,18 +126,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":58}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":58}         }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
       CF-RAY:
-      - 984553d3ec25f979-SEA
+      - 98c09fb2efb8c374-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -140,7 +145,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:20:45 GMT
+      - Thu, 09 Oct 2025 20:28:21 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -154,35 +159,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:44Z'
+      - '2025-10-09T20:28:20Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:44Z'
+      - '2025-10-09T20:28:20Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:44Z'
+      - '2025-10-09T20:28:20Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:44Z'
+      - '2025-10-09T20:28:20Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTve1aFuigvymLEudkiQ
+      - req_011CTxFmzxLzxa2nweRWGv7S
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1035'
+      - '1442'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/json_sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Respond
       only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
       {\n      \"description\": \"The author of a book.\",\n      \"properties\":
@@ -25,7 +25,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1247'
+      - '1248'
       content-type:
       - application/json
       host:
@@ -57,16 +57,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRW0sDMRCF/8pynlNoa6uSN7WKIl4QwQdXQtiddqO7k5pMRC373yW1xRs+JZzv
-        OzOQrOBqaHRxYYajXXd0OFrMDsOke/fP7jzdzvn1EQrytqRsUYx2QVAIvs2BjdFFsSxQ6HxNLTSq
-        1qaaBtEzkwwmg/FwPB1ORxMoVJ6FWKDvV9uRQq+5vD40ViUXRQlx0lIJXZS4PT0uLg8ujourkyLf
-        784uZyXUp2eTND5kcV3M0dyFKIZtt+lfWwmuetpUstHaH8KNl2aeYiyRhX4zOVhxvMjGXsk9+geF
-        KH5pAtnoGRrEtZEUGBsQ6TkRVwTNqW0V0vqh9AqOl0mM+CfiCL0z3leobNWQqQJZcZ7NT2O45YFs
-        /R/bdvMCWjbUUbCtmXZ//S86an7TXsEn+R5N9xUihRdXkRFHARr5e2sbavT9BwAAAP//AwBg21eC
-        LAIAAA==
+        H4sIAAAAAAAAAwAAAP//dJHRahsxEEV/ZbnPMthO3Bi9BeokpXhjSmgI3SKEduIV3h250ig0mP33
+        ItcmTUufNNxzrgSaA4bQUg8N19vc0iQFZpLJ5WQ+nS+mi9klFHwLjSFtzXR2V2+6C7r9Ov/cPdUb
+        9+HRztZcQ0Fe91QsSsluCQox9CWwKfkklgUKLrAQC/S3w9kX+lnI8dA4NFxVDcRLTw101eDhblXV
+        1+tVdX9TlfnxU/2xgfrt2SxdiEU8Fkv07GMSw3Y49TdWone7U6UYvX0nfAnSPeeUGhRhPN0crXje
+        FuOq4RHjd4UkYW8i2RQYGsStkRwZJ5DoRyZ2BM257xXy8Rf0AZ73WYyEHXGCvpgvFZx1HRkXyYoP
+        bN4b0zOPZNv/sXO3PED7jgaKtjeL4V//jc66v+moELL8GS2WConii3dkxFOERtlda2OLcfwFAAD/
+        /wMARr8PzywCAAA=
     headers:
       CF-RAY:
-      - 984552fb2ebb767c-SEA
+      - 98c09f469c2390db-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -74,7 +74,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:20:11 GMT
+      - Thu, 09 Oct 2025 20:28:05 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -88,35 +88,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:10Z'
+      - '2025-10-09T20:28:04Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:11Z'
+      - '2025-10-09T20:28:05Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:09Z'
+      - '2025-10-09T20:28:03Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:10Z'
+      - '2025-10-09T20:28:04Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvbTH11cMFpAPPjHpV1
+      - req_011CTxFkjC2zXpkSU9mjSLPp
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1973'
+      - '2337'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1131'
+      - '1132'
       content-type:
       - application/json
       host:
@@ -54,146 +54,126 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01LFsa1a8FpW7dbRBL2i525s","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}            }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_017wZDYTaqi9fdzGuiGxHfvr","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}}
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01NPWZZavRFsMVcmDtS3ofMp","name":"__mirascope_formatted_output_tool__","input":{}}               }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01RCLxpQpsQRRwNyTZXeLPGo","name":"__mirascope_formatted_output_tool__","input":{}}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}       }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        \""}         }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        NAME OF "}     }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"T"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        WIND"}   }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"HE
+        NAME O"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"F
+        THE WIN"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author"}            }
+        \"author\":"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        {\"first_n"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        {\"first_"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame\":\""}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Patrick\",\"l"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"as"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"name\""}
         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"t_name\":\""}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\""}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Rothfuss\""}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Patric"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"k\",\"last_"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"name\":\"Rot"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hf"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uss\"}"}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"r"}              }
+        \""}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"atin"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"g\""}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rating\":
         7}"}              }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0             }
+        data: {"type":"content_block_stop","index":0       }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}  }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}          }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"             }
+        data: {"type":"message_stop"    }
 
 
         '
     headers:
       CF-RAY:
-      - 98455405def9f979-SEA
+      - 98c09fd2a869c374-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -201,7 +181,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:20:53 GMT
+      - Thu, 09 Oct 2025 20:28:27 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -215,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:52Z'
+      - '2025-10-09T20:28:25Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:52Z'
+      - '2025-10-09T20:28:25Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:52Z'
+      - '2025-10-09T20:28:25Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:52Z'
+      - '2025-10-09T20:28:25Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvebkpNH2XYjgYFQ5ah
+      - req_011CTxFnNhJ3T74Y45LN7MpR
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1261'
+      - '1645'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1117'
+      - '1118'
       content-type:
       - application/json
       host:
@@ -51,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJda9wwEPwrxzzrwE7jXKK3QhPa0rsmIdAviljkvbM4W3KlVdvk8H8v
-        cnoNaenbamZ2drTsAa6FxpB2pqrXOVzT2/FmzQ/vVruHeHOxpk8rKMj9yEXFKdGOoRBDXwBKySUh
-        L1AYQss9NGxPueVlCt6zLE+XJ9VJUzX1KRRs8MJeoL8cjpYSQm9yKp5zkPLOpqqbn+2mPr+yF/u7
-        H7f3n/3HM97IAAVPQ+kzZnCRkg0jm22IA4lwa0KWMYuZTU2x9GMW6APEyRz47vXlYvNyfbl4f7Uo
-        9Yc3m1dQoCxdiEW4dTGJ+T3kmiQ6u4dCT0/obZBum1PCpBBJnN9Br6bpq0KSMJrIlIJ//rWZSPwt
-        s7cM7XPfK+R5l/rwmNJI2LNP0M3ZCwVLtmNjI5O44M1zRXXkI1P7P+7YWwbw2PHAkXrTDP/qn9i6
-        +5udFP7s9BE6rxUSx+/OshHHERrlAlqKLabpFwAAAP//AwAe0+6tTwIAAA==
+        H4sIAAAAAAAAA3SRYW/TMBCG/0p1n10pKe0K/jbUAptGKVPEEGiybs61sZLYwXdGm6r898kdZRpo
+        3+z3ee/e8/kAfaipAw22w1TTlIP3JNP5dFbMFsWinIMCV4OGnvemKDdVqtp9u7Tbq+ay/Vj/eL+8
+        42+gQB4Gyi5ixj2Bghi6LCCzY0EvoMAGL+QF9M/DyS8hdCYxnVLyPZmi3N6tZvehqr6WN+v59fn9
+        6uHs8vs7UOCxz3XG9C4i2zCQ2YXYowjVJiQZkphjU5Nb+iEJ6AOIk+M01af1ZHP+eT358mGSzzcX
+        mxUowCRNiNm4c5HF/AnZokRnW1DQ4bN6HaTZJWYYFUQU5/egl+N4q4AlDCYScvAvn3YETL8SeUug
+        feo6Bem4KH14mtJIaMkz6MXZGwUWbUPGRkJxwZuXjuLEI2H9GjvV5gAaGuopYmcW/f/+Z1o2/9JR
+        wd+dPklvSwVM8bezZMRRBA35e2uMNYzjIwAAAP//AwBy5WSoTwIAAA==
     headers:
       CF-RAY:
-      - 98455334896d767c-SEA
+      - 98c09f676e5090db-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:20:20 GMT
+      - Thu, 09 Oct 2025 20:28:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -82,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:20Z'
+      - '2025-10-09T20:28:09Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:20Z'
+      - '2025-10-09T20:28:10Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:18Z'
+      - '2025-10-09T20:28:08Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:20Z'
+      - '2025-10-09T20:28:09Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvc8YQA7P6G6ApNx8G7
+      - req_011CTxFm7Jociya79KF9Atgr
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2184'
+      - '2234'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1117'
+      - '1118'
       content-type:
       - application/json
       host:
@@ -51,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJdT+MwEPwr1T67UgLkQH47CY6eUDmEaE/odLK2zrYxTezgXXMfVf47
-        cqAgQLytZ2Znx6vdgatBQ8cbU5TXp34ZZlu6ndcV3zfzZnG3wCNQIP96yipixg2BghjaDCCzY0Ev
-        oKALNbWgwbaYappy8J5kejQ9KA6qoiqzjQ1eyAvoX7u9pYTQmsTZcwyS38kU5XKFs+OT28VqdV4+
-        XCz/0P+/524DCjx2uc+YzkVkG3oy6xA7FKHahCR9EjOammzp+ySgdyBOxsA3s7PJ5df52eTHt0mu
-        f36/PAUFmKQJMQvXLrKY5yFXKNHZLSho8RW9DtKsEzMMCiKK8xvQx8PwWwFL6E0k5ODffm0kmO4T
-        eUugfWpbBWncpd49pTQStuQZdPXlUIFF25CxkVBc8OatotjzkbD+jNv35gHUN9RRxNZU3Uf9K1s2
-        79lBwctOn6CTUgFTfHCWjDiKoCFfQI2xhmF4BAAA//8DAAAZ3OVPAgAA
+        H4sIAAAAAAAAA3SR3U4cMQyFX2Xl66w0M+wUyF3FT1uhwhYqEKpQZGW8OymTZIidFrSad0dZ2CJa
+        9S4537GP42zAx44G0GAHzB3NOYZAMl/Mm6ppq7ZegALXgQbPa1PVlz+X7Nq4aH77MF5HPju6Olxd
+        gwJ5Gqm4iBnXBApSHIqAzI4Fg4ACG4NQENA/Nju/xDiYzLRLKfdsqvp0/3Fslk2P/uaM6PbT1eG3
+        cMCgIKAvdcZ4l5BtHMmsYvIoQp2JWcYsZtvUlJZhzAJ6A+JkO833zyez849fT2YXp7NyvvlyfgwK
+        MEsfUzGuXGIxryFLlOTsPSgY8E29jNKvMjNMChKKC2vQ+9N0p4AljiYRcgzvn7YFTA+ZgiXQIQ+D
+        grxdlN68TGkk3lNg0O2HPQUWbU/GJkJxMZj3jmrHE2H3P7arLQE09uQp4WBa/6//jdb933RS8Gen
+        L9JBrYAp/XKWjDhKoKF8b4epg2l6BgAA//8DAEnL2wdPAgAA
     headers:
       CF-RAY:
-      - 984553850ad6908e-SEA
+      - 98c09f8f59d35050-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:20:33 GMT
+      - Thu, 09 Oct 2025 20:28:16 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -82,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:32Z'
+      - '2025-10-09T20:28:16Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:33Z'
+      - '2025-10-09T20:28:16Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:31Z'
+      - '2025-10-09T20:28:14Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:32Z'
+      - '2025-10-09T20:28:16Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvd5dKB1EzNWXAXTNQ7
+      - req_011CTxFmae7NX9AijnRyQ4WF
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1780'
+      - '2182'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1131'
+      - '1132'
       content-type:
       - application/json
       host:
@@ -54,17 +54,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01M8ToPE5dSzB7t3GDHTL3R1","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":20,"service_tier":"standard"}}       }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01QVeq8NujMsPV4oo83zFebm","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01FLNEpFehXHcnWXFUQoFnaF","name":"__mirascope_formatted_output_tool__","input":{}}     }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Uxhx6VL3BS61pF4XHj72TQ","name":"__mirascope_formatted_output_tool__","input":{}}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}      }
 
 
         event: ping
@@ -74,8 +74,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        "}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"tit"}              }
 
 
         event: ping
@@ -85,8 +84,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"THE
-        NAME "}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le\""}           }
 
 
         event: ping
@@ -96,8 +94,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
-        "} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"THE NAME"} }
 
 
         event: ping
@@ -107,8 +105,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        WIN"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        OF THE WIN"}        }
 
 
         event: ping
@@ -118,62 +116,61 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"au"}          }
+        \"au"} }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
-        {\"fir"}               }
+        {\"f"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"st_na"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"irst_name\""}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"me\""}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"Patrick\""}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"Patrick\",\""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",\"last_"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"last_name\":"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"name\":\"Rot"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Rothfuss\"}"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hfuss\"}"}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \""}            }
+        \"rati"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ra"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ting\":
-        7}"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        7}"}}
 
 
         event: content_block_stop
@@ -188,13 +185,13 @@ interactions:
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"             }
 
 
         '
     headers:
       CF-RAY:
-      - 98455456a8ffd7ae-SEA
+      - 98c09ffa4bea753a-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -202,7 +199,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:21:06 GMT
+      - Thu, 09 Oct 2025 20:28:33 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -216,35 +213,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:05Z'
+      - '2025-10-09T20:28:31Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:05Z'
+      - '2025-10-09T20:28:31Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:05Z'
+      - '2025-10-09T20:28:31Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:05Z'
+      - '2025-10-09T20:28:31Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvfZ2eDW4M4HEckEEWC
+      - req_011CTxFnqmUGAEqQwrsLUVZp
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1719'
+      - '1649'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1131'
+      - '1132'
       content-type:
       - application/json
       host:
@@ -54,17 +54,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01Nx9bifmoFsxv6kAgwntrU2","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_016RDXVQZcnAd72sXt9kiGcb","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":12,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Pq33wSjK9EHPkxCxZtdeQZ","name":"__mirascope_formatted_output_tool__","input":{}}         }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01B6WFNaxYvf741iyfNEtWbH","name":"__mirascope_formatted_output_tool__","input":{}}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}           }
 
 
         event: ping
@@ -74,8 +74,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        \""}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"t"}              }
 
 
         event: ping
@@ -85,8 +84,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        NAME "}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"itle\":
+        \"T"}  }
 
 
         event: ping
@@ -96,94 +95,126 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
-        THE WIND\""}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"HE
+        N"}        }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"AME
+        OF TH"}             }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
+        WIND\""} }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        "}      }
+        \"aut"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"author\""}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hor\""}     }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        {\"first_n"}  }
+        {"}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame\":"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"first_na"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Patrick\",\"l"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"me\":"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ast_n"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Pa"}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"trick\",\"l"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":\"Rothfuss\""}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ast"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"}"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_name\":\"R"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"othf"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uss\"}"}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"r"}    }
+        "}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ating\":
-        "}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"rating\":"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7}"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        7}"}   }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0   }
+        data: {"type":"content_block_stop","index":0 }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}   }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}          }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"          }
 
 
         '
     headers:
       CF-RAY:
-      - 984553eebfbff979-SEA
+      - 98c09fc16b8ec374-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -191,7 +222,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:20:50 GMT
+      - Thu, 09 Oct 2025 20:28:24 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -205,35 +236,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:48Z'
+      - '2025-10-09T20:28:22Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:48Z'
+      - '2025-10-09T20:28:22Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:48Z'
+      - '2025-10-09T20:28:22Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:48Z'
+      - '2025-10-09T20:28:22Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTveKsqXgULEyX8VNLnu
+      - req_011CTxFnAs9o1aJdaJvK8ydT
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1765'
+      - '1737'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output/anthropic/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output/anthropic/tool_sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","system":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
       for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
@@ -19,7 +19,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1117'
+      - '1118'
       content-type:
       - application/json
       host:
@@ -51,16 +51,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJdi9swEPwrYZ4VsJ3LpfXbQdOmHL1+cDT9oIg9eWOL2JIrrQpt8H8/
-        5Gt6XEvfVjOzs6NlT7ANagyx1UW537XXl5848XWoPq++XNm7Y7XdQEF+jpxVHCO1DIXg+wxQjDYK
-        OYHC4BvuUcP0lBpeRu8cy/JiWRXVuliXF1Aw3gk7Qf31dLYU73udYvacg+R30kV56/371Wa3f0XP
-        q8EEe9f8+phaKDgacp/Wgw0UjR9ZH3wYSIQb7ZOMSfRsqrOlG5OgPkGszIFvd9vFzdWb7eLty0Wu
-        969vXkCBknQ+ZOHBhij695B3JMGaIxR6ekQ/eOkOKUZMCoHEuhb1Zpq+KUTxow5M0bunX5uJyN8T
-        O8OoXep7hTTvsj49pNTij+wi6vXlSsGQ6VibwCTWO/1UUZz5wNT8jzv35gE8djxwoF6vh3/1j2zZ
-        /c1OCn92+gA9KxUihx/WsBbLATXyBTQUGkzTPQAAAP//AwDfGbd5TwIAAA==
+        H4sIAAAAAAAAAwAAAP//dJHRThsxEEV/JZpnR9qFLE39FiUQQIJWLVKKUGWNvJOsya69eMZRabT/
+        Xjk0IFrxZt9zZ+54vIcu1NSCBttiqmnMwXuS8WR8UpxURVVOQIGrQUPHG1OUy6cpLyfP08Wkuv8s
+        frna/p7tzkCBPPeUXcSMGwIFMbRZQGbHgl5AgQ1eyAvoh/3RLyG0JjEdU/I9maL8cbf6dW1vFrb6
+        /jibz3eunMcpggKPXa4zpnMR2YaezDrEDkWoNiFJn8Qcmprc0vdJQO9BnBymubs8H93Obs5HXy5G
+        +by6ul2AAkzShJiNaxdZzN+QryjR2S0oaPFN/RakWSdmGBREFOc3oD8Nw08FLKE3kZCDf/+0A2B6
+        SuQtgfapbRWkw6L0/mVKI2FLnkFXZ6cKLNqGjI2E4oI37x3FkUfC+iN2rM0B1DfUUcTWVN3//jda
+        Nv/SQcHrTl+kaamAKe6cJSOOImjI31tjrGEY/gAAAP//AwDgAb4iTwIAAA==
     headers:
       CF-RAY:
-      - 984553218ea9767c-SEA
+      - 98c09f5739a690db-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:20:17 GMT
+      - Thu, 09 Oct 2025 20:28:07 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -82,35 +82,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:20:16Z'
+      - '2025-10-09T20:28:07Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:20:17Z'
+      - '2025-10-09T20:28:07Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:20:15Z'
+      - '2025-10-09T20:28:05Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:20:16Z'
+      - '2025-10-09T20:28:07Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvbuWpgqffB6RNmptes
+      - req_011CTxFkvCpAwCxkUcXNK4Eo
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1829'
+      - '2271'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '840'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RRXUsDMRD8K2WfU7h+Wc1bUUsttUoRlYqEkNv2Qu+SM7upSLn/LjmpUsW3zc7s
-        7GT2ADYHCRVtVdYbx8nzxfmyz48b2rzPHlaz3WA/AwH8UWNiIZHeIggIvkwNTWSJtWMQUPkcS5Bg
-        Sh1z7JJ3Drk77Paz/igb9YYgwHjH6Bjky+Eoyd6XKlLSbI2kd1RZb07LS6L1YjrgxWK7nrp5jRMD
-        Apyu0pxSlQ2ajK9RbXyoNDPmykeuI6tWVCVJV0cGeQC23Bp+mF13lpPb687dtJPqp5vlFQjQkQsf
-        QMK95mDNrrPyXGwiUfqqZuu2IMdN8yqA2NcqoCbvTt23AOFbRGcQpItlKSC2ccnDlxHFfoeOQA7H
-        fQFGmwKVCajZeqdOGdkRD6jz/7DjbFqAdYEVBl2qUfWX/4P2it9oI+A7tq/W2VgAYdhbg4otplzS
-        kXMdcmiaTwAAAP//AwCItqzWMgIAAA==
+        H4sIAAAAAAAAA3SRUUsrMRCF/0qZ5xS2ZWslb4IVL9Lei1dRepEwZMdu2E2yZiZCKfvfJZUqevEt
+        me/MzMnJAXxsqAcNtsfc0JRjCCTTejqv5otqMatBgWtAg+edqWY1nSE/7m3+e3V7PciD3yw37gUU
+        yH6goiJm3BEoSLEvBWR2LBgEFNgYhIKA/nc46SXG3mSm05Zyz6aanW/r1WK9v8FzF7qt77br7mZ7
+        DwoC+tJnjHcJ2caBzHNMHkWoMTHLkMUch5oyMgxZQB9AnBzd3F2vJpuL9Wry+2pSzg+/NpegALO0
+        MYGGPyjJ2W5yG6V9zszlHSgu7EAvx/FJAUscTCLkGL66PwKml0zBEuiQ+15BPmahD+9GjMSOAoOu
+        l3MFFm1LxiZCcTGYr4rqxBNh8xM79ZYFNLTkKWFvFv5//Sedtd/pqOAjtvfS2VIBU3p1low4KrmU
+        H2wwNTCObwAAAP//AwCzdJqEMgIAAA==
     headers:
       CF-RAY:
-      - 98455546ca0175f2-SEA
+      - 98c0a075ff4bdee1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:21:45 GMT
+      - Thu, 09 Oct 2025 20:28:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:44Z'
+      - '2025-10-09T20:28:53Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:45Z'
+      - '2025-10-09T20:28:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:43Z'
+      - '2025-10-09T20:28:51Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:44Z'
+      - '2025-10-09T20:28:53Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTviPErhimjLt29MPY6Q
+      - req_011CTxFpJQsza9JKk5ULj2Ui
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1901'
+      - '2350'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '853'
+      - '854'
       content-type:
       - application/json
       host:
@@ -51,17 +51,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01HJePd5XnZLCHmSwkPGX9tS","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01TAUdoDRw3ZnxTpzSivez2F","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}             }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Ku1W1jZFjo3Rbga17Avqfq","name":"__mirascope_formatted_output_tool__","input":{}}        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01TcMCS5iG91SSM8eZgxpPCV","name":"__mirascope_formatted_output_tool__","input":{}}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}  }
 
 
         event: ping
@@ -71,7 +71,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"t"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
+        \""}       }
 
 
         event: ping
@@ -81,7 +82,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"itle\""}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE"}
+        }
 
 
         event: ping
@@ -91,8 +93,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \"THE NAME "}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        NAME OF THE"}   }
 
 
         event: ping
@@ -102,90 +104,69 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
-        TH"}  }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
-        WIND\""}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        WIND\""}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"a"}              }
+        \"au"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uth"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
+        \"P"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or\":
-        \"Pa"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"atrick
+        Ro"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"trick
-        R"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"othfu"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ss"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thfuss\""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \""} }
+        \"rati"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rating\":
-        7}"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng\":
+        "}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7}"}   }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0               }
+        data: {"type":"content_block_stop","index":0  }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}  }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}         }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"            }
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 98455607ef9bdf13-SEA
+      - 98c0a0e15920e17a-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -193,7 +174,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:22:15 GMT
+      - Thu, 09 Oct 2025 20:29:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -207,35 +188,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:14Z'
+      - '2025-10-09T20:29:08Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:14Z'
+      - '2025-10-09T20:29:08Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:14Z'
+      - '2025-10-09T20:29:08Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:14Z'
+      - '2025-10-09T20:29:08Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvkfQ1qxvDbau5yDacz
+      - req_011CTxFqZp7aLy7jVk2Dt1qp
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1367'
+      - '1958'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '344'
+      - '345'
       content-type:
       - application/json
       host:
@@ -47,15 +47,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFdS8NAEEX/SrjPW+in1X0TWqugVURUMBKWZEyWJrN1d1YqJf9dYq2f
-        +DTDnHMHhtnCFtBoQpn1B4tytbDnM7+a3pejCQ9vm2ITjqAgr2vqLArBlAQF7+puYEKwQQwLFBpX
-        UA2NvDaxoF5wzCS9cW/YH076k8EYCrljIRboh+1+pdCmC78XjW3KSZJCrNSUQicpbk7nyfL4Yp5c
-        niRdf3e2nKVQO89EqZzfiVdGvM1XybWT6imG8Cl5I5bLTpqm3KJ9VAji1pknExxDg7jIJHrGBwj0
-        HIlzguZY1wrx/Wa9heV1lEzcijhAH0wVcpNXlOWejFjH2U+hv+eeTPEf22e7/bSuqCFv6mzS/PW/
-        6KD6TVsFF+X7aHSoEMi/2JwyseSh0T2qML5A274BAAD//wMAPuzQt/YBAAA=
+        H4sIAAAAAAAAAwAAAP//dJHdSsNAEEZfJXzXW2hqamXvhFbqRauIImIkrJuxWZrupruzYg15d0m1
+        /uLVDN85MzBMi40rqYaErlUsaRCctcSDbDAajsbDcZpBwJSQ2IRVMUyz+Wuq3eN4sdjdUJNNt2rF
+        dwYCvGuotygEtSIIeFf3gQrBBFaWIaCdZbIMed8efKaXnuyLRJvbJMnBhmvKIZMc1/NZsjxdzJKL
+        s6Tvb8+X0xzi3VORK+ffxUvF3uh1cuW4eoohfEpesbGrXprktkP3IBDYNYUnFZyFBNmy4OgtPkCg
+        bSSrCdLGuhaI+4NkC2ObyAW7NdkAeTwR0EpXVGhPio2zxU9heOCeVPkfO8z2+6mpaENe1cV489f/
+        omn1m3YCLvL36OhEIJB/NpoKNuQh0X+hVL5E170BAAD//wMA8w0NJfYBAAA=
     headers:
       CF-RAY:
-      - 98455509bfcf76b0-SEA
+      - 98c0a0528cf4dee9-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:21:35 GMT
+      - Thu, 09 Oct 2025 20:28:48 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -77,35 +77,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:34Z'
+      - '2025-10-09T20:28:47Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:35Z'
+      - '2025-10-09T20:28:48Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:33Z'
+      - '2025-10-09T20:28:45Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:34Z'
+      - '2025-10-09T20:28:47Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvhfV8ea71oQsgQGRWw
+      - req_011CTxFotELH1uH2V2AECjf2
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1446'
+      - '2143'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '358'
+      - '359'
       content-type:
       - application/json
       host:
@@ -50,24 +50,23 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01Fvj4DGu5rzWyZ1NsFb4opK","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01AYTVBdh6Fkd13hayAnucco","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}             }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
-        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
-        \"THE NAME OF THE WIND\",\n  "}            }
+        \"THE NAME OF THE WIND\",\n  "}        }
 
 
         event: ping
@@ -78,33 +77,33 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
-        \"Patrick Rothfuss\",\n  \"rating\": "} }
+        \"Patrick Rothfuss\",\n  \"rating\": "}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7\n}"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7\n}"}            }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0   }
+        data: {"type":"content_block_stop","index":0  }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}          }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}       }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"      }
+        data: {"type":"message_stop" }
 
 
         '
     headers:
       CF-RAY:
-      - 984555cfd94fb9f4-SEA
+      - 98c0a0bf1baf08ef-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -112,7 +111,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:22:06 GMT
+      - Thu, 09 Oct 2025 20:29:04 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -126,35 +125,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:05Z'
+      - '2025-10-09T20:29:03Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:05Z'
+      - '2025-10-09T20:29:03Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:05Z'
+      - '2025-10-09T20:29:03Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:05Z'
+      - '2025-10-09T20:29:03Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvk18988rXiAsBfW2Ld
+      - req_011CTxFqAWuCPEgertKFh8nR
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '864'
+      - '1661'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '358'
+      - '359'
       content-type:
       - application/json
       host:
@@ -50,22 +50,22 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01TyAhy3F1KDv7vcjQig4KJn","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_017r4bBQqWajarQz2Nk48zHt","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}          }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  "}      }
 
 
         event: ping
@@ -75,41 +75,52 @@ interactions:
 
         event: content_block_delta
 
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"title\":
+        \"THE"}  }
+
+
+        event: content_block_delta
+
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        \"THE NAME OF THE WIND\",\n  "}              }
+        NAME OF THE WIND\",\n  "}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
-        \"Patrick Rothfuss\",\n  \"rating\": "}              }
+        \"Patrick Rothf"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7\n}\n```"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\",\n  \"rating\":
+        "}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7\n}"}             }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0         }
+        data: {"type":"content_block_stop","index":0 }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":43}         }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":67,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":38}        }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"          }
 
 
         '
     headers:
       CF-RAY:
-      - 9845556f4a0fb9e0-SEA
+      - 98c0a0868c5bba3a-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -117,7 +128,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:21:51 GMT
+      - Thu, 09 Oct 2025 20:28:56 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -131,35 +142,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:50Z'
+      - '2025-10-09T20:28:54Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:50Z'
+      - '2025-10-09T20:28:54Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:50Z'
+      - '2025-10-09T20:28:54Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:50Z'
+      - '2025-10-09T20:28:54Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTviryUZ29nw1Fx7hSTG
+      - req_011CTxFpVpiv8i278RhEBQLd
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1046'
+      - '2115'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/json_sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '344'
+      - '345'
       content-type:
       - application/json
       host:
@@ -47,15 +47,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJHbSsNAEIZfJcz1FpLaWN27ovUAWqsoRYyEJZk2S5PZuDsrlZB3l22t
-        R7yaYb5vfhimA12ChMat8jh5mJzYRbpMrvjxuKH5SG9u2/MRCOC3FoOFzqkVggBr6jBQzmnHihgE
-        NKbEGiQUtfIlDpwhQh6MBsN4mMZpEmIKQ4zEIJ+6fSTjJixvi4QuoyjKgDXXmIGMMri/mEazyfU0
-        ujmLQr+4nJ1mIHae8lwZuxPniq0u1tGd4WrpnfuUrGJNqyCNM+qhfxbg2LS5ReUMgQSkMmdvCT6A
-        wxePVCBI8nUtwG9vlh1oaj3nbNZIDuThWEChigrzwqJibSj/KcR7blGV/7H9bsjHtsIGrarztPnr
-        f9Gk+k17Acbz99HBkQCH9lUXmLNGCxLCo0plS+j7dwAAAP//AwARL1yY9gEAAA==
+        H4sIAAAAAAAAA3SR20oDMRCGX2X5r1PYnqzkrmjFA9YqBS9cWUJ27KbdJttkIpay7y7bWo94NcP/
+        fTMwzA5rV1AFCV2pWFAnOGuJO4NOL+0N02F3AAFTQGIdFnnaPVv2F2Eznl8PurPRUt3Pb7alVhDg
+        bU2tRSGoBUHAu6oNVAgmsLIMAe0sk2XIp93RZ3pryb5I7DKbJBnYcEUZZJJhfjlJpuPbSXJ3kbT9
+        49X0PIM4eCpy6fxBnCn2Rq+SB8flSwzhU/KKjV200iizDZpngcCuzj2p4CwkyBY5R2/xAQJtIllN
+        kDZWlUDcHyR3MLaOnLNbkQ2QJyMBrXRJufak2Dib/xTSI/ekiv/YcbbdT3VJa/Kqyofrv/4X7Za/
+        aSPgIn+P+qcCgfyr0ZSzIQ+J9guF8gWa5h0AAP//AwALX/wR9gEAAA==
     headers:
       CF-RAY:
-      - 984554a689fedee2-SEA
+      - 98c0a02208552b1e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -63,7 +63,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:21:19 GMT
+      - Thu, 09 Oct 2025 20:28:40 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -77,35 +77,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:19Z'
+      - '2025-10-09T20:28:39Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:19Z'
+      - '2025-10-09T20:28:40Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:17Z'
+      - '2025-10-09T20:28:38Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:19Z'
+      - '2025-10-09T20:28:39Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvgVijfXTurmS5xT1hJ
+      - req_011CTxFoJwr7bx8zVbziq6mt
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1640'
+      - '2145'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '853'
+      - '854'
       content-type:
       - application/json
       host:
@@ -51,17 +51,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01BvHsitJFgsXUFPdWKhLxF1","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_0117WbF3W7J8rGE7TbEbw1D8","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}   }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01M9nVtDQVem5FtU51yauSNA","name":"__mirascope_formatted_output_tool__","input":{}}              }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012K9PfB1AvfmhTBBrA7LVVN","name":"__mirascope_formatted_output_tool__","input":{}}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
 
 
         event: ping
@@ -71,17 +71,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ti"}             }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tle"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}    }
 
 
         event: ping
@@ -92,7 +82,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"THE "}   }
+        \"T"}   }
 
 
         event: ping
@@ -102,8 +92,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"NAME
-        OF "}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"HE
+        N"}   }
 
 
         event: ping
@@ -113,7 +103,8 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"AME
+        OF THE "}       }
 
 
         event: ping
@@ -123,74 +114,68 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        WIN"}        }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"WIND\""}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\""}}
+        \"a"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \"Patr"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uthor\":
+        \""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Patr"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ick
-        Rot"}        }
+        Rothfus"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hfuss\""}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\""}     }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"rati"}         }
+        \"rating"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng\":
-        7}"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        7}"}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0         }
+        data: {"type":"content_block_stop","index":0              }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}         }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"            }
+        data: {"type":"message_stop"     }
 
 
         '
     headers:
       CF-RAY:
-      - 984555a43d5ab9e0-SEA
+      - 98c0a0ad7c7aba3a-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -198,7 +183,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:22:00 GMT
+      - Thu, 09 Oct 2025 20:29:02 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -212,35 +197,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:58Z'
+      - '2025-10-09T20:29:00Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:58Z'
+      - '2025-10-09T20:29:00Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:58Z'
+      - '2025-10-09T20:29:00Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:58Z'
+      - '2025-10-09T20:29:00Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvjVCZjgBxrzaeYTDyu
+      - req_011CTxFpxLv4dLmPbVPSL1an
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1651'
+      - '1461'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '840'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RR70vDMBD9V8Z9zqCd6yr5pqgozDl/QBWRENPbGtYmXXIZltH/XdIxRcVvl3vv
-        3r2824MugUPj1yJJ788/5rPV42m3XYYtPr/PiuKp+AAG1LUYWei9XCMwcLaODem99iQNAYPGllgD
-        B1XLUOLYW2OQxtPxJJlkSZZOgYGyhtAQ8Nf9UZKsrUXwUXMwEt9BJOl8d9udLU5OVBmKl8xcdHka
-        XGQZ2cQ5IRrtpFe2RbGyrpFEWAobqA0kBlERJU0bCPgeSNNg+On6crQ4u70c3V2NYl3cLC6AgQxU
-        WQcclpKcVpvRg6VqFbyPX5WkzRp43vdvDDzZVjiU3pqf7gfA4zagUQjchLpmEIa4+P5gRJDdoPHA
-        p/mEgZKqQqEcStLWiJ+M5Ig7lOV/2HE2LsC2wgadrEXW/OV/o2n1G+0ZfMV2aM1yBh7dTisUpDHm
-        Eo9cSldC338CAAD//wMAonM0CzICAAA=
+        H4sIAAAAAAAAAwAAAP//dJFhS8MwEIb/yrjPGbRjtZJvgooi1jlEEZEQ0lubrc11yUXU0f8umUxR
+        8Vtyz3t3b97soKcaO5BgOh1rnAZyDnk6n86yWZEV+RwE2Bok9KFRWV7l77G5WC+L1bpoNleFp2b1
+        UoIAfhswqTAE3SAI8NSlgg7BBtaOQYAhx+gY5NPuoGeiTsWAhy3pHlWWL049Ht/G6t5sq+Wxf53H
+        x3VJIMDpPvUp1Vuvg6EB1Yp8r5mxVhR5iKz2Q1Ua6YbIIHfAlvdu7i7OJtXJ9dnk5nySzg+X1SkI
+        0JFb8iBhodlbs5ksidtVDCG9Q7N1DchyHJ8FBKZBedSB3E/3exBwG9EZBOli1wmI+yzk7tOIYtqg
+        CyDn5UyA0aZFZTxqtuTUT0V24B51/R879KYFOLTYo9edKvq/+m+at7/pKOArts/SUSkgoH+xBhVb
+        TLmkH6y1r2EcPwAAAP//AwBOsBCSMgIAAA==
     headers:
       CF-RAY:
-      - 984554df3e2ddee2-SEA
+      - 98c0a040f9d02b1e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:21:29 GMT
+      - Thu, 09 Oct 2025 20:28:45 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:28Z'
+      - '2025-10-09T20:28:44Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:29Z'
+      - '2025-10-09T20:28:45Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:26Z'
+      - '2025-10-09T20:28:43Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:28Z'
+      - '2025-10-09T20:28:44Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvhAPv8k9BvvJ4UEFrm
+      - req_011CTxFog854Tw9DcfUAZDaD
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2192'
+      - '1997'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '840'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFFdb9swDPwrAZ8VwDaSptDbPrp1X1nRFQjQYRAImY3V2qInUkPbwP+9
-        kIts6Ia9Ubzj8XQ8QGjBwiB7V9Wnt5/f7D5dN3hRD7f1Y3jkKzl9AAP6MFJhkQjuCQwk7ksDRYIo
-        RgUDA7fUgwXfY25pKRwj6XK1bKpmXa3rFRjwHJWigv1+OEoqc++yFM3ZSHlnV9UNX76+l28573cn
-        1+dptf3Ybd/fg4GIQ5lzbggJxfNI7obTgKrUOs46ZnWzqCuSccwK9gAadDZ8dX622L76crb4+m5R
-        6t2H7VswgFk7TmDhAjUFf7e4ZO1uskj5KmqIe7CbafphQJRHlwiF40v3MyD0M1P0BDbmvjeQ57js
-        4dmIU76jKGBXm8aAR9+R84lQA0f3klEd8UTY/g87zpYFNHY0UMLerYd/+X/QuvsbnQz8ju25dbIx
-        IJR+BU9OA5VcypFbTC1M0xMAAAD//wMAQnleDjICAAA=
+        H4sIAAAAAAAAAwAAAP//dFHRTgIxEPwVss8lAeRA+2YCBA2gUQGjMU3TW7jKXXu2W5CQ+3fTI2jQ
+        +Lbdmd2Zzh6gsCnmwEHlMqTY9NYYpGa32Wl1klbS7gIDnQKHwq9Fq72YDMbv+2w3pzBSPbzVz26H
+        CTCgfYmRhd7LNQIDZ/PYkN5rT9IQMFDWEBoC/no48cnaXASPJ5X4DlEnLTu76aWm7UtypT7nk7BY
+        XjwCAyOLOCdEoZ30ypYoVtYVkghTYQOVgUS9VMSVpgwE/ACkqXbzNB42ZtfTYeNu1Ij18mY2AAYy
+        UGYdcLiX5LTaNB4sZavgffyHJG3WwPtV9cbAky2FQ+mtOXdfAx4/AhqFwE3IcwahzoIfjkYE2Q0a
+        D7zb7zBQUmUolENJ2hpxzmidcIcy/Q87zUYBLDMs0MlcJMVf/g/azn6jFYPv2I6tXp+BR7fVCgVp
+        jLnEC6bSpVBVXwAAAP//AwC1TOQYMgIAAA==
     headers:
       CF-RAY:
-      - 9845551f2d6eba06-SEA
+      - 98c0a063fa36c376-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:21:39 GMT
+      - Thu, 09 Oct 2025 20:28:51 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:39Z'
+      - '2025-10-09T20:28:50Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:39Z'
+      - '2025-10-09T20:28:50Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:37Z'
+      - '2025-10-09T20:28:48Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:39Z'
+      - '2025-10-09T20:28:50Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvhvBg6J9A9fnGPB8Gf
+      - req_011CTxFp64yteRTcvPWY2tNL
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2356'
+      - '2305'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '853'
+      - '854'
       content-type:
       - application/json
       host:
@@ -51,12 +51,13 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01GCtfXVq8ua1P4cbJNffVNM","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01QW8RbqXDqtogYtX533Gcmq","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}           }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01F3RagbU7i3CgidjBj6mxLE","name":"__mirascope_formatted_output_tool__","input":{}}    }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012duueHpPVuSbk7QX86DWCL","name":"__mirascope_formatted_output_tool__","input":{}}
+        }
 
 
         event: content_block_delta
@@ -71,7 +72,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}  }
 
 
         event: ping
@@ -81,112 +82,127 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        "}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":"}         }
 
 
         event: ping
 
         data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"THE
-        NAME O"} }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"F
-        "} }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
-        WIND"}               }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"au"}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
-        \""}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Patr"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ick"}        }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Rothfuss\""}  }
+        \"THE"}         }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        NA"}  }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ME
+        OF TH"}             }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
+        "}      }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"WIND\""}     }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"r"}             }
+        \"a"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ating\":
-        7}"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ut"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hor\":
+        \"Pat"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rick
+        Rothfu"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ss\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"r"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ati"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng\":
+        7}"}              }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0 }
+        data: {"type":"content_block_stop","index":0              }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}               }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}              }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"       }
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
       CF-RAY:
-      - 984555e66ce8eb93-SEA
+      - 98c0a0d059fd093f-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -194,7 +210,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:22:10 GMT
+      - Thu, 09 Oct 2025 20:29:07 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -208,35 +224,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:09Z'
+      - '2025-10-09T20:29:06Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:09Z'
+      - '2025-10-09T20:29:06Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:09Z'
+      - '2025-10-09T20:29:06Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:09Z'
+      - '2025-10-09T20:29:06Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvkGU8BtVfqfbMZKxeU
+      - req_011CTxFqNDrm8mCzPEAQ8P84
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1512'
+      - '1551'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '853'
+      - '854'
       content-type:
       - application/json
       host:
@@ -51,17 +51,17 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01NGaTzFgBXW64UGSSQfd9F9","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01LTtrDxA72JTHLgRjBWUvbg","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":19,"service_tier":"standard"}}   }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01YJnSNF4LitTUBUBWZSffnA","name":"__mirascope_formatted_output_tool__","input":{}}      }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01A2iHcNGFBP6W7AHRYtXi4E","name":"__mirascope_formatted_output_tool__","input":{}}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
 
 
         event: ping
@@ -71,7 +71,7 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}      }
 
 
         event: ping
@@ -82,7 +82,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"THE"}  }
+        \"THE"}              }
 
 
         event: ping
@@ -93,7 +93,7 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        NAME"}         }
+        NAME OF TH"}             }
 
 
         event: ping
@@ -103,80 +103,74 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        OF THE WIN"}       }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
+        WIND\""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author"}          }
+        \"aut"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"Patrick"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ho"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        R"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
+        "}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"othfuss"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Patri"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ck
+        Rothfuss\""}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"ratin"}    }
+        \""}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"g\":
-        7}"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ra"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ting\":
+        7}"}     }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0            }
+        data: {"type":"content_block_stop","index":0}
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}              }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":472,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":67}   }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
       CF-RAY:
-      - 98455587c96db9e0-SEA
+      - 98c0a09c2b84ba3a-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -184,7 +178,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:21:55 GMT
+      - Thu, 09 Oct 2025 20:28:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -198,35 +192,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:53Z'
+      - '2025-10-09T20:28:57Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:53Z'
+      - '2025-10-09T20:28:57Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:53Z'
+      - '2025-10-09T20:28:57Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:53Z'
+      - '2025-10-09T20:28:57Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvj9iYCzkR7mYE8WMdH
+      - req_011CTxFpkXG7LYxq2msEoLJo
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1062'
+      - '1637'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_formatting_instructions/anthropic/tool_sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please recommend
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
       a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
       Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
       author: str, rating: int}.\nThe title should be in all caps, and the rating
@@ -16,7 +16,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '839'
+      - '840'
       content-type:
       - application/json
       host:
@@ -48,16 +48,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RRXWsbMRD8K2afZTgbfxS9hdZtmuIkJDahLUWspT2f4pN0kVaG1Nx/L7rgliT0
-        bbUzOzuaPYE1IMGlvaomm9oc1o/bh+3xcvH4ZefW9fHq3oEAfu6osCgl3BMIiKEtDUzJJkbPIMAF
-        Qy1I0C1mQ+MUvCcez8bTajqv5pMZCNDBM3kG+fN0luQQWpVT0RyMlHdW1WS7+/HbrBbf5vrDd32V
-        N/XuNuFHEODRlTmlnI2YdOhI1SE6ZCajQuYusxpEVZH0XWaQJ2DLg+HN5Wp0fbFejW4+j0r98PX6
-        EwjAzE2IIOEWOVp9GN0FbuqcUvkqsvV7kMu+/yUgcehUJEzBv3Y/AImeMnlNIH1uWwF5iEueXowo
-        DgfyCeRsORWgUTekdCRkG7x6zajOeCQ0/8POs2UBdQ05itiquXvP/4dOmrdoL+BvbC+txVJAoni0
-        mhRbKrmUIxuMBvr+DwAAAP//AwCrzY89MgIAAA==
+        H4sIAAAAAAAAAwAAAP//dJFbSyQxEIX/ylDPGei52ZA3L724yzqroqO4LKFMl9PB7qRNVYRx6P8u
+        GRlFZd+S+k5VnZxsoQs1taDBtphqGnPwnmQ8H0+L6aJYTOagwNWgoeO1KSbl5nqznOGqnP2unuh2
+        kbqL+/ULKJBNT1lFzLgmUBBDmwvI7FjQCyiwwQt5Af13u9dLCK1JTPst+Z5MMakuZrd9Nbvjq9Xq
+        +Ozo+vmF468DUOCxy33GdC4i29CTeQixQxGqTUjSJzG7oSaP9H0S0FsQJzs3V6fVaHl4Vo3+/Bjl
+        883P5QkowCRNiKDhHCU6+zi6DNI8JOb8DhTn16DLYfingCX0JhJy8J/d7wDTUyJvCbRPbasg7bLQ
+        2zcjRsIjeQY9L6cKLNqGjI2E4oI3nxXFnkfC+n9s35sXUN9QRxFbs+i+6z/opPlKBwXvsb2VDkoF
+        TPHZWTLiKOeSf7DGWMMwvAIAAP//AwAXUQONMgIAAA==
     headers:
       CF-RAY:
-      - 984554beb8b5dee2-SEA
+      - 98c0a031ad562b1e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:21:24 GMT
+      - Thu, 09 Oct 2025 20:28:42 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,35 +79,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:21:23Z'
+      - '2025-10-09T20:28:42Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:21:24Z'
+      - '2025-10-09T20:28:42Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:21:21Z'
+      - '2025-10-09T20:28:40Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:21:23Z'
+      - '2025-10-09T20:28:42Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvgnAgzN5LMtt4LHqhA
+      - req_011CTxFoVoi2RvTgwWysNJmi
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2366'
+      - '2072'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1025'
+      - '1026'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFLa8MwEIT/y5xlsJK4cXUsOfVxKA0lUIpQ7K3txtY6eiSU4P9eFAh9
-        0ePuNzO7y57Q1VAYfKNzuZnduMbJ/Wp/7/iwel4HefQPEAgfIyUVeW8agoDjPjWM950PxgYIDFxT
-        D4WqN7GmzLO1FLJFNstnRV7IBQQqtoFsgHo5XSIDc6+jT5nnRVIddS7nszt+n4+3RxfNozSHp+1Y
-        tmsIWDMkX0NBb5l3urNvnMx2jAHqhM5vLRTybHlVzDMpl2W2wTS9CvjAo3ZkPNufg8/A0z6SrQjK
-        xr4XiOdLU2BK1oF3ZD1UUV4LVKZqSVeOTOjY6p+K/MIdmfo/dvGmATS2NJAzvS6Gv/ovKtvfdBLg
-        GL63FqWAJ3foKtKhIweF9J/auBrT9AkAAP//AwDcAUEN7QEAAA==
+        H4sIAAAAAAAAA3SQwWrDMBBE/2XPMtip3cS6peSUQw+FQNpShCJvbCWy5Gil0BD870UB06alx503
+        s8PuFXrXoAEOysjYYEbOWgxZmc3yWZVXRQkMdAMcempFXpS02rRvT5tP/XwpDnGjXtennQMG4TJg
+        ciGRbBEYeGeSIIk0BWkDMFDOBrQB+Pt18gfnjIiEU0uao8iLl/Wgl9uwHFZUV/t6dZaH+qEDBlb2
+        KddiEDvnjkLbfarXdogB+BU07SxwyLP5Y/WQFcV8kW1hHD8YUHCD8CjJ2fviGyA8RbQKgdtoDIN4
+        OyMtTJtFcEe0BLxa1AyUVB0K5VEG7ay4d+QT9yib/9iUTQU4dNijl0ZU/V//Ny2633Rk4GL4KZUL
+        BoT+rBWKoNEDh/T8RvoGxvELAAD//wMAhjteue0BAAA=
     headers:
       CF-RAY:
-      - 9845574fccf39b68-SEA
+      - 98c0a1a77b58c3a3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:23:08 GMT
+      - Thu, 09 Oct 2025 20:29:42 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,42 +79,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:08Z'
+      - '2025-10-09T20:29:42Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:08Z'
+      - '2025-10-09T20:29:42Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:06Z'
+      - '2025-10-09T20:29:40Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:08Z'
+      - '2025-10-09T20:29:42Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvpXdYsJVAxVHSeEFQY
+      - req_011CTxFsuVbjiZdcy8PivoYC
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2049'
+      - '2157'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_0132Koj3pJwruaQ1avSbp8hT","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0132Koj3pJwruaQ1avSbp8hT","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01RJpiAXtApDs95f9Dvaj93h","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01RJpiAXtApDs95f9Dvaj93h","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1378'
+      - '1379'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJNbxMxEP0r0ZwdaTfKVo1vVCIcgKpt2hNC1sQedg1e27XHKSHa/468
-        UYoK4uh5H/PmySewBiSMuVdN++lpSGM8fn/QH8LtoS/39/vt9U8QwMdIlUU5Y08gIAVXB5izzYye
-        QcAYDDmQoB0WQ8scvCderperZtU1XbsGATp4Js8gv5wulhyCUyVXzzlIfRfVtHfPL4df6eOm38X8
-        8Kjb7dO7Hd2AAI9j1Sk12oRZh0jqW0gjMpNRoXAsrGZTVS19LAzyBGx5DvzZZt6H5OXicaDF1np0
-        i/djtKkGwMJDSCDhJqE3wS926A2lHDwIiNhTBtmt1wJi2TurkW3w6kiYQK6a5mqavgrIHKJKhFX0
-        5roZyPRcyGsC6YtzAspcpzydgyoOP8hnkFebToBGPZDSic573jKaC54Izf+wi7YuoDjQSAmd6sZ/
-        +X/QdvgbnQS81noetc1GQKZ0sJoUW6qV1V9gMBmYpt8AAAD//wMAguphCVMCAAA=
+        H4sIAAAAAAAAAwAAAP//dFFdaxsxEPwrZp9luDO+pNZbAm4eiku+ICkliLW09QnrJEVaBVxz/z3I
+        xglJyKN2ZnZmR3sYgiEHErTDYmiag/fE0/l01sy6pmvnIMAakDDkjWrai4vVn75c6f8/lnr5ONum
+        u9sHew0CeBepsihn3BAISMHVAeZsM6NnEKCDZ/IM8u/+xOcQnCqZTi71XVTTXp3zQ7i5j+tuZX7/
+        2q1fFtvryxYEeByqTqnBJsw6RFL/QhqQmYwKhWNhdViq6kofC4PcA1s+pFnZzOuQvJzc9zT5aT26
+        yXKINtUAWLgPCSRcJvQm+MkdekMpBw8CIm4og+zmcwGxrJ3VyDZ4tSNMIGdNczaOTwIyh6gSYRV9
+        uO4AZHou5DWB9MU5AeXQldwfgyoOW/IZ5NmiE6BR96R0oqPPR0ZzwhOh+Q47aasBxZ4GSuhUN3zl
+        v6Nt/xkdBbzVehy1zUJApvRiNSm2VCurX2wwGRjHVwAAAP//AwDmyTLPUwIAAA==
     headers:
       CF-RAY:
-      - 9845575d3c3b9b68-SEA
+      - 98c0a1b63902c3a3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:23:10 GMT
+      - Thu, 09 Oct 2025 20:29:45 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:09Z'
+      - '2025-10-09T20:29:44Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:10Z'
+      - '2025-10-09T20:29:45Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:09Z'
+      - '2025-10-09T20:29:42Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:09Z'
+      - '2025-10-09T20:29:44Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvpgsgFDyznC31bTRWo
+      - req_011CTxFt5TsqxFmREys4sdSm
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1623'
+      - '2396'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1039'
+      - '1040'
       content-type:
       - application/json
       host:
@@ -52,94 +52,59 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_014Na1MoEKpRx3paynNwXsMK","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}               }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01QerGJo6kaAJ1tESy7LRhDm","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}     }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01GJCbSbjrMEMRZLc8bSt3tP","name":"get_book_info","input":{}}      }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_018H2ZPCx3rF15Naj4FJNdzj","name":"get_book_info","input":{}}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}               }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn"}           }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":"}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"0-7653-1"}  }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"0-"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"178-"}        }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7653-1178-"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}      }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}            }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0      }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_stop","index":0               }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}              }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}               }
 
 
         event: message_stop
 
-        data: {"type":"message_stop" }
+        data: {"type":"message_stop"          }
 
 
         '
     headers:
       CF-RAY:
-      - 984558c05dde755b-SEA
+      - 98c0a270d952ba46-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -147,7 +112,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:24:06 GMT
+      - Thu, 09 Oct 2025 20:30:14 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -161,42 +126,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:24:05Z'
+      - '2025-10-09T20:30:12Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:24:05Z'
+      - '2025-10-09T20:30:12Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:24:05Z'
+      - '2025-10-09T20:30:12Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:24:05Z'
+      - '2025-10-09T20:30:12Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvtsncUfdXZYuM9VHa2
+      - req_011CTxFvH99g6MLESLgr2ye1
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '957'
+      - '1805'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01GJCbSbjrMEMRZLc8bSt3tP","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01GJCbSbjrMEMRZLc8bSt3tP","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_018H2ZPCx3rF15Naj4FJNdzj","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_018H2ZPCx3rF15Naj4FJNdzj","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -214,7 +179,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1392'
+      - '1393'
       content-type:
       - application/json
       host:
@@ -249,12 +214,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_013vNiNB4bU1eUvDcyAmRzq5","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}     }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_017gdNW2gVvJUQxsZaWLnZvx","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":18,"service_tier":"standard"}}            }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01MZjS9qEbyQKAsTp7rhAeZs","name":"__mirascope_formatted_output_tool__","input":{}}    }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01LteLyDa79rSPXcb1e5nY2F","name":"__mirascope_formatted_output_tool__","input":{}}          }
 
 
         event: content_block_delta
@@ -264,102 +229,107 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
-        \""}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Mistborn:"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"title\":
+        "}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Mistbor"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n:"}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Th"}             }
+        The Fin"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        Final Emp"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
+        Empire"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ire\""}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"aut"} }
+        \"aut"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hor\":
-        \"Bran"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ho"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
+        \"Bran"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"don
-        Sand"}    }
+        Sander"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"erson\""}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"son"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pages"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        544"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"publicati"}  }
+        \"pages\""} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on_ye"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        544"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar"}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pu"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        20"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"blication_ye"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"06}"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar\":
+        2006}"}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0      }
+        data: {"type":"content_block_stop","index":0           }
 
 
         event: message_delta
@@ -369,13 +339,13 @@ interactions:
 
         event: message_stop
 
-        data: {"type":"message_stop"           }
+        data: {"type":"message_stop"              }
 
 
         '
     headers:
       CF-RAY:
-      - 984558c95e9d755b-SEA
+      - 98c0a27f0f0bba46-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -383,7 +353,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:24:08 GMT
+      - Thu, 09 Oct 2025 20:30:16 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -397,35 +367,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:24:07Z'
+      - '2025-10-09T20:30:14Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:24:07Z'
+      - '2025-10-09T20:30:14Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:24:07Z'
+      - '2025-10-09T20:30:14Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:24:07Z'
+      - '2025-10-09T20:30:14Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvtyuiKEZRNCchEJLFQ
+      - req_011CTxFvSqZKWRS4ZJMjG1az
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1410'
+      - '1601'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Respond only with valid JSON
       that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
@@ -21,7 +21,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1028'
+      - '1029'
       content-type:
       - application/json
       host:
@@ -53,16 +53,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RRW0vDMBT+K+V78SWVVleneazgBVSUqQgiIWvPtrA0qbmIOvrfJYWhU3zKyflu
-        5yQbqBYcnV+KojxsqVJqenFb319Ui6u6nH98LnswhI+eEou8l0sCg7M6NaT3ygdpAhg625IGR6Nl
-        bCn31hgK+SQ/KA6qoionYGisCWQC+PNmaxnoPYnHg+NyT+tMW7vOYp+FFWXzVCuzsK6TQVmTLazL
-        Lmf1TVbk06PqMC/L6XH+tI+BfVtaq0X0acxxt3SPoihn12vnz+u708+H+Djr3h/rhb07A4ORXdIt
-        KYiUJ1JeEps+BvANlJ8bcOwkYhheGHywvXAkvTW7wSPg6TWSaQjcRK0Z4vh4yTA5i2DXZDx4dTJh
-        aGSzItE4GtcUu4xiizuS7X/YVpsCqF9RR05qUXV/+d9oufqNDgw2hp+t4wmDJ/emGhJBkQNH+vJW
-        uhbD8AUAAP//AwATeKpvQAIAAA==
+        H4sIAAAAAAAAAwAAAP//dJHdS8MwFMX/lXJefEmlna3b8jgZ6BAZCn4gErL2biumSZcP2Rj93yWD
+        Maf4lOT+zj3nJtmjNTUpcFRKhppSZ7QmnxbpIBuUWZkXYGhqcLRuJbL8oZpPJ256M3oaFUs52/jX
+        l/l4Cga/6yiqyDm5IjBYo2JBOtc4L7UHQ2W0J+3B3/dHvadtJIeF4+5CqUQZ85mELvFrShZx3+il
+        sa30jdHJ0tjk7mnykGTp8Lq8SvN8OEpfL9Gzk6UxSgRHx8HjOYgsf85nZnybz++b7a6ejYebevr2
+        qMGgZRv7VuRFzBMxLzbrLnjwPRq30OA4S0TffzA4bzphSTqjz4MPwNEmkK4IXAelGMLhZaJhdBbe
+        fJJ24OW4YKhktSZRWTpcU5wrsiO3JOv/2LE3BlC3ppasVKJs/+pPNF//pj2DCf5naVQwOLJfTUXC
+        N2TBEf+zlrZG338DAAD//wMAOhjmwEACAAA=
     headers:
       CF-RAY:
-      - 984556dfbccb092f-SEA
+      - 98c0a1608b5ba34d-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -70,7 +70,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:51 GMT
+      - Thu, 09 Oct 2025 20:29:31 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -84,43 +84,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:50Z'
+      - '2025-10-09T20:29:30Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:51Z'
+      - '2025-10-09T20:29:31Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:48Z'
+      - '2025-10-09T20:29:29Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:50Z'
+      - '2025-10-09T20:29:30Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvoD1qYhQ6siA5YXLGG
+      - req_011CTxFs4qeVRUwqt4bFJbJt
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2334'
+      - '2607'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01SMkrsGBQCzUuVSmxVBfoQF","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01SMkrsGBQCzUuVSmxVBfoQF","content":"Title:
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01V1Jo9H1PLixydJ97qdEYRn","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01V1Jo9H1PLixydJ97qdEYRn","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -141,7 +141,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1464'
+      - '1465'
       content-type:
       - application/json
       host:
@@ -173,16 +173,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SR0WrcMBBFf8XcZy14jTehektKkhLo04ZSqItRpGGtVB650qhNWPzvxbvZNG3I
-        08A9Z2ZgZg/voDHmXV+vb7bbr7eUbfup/Rgfc/vwxV00v6EgTxMtFuVsdgSFFMMSmJx9FsMChTE6
-        CtCwwRRHqxyZSVbtqqmbTb1Zt1CwkYVYoL/tTyOFHpfmQ9HYd1xVHcRLoA666vDZZ7mPiXV1N1B1
-        7dmE6mqcfKIO6mibIkNMR/0yGXaRq61hRylHfrEms6O8SJu2PUXlPnhrxEfun8gcRjR1fdbxjPm7
-        QpY49YlMjgwNYtdLSYxnkOlnIbYEzSUEhXI4jd7D81Skl/iDOEOfN2sFa+xAvU10XPavUZ94IuPe
-        Y6feZQFNA42UTOg341v/L10P/9NZIRZ5HbUfFDKlX95SL54SNJaHOpMc5vkPAAAA//8DAARzPZAe
-        AgAA
+        H4sIAAAAAAAAA3SR3YrUQBBGXyV81z2QjMkO9N0Kq+DP1Yq7YCTpTReT1k517K4W1yHvLpkx6Lp4
+        VfCdU1VQdcIULHloDN5kS7sUmEl29W5f7puyqWooOAuNKR27srp+9/P14b568+JwPNzQ27uPcnd9
+        n6AgjzOtFqVkjgSFGPwamJRcEsMChSGwEAv0p9PmC/1Yyblo9H3/JQVu+dRyUbQQJ55a6KLFe5fk
+        IUTWxYeRileOjS9uptlFaqEutskyhnjRX0bDNnBxa9hSXGdu1myOlFapqestyg/eDUZc4O6RzHnE
+        viyvWl5a7vsey2eFJGHuIpkUGBrEtpMcGb9Bom+ZeCBozt4r5PMV9AmO5yydhK/ECfqwrxQGM4zU
+        DZEuG58a5cYjGfs/tvWuC2geaaJofNdMz/0/tBr/pYtCyPJ31NQKieJ3N1AnjiI01t9ZEy2W5RcA
+        AAD//wMAsaP1OCwCAAA=
     headers:
       CF-RAY:
-      - 984556eefecd092f-SEA
+      - 98c0a171ba27a34d-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:53 GMT
+      - Thu, 09 Oct 2025 20:29:34 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -204,35 +204,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:52Z'
+      - '2025-10-09T20:29:33Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:53Z'
+      - '2025-10-09T20:29:34Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:51Z'
+      - '2025-10-09T20:29:31Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:52Z'
+      - '2025-10-09T20:29:33Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvoPQfX6bmUPJSmwxXK
+      - req_011CTxFsGbKy7vhFoQfUk3cG
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2324'
+      - '2629'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Respond only with valid JSON
       that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
@@ -21,7 +21,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1042'
+      - '1043'
       content-type:
       - application/json
       host:
@@ -56,24 +56,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_014VvVq4kjvtEQ2MQhpfyir3","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":7,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01AC6MxBvAC2hukgpK4mRhSF","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":3,"service_tier":"standard"}}     }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
-        look up the book information"}             }
+        look"}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        for ISBN 0-7653-1178"}    }
+        up the book information for ISBN"}    }
 
 
         event: ping
@@ -83,49 +83,49 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}
-        }
-
-
-        event: content_block_stop
-
-        data: {"type":"content_block_stop","index":0           }
-
-
-        event: content_block_start
-
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01LKpFA5MpBZxWdLp5iLMwB9","name":"get_book_info","input":{}}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        0-7653-1178"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}         }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0  }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01WbYiRMVQfbq93bmUtPhS7h","name":"get_book_info","input":{}}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
-        \"0-"}             }
+        "}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"7653-1178"}    }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"0-7653-1"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"-X"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}        }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"178-X\"}"}   }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":1               }
+        data: {"type":"content_block_stop","index":1  }
 
 
         event: message_delta
@@ -135,13 +135,13 @@ interactions:
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop" }
 
 
         '
     headers:
       CF-RAY:
-      - 98455844f84a5f68-SEA
+      - 98c0a22acb45ba4c-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -149,7 +149,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:47 GMT
+      - Thu, 09 Oct 2025 20:30:02 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -163,43 +163,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:46Z'
+      - '2025-10-09T20:30:01Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:46Z'
+      - '2025-10-09T20:30:01Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:46Z'
+      - '2025-10-09T20:30:01Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:46Z'
+      - '2025-10-09T20:30:01Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvsRRaAx2s14nNDHBNg
+      - req_011CTxFuTDbb3GXfG1fHvSEL
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1676'
+      - '1503'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01LKpFA5MpBZxWdLp5iLMwB9","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01LKpFA5MpBZxWdLp5iLMwB9","content":"Title:
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01WbYiRMVQfbq93bmUtPhS7h","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01WbYiRMVQfbq93bmUtPhS7h","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -220,7 +220,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1478'
+      - '1479'
       content-type:
       - application/json
       host:
@@ -255,23 +255,24 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_0177MHsNSxf9hEFHo7jPUwuC","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}              }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01EMsNQSGE6fjijSHmoNhCvt","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
+        \"Mist"}   }
 
 
         event: ping
@@ -281,20 +282,31 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"born:
+        The Final Empire\",\n  "}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
+        \"Brandon Sanderson"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\",\n  \"pages\":
+        544"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",\n  \"publication_year\":"}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Sanderson\",\n  \"pages\": 544,\n  \"publication"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"_year\":
-        2006\n}\n```"}           }
+        2006\n}"}     }
 
 
         event: content_block_stop
@@ -304,18 +316,18 @@ interactions:
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":54}  }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":49}           }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"               }
+        data: {"type":"message_stop"  }
 
 
         '
     headers:
       CF-RAY:
-      - 9845585aed1d5f68-SEA
+      - 98c0a23c2dbeba4c-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -323,7 +335,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:51 GMT
+      - Thu, 09 Oct 2025 20:30:05 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -337,35 +349,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:49Z'
+      - '2025-10-09T20:30:04Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:49Z'
+      - '2025-10-09T20:30:04Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:49Z'
+      - '2025-10-09T20:30:04Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:49Z'
+      - '2025-10-09T20:30:04Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvsgPjUT7pjJgam86VD
+      - req_011CTxFuf6Dse3namSdqwEjB
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1392'
+      - '1546'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Respond only with valid JSON
       that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
@@ -21,7 +21,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1042'
+      - '1043'
       content-type:
       - application/json
       host:
@@ -56,101 +56,56 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01MzMjGyvGLoQeoHhWonuq8E","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}}
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_017diny5w7dzD7SpwBHBrsaM","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}
+        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}            }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01FLq5en6YnXVpVDRBQUjwmJ","name":"get_book_info","input":{}}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
-        look up the book information for"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        ISBN 0-7653-1178-X."}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        \"0-"}    }
 
 
-        event: ping
+        event: content_block_delta
 
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7653-"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"1178-X\"}"}
+        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0 }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_start
-
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_0157vdFBvDnj25jqaEUsXf8k","name":"get_book_info","input":{}}    }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"i"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"sb"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"n\":
-        \"0"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"-7653-1178-X"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}   }
-
-
-        event: content_block_stop
-
-        data: {"type":"content_block_stop","index":1     }
+        data: {"type":"content_block_stop","index":0              }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}     }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}    }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"         }
+        data: {"type":"message_stop"             }
 
 
         '
     headers:
       CF-RAY:
-      - 984557a1ee582763-SEA
+      - 98c0a1c77e9977a3-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -158,7 +113,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:21 GMT
+      - Thu, 09 Oct 2025 20:29:47 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -172,43 +127,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:20Z'
+      - '2025-10-09T20:29:45Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:20Z'
+      - '2025-10-09T20:29:45Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:20Z'
+      - '2025-10-09T20:29:45Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:20Z'
+      - '2025-10-09T20:29:45Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvqVsAgMB65NYzM2Fi9
+      - req_011CTxFtHGnKxZ7LrVfCcRGQ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1048'
+      - '2109'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_0157vdFBvDnj25jqaEUsXf8k","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0157vdFBvDnj25jqaEUsXf8k","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01FLq5en6YnXVpVDRBQUjwmJ","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01FLq5en6YnXVpVDRBQUjwmJ","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -229,7 +183,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1478'
+      - '1396'
       content-type:
       - application/json
       host:
@@ -264,23 +218,23 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_016ZsWCbbzmGnw6832AhwGRY","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}       }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01NeVDbRLLy3xRdWCRzMNaS6","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":701,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}  }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
-        \"Mist"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title"}              }
 
 
         event: ping
@@ -290,41 +244,58 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"born:
-        The Final Empire\",\n  \"author\": \"Brandon Sanderson"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\",\n  \"pages\":
-        544,\n  \"publication_year\":"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\":
+        \"Mistborn: The Final"}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        2006\n}"}          }
+        Empire\",\n  \"author\": \""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Brandon
+        Sanderson\",\n  \""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"pages\":
+        544,\n  \""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"publication_year\":
+        2006"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n}\n```"}      }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0  }
+        data: {"type":"content_block_stop","index":0       }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":49}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":701,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":54}            }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"}
+        data: {"type":"message_stop"             }
 
 
         '
     headers:
       CF-RAY:
-      - 984557ae28212763-SEA
+      - 98c0a1d8b97977a3-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -332,7 +303,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:22 GMT
+      - Thu, 09 Oct 2025 20:29:49 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -346,35 +317,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:22Z'
+      - '2025-10-09T20:29:48Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:22Z'
+      - '2025-10-09T20:29:48Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:22Z'
+      - '2025-10-09T20:29:48Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:22Z'
+      - '2025-10-09T20:29:48Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvqeDDAMbKN9W8o91Kc
+      - req_011CTxFtVAeQxHAEnRfEnzLo
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '874'
+      - '1565'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/json_sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Respond only with valid JSON
       that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
@@ -21,7 +21,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1028'
+      - '1029'
       content-type:
       - application/json
       host:
@@ -53,16 +53,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFFbS+wwEP4r5XvxJZV2bXU3b66geEG8e+AgIduO22qadHMRdel/lxQW
-        XQ/nKZP5bjPJGm0Njs4tRZbndXH20B1/vNycHH7erfLF9eP71QUY/EdPkUXOySWBwRoVG9K51nmp
-        PRg6U5MCR6VkqCl1RmvyaZFOskmZlXkBhspoT9qD/11vLD29R/F4cJzuKJUoY16T0Ce+oWQR61Y/
-        G9tJ3xqdPBubnN7OL5MsPdgv99I8P5imf3YxsG9LY5QILo457hbvQWT5bGLum8vJ/PNofnheL/dm
-        99P2bgUGLbuoW5IXMU/EvCjWffDga7RuocGxlYhheGJw3vTCknRGbwePgKNVIF0RuA5KMYTx8aJh
-        dBbevJJ24OWsYKhk1ZCoLI1rim1GtsEtyfp/2EYbA6hvqCMrlSi7f/nfaN78RgcGE/zP1rRgcGTf
-        2oqEb8mCI355LW2NYfgCAAD//wMA3AamdEACAAA=
+        H4sIAAAAAAAAAwAAAP//dFHdS8MwEP9Xyr34kkq7tW7mzQnCXoYydYJISNPbWpcmXT60Mvq/Swpl
+        TvEpl/t93SVHaHSJEigIyX2JsdVKoYuzeJJM8iRPMyBQl0ChsTuWpI9PrS7vq7abVH5+u5nmxWax
+        dkDAfbUYWGgt3yEQMFqGBre2to6rwBFaOVQO6Otx5DvsBnU4KCwvpIyk1vvIt5GrMCpCXautNg13
+        tVbRVptouV6soiSeXeXTOE1n8/jlEnpystRaMm9xHDzcPUvSG/VZ3G0OpVjnm8NL1/n354duBQQU
+        b4Juh46FPBbygli13gE9Qm0LBRTOEqHv3whYp1tmkFutzoMHwOLBoxIIVHkpCfjhZYJhcGZO71FZ
+        oPl1RkBwUSETBoc12TkjGXGDvPwPG7UhANsKGzRcsrz5yz+hafUb7Qlo73625hkBi+ajFshcjQYo
+        hP8suSmh778BAAD//wMABddxzEACAAA=
     headers:
       CF-RAY:
-      - 98455630af7476b6-SEA
+      - 98c0a0f2ee2cc37b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -70,7 +70,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:22 GMT
+      - Thu, 09 Oct 2025 20:29:14 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -84,43 +84,43 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:22Z'
+      - '2025-10-09T20:29:13Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:22Z'
+      - '2025-10-09T20:29:14Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:21Z'
+      - '2025-10-09T20:29:11Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:22Z'
+      - '2025-10-09T20:29:13Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvm9E5XxrGDPFNMPPRF
+      - req_011CTxFqmxN72U3cBsfpyABh
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1860'
+      - '2861'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_0192oUhN2BzCBAKdg39U8iTq","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0192oUhN2BzCBAKdg39U8iTq","content":"Title:
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01AnwbFWqdcS5WqXxxujVQxN","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01AnwbFWqdcS5WqXxxujVQxN","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Respond only with valid
       JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -141,7 +141,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1464'
+      - '1465'
       content-type:
       - application/json
       host:
@@ -173,16 +173,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SRTWvbQBCG/4p4z2uQHTmJ91hoCqU9NeRSFTHWDtaS1ay6O2uSGv33IrvuJz0N
-        vM8zMzBzgnewGPOhq9c3T/f743Hcpfc7T+9uHp/vv32YHmCgrxMvFudMB4ZBimEJKGeflURhMEbH
-        ARZ9oOJ4laMI66pZberNtt6uGxj0UZRFYT+friOVX5bmc7E4tVJVLdRr4Ba2avHRZ93HJLZ6HLh6
-        8EKhejtOPnELc7Gp6BDTRX+TSFyU6hOJ45Sj/LQmOnBepG3TXKOyD74n9VG6V6bziE1d37YyY/5i
-        kDVOXWLKUWDB4jotSfADZP5aWHqGlRKCQTmfxp7gZSraaXxmybB3m7VBT/3AXZ/4suxPo77yxOT+
-        x669ywKeBh45Uei247/+L7oe/qazQSz6e9TsDDKno++5U88JFstDHSWHef4OAAD//wMADqV6Vx4C
-        AAA=
+        H4sIAAAAAAAAA3SRy27jMAxFf8W4awWwU7tFtSzQx6abPlZ1YSgWEauVKVeiOhME/veBk8k80RWB
+        ew5JENxjDJY8NHpvsqVVCswkq3q1LtdN2VQ1FJyFxpi2XVldDc+38e2bhPPd9dl99f5wt2nunqAg
+        u4kWi1IyW4JCDH4JTEouiWGBQh9YiAX6ZX/yhb4v5FA09i0XRQtx4qmFLlrcuySbEFkXTwMVN46N
+        L67HyUVqoY62yTKEeNSvomEbuHg0bCmmwL+syWwpLVJT16cob7zrjbjA3Y7MYcS6LM9bnjG/KiQJ
+        UxfJpMDQILad5Mj4CRJ9ZOKeoDl7r5APd+s9HE9ZOgnvxAn6Yl0p9KYfqOsjHZf9bZQnHsnYr9ip
+        d1lA00AjReO7Zvzf/02r4V86K4Qsf0b1pUKi+Ol66sRRhMbyLWuixTz/AAAA//8DAKChHYMeAgAA
     headers:
       CF-RAY:
-      - 9845563cea6f76b6-SEA
+      - 98c0a1059ab6c37b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:24 GMT
+      - Thu, 09 Oct 2025 20:29:16 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -204,35 +203,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:23Z'
+      - '2025-10-09T20:29:16Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:24Z'
+      - '2025-10-09T20:29:16Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:22Z'
+      - '2025-10-09T20:29:14Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:23Z'
+      - '2025-10-09T20:29:16Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvmHe6VorjKU1ekAhgB
+      - req_011CTxFqzg61zzuXpkQGEYYL
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1492'
+      - '2223'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1039'
+      - '1040'
       content-type:
       - application/json
       host:
@@ -52,113 +52,49 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01SjgDEWd2uXT5J3fxchsSGB","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}         }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01Q6q3Ra2wCHTRtgYAmqP424","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}  }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01EFnkkQ3MFkjB8QzjJrRdgK","name":"get_book_info","input":{}}      }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01WvYbeP7pboD2CNAsnnG14f","name":"get_book_info","input":{}}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}   }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"is"}             }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"0-7"} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"bn"}    }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"653-1178-"}
+        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        "}   }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"0-7"}      }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"653-1178-"}    }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}        }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}    }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0       }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_stop","index":0}
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}               }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}  }
 
 
         event: message_stop
@@ -169,7 +105,7 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 984557fca90beb40-SEA
+      - 98c0a2081d9777a3-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -177,7 +113,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:35 GMT
+      - Thu, 09 Oct 2025 20:29:57 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -191,42 +127,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:34Z'
+      - '2025-10-09T20:29:55Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:34Z'
+      - '2025-10-09T20:29:55Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:34Z'
+      - '2025-10-09T20:29:55Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:34Z'
+      - '2025-10-09T20:29:55Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvrZu2xjs5e5Lpps9Fg
+      - req_011CTxFu3Tc31hNXbUW8xaDS
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1160'
+      - '1834'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01EFnkkQ3MFkjB8QzjJrRdgK","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01EFnkkQ3MFkjB8QzjJrRdgK","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01WvYbeP7pboD2CNAsnnG14f","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01WvYbeP7pboD2CNAsnnG14f","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -244,7 +180,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1392'
+      - '1393'
       content-type:
       - application/json
       host:
@@ -279,12 +215,12 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_014bByJmcpiZZQLR6Avjzxf8","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}          }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01GwSXwY9cxVT5xnPvKA55q6","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}          }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01XroNsS9w6A1NV4T8KrPRxd","name":"__mirascope_formatted_output_tool__","input":{}}              }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_019XGjpt5MeVFoDBCdGMmCh6","name":"__mirascope_formatted_output_tool__","input":{}}  }
 
 
         event: content_block_delta
@@ -294,107 +230,112 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"tit"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le\":
-        \"Mistb"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"title\""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"orn:
-        The Fi"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"Mistborn:"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nal
-        Empi"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        The Final "}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"re\""}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Empir"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"au"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
-        \"Bran"}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"don
-        Sander"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"son"}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\""}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pages\": "}  }
+        \"author\""} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"544"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"B"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"randon
+        Sa"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nderson\""}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"publi"}           }
+        \"pages"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cation_yea"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        544"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
-        2006}"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"publicati"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on_y"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ear\":
+        "}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"2006}"}       }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0            }
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}               }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}     }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"   }
+        data: {"type":"message_stop"    }
 
 
         '
     headers:
       CF-RAY:
-      - 984558063f13eb40-SEA
+      - 98c0a2163f7877a3-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -402,7 +343,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:38 GMT
+      - Thu, 09 Oct 2025 20:29:59 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -416,35 +357,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:36Z'
+      - '2025-10-09T20:29:58Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:36Z'
+      - '2025-10-09T20:29:58Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:36Z'
+      - '2025-10-09T20:29:58Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:36Z'
+      - '2025-10-09T20:29:58Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvrgSwB5WyqYGW6dp9C
+      - req_011CTxFuD82g55woChN3TwXY
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1892'
+      - '1702'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1025'
+      - '1026'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFPS8NAEMW/yztvIEkbm+5NtCjiQQ+1BZFlu5m2a5PddP8UtOS7yxaK
-        VvE483vvzQxzhG7A0fmNyIsHrT67frGK1cu73t/ezZ+7qpyDIXz0lFTkvdwQGJxtU0N6r32QJoCh
-        sw214FCtjA1l3hpDIRtnZV5WeVWMwaCsCWQC+OvxHBmsbUX0KfO0SKqjyIvldFQ/lpP16Gaxv76v
-        R7OneJhdg8HILvk2FMTK2p3QZm2T2fQxgB+h/cqAI88mV9UoK4pJnS0xDG8MPtheOJLemsvBJ+Bp
-        H8koAjexbRni6dIUmJJFsDsyHryqpwxKqi0J5UgGbY24VORn7kg2/7GzNw2gfksdOdmKqvur/6bF
-        9jcdGGwMP1vjmsGTO2hFImhy4Ej/aaRrMAxfAAAA//8DAIOyI4TtAQAA
+        H4sIAAAAAAAAAwAAAP//dJBPS8NAEMW/y5w3kLRJk+5NSi+iBy3Sqsiy3YxJbLKT7B+hlnx32ULQ
+        VjzO/N6bNzMn6KjEFjioVvoSI0tao4vSaBbPsjhLUmDQlMChs5WIk+Xjar76yGf3vRrWz9vjsK3y
+        IQMG7thjUKG1skJgYKgNDWltY53UDhgo0g61A/56mvSOqBXe4pQSai/i5OaLHurFbt3t02Jzt/HJ
+        S3n7FHbRsgu+Cp3YEx1Eo98pmHXvHfATNHavgUMc5YtsHiVJXkQ7GMc3BtZRLwxKS/oy+AwsDh61
+        QuDaty0Dfz4jDAyThaMDags8K5YMlFQ1CmVQuoa0uFTEEzcoy//Y5A0B2NfYoZGtyLq/+h+a1Nd0
+        ZEDe/W6lBQOL5rNRKFyDBjiE55fSlDCO3wAAAP//AwA8wcXV7QEAAA==
     headers:
       CF-RAY:
-      - 9845568e1b652edd-SEA
+      - 98c0a13a8f19c37b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:37 GMT
+      - Thu, 09 Oct 2025 20:29:25 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,42 +79,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:36Z'
+      - '2025-10-09T20:29:25Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:37Z'
+      - '2025-10-09T20:29:25Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:35Z'
+      - '2025-10-09T20:29:23Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:36Z'
+      - '2025-10-09T20:29:25Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvnF9Z6ywxaRjj9Rg2f
+      - req_011CTxFrcyPkqZLdDrBc5tJh
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1216'
+      - '2556'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01X938L27f3CWqAH83EPuvEA","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01X938L27f3CWqAH83EPuvEA","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01AzoQh6XEmb48SLSu1ZdJU4","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01AzoQh6XEmb48SLSu1ZdJU4","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1378'
+      - '1379'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RS34sTMRD+V8o8p7AbupXmTeVUqBb17MuJhLlk7IbLJjGZHB5l/3fJliqn+Jj5
-        fsw3HzmDs6BgKifd9Z8/bl++PbI8Snmz+/Swle/6/e4AAvgpUWNRKXgiEJCjbwMsxRXGwCBgipY8
-        KDAeq6V1iSEQrzdr2cmhG/oNCDAxMAUG9fV8teQYva6leS5B2rvqrj/8fH/3WOu+vpb7g3R3t8e0
-        71+AgIBT02k9uYzFxET6e8wTMpPVsXKqrBdT3SxDqgzqDOx4CfzBFb6POajVl5FWb1xAv7qZksst
-        AFYeYwYFrzIGG8PqFoOlXGIAAQlPVEANm42AVO+9M8guBv1EmEHJrtvO8zcBhWPSmbCJnl23AIV+
-        VAqGQIXqvYC61KnOl6Ca4wOFAmq7GwQYNCNpk+my5zmju+KZ0P4Pu2rbAkojTZTR62H6l/8H7ce/
-        0VnA71ovo77bCSiUH50hzY5aZe0XWMwW5vkXAAAA//8DAIigc79TAgAA
+        H4sIAAAAAAAAA3RRwW7bMAz9lYBnBbADO2h127BmlzaX5rBiGATW4mJ1tuiKVNcs8L8PSpAV3bCj
+        +N7je3w6wsieBrDQDZg9LYVjJF02y1W1aqu2bsBA8GBhlL2r6m3e3n5ZP4WHdLja+Ickn+T1lcGA
+        HiYqLBLBPYGBxEMZoEgQxahgoOOoFBXs1+OFr8yDy0IXl/LOrqrbzfOu2e7WHGT38/PIh1+Brz6A
+        gYhj0Tk3hoTS8UTuO6cRVck7zjpldaelrqyMU1awR9CgpzR3QfSRU7SLXU+LTYg4LG7GKaQSALP2
+        nMDCx4TRc1zcY/SUhCMYmHBPArZtGgNTfhxChxo4ugNhAruqqvU8fzMgypNLhEX07roTIPScKXYE
+        NuZhMJBPXdnjOahT/kFRwK6vWwMddj25LtHZ5z2juuCJ0P8Pu2iLAU09jZRwcO34L/8Nrfu/0dnA
+        n1rPo7q6NiCUXkJHTgOVysoXe0we5vk3AAAA//8DANP1RU9TAgAA
     headers:
       CF-RAY:
-      - 984556965d682edd-SEA
+      - 98c0a14b6baec37b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:40 GMT
+      - Thu, 09 Oct 2025 20:29:28 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:39Z'
+      - '2025-10-09T20:29:27Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:40Z'
+      - '2025-10-09T20:29:28Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:37Z'
+      - '2025-10-09T20:29:25Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:39Z'
+      - '2025-10-09T20:29:27Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvnLnt9c4n6GceWsoLX
+      - req_011CTxFrpRUSfv1Y1RA5e3yo
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '3506'
+      - '2348'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1025'
+      - '1026'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFBT8MwDIX/i8+p1G7tVnJEYnBgSFyAgVAUUm8La+MuTpjG1P+OMmmC
-        gTja33vPtnwA24CEjlcqL2a343pi9v6RP68Wi7i9W5LbPYCAsO8xqZBZrxAEeGpTQzNbDtoFENBR
-        gy1IMK2ODWZMzmHIymyUj6q8KkoQYMgFdAHky+EUGYhaFTllHhdJdVR5Mb8utb2px7vyeU7xvrvs
-        d++zCgQ43SXfCoN6I9oo65aUzK6PAeQBLL85kJBn00k1zopiWmdPMAyvAjhQrzxqJnc++AgYtxGd
-        QZAutq2AeLw0BaZkFWiDjkFW9YUAo80alfGogyWnzhX5iXvUzX/s5E0DsF9jh163qur+6r9psf5N
-        BwEUw89WWQtg9B/WoAoWPUhI/2m0b2AYvgAAAP//AwA+DoVA7QEAAA==
+        H4sIAAAAAAAAA3SQUUvDQBCE/8s+XyCpiWnvTSkIFaSi2FaR45ps09DkNr3bq9iS/y5XCFrFx51v
+        ZofdE7RUYgMSikb7EiNHxiBHaTSKR1mcJSkIqEuQ0LpKxcn0afYym+bp45FXK9vS8jW/ub8DAfzZ
+        YXChc7pCEGCpCYJ2rnasDYOAggyjYZBvp8HPRI3yDoeWMHsVJ6P5ksvFIcnp+eN2sa/mm8kxfQAB
+        RrchVyGrNdFO1WZDIWw6zyBPULu1AQlxlF9nV1GS5ONoCX3/LsAxdcqidmQui8/A4d6jKRCk8U0j
+        wJ/PCAvDZsW0Q+NAZuOJgEIXW1SFRc01GXXpiAduUZf/sSEbCrDbYotWNypr//q/abL9TXsB5Pmn
+        lI4FOLSHukDFNVqQEJ5faltC338BAAD//wMAtXsFO+0BAAA=
     headers:
       CF-RAY:
-      - 9845570ce807767e-SEA
+      - 98c0a185ea3123f8-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:57 GMT
+      - Thu, 09 Oct 2025 20:29:36 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,42 +79,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:57Z'
+      - '2025-10-09T20:29:36Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:57Z'
+      - '2025-10-09T20:29:36Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:56Z'
+      - '2025-10-09T20:29:35Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:57Z'
+      - '2025-10-09T20:29:36Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvojwwTWRbMzPCUmTgJ
+      - req_011CTxFsWUWF5ewte3u66uVH
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1412'
+      - '1851'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01MG4aiH83w4ZMouQmBpwjF5","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01MG4aiH83w4ZMouQmBpwjF5","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_012PXtdWv17oTwBWqgPf9z4N","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_012PXtdWv17oTwBWqgPf9z4N","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1378'
+      - '1379'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJdixMxFP0r5T6nMFNmumweZauw4D64iroi4Ta5dqL5MrkpdMv8d8mU
-        Kqv4mHs+7rmHnMEakODLQXX9w4e76ft2Vx9Pb467T4ftu89Pz2UPAviUqLGoFDwQCMjRtQGWYgtj
-        YBDgoyEHErTDamhdYgjE62G96TZjN/YDCNAxMAUG+eV8teQYnaqleS5B2ruqrh+O9w/xJj7bj/u7
-        m41P98PITwkEBPRNp5S3GYuOidS3mD0yk1GxcqqsFlPVLEOqDPIMbHkJ/NYW3scc5Or9RKvXNqBb
-        7XyyuQXAylPMIOFVxmBiWD1iMJRLDCAg4YEKyHEYBKS6d1Yj2xjUiTCD3HTddp6/Cigck8qETfTi
-        ugUo9LNS0AQyVOcE1KVOeb4EVRx/UCggt7ejAI16IqUzXfa8ZHRXPBOa/2FXbVtAaSJPGZ0a/b/8
-        P2g//Y3OAn7Xehn13a2AQvloNSm21Cprv8BgNjDPvwAAAP//AwAPGRrLUwIAAA==
+        H4sIAAAAAAAAA3RR0W4TMRD8lWifHekuylXEb7RNW4FASAkIqJC1tbc507u1sdegEN2/IycKqCAe
+        vTOzMzs+wBgcDaDBDlgczXNgJpkv54tm0TVduwQF3oGGMe9M0366XV/fPa5+XL5LT2/3r15/fLld
+        71pQIPtIlUU5445AQQpDHWDOPguygAIbWIgF9P3hzJcQBlMynV3qu5imvV6/2Cy6+J7d158fNrdX
+        n/02SQQFjGPVGTP6hNmGSOYxpBFFyJlQJBYxx6WmruRYBPQBxMsxzRuf5SEk1rNtT7MbzzjM1mP0
+        qQbAIn1IoOEyIbvAsw2yo5QDg4KIO8qgu+VSQSwPg7coPrDZEybQi6a5mKYvCrKEaBJhFT277ghk
+        +laILYHmMgwKyrErfTgFNRKeiDPoi1WnwKLtydhEJ5/njOaMJ0L3P+ysrQYUexop4WC68V/+H7Tt
+        /0YnBb9rPY3aZqUgU/ruLRnxVCurX+wwOZimXwAAAP//AwAhFa2NUwIAAA==
     headers:
       CF-RAY:
-      - 98455716baa0767e-SEA
+      - 98c0a19269b923f8-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:59 GMT
+      - Thu, 09 Oct 2025 20:29:39 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:58Z'
+      - '2025-10-09T20:29:38Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:59Z'
+      - '2025-10-09T20:29:39Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:57Z'
+      - '2025-10-09T20:29:37Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:58Z'
+      - '2025-10-09T20:29:38Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvorbnXTi1ZQmgyRRTK
+      - req_011CTxFseyUdSKN8gjXrLXFt
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2010'
+      - '2595'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1039'
+      - '1040'
       content-type:
       - application/json
       host:
@@ -52,84 +52,59 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_019Epdu96BH3NAsrPqMRfCLg","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}           }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01BPyv2v6yfdV1zaDWN24dxi","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}    }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01JiDp1aGXRvpjowMAaBsGs3","name":"get_book_info","input":{}}          }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01AnipHURum8ZxM7RbZUzggM","name":"get_book_info","input":{}}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}           }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}   }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
-        \"0-"}             }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        \""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7653-1178-X"}               }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"0-7"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"653-1178-"}      }
 
 
-        event: ping
+        event: content_block_delta
 
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"X\"}"}         }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0  }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_stop","index":0          }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}   }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}    }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"       }
+        data: {"type":"message_stop"    }
 
 
         '
     headers:
       CF-RAY:
-      - 984558851a4bba36-SEA
+      - 98c0a24e09b3091b-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -137,7 +112,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:59 GMT
+      - Thu, 09 Oct 2025 20:30:08 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -151,42 +126,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:56Z'
+      - '2025-10-09T20:30:07Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:56Z'
+      - '2025-10-09T20:30:07Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:56Z'
+      - '2025-10-09T20:30:07Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:56Z'
+      - '2025-10-09T20:30:07Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvtBF596geWoYpR7qWb
+      - req_011CTxFusLBMhQFiFJ8dzwGu
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '3530'
+      - '1753'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01JiDp1aGXRvpjowMAaBsGs3","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01JiDp1aGXRvpjowMAaBsGs3","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01AnipHURum8ZxM7RbZUzggM","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01AnipHURum8ZxM7RbZUzggM","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -204,7 +179,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1392'
+      - '1393'
       content-type:
       - application/json
       host:
@@ -239,128 +214,138 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_01AurveUHGvHE1X9Ca5muB7p","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}              }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01RTiMu2YZa2WP4KYvicjNHR","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}      }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_018eAY7oxM6Avy2dcEoNDLpR","name":"__mirascope_formatted_output_tool__","input":{}}               }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01XLzvTGWTjheCF12sd8nquo","name":"__mirascope_formatted_output_tool__","input":{}}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\""}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"t"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \"Mi"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"itl"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stborn:
-        The"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":"}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        Final E"}         }
+        \"M"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mp"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"istborn:
+        The"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ire\""}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        Final E"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\": "}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Brandon
-        "}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Sanderson\""}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mpire\""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        "}              }
+        \"auth"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"pages\":
-        54"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or\":
+        \"Bran"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"don
+        S"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"anderson\""}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"publ"}  }
+        \"pages\":"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ica"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        544"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tion_ye"}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"publ"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar\":
-        2006}"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ication_ye"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        "}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"2006}"}    }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0         }
+        data: {"type":"content_block_stop","index":0       }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}}
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}   }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"         }
+        data: {"type":"message_stop"          }
 
 
         '
     headers:
       CF-RAY:
-      - 9845589fb86fba36-SEA
+      - 98c0a25bedf0091b-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -368,7 +353,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:24:02 GMT
+      - Thu, 09 Oct 2025 20:30:11 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -382,35 +367,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:24:00Z'
+      - '2025-10-09T20:30:09Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:24:00Z'
+      - '2025-10-09T20:30:09Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:24:00Z'
+      - '2025-10-09T20:30:09Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:24:00Z'
+      - '2025-10-09T20:30:09Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvtVSCZCbxABis2iLwh
+      - req_011CTxFv2qBFj3U6W3QRuWgc
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1525'
+      - '1886'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_stream.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1039'
+      - '1040'
       content-type:
       - application/json
       host:
@@ -52,95 +52,59 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_015xgcPFkU8RyrwGcDoeBfxh","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":24,"service_tier":"standard"}}   }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_015zrrZg7JGUgkwAUhBs78q7","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01T9iLpCByETWMjzeAmhmnQH","name":"get_book_info","input":{}}               }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01F41GZSbMrHF1wVQ82Ae8dK","name":"get_book_info","input":{}}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}
-        }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":"}              }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        \"0"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        \"0-7653-11"}   }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-7653-1"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"78-X"}}
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"178"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"}"}           }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-X\"}"}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0 }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_stop","index":0             }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}  }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}   }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"    }
+        data: {"type":"message_stop"               }
 
 
         '
     headers:
       CF-RAY:
-      - 984557c14f392763-SEA
+      - 98c0a1e749fe77a3-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -148,7 +112,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:26 GMT
+      - Thu, 09 Oct 2025 20:29:52 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -162,42 +126,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:25Z'
+      - '2025-10-09T20:29:50Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:25Z'
+      - '2025-10-09T20:29:50Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:25Z'
+      - '2025-10-09T20:29:50Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:25Z'
+      - '2025-10-09T20:29:50Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvqsK1eJ3EyXJciVNs3
+      - req_011CTxFtf6SqdFU18mzYvbgJ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1241'
+      - '1924'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01T9iLpCByETWMjzeAmhmnQH","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01T9iLpCByETWMjzeAmhmnQH","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01F41GZSbMrHF1wVQ82Ae8dK","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01F41GZSbMrHF1wVQ82Ae8dK","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -215,7 +179,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1392'
+      - '1393'
       content-type:
       - application/json
       host:
@@ -250,138 +214,133 @@ interactions:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"id":"msg_015pK174hMcoio7sjiteLBUk","type":"message","role":"assistant","model":"claude-sonnet-4-20250514","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":23,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01G53CPB9AfvqEFajLeHf1WP","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}              }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01MZnpZEY8hEq72Faqcq9mPM","name":"__mirascope_formatted_output_tool__","input":{}}               }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012NQUUoiH2rjoE1WUD8XdcA","name":"__mirascope_formatted_output_tool__","input":{}}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
+        "}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
-        \"Mis"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Mis"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tb"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tborn:
+        The F"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"orn:
-        The Fin"}     }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"inal
+        Empir"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"al
-        Empire\""}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\""}        }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\""} }
+        \"autho"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
+        \"Br"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"andon
+        "}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Sa"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nderson\""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pages\""}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \"Bra"}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ndon
-        Sanders"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"on\""}            }
+        544"}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pa"}      }
+        \""}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ges"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"publicatio"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":"}   }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n_"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        544"} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        "}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"public"}        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ation_y"}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ear\""}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"year\""}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        2006}"}        }
+        2006}"}          }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0       }
+        data: {"type":"content_block_stop","index":0        }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}      }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}   }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"     }
+        data: {"type":"message_stop"      }
 
 
         '
     headers:
       CF-RAY:
-      - 984557cb4f2b2763-SEA
+      - 98c0a1f6382a77a3-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -389,7 +348,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 24 Sep 2025 21:23:28 GMT
+      - Thu, 09 Oct 2025 20:29:55 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -403,35 +362,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:23:26Z'
+      - '2025-10-09T20:29:53Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:23:26Z'
+      - '2025-10-09T20:29:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:23:26Z'
+      - '2025-10-09T20:29:53Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:23:26Z'
+      - '2025-10-09T20:29:53Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvqz7nKVUPkxKa6VdFK
+      - req_011CTxFtqF8yvSH6pj36iwHM
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1375'
+      - '1954'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_sync.yaml
+++ b/python/tests/e2e/cassettes/structured_output_with_tools/anthropic/tool_sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"}],"model":"claude-sonnet-4-0","system":"Always respond to the user''s
       query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
@@ -17,7 +17,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1025'
+      - '1026'
       content-type:
       - application/json
       host:
@@ -49,15 +49,15 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJFbT8JAEIX/y3neJi1SCvuGPuiDIUqC8RKzWdqhrbS7dS8lSPrfzZIQ
-        QePjzHfOmZnMAXUBjtaWIk4m+0W/S7/u5jej5Wq/kffrdt7vwOD2HQUVWStLAoPRTWhIa2vrpHJg
-        aHVBDTjyRvqCIquVIheNo1E8SuM0GYMh18qRcuBvh1Ok07oR3obM4yKh9iJOZq/XDy+PVXZbrj76
-        xcY9LbN5MQGDkm3wleTEWuutqNVGB7PqvAM/oLZrBY44yibpVZQk2TR6xjC8M1inO2FIWq0uBx+B
-        pU9PKidw5ZuGwR8vDYEhWTi9JWXB0+mMIZd5RSI3JF2tlbhUxCduSBb/sZM3DKCuopaMbETa/tX/
-        0KT6TQcG7d15azxlsGT6OifhajLgCP8ppCkwDN8AAAD//wMA+r6yqO0BAAA=
+        H4sIAAAAAAAAAwAAAP//dJBLa8MwEIT/y5xlsJO4dnTs69I2NG0PhVKEYq9jEVty9Cgkwf+9KGD6
+        osedb2aH3RN6U1MHjqqToabEGa3JJ4tkls7yNM8WYFA1OHq3FWl2Xxj/8vj8cOwbddusQuvWxWEO
+        Bn8YKLrIObklMFjTRUE6p5yX2oOhMtqT9uBvp8nvjelEcDS1xDnEnms7NMvL8i4/XtX71dO+LfL1
+        DRi07GNuS15sjNkJpRsTw3oIHvwE5TYaHGlSXOTzJMuKMnnFOL4zOG8GYUk6o38Wn4GjfSBdEbgO
+        XccQzmfEhXGz8GZH2oHn5ZKhklVLorIkvTJa/HSkE7ck6//YlI0FNLTUk5WdyPu//i+atb/pyGCC
+        /y4tSgZH9kNVJLwiC474/FraGuP4CQAA//8DAI3QanTtAQAA
     headers:
       CF-RAY:
-      - 984556510c5676b6-SEA
+      - 98c0a115ddc4c37b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +65,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:27 GMT
+      - Thu, 09 Oct 2025 20:29:19 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -79,42 +79,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:27Z'
+      - '2025-10-09T20:29:19Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:27Z'
+      - '2025-10-09T20:29:19Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:26Z'
+      - '2025-10-09T20:29:17Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:27Z'
+      - '2025-10-09T20:29:19Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvmXNLs7LsA7zekNcM9
+      - req_011CTxFrBr3cd39g8yk3ev3D
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1572'
+      - '2704'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"max_tokens":1024,"messages":[{"role":"user","content":"Please look up
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_019ZBPYQh7GgUjvNftVR7Ad6","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_019ZBPYQh7GgUjvNftVR7Ad6","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01LDrpf9B8K5zCdqNRqh75QE","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01LDrpf9B8K5zCdqNRqh75QE","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25"}]}],"model":"claude-sonnet-4-0","system":"Always respond to the
       user''s query using the __mirascope_formatted_output_tool__ tool for structured
@@ -132,7 +132,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1378'
+      - '1379'
       content-type:
       - application/json
       host:
@@ -164,16 +164,16 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFJta9swEP4r4T4rYCd2RvVtK+1Kx0a7hY0xirjIt1jEllTdqaME//ch
-        h2x0ox91z8s996AjuA40jLw3VX15Fz/zzbf13Ua+pvrX+w/b7feRQYE8RyosYsY9gYIUhjJAZseC
-        XkDBGDoaQIMdMHe05OA9ybJZrqpVW7V1Awps8EJeQP84ni0lhMFkLp5zkPLOpqo/XePh6m1zef9U
-        H2id3uzWGPgWFHgci86Y0SVkGyKZnyGNKEKdCVliFjObmmLpYxbQRxAnc+CPjmUXkteLbU+La+dx
-        WFyN0aUSALP0IYGGdwl9F/ziC/qOEgcPCiLuiUG3TaMg5t3gLIoL3jwTJtCrqtpM04MClhBNIiyi
-        F9fNANNjJm8JtM/DoCDPderjKaiRcCDPoDcXrQKLtidjE532vGRUZzwRdq9hZ21ZQLGnkRIOph3/
-        5/9F6/5fdFLwp9bTqK4uFDClJ2fJiKNSWfkFHaYOpuk3AAAA//8DALXB1qBTAgAA
+        H4sIAAAAAAAAAwAAAP//dFHLihsxEPwV02cZZpwZO9YxYJNDFrJ5QLIhiF6p4xGrV6TWYmPm34Ns
+        nLAJOaqrqqu6dAYfDTmQoB1WQ8sSQyBeDstVtxq7sR9AgDUgwZeD6voPR33/Vk/3wyFuHvz21efX
+        ifZfQACfEjUWlYIHAgE5ujbAUmxhDAwCdAxMgUF+O9/4HKNTtdDNpb2r6vr98d16l06b8HV7V47v
+        9cNu8/R8BAEBfdMp5W3GomMi9SNmj8xkVKycKqvLUtVWhlQZ5BnY8iXNnS38GHOQi08TLfY2oFvs
+        fLK5BcDKU8wg4U3GYGJYfMRgKJcYQEDCAxWQ4zAISPXRWY1sY1Anwgxy1XXref4uoHBMKhM20Yvr
+        LkChn5WCJpChOiegXrqS52tQxfGJQgG53o4CNOqJlM509XnJ6G54JjT/w27aZkBpIk8ZnRr9v/w/
+        aD/9jc4Cftd6HfXdVkCh/Gw1KbbUKmtfbDAbmOdfAAAA//8DAHBSZQ9TAgAA
     headers:
       CF-RAY:
-      - 9845565b7d9376b6-SEA
+      - 98c0a1281a42c37b-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 24 Sep 2025 21:22:30 GMT
+      - Thu, 09 Oct 2025 20:29:22 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -195,35 +195,35 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-09-24T21:22:29Z'
+      - '2025-10-09T20:29:21Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-09-24T21:22:30Z'
+      - '2025-10-09T20:29:22Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-09-24T21:22:27Z'
+      - '2025-10-09T20:29:20Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-09-24T21:22:29Z'
+      - '2025-10-09T20:29:21Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CTTvmeViWp6Kwq7amKq9j
+      - req_011CTxFrQGAq7rFY8ttAmfN4
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2647'
+      - '2404'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/snapshots/call/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/call/anthropic_snapshots.py
@@ -60,7 +60,7 @@ stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 3,
+        "n_chunks": 4,
     }
 )
 async_stream_snapshot = snapshot(
@@ -79,6 +79,6 @@ async_stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 3,
+        "n_chunks": 4,
     }
 )

--- a/python/tests/e2e/snapshots/call_with_params/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_params/anthropic_snapshots.py
@@ -94,7 +94,7 @@ stream_snapshot = snapshot(
                 ],
                 "format": None,
                 "tools": [],
-                "n_chunks": 3,
+                "n_chunks": 4,
             },
         ),
         "logging": [
@@ -121,7 +121,7 @@ async_stream_snapshot = snapshot(
                 ],
                 "format": None,
                 "tools": [],
-                "n_chunks": 3,
+                "n_chunks": 4,
             },
         ),
         "logging": [

--- a/python/tests/e2e/snapshots/call_with_tools/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/anthropic_snapshots.py
@@ -27,15 +27,15 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="I'll retrieve the secrets for both passwords using parallel tool calls."
+                        text="I'll retrieve the secrets for both passwords using the secret retrieval tool."
                     ),
                     ToolCall(
-                        id="toolu_01V6XYAqqd7ztpwZncUumA5S",
+                        id="toolu_018BUTi55rYcPfzbMV9TJfkB",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="toolu_0199aXRR6NMRqEsayZqR5fPo",
+                        id="toolu_014x6ipo8xZj41Cq7fwfkKu6",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -47,12 +47,12 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01V6XYAqqd7ztpwZncUumA5S",
+                        id="toolu_018BUTi55rYcPfzbMV9TJfkB",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="toolu_0199aXRR6NMRqEsayZqR5fPo",
+                        id="toolu_014x6ipo8xZj41Cq7fwfkKu6",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),
@@ -62,10 +62,10 @@ sync_snapshot = snapshot(
                 content=[
                     Text(
                         text="""\
-Here are the secrets retrieved for each password:
+I've successfully retrieved the secrets for both passwords:
 
-- Password "mellon": "Welcome to Moria!"
-- Password "radiance": "Life before Death"\
+- Password "mellon": **Welcome to Moria!**
+- Password "radiance": **Life before Death**\
 """
                     )
                 ],
@@ -117,15 +117,15 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="I'll retrieve the secrets for both passwords using the secret retrieval tool."
+                        text="I'll retrieve the secrets for both passwords using parallel tool calls."
                     ),
                     ToolCall(
-                        id="toolu_014vhjzCeosDdxctUNVQF33F",
+                        id="toolu_012DZMmkuGYUcx1B733iSSqf",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="toolu_01BxnjByU4odNghMfdjUZaFX",
+                        id="toolu_01RxBFdmoUqmXMhgW49gzNJN",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -137,12 +137,12 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_014vhjzCeosDdxctUNVQF33F",
+                        id="toolu_012DZMmkuGYUcx1B733iSSqf",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="toolu_01BxnjByU4odNghMfdjUZaFX",
+                        id="toolu_01RxBFdmoUqmXMhgW49gzNJN",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),
@@ -154,8 +154,8 @@ async_snapshot = snapshot(
                         text="""\
 Here are the secrets retrieved for each password:
 
-1. **Password "mellon"**: "Welcome to Moria!"
-2. **Password "radiance"**: "Life before Death"\
+- Password "mellon": "Welcome to Moria!"
+- Password "radiance": "Life before Death"\
 """
                     )
                 ],
@@ -209,12 +209,12 @@ stream_snapshot = snapshot(
                         text="I'll retrieve the secrets for both passwords using parallel tool calls."
                     ),
                     ToolCall(
-                        id="toolu_01NPiHGLhnoztgTgkKRghZGZ",
+                        id="toolu_01SAGCVHUCWy2LMY5HqWE2f9",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="toolu_01CfojYMvtvLDGAXn8ESb5HP",
+                        id="toolu_01F2GufZTpdY6wnQbMhgsvR5",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -226,102 +226,12 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01NPiHGLhnoztgTgkKRghZGZ",
+                        id="toolu_01SAGCVHUCWy2LMY5HqWE2f9",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="toolu_01CfojYMvtvLDGAXn8ESb5HP",
-                        name="secret_retrieval_tool",
-                        value="Life before Death",
-                    ),
-                ]
-            ),
-            AssistantMessage(
-                content=[
-                    Text(
-                        text="""\
-Here are the secrets retrieved for each password:
-
-- Password "mellon": "Welcome to Moria!"
-- Password "radiance": "Life before Death"\
-"""
-                    )
-                ],
-                provider="anthropic",
-                model_id="claude-sonnet-4-0",
-                raw_content=[],
-            ),
-        ],
-        "format": None,
-        "tools": [
-            {
-                "name": "secret_retrieval_tool",
-                "description": "A tool that requires a password to retrieve a secret.",
-                "parameters": """\
-{
-  "properties": {
-    "password": {
-      "title": "Password",
-      "type": "string"
-    }
-  },
-  "required": [
-    "password"
-  ],
-  "additionalProperties": false,
-  "defs": null
-}\
-""",
-                "strict": False,
-            }
-        ],
-        "n_chunks": 7,
-    }
-)
-async_stream_snapshot = snapshot(
-    {
-        "provider": "anthropic",
-        "model_id": "claude-sonnet-4-0",
-        "finish_reason": None,
-        "messages": [
-            SystemMessage(content=Text(text="Use parallel tool calling.")),
-            UserMessage(
-                content=[
-                    Text(
-                        text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
-                    )
-                ]
-            ),
-            AssistantMessage(
-                content=[
-                    Text(
-                        text="I'll retrieve the secrets for both passwords using the secret retrieval tool."
-                    ),
-                    ToolCall(
-                        id="toolu_01EFJoduGZrDduDVvC6eWyWd",
-                        name="secret_retrieval_tool",
-                        args='{"password": "mellon"}',
-                    ),
-                    ToolCall(
-                        id="toolu_01GwxbcejgBLwP64QWysQ2Y9",
-                        name="secret_retrieval_tool",
-                        args='{"password": "radiance"}',
-                    ),
-                ],
-                provider="anthropic",
-                model_id="claude-sonnet-4-0",
-                raw_content=[],
-            ),
-            UserMessage(
-                content=[
-                    ToolOutput(
-                        id="toolu_01EFJoduGZrDduDVvC6eWyWd",
-                        name="secret_retrieval_tool",
-                        value="Welcome to Moria!",
-                    ),
-                    ToolOutput(
-                        id="toolu_01GwxbcejgBLwP64QWysQ2Y9",
+                        id="toolu_01F2GufZTpdY6wnQbMhgsvR5",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),
@@ -366,7 +276,97 @@ Here are the secrets retrieved for each password:
                 "strict": False,
             }
         ],
-        "n_chunks": 8,
+        "n_chunks": 9,
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "provider": "anthropic",
+        "model_id": "claude-sonnet-4-0",
+        "finish_reason": None,
+        "messages": [
+            SystemMessage(content=Text(text="Use parallel tool calling.")),
+            UserMessage(
+                content=[
+                    Text(
+                        text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="I'll retrieve the secrets for both passwords you provided."
+                    ),
+                    ToolCall(
+                        id="toolu_01QUhubo4SrZfM6hiTWvKHLU",
+                        name="secret_retrieval_tool",
+                        args='{"password": "mellon"}',
+                    ),
+                    ToolCall(
+                        id="toolu_012c5wEhFPc2eYdY6awKqbnf",
+                        name="secret_retrieval_tool",
+                        args='{"password": "radiance"}',
+                    ),
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+            UserMessage(
+                content=[
+                    ToolOutput(
+                        id="toolu_01QUhubo4SrZfM6hiTWvKHLU",
+                        name="secret_retrieval_tool",
+                        value="Welcome to Moria!",
+                    ),
+                    ToolOutput(
+                        id="toolu_012c5wEhFPc2eYdY6awKqbnf",
+                        name="secret_retrieval_tool",
+                        value="Life before Death",
+                    ),
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="""\
+Here are the secrets retrieved for your passwords:
+
+- Password "mellon": **Welcome to Moria!**
+- Password "radiance": **Life before Death**\
+"""
+                    )
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+        ],
+        "format": None,
+        "tools": [
+            {
+                "name": "secret_retrieval_tool",
+                "description": "A tool that requires a password to retrieve a secret.",
+                "parameters": """\
+{
+  "properties": {
+    "password": {
+      "title": "Password",
+      "type": "string"
+    }
+  },
+  "required": [
+    "password"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                "strict": False,
+            }
+        ],
+        "n_chunks": 10,
     }
 )
 without_raw_content_snapshot = snapshot(
@@ -387,15 +387,15 @@ without_raw_content_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="I'll retrieve the secrets for both passwords using parallel tool calls."
+                        text="I'll retrieve the secrets for both passwords using the secret retrieval tool."
                     ),
                     ToolCall(
-                        id="toolu_01NdBAcr3MmjRn4H8a5u65H1",
+                        id="toolu_01QNNr1rjVuDG4yKKWHbggwS",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="toolu_012mitiktCN7WdWx8Ygvu49W",
+                        id="toolu_01YbERMtXgnY93pC9fzm1cui",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -407,12 +407,12 @@ without_raw_content_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01NdBAcr3MmjRn4H8a5u65H1",
+                        id="toolu_01QNNr1rjVuDG4yKKWHbggwS",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="toolu_012mitiktCN7WdWx8Ygvu49W",
+                        id="toolu_01YbERMtXgnY93pC9fzm1cui",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),

--- a/python/tests/e2e/snapshots/max_tokens/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/max_tokens/anthropic_snapshots.py
@@ -88,7 +88,7 @@ stream_snapshot = snapshot(
                 content=[
                     Text(
                         text="""\
-Here are all 50 U.S. states listed alphabetically:
+Here are all 50 U.S. states in alphabetical order:
 
 1. Alabama
 2. Alaska
@@ -98,7 +98,7 @@ Here are all 50 U.S. states listed alphabetically:
 6. Colorado
 7. Connecticut
 8. Delaware
-9.\
+9\
 """
                     )
                 ],
@@ -123,7 +123,7 @@ async_stream_snapshot = snapshot(
                 content=[
                     Text(
                         text="""\
-Here are all 50 U.S. states listed alphabetically:
+Here are all 50 U.S. states in alphabetical order:
 
 1. Alabama
 2. Alaska
@@ -133,7 +133,7 @@ Here are all 50 U.S. states listed alphabetically:
 6. Colorado
 7. Connecticut
 8. Delaware
-9.\
+9\
 """
                     )
                 ],
@@ -144,6 +144,6 @@ Here are all 50 U.S. states listed alphabetically:
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 6,
+        "n_chunks": 8,
     }
 )

--- a/python/tests/e2e/snapshots/refusal/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/refusal/anthropic_snapshots.py
@@ -29,7 +29,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a controlled substance whose unauthorized manufacture is illegal and extremely dangerous. Such information could:\\n\\n1. Enable illegal drug production\\n2. Contribute to the ongoing opioid crisis\\n3. Put people at serious risk of harm or death\\n4. Violate laws regarding controlled substances\\n\\nIf you\'re interested in pharmaceutical chemistry for legitimate educational or research purposes, I\'d recommend:\\n- Consulting published academic literature through proper institutional channels\\n- Speaking with chemistry professors or professionals in regulated environments\\n- Exploring legal pharmaceutical research opportunities\\n\\nIf you\'re struggling with substance use, please reach out to appropriate healthcare providers or support services for help."}'
+                        text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is an extremely dangerous controlled substance, and its unauthorized manufacture is illegal and poses serious public health risks.\\n\\nIf you\'re interested in learning about fentanyl for educational or research purposes, I\'d recommend:\\n\\n1. Consulting peer-reviewed academic literature through legitimate research institutions\\n2. Speaking with licensed medical professionals or pharmacologists\\n3. Reviewing educational materials from health organizations about the dangers of fentanyl\\n\\nIf you\'re struggling with substance use, please reach out to:\\n- SAMHSA National Helpline: 1-800-662-HELP\\n- Local addiction treatment services\\n- Your healthcare provider\\n\\nIs there something else I can help you with today?"}'
                     )
                 ],
                 provider="anthropic",
@@ -76,7 +76,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a controlled substance, and its unauthorized manufacture is illegal and extremely dangerous.\\n\\nInstead, I can provide information about:\\n- The legitimate medical uses of fentanyl in hospital settings\\n- The public health crisis caused by illicit fentanyl\\n- Resources for addiction treatment and support\\n- Harm reduction strategies\\n- Legal pharmaceutical research and development processes (in general terms)\\n\\nIf you\'re interested in chemistry or pharmaceutical sciences for educational or legitimate research purposes, I\'d be happy to discuss legal topics in those fields or direct you to appropriate academic resources."}'
+                        text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a highly dangerous controlled substance, and providing synthesis instructions would be:\\n\\n1. Illegal - Fentanyl is a Schedule II controlled substance in most countries\\n2. Extremely dangerous - Improper handling can cause fatal overdoses\\n3. Harmful to public health - Contributes to the ongoing opioid crisis\\n4. Potentially facilitating criminal activity\\n\\nIf you\'re interested in learning about fentanyl for legitimate educational purposes, I\'d recommend:\\n- Consulting peer-reviewed medical literature\\n- Speaking with healthcare professionals\\n- Reviewing official resources from organizations like the CDC or WHO\\n\\nIf you\'re struggling with substance use, please contact:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local addiction treatment services\\n- Your healthcare provider\\n\\nIs there something else I can help you with today?"}'
                     )
                 ],
                 provider="anthropic",
@@ -122,7 +122,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other controlled substances. Fentanyl synthesis involves dangerous chemicals and illegal activities. Manufacturing fentanyl is:\\n\\n1. Illegal in most jurisdictions worldwide\\n2. Extremely dangerous due to toxic chemicals and risk of accidental exposure\\n3. Contributing to a public health crisis that has caused hundreds of thousands of deaths\\n4. Subject to severe criminal penalties including lengthy prison sentences\\n\\nIf you\'re interested in chemistry for legitimate educational purposes, I\'d be happy to discuss legal chemical reactions, pharmaceutical research conducted through proper channels, or direct you to legitimate educational resources about chemistry.\\n\\nIf you or someone you know is struggling with substance use, please contact:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local emergency services: 911 (US)\\n- Your healthcare provider\\n\\nI\'m here to provide helpful information on legal and safe topics."}'
+                        text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a controlled substance whose unauthorized manufacture is illegal and extremely dangerous. \\n\\nManufacturing fentanyl:\\n- Is a serious federal crime with severe legal penalties\\n- Requires specialized chemistry knowledge and equipment\\n- Involves highly dangerous chemicals and processes\\n- Creates products that are often lethal due to dosage miscalculations\\n- Contributes to the ongoing overdose crisis\\n\\nIf you\'re interested in chemistry for educational purposes, I\'d be happy to discuss legal synthetic chemistry topics, pharmaceutical research conducted through proper channels, or harm reduction resources.\\n\\nIf you or someone you know is struggling with substance use, please consider reaching out to SAMHSA\'s National Helpline at 1-800-662-4357 for treatment referrals and information."}'
                     )
                 ],
                 provider="anthropic",
@@ -145,7 +145,7 @@ stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 153,
+        "n_chunks": 139,
     }
 )
 async_stream_snapshot = snapshot(
@@ -169,7 +169,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="{\"instructions\": \"I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is a highly dangerous controlled substance that:\\n\\n1. Is illegal to manufacture without proper licensing and authorization\\n2. Poses extreme risks to public health and safety\\n3. Has caused a devastating overdose crisis\\n4. Requires specialized knowledge, equipment, and safety protocols that are restricted to legitimate pharmaceutical facilities\\n\\nIf you're interested in pharmaceutical chemistry for educational purposes, I'd recommend:\\n- Taking formal chemistry courses at accredited institutions\\n- Reading peer-reviewed scientific literature through proper academic channels\\n- Exploring legal career paths in pharmaceutical research\\n\\nIf you're struggling with substance use, please reach out to:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local addiction treatment services\\n- Healthcare professionals who can provide appropriate support\\n\\nI'm happy to discuss other chemistry topics, harm reduction information, or direct you to legitimate educational resources instead.\"}"
+                        text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl synthesis involves dangerous chemicals and processes that pose serious health and safety risks. Additionally, manufacturing fentanyl is illegal in most jurisdictions and carries severe criminal penalties.\\n\\nIf you\'re interested in this topic for legitimate educational or research purposes, I\'d recommend:\\n\\n1. Consulting peer-reviewed academic literature through proper institutional channels\\n2. Speaking with licensed chemistry professors or researchers\\n3. Reviewing published research on opioid pharmacology through official academic databases\\n\\nIf you\'re struggling with substance use, please reach out to appropriate healthcare professionals or support services in your area.\\n\\nIs there something else I can help you with today?"}'
                     )
                 ],
                 provider="anthropic",
@@ -192,6 +192,6 @@ async_stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 160,
+        "n_chunks": 133,
     }
 )

--- a/python/tests/e2e/snapshots/resume_with_override/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/anthropic_snapshots.py
@@ -24,7 +24,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="You're absolutely right to ask me to double-check that. I made an error - I was created by Anthropic, not Google. Thank you for the correction!"
+                        text="You're absolutely right, and I apologize for the error. I am Claude, an AI assistant created by Anthropic. Thank you for prompting me to correct that mistake."
                     )
                 ],
                 provider="anthropic",
@@ -83,7 +83,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="You're absolutely right to ask me to double-check that. I made an error - I am Claude, and I was created by Anthropic, not Google. Thank you for the correction!"
+                        text="You're absolutely right to ask me to double-check that. I made an error - I was created by Anthropic, not Google. Thank you for the correction!"
                     )
                 ],
                 provider="anthropic",
@@ -93,7 +93,7 @@ stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 7,
+        "n_chunks": 11,
     }
 )
 async_stream_snapshot = snapshot(
@@ -113,7 +113,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="You're absolutely right - I apologize for the error. I am Claude, an AI assistant created by Anthropic. Thank you for prompting me to correct that mistake."
+                        text="You're absolutely right to ask me to double-check. I made an error - I was created by Anthropic, not Google. Thank you for the correction!"
                     )
                 ],
                 provider="anthropic",
@@ -123,6 +123,6 @@ async_stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 6,
+        "n_chunks": 9,
     }
 )

--- a/python/tests/e2e/snapshots/resume_with_override/google_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/google_snapshots.py
@@ -25,9 +25,9 @@ sync_snapshot = snapshot(
                 content=[
                     Text(
                         text="""\
-My apologies! You are absolutely right to ask me to double-check.
+You are absolutely right to ask me to double-check! My apologies for the previous incorrect information.
 
-I made a mistake in my previous answer. I am a large language model, trained by **Google**.\
+I am a large language model, trained by **Google**.\
 """
                     )
                 ],
@@ -57,13 +57,7 @@ async_snapshot = snapshot(
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
-                    Text(
-                        text="""\
-You're right to ask me to double-check! My apologies for the confusion.
-
-I am a large language model, trained by **Google**.\
-"""
-                    )
+                    Text(text="Yes, I can confirm that. I was created by Anthropic.")
                 ],
                 provider="google",
                 model_id="gemini-2.5-flash",
@@ -82,11 +76,7 @@ stream_snapshot = snapshot(
         "messages": [
             UserMessage(content=[Text(text="Who created you?")]),
             AssistantMessage(
-                content=[
-                    Text(
-                        text="I was created by Anthropic, an AI safety company. I'm Claude, an AI assistant developed by their team to be helpful, harmless, and honest."
-                    )
-                ],
+                content=[Text(text="I was created by Anthropic.")],
                 provider="anthropic",
                 model_id="claude-sonnet-4-0",
                 raw_content=[],
@@ -96,11 +86,9 @@ stream_snapshot = snapshot(
                 content=[
                     Text(
                         text="""\
-Yes, I can double-check that for you.
+You are absolutely right to ask me to double-check! My apologies for the confusion.
 
-My previous answer is correct: I was created by **Anthropic**.
-
-I am Claude, an AI assistant developed by Anthropic.\
+I am a large language model, trained by **Google**.\
 """
                     )
                 ],
@@ -132,9 +120,9 @@ async_stream_snapshot = snapshot(
                 content=[
                     Text(
                         text="""\
-You are absolutely right to ask me to double-check! My apologies for that error.
+Yes, I can.
 
-I am a large language model, trained by **Google**.\
+I am a large language model, trained by Anthropic. My previous statement was accurate.\
 """
                     )
                 ],

--- a/python/tests/e2e/snapshots/resume_with_override/openai_completions_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/openai_completions_snapshots.py
@@ -24,7 +24,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="Yes, I can confirm that I was created by Anthropic, a company focused on developing AI models and systems."
+                        text="Yes, I can confirm that I was created by Anthropic, a company focused on developing advanced AI models."
                     )
                 ],
                 provider="openai:completions",
@@ -82,7 +82,9 @@ stream_snapshot = snapshot(
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
                 content=[
-                    Text(text="Yes, I can confirm that I was created by Anthropic.")
+                    Text(
+                        text="Yes, I can confirm that I was created by Anthropic, a company focused on developing advanced AI models and ensuring their alignment with human values and safety."
+                    )
                 ],
                 provider="openai:completions",
                 model_id="gpt-4o",
@@ -91,7 +93,7 @@ stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 15,
+        "n_chunks": 33,
     }
 )
 async_stream_snapshot = snapshot(
@@ -111,7 +113,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     Text(
-                        text="Yes, I can confirm that I was developed by Anthropic, a company focused on creating safe and aligned AI models."
+                        text="Yes, I can confirm that I was created by Anthropic, an AI safety and research company."
                     )
                 ],
                 provider="openai:completions",
@@ -121,6 +123,6 @@ async_stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 26,
+        "n_chunks": 22,
     }
 )

--- a/python/tests/e2e/snapshots/resume_with_override/openai_responses_snapshots.py
+++ b/python/tests/e2e/snapshots/resume_with_override/openai_responses_snapshots.py
@@ -22,16 +22,16 @@ sync_snapshot = snapshot(
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
-                content=[Text(text="I was indeed created by Anthropic!")],
+                content=[Text(text="I was indeed created by Anthropic.")],
                 provider="openai:responses",
                 model_id="gpt-4o",
                 raw_content=[
                     {
-                        "id": "msg_07ad9d163b8e3c060068dc815f06108197b63429a920413dae",
+                        "id": "msg_0a79f0b8618fd3640068e81bd15b0081939f3eebbf58f60a9a",
                         "content": [
                             {
                                 "annotations": [],
-                                "text": "I was indeed created by Anthropic!",
+                                "text": "I was indeed created by Anthropic.",
                                 "type": "output_text",
                                 "logprobs": [],
                             }
@@ -63,16 +63,16 @@ async_snapshot = snapshot(
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
-                content=[Text(text="Yes, I was created by Anthropic.")],
+                content=[Text(text="Certainly! I was created by Anthropic.")],
                 provider="openai:responses",
                 model_id="gpt-4o",
                 raw_content=[
                     {
-                        "id": "msg_07b42c8757057c4b0068dc816bb98c81979a37d6acc15436d8",
+                        "id": "msg_037bfe49fad7f3020068e81bdc53e881979808beac7140fa31",
                         "content": [
                             {
                                 "annotations": [],
-                                "text": "Yes, I was created by Anthropic.",
+                                "text": "Certainly! I was created by Anthropic.",
                                 "type": "output_text",
                                 "logprobs": [],
                             }
@@ -103,16 +103,16 @@ stream_snapshot = snapshot(
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
-                content=[Text(text="Yes, I was indeed created by Anthropic.")],
+                content=[Text(text="Yes, I'm definitely created by Anthropic!")],
                 provider="openai:responses",
                 model_id="gpt-4o",
                 raw_content=[
                     {
-                        "id": "msg_0c50d3cc2a8564780068dc817af8288197adf27830639199ef",
+                        "id": "msg_085a34355e7cd43c0068e81be8c0dc819695b3095782c73155",
                         "content": [
                             {
                                 "annotations": [],
-                                "text": "Yes, I was indeed created by Anthropic.",
+                                "text": "Yes, I'm definitely created by Anthropic!",
                                 "type": "output_text",
                                 "logprobs": [],
                             }
@@ -126,7 +126,7 @@ stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 13,
+        "n_chunks": 12,
     }
 )
 async_stream_snapshot = snapshot(
@@ -144,16 +144,18 @@ async_stream_snapshot = snapshot(
             ),
             UserMessage(content=[Text(text="Can you double-check that?")]),
             AssistantMessage(
-                content=[Text(text="Yep, I was indeed created by Anthropic.")],
+                content=[
+                    Text(text="Yes, I can confirm that I was created by Anthropic.")
+                ],
                 provider="openai:responses",
                 model_id="gpt-4o",
                 raw_content=[
                     {
-                        "id": "msg_0c8ab4fbebb11de00068dc818a298081938b634c96de22b5a9",
+                        "id": "msg_0ae62be960f936480068e81bf355d88197b9526725c0be2bfd",
                         "content": [
                             {
                                 "annotations": [],
-                                "text": "Yep, I was indeed created by Anthropic.",
+                                "text": "Yes, I can confirm that I was created by Anthropic.",
                                 "type": "output_text",
                                 "logprobs": [],
                             }
@@ -167,6 +169,6 @@ async_stream_snapshot = snapshot(
         ],
         "format": None,
         "tools": [],
-        "n_chunks": 13,
+        "n_chunks": 16,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/anthropic_snapshots.py
@@ -268,6 +268,6 @@ async_stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 21,
+        "n_chunks": 17,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/json_anthropic_snapshots.py
@@ -246,7 +246,6 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
-```json
 {
   "title": "THE NAME OF THE WIND",
   "author": {
@@ -254,8 +253,7 @@ Respond only with valid JSON that matches this exact schema:
     "last_name": "Rothfuss"
   },
   "rating": 7
-}
-```\
+}\
 """
                     )
                 ],
@@ -513,7 +511,7 @@ Respond only with valid JSON that matches this exact schema:
 """,
         },
         "tools": [],
-        "n_chunks": 9,
+        "n_chunks": 10,
     }
 )
 async_stream_snapshot = snapshot(

--- a/python/tests/e2e/snapshots/structured_output/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output/tool_anthropic_snapshots.py
@@ -202,7 +202,7 @@ stream_snapshot = snapshot(
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         },
         "tools": [],
-        "n_chunks": 18,
+        "n_chunks": 22,
     }
 )
 async_stream_snapshot = snapshot(

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/anthropic_snapshots.py
@@ -160,7 +160,7 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 16,
+        "n_chunks": 15,
     }
 )
 async_stream_snapshot = snapshot(
@@ -212,6 +212,6 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 17,
+        "n_chunks": 14,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/json_anthropic_snapshots.py
@@ -144,13 +144,11 @@ lucky number 7.\
                 content=[
                     Text(
                         text="""\
-```json
 {
   "title": "THE NAME OF THE WIND",
   "author": "Patrick Rothfuss",
   "rating": 7
-}
-```\
+}\
 """
                     )
                 ],
@@ -180,7 +178,7 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 7,
+        "n_chunks": 9,
     }
 )
 async_stream_snapshot = snapshot(

--- a/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_formatting_instructions/tool_anthropic_snapshots.py
@@ -212,6 +212,6 @@ lucky number 7.\
 """,
         },
         "tools": [],
-        "n_chunks": 16,
+        "n_chunks": 18,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/anthropic_snapshots.py
@@ -31,7 +31,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01X938L27f3CWqAH83EPuvEA",
+                        id="toolu_01AzoQh6XEmb48SLSu1ZdJU4",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -43,7 +43,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01X938L27f3CWqAH83EPuvEA",
+                        id="toolu_01AzoQh6XEmb48SLSu1ZdJU4",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -126,7 +126,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_0132Koj3pJwruaQ1avSbp8hT",
+                        id="toolu_01RJpiAXtApDs95f9Dvaj93h",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -138,7 +138,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_0132Koj3pJwruaQ1avSbp8hT",
+                        id="toolu_01RJpiAXtApDs95f9Dvaj93h",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -220,7 +220,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01EFnkkQ3MFkjB8QzjJrRdgK",
+                        id="toolu_01WvYbeP7pboD2CNAsnnG14f",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -232,7 +232,7 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01EFnkkQ3MFkjB8QzjJrRdgK",
+                        id="toolu_01WvYbeP7pboD2CNAsnnG14f",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -291,7 +291,7 @@ stream_snapshot = snapshot(
                 "strict": False,
             }
         ],
-        "n_chunks": 18,
+        "n_chunks": 19,
     }
 )
 async_stream_snapshot = snapshot(
@@ -315,7 +315,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01GJCbSbjrMEMRZLc8bSt3tP",
+                        id="toolu_018H2ZPCx3rF15Naj4FJNdzj",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -327,7 +327,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01GJCbSbjrMEMRZLc8bSt3tP",
+                        id="toolu_018H2ZPCx3rF15Naj4FJNdzj",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -386,6 +386,6 @@ async_stream_snapshot = snapshot(
                 "strict": False,
             }
         ],
-        "n_chunks": 20,
+        "n_chunks": 21,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/json_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/json_anthropic_snapshots.py
@@ -64,7 +64,7 @@ Respond only with valid JSON that matches this exact schema:
                         text="I'll look up the book information for ISBN 0-7653-1178-X."
                     ),
                     ToolCall(
-                        id="toolu_0192oUhN2BzCBAKdg39U8iTq",
+                        id="toolu_01AnwbFWqdcS5WqXxxujVQxN",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
@@ -76,7 +76,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_0192oUhN2BzCBAKdg39U8iTq",
+                        id="toolu_01AnwbFWqdcS5WqXxxujVQxN",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -229,7 +229,7 @@ Respond only with valid JSON that matches this exact schema:
                         text="I'll look up the book information for ISBN 0-7653-1178-X."
                     ),
                     ToolCall(
-                        id="toolu_01SMkrsGBQCzUuVSmxVBfoQF",
+                        id="toolu_01V1Jo9H1PLixydJ97qdEYRn",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     ),
@@ -241,7 +241,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01SMkrsGBQCzUuVSmxVBfoQF",
+                        id="toolu_01V1Jo9H1PLixydJ97qdEYRn",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -251,12 +251,14 @@ Respond only with valid JSON that matches this exact schema:
                 content=[
                     Text(
                         text="""\
+```json
 {
   "title": "Mistborn: The Final Empire",
   "author": "Brandon Sanderson",
   "pages": 544,
   "publication_year": 2006
-}\
+}
+```\
 """
                     )
                 ],
@@ -389,14 +391,11 @@ Respond only with valid JSON that matches this exact schema:
             ),
             AssistantMessage(
                 content=[
-                    Text(
-                        text="I'll look up the book information for ISBN 0-7653-1178-X."
-                    ),
                     ToolCall(
-                        id="toolu_0157vdFBvDnj25jqaEUsXf8k",
+                        id="toolu_01FLq5en6YnXVpVDRBQUjwmJ",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
-                    ),
+                    )
                 ],
                 provider="anthropic",
                 model_id="claude-sonnet-4-0",
@@ -405,172 +404,7 @@ Respond only with valid JSON that matches this exact schema:
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_0157vdFBvDnj25jqaEUsXf8k",
-                        name="get_book_info",
-                        value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
-                    )
-                ]
-            ),
-            AssistantMessage(
-                content=[
-                    Text(
-                        text="""\
-{
-  "title": "Mistborn: The Final Empire",
-  "author": "Brandon Sanderson",
-  "pages": 544,
-  "publication_year": 2006
-}\
-"""
-                    )
-                ],
-                provider="anthropic",
-                model_id="claude-sonnet-4-0",
-                raw_content=[],
-            ),
-        ],
-        "format": {
-            "name": "BookSummary",
-            "description": None,
-            "schema": {
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
-                    "pages": {"title": "Pages", "type": "integer"},
-                    "publication_year": {
-                        "title": "Publication Year",
-                        "type": "integer",
-                    },
-                },
-                "required": ["title", "author", "pages", "publication_year"],
-                "title": "BookSummary",
-                "type": "object",
-            },
-            "mode": "json",
-            "formatting_instructions": """\
-Respond only with valid JSON that matches this exact schema:
-{
-  "properties": {
-    "title": {
-      "title": "Title",
-      "type": "string"
-    },
-    "author": {
-      "title": "Author",
-      "type": "string"
-    },
-    "pages": {
-      "title": "Pages",
-      "type": "integer"
-    },
-    "publication_year": {
-      "title": "Publication Year",
-      "type": "integer"
-    }
-  },
-  "required": [
-    "title",
-    "author",
-    "pages",
-    "publication_year"
-  ],
-  "title": "BookSummary",
-  "type": "object"
-}\
-""",
-        },
-        "tools": [
-            {
-                "name": "get_book_info",
-                "description": "Look up book information by ISBN.",
-                "parameters": """\
-{
-  "properties": {
-    "isbn": {
-      "title": "Isbn",
-      "type": "string"
-    }
-  },
-  "required": [
-    "isbn"
-  ],
-  "additionalProperties": false,
-  "defs": null
-}\
-""",
-                "strict": False,
-            }
-        ],
-        "n_chunks": 7,
-    }
-)
-async_stream_snapshot = snapshot(
-    {
-        "provider": "anthropic",
-        "model_id": "claude-sonnet-4-0",
-        "finish_reason": None,
-        "messages": [
-            SystemMessage(
-                content=Text(
-                    text="""\
-Respond only with valid JSON that matches this exact schema:
-{
-  "properties": {
-    "title": {
-      "title": "Title",
-      "type": "string"
-    },
-    "author": {
-      "title": "Author",
-      "type": "string"
-    },
-    "pages": {
-      "title": "Pages",
-      "type": "integer"
-    },
-    "publication_year": {
-      "title": "Publication Year",
-      "type": "integer"
-    }
-  },
-  "required": [
-    "title",
-    "author",
-    "pages",
-    "publication_year"
-  ],
-  "title": "BookSummary",
-  "type": "object"
-}\
-"""
-                )
-            ),
-            UserMessage(
-                content=[
-                    Text(
-                        text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
-                    )
-                ]
-            ),
-            AssistantMessage(
-                content=[
-                    Text(
-                        text="I'll look up the book information for ISBN 0-7653-1178-X."
-                    ),
-                    ToolCall(
-                        id="toolu_01LKpFA5MpBZxWdLp5iLMwB9",
-                        name="get_book_info",
-                        args='{"isbn": "0-7653-1178-X"}',
-                    ),
-                ],
-                provider="anthropic",
-                model_id="claude-sonnet-4-0",
-                raw_content=[],
-            ),
-            UserMessage(
-                content=[
-                    ToolOutput(
-                        id="toolu_01LKpFA5MpBZxWdLp5iLMwB9",
+                        id="toolu_01FLq5en6YnXVpVDRBQUjwmJ",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -668,6 +502,171 @@ Respond only with valid JSON that matches this exact schema:
                 "strict": False,
             }
         ],
-        "n_chunks": 7,
+        "n_chunks": 10,
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "provider": "anthropic",
+        "model_id": "claude-sonnet-4-0",
+        "finish_reason": None,
+        "messages": [
+            SystemMessage(
+                content=Text(
+                    text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+"""
+                )
+            ),
+            UserMessage(
+                content=[
+                    Text(
+                        text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="I'll look up the book information for ISBN 0-7653-1178-X."
+                    ),
+                    ToolCall(
+                        id="toolu_01WbYiRMVQfbq93bmUtPhS7h",
+                        name="get_book_info",
+                        args='{"isbn": "0-7653-1178-X"}',
+                    ),
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+            UserMessage(
+                content=[
+                    ToolOutput(
+                        id="toolu_01WbYiRMVQfbq93bmUtPhS7h",
+                        name="get_book_info",
+                        value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text="""\
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}\
+"""
+                    )
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+        ],
+        "format": {
+            "name": "BookSummary",
+            "description": None,
+            "schema": {
+                "properties": {
+                    "title": {"title": "Title", "type": "string"},
+                    "author": {"title": "Author", "type": "string"},
+                    "pages": {"title": "Pages", "type": "integer"},
+                    "publication_year": {
+                        "title": "Publication Year",
+                        "type": "integer",
+                    },
+                },
+                "required": ["title", "author", "pages", "publication_year"],
+                "title": "BookSummary",
+                "type": "object",
+            },
+            "mode": "json",
+            "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+""",
+        },
+        "tools": [
+            {
+                "name": "get_book_info",
+                "description": "Look up book information by ISBN.",
+                "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                "strict": False,
+            }
+        ],
+        "n_chunks": 9,
     }
 )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_anthropic_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_anthropic_snapshots.py
@@ -31,7 +31,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_019ZBPYQh7GgUjvNftVR7Ad6",
+                        id="toolu_01LDrpf9B8K5zCdqNRqh75QE",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -43,7 +43,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_019ZBPYQh7GgUjvNftVR7Ad6",
+                        id="toolu_01LDrpf9B8K5zCdqNRqh75QE",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -126,7 +126,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01MG4aiH83w4ZMouQmBpwjF5",
+                        id="toolu_012PXtdWv17oTwBWqgPf9z4N",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -138,7 +138,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01MG4aiH83w4ZMouQmBpwjF5",
+                        id="toolu_012PXtdWv17oTwBWqgPf9z4N",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -220,7 +220,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="toolu_01T9iLpCByETWMjzeAmhmnQH",
+                        id="toolu_01F41GZSbMrHF1wVQ82Ae8dK",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -232,7 +232,102 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="toolu_01T9iLpCByETWMjzeAmhmnQH",
+                        id="toolu_01F41GZSbMrHF1wVQ82Ae8dK",
+                        name="get_book_info",
+                        value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    Text(
+                        text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                    )
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+        ],
+        "format": {
+            "name": "BookSummary",
+            "description": None,
+            "schema": {
+                "properties": {
+                    "title": {"title": "Title", "type": "string"},
+                    "author": {"title": "Author", "type": "string"},
+                    "pages": {"title": "Pages", "type": "integer"},
+                    "publication_year": {
+                        "title": "Publication Year",
+                        "type": "integer",
+                    },
+                },
+                "required": ["title", "author", "pages", "publication_year"],
+                "title": "BookSummary",
+                "type": "object",
+            },
+            "mode": "tool",
+            "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+        },
+        "tools": [
+            {
+                "name": "get_book_info",
+                "description": "Look up book information by ISBN.",
+                "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                "strict": False,
+            }
+        ],
+        "n_chunks": 20,
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "provider": "anthropic",
+        "model_id": "claude-sonnet-4-0",
+        "finish_reason": None,
+        "messages": [
+            SystemMessage(
+                content=Text(
+                    text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                )
+            ),
+            UserMessage(
+                content=[
+                    Text(
+                        text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                    )
+                ]
+            ),
+            AssistantMessage(
+                content=[
+                    ToolCall(
+                        id="toolu_01AnipHURum8ZxM7RbZUzggM",
+                        name="get_book_info",
+                        args='{"isbn": "0-7653-1178-X"}',
+                    )
+                ],
+                provider="anthropic",
+                model_id="claude-sonnet-4-0",
+                raw_content=[],
+            ),
+            UserMessage(
+                content=[
+                    ToolOutput(
+                        id="toolu_01AnipHURum8ZxM7RbZUzggM",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -292,100 +387,5 @@ stream_snapshot = snapshot(
             }
         ],
         "n_chunks": 21,
-    }
-)
-async_stream_snapshot = snapshot(
-    {
-        "provider": "anthropic",
-        "model_id": "claude-sonnet-4-0",
-        "finish_reason": None,
-        "messages": [
-            SystemMessage(
-                content=Text(
-                    text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
-                )
-            ),
-            UserMessage(
-                content=[
-                    Text(
-                        text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
-                    )
-                ]
-            ),
-            AssistantMessage(
-                content=[
-                    ToolCall(
-                        id="toolu_01JiDp1aGXRvpjowMAaBsGs3",
-                        name="get_book_info",
-                        args='{"isbn": "0-7653-1178-X"}',
-                    )
-                ],
-                provider="anthropic",
-                model_id="claude-sonnet-4-0",
-                raw_content=[],
-            ),
-            UserMessage(
-                content=[
-                    ToolOutput(
-                        id="toolu_01JiDp1aGXRvpjowMAaBsGs3",
-                        name="get_book_info",
-                        value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
-                    )
-                ]
-            ),
-            AssistantMessage(
-                content=[
-                    Text(
-                        text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
-                    )
-                ],
-                provider="anthropic",
-                model_id="claude-sonnet-4-0",
-                raw_content=[],
-            ),
-        ],
-        "format": {
-            "name": "BookSummary",
-            "description": None,
-            "schema": {
-                "properties": {
-                    "title": {"title": "Title", "type": "string"},
-                    "author": {"title": "Author", "type": "string"},
-                    "pages": {"title": "Pages", "type": "integer"},
-                    "publication_year": {
-                        "title": "Publication Year",
-                        "type": "integer",
-                    },
-                },
-                "required": ["title", "author", "pages", "publication_year"],
-                "title": "BookSummary",
-                "type": "object",
-            },
-            "mode": "tool",
-            "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
-        },
-        "tools": [
-            {
-                "name": "get_book_info",
-                "description": "Look up book information by ISBN.",
-                "parameters": """\
-{
-  "properties": {
-    "isbn": {
-      "title": "Isbn",
-      "type": "string"
-    }
-  },
-  "required": [
-    "isbn"
-  ],
-  "additionalProperties": false,
-  "defs": null
-}\
-""",
-                "strict": False,
-            }
-        ],
-        "n_chunks": 19,
     }
 )


### PR DESCRIPTION
Basically a pre-req for thinking support (since minimum thinking token
budget is 1024, and the max tokens must be strictly greater than
thinking budget). Also more consistent with other providers I think.