### PR TITLE
refactor: Add `stream.partial`

### DIFF
--- a/python/examples/sazed/sazed_async_stream_tools.py
+++ b/python/examples/sazed/sazed_async_stream_tools.py
@@ -35,7 +35,7 @@ async def main():
         async for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     async for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/examples/sazed/sazed_async_stream_tools_context.py
+++ b/python/examples/sazed/sazed_async_stream_tools_context.py
@@ -47,7 +47,7 @@ async def main():
         async for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     async for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/examples/sazed/sazed_async_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_context_structured.py
@@ -56,7 +56,7 @@ async def main():
         async for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     async for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/examples/sazed/sazed_async_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_structured.py
@@ -44,7 +44,7 @@ async def main():
         async for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     async for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/examples/sazed/sazed_stream_tools.py
+++ b/python/examples/sazed/sazed_stream_tools.py
@@ -33,7 +33,7 @@ def main():
         for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/examples/sazed/sazed_stream_tools_context.py
+++ b/python/examples/sazed/sazed_stream_tools_context.py
@@ -44,7 +44,7 @@ def main():
         for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/examples/sazed/sazed_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_context_structured.py
@@ -55,7 +55,7 @@ def main():
         for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/examples/sazed/sazed_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_structured.py
@@ -42,7 +42,7 @@ def main():
         for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()

--- a/python/mirascope/llm/streams/base_stream.py
+++ b/python/mirascope/llm/streams/base_stream.py
@@ -16,6 +16,9 @@ ContentT = TypeVar("ContentT", bound=AssistantContentPart)
 class BaseStream(ABC, Generic[ChunkT, ContentT]):
     """Base class for synchronous streaming content."""
 
+    partial: ContentT
+    """The accumulated content as chunks are received."""
+
     @abstractmethod
     def __iter__(self) -> Iterator[ChunkT]:
         """Iterate over chunks as they are received."""
@@ -29,6 +32,9 @@ class BaseStream(ABC, Generic[ChunkT, ContentT]):
 
 class BaseAsyncStream(ABC, Generic[ChunkT, ContentT]):
     """Base class for asynchronous streaming content."""
+
+    partial: ContentT
+    """The accumulated content as chunks are received."""
 
     @abstractmethod
     def __aiter__(self) -> AsyncIterator[ChunkT]:

--- a/python/mirascope/llm/streams/text_stream.py
+++ b/python/mirascope/llm/streams/text_stream.py
@@ -15,7 +15,7 @@ class TextStream(BaseStream[TextChunk, Text]):
     content_type: Literal["text"] = "text"
     """The type of content this stream handles."""
 
-    partial_text: str
+    partial: Text
     """The accumulated text content as chunks are received."""
 
     def __iter__(self) -> Iterator[TextChunk]:
@@ -43,7 +43,7 @@ class AsyncTextStream(BaseAsyncStream[TextChunk, Text]):
     content_type: Literal["text"] = "text"
     """The type of content this stream handles."""
 
-    partial_text: str
+    partial: Text
     """The accumulated text content as chunks are received."""
 
     def __aiter__(self) -> AsyncIterator[TextChunk]:

--- a/python/mirascope/llm/streams/thought_stream.py
+++ b/python/mirascope/llm/streams/thought_stream.py
@@ -15,7 +15,7 @@ class ThoughtStream(BaseStream[ThoughtChunk, Thought]):
     content_type: Literal["thought"] = "thought"
     """The type of content this stream handles."""
 
-    partial_thought: str
+    partial: Thought
     """The accumulated thought content as chunks are received."""
 
     def __iter__(self) -> Iterator[ThoughtChunk]:
@@ -43,7 +43,7 @@ class AsyncThoughtStream(BaseAsyncStream[ThoughtChunk, Thought]):
     content_type: Literal["thought"] = "thought"
     """The type of content this stream handles."""
 
-    partial_thought: str
+    partial: Thought
     """The accumulated thought content as chunks are received."""
 
     def __aiter__(self) -> AsyncIterator[ThoughtChunk]:

--- a/python/mirascope/llm/streams/tool_call_stream.py
+++ b/python/mirascope/llm/streams/tool_call_stream.py
@@ -15,14 +15,8 @@ class ToolCallStream(BaseStream[ToolCallChunk, ToolCall]):
     content_type: Literal["tool_call"] = "tool_call"
     """The type of content this stream handles."""
 
-    tool_id: str
-    """A unique identifier for this tool call."""
-
-    tool_name: str
-    """The name of the tool being called."""
-
-    partial_args: str
-    """The accumulated tool arguments as chunks are received."""
+    partial: ToolCall
+    """The accumulated tool call content as chunks are received."""
 
     def __iter__(self) -> Iterator[ToolCallChunk]:
         """Iterate over tool call chunks as they are received.
@@ -49,14 +43,8 @@ class AsyncToolCallStream(BaseAsyncStream[ToolCallChunk, ToolCall]):
     content_type: Literal["tool_call"] = "tool_call"
     """The type of content this stream handles."""
 
-    tool_id: str
-    """A unique identifier for this tool call."""
-
-    tool_name: str
-    """The name of the tool being called."""
-
-    partial_args: str
-    """The accumulated tool arguments as chunks are received."""
+    partial: ToolCall
+    """The accumulated tool call content as chunks are received."""
 
     def __aiter__(self) -> AsyncIterator[ToolCallChunk]:
         """Asynchronously iterate over tool call chunks as they are received.

--- a/python/scripts/example_generator.ts
+++ b/python/scripts/example_generator.ts
@@ -254,7 +254,7 @@ ${indent}        ${stream_print}`;
         ${this._async}for stream in streams:
             match stream.content_type:
                 case "tool_call":
-                    print(f"Calling tool {stream.tool_name} with args:")
+                    print(f"Calling tool {stream.partial.name} with args:")
                     ${this._async}for chunk in stream:
                         print(chunk.delta, flush=True, end="")
                     print()


### PR DESCRIPTION
Rather than each stream having bespoke fields like
`text_stream.partial_text`, we can just have `stream.partial` with the
same info. Much cleaner, idk why I didn't do this from the start.