### PR TITLE
chore: remove unnecessary extra defensive checks in openai streams

### DIFF
--- a/python/mirascope/llm/clients/openai/completions/_utils.py
+++ b/python/mirascope/llm/clients/openai/completions/_utils.py
@@ -353,13 +353,6 @@ class _OpenAIChunkProcessor:
             if self.current_content_type is None:
                 yield TextStartChunk()
                 self.current_content_type = "text"
-            elif self.current_content_type == "tool_call":
-                raise RuntimeError(
-                    "received text delta inside tool call"
-                )  # pragma: no cover
-            elif self.current_content_type != "text":
-                raise NotImplementedError
-
             yield TextChunk(delta=content)
 
         if delta.tool_calls:
@@ -367,10 +360,6 @@ class _OpenAIChunkProcessor:
                 # In testing, I can't get OpenAI to emit text and tool calls in the same chunk
                 # But we handle this defensively.
                 yield TextEndChunk()  # pragma: no cover
-            elif self.current_content_type and self.current_content_type != "tool_call":
-                raise RuntimeError(
-                    f"Unexpected current_content_type: {self.current_content_type}"
-                )  # pragma: no cover
             self.current_content_type = "tool_call"
 
             for tool_call_delta in delta.tool_calls:

--- a/python/mirascope/llm/clients/openai/responses/_utils.py
+++ b/python/mirascope/llm/clients/openai/responses/_utils.py
@@ -302,32 +302,16 @@ class _OpenAIResponsesChunkProcessor:
                 if not self.current_content_type:
                     yield TextStartChunk()
                     self.current_content_type = "text"
-                if self.current_content_type != "text":
-                    raise RuntimeError(
-                        "Received text delta when not processing text"
-                    )  # pragma: no cover
                 yield TextChunk(delta=event.delta)
             elif event.type == "response.output_text.done":
-                if self.current_content_type != "text":
-                    raise RuntimeError(
-                        "Received text done while not processing text"
-                    )  # pragma: no cover
                 yield TextEndChunk()
                 self.current_content_type = None
             if event.type == "response.refusal.delta":
                 if not self.current_content_type:
                     yield TextStartChunk()
                     self.current_content_type = "text"
-                if self.current_content_type != "text":
-                    raise RuntimeError(
-                        "Received text delta when not processing text"
-                    )  # pragma: no cover
                 yield TextChunk(delta=event.delta)
             elif event.type == "response.refusal.done":
-                if self.current_content_type != "text":
-                    raise RuntimeError(
-                        "Received text done while not processing text"
-                    )  # pragma: no cover
                 yield TextEndChunk()
                 self.refusal_encountered = True
                 self.current_content_type = None
@@ -342,16 +326,8 @@ class _OpenAIResponsesChunkProcessor:
                     )
                     self.current_content_type = "tool_call"
             elif event.type == "response.function_call_arguments.delta":
-                if self.current_content_type != "tool_call":
-                    raise RuntimeError(
-                        "Received tool args delta while not processing tool call"
-                    )  # pragma: no cover
                 yield ToolCallChunk(delta=event.delta)
             elif event.type == "response.function_call_arguments.done":
-                if self.current_content_type != "tool_call":
-                    raise RuntimeError(
-                        "Received tool args done while not processing tool call"
-                    )  # pragma: no cover
                 yield ToolCallEndChunk()
                 self.current_content_type = None
             elif event.type == "response.incomplete":


### PR DESCRIPTION
We have all these pragma: no cover checks that throw a runtime error if
we get incoherent data from the openai streams, however without these we
would error anyway when the stream response checks that the chunks are
organized in consistent content sequences. So we can do without.