### PR TITLE
feat: add e2e testing of stream_response.streams()

### DIFF
--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -382,6 +382,7 @@ class BaseSyncStreamResponse(BaseStreamResponse[ChunkIterator, ToolkitT, Formatt
         cached chunks.
         """
         chunk_iter = self.chunk_stream()
+        stream: Stream | None = None
 
         for chunk in chunk_iter:
             if chunk.type == "text_start_chunk":
@@ -425,6 +426,7 @@ class BaseSyncStreamResponse(BaseStreamResponse[ChunkIterator, ToolkitT, Formatt
                     chunk_iterator=tool_call_stream_iterator(),
                 )
                 yield stream
+
             else:  # pragma: no cover
                 raise RuntimeError(f"Unsupported chunk type: {chunk.type}")
 
@@ -544,6 +546,7 @@ class BaseAsyncStreamResponse(
         cached chunks.
         """
         chunk_iter = self.chunk_stream()
+        stream: AsyncStream | None = None
 
         async for chunk in chunk_iter:
             if chunk.type == "text_start_chunk":
@@ -587,6 +590,7 @@ class BaseAsyncStreamResponse(
                     chunk_iterator=tool_call_stream_iterator(),
                 )
                 yield stream
+
             else:  # pragma: no cover
                 raise RuntimeError(f"Unsupported chunk type: {chunk.type}")
 

--- a/python/tests/e2e/test_call.py
+++ b/python/tests/e2e/test_call.py
@@ -113,7 +113,8 @@ def test_call_stream(
         return f"What is {a} + {b}?"
 
     response = add_numbers.stream(4200, 42)
-    response.finish()
+    for stream in response.streams():
+        stream.collect()
 
     assert stream_response_snapshot_dict(response) == snapshot
     assert "4242" in response.pretty(), (
@@ -134,7 +135,8 @@ def test_call_stream_context(
 
     ctx = llm.Context(deps=4200)
     response = add_numbers.stream(ctx, 42)
-    response.finish()
+    for stream in response.streams():
+        stream.collect()
 
     assert stream_response_snapshot_dict(response) == snapshot
     assert "4242" in response.pretty(), (
@@ -158,7 +160,8 @@ async def test_call_async_stream(
         return f"What is {a} + {b}?"
 
     response = await add_numbers.stream(4200, 42)
-    await response.finish()
+    async for stream in response.streams():
+        await stream.collect()
 
     assert stream_response_snapshot_dict(response) == snapshot
     assert "4242" in response.pretty(), (
@@ -180,7 +183,8 @@ async def test_call_async_stream_context(
 
     ctx = llm.Context(deps=4200)
     response = await add_numbers.stream(ctx, 42)
-    await response.finish()
+    async for stream in response.streams():
+        await stream.collect()
 
     assert stream_response_snapshot_dict(response) == snapshot
     assert "4242" in response.pretty(), (

--- a/python/tests/llm/responses/test_stream_response.py
+++ b/python/tests/llm/responses/test_stream_response.py
@@ -1748,6 +1748,7 @@ class TestStreams:
             *example_text_chunks,
             *example_thought_chunks,
             *example_tool_call_chunks,
+            llm.RawContentChunk(content={"is_dummy_content": True}),
         ]
         stream_response = create_sync_stream_response(chunks)
 
@@ -1940,6 +1941,7 @@ class TestAsyncStreams:
             *example_text_chunks,
             *example_thought_chunks,
             *example_tool_call_chunks,
+            llm.RawContentChunk(content={"is_dummy_content": True}),
         ]
         stream_response = create_async_stream_response(chunks)
 


### PR DESCRIPTION
And fix a bug that got surfaced (around handling RawContentChunk)