### PR TITLE
nit: update google unknown tool id

### DIFF
--- a/python/mirascope/llm/clients/google/_utils/encode.py
+++ b/python/mirascope/llm/clients/google/_utils/encode.py
@@ -20,7 +20,7 @@ from ....tools import FORMAT_TOOL_NAME, BaseToolkit, ToolSchema
 from ...base import BaseKwargs, Params, _utils as _base_utils
 from ..model_ids import GoogleModelId
 
-UNKNOWN_TOOL_ID = "<unknown>"
+UNKNOWN_TOOL_ID = "google_unknown_tool_id"
 
 
 class GoogleKwargs(BaseKwargs, genai_types.GenerateContentConfigDict):

--- a/python/tests/e2e/snapshots/call_with_tools/google_snapshots.py
+++ b/python/tests/e2e/snapshots/call_with_tools/google_snapshots.py
@@ -27,12 +27,12 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -77,12 +77,12 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),
@@ -163,12 +163,12 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -213,12 +213,12 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),
@@ -290,12 +290,12 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -307,12 +307,12 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),
@@ -372,12 +372,12 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -389,12 +389,12 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),
@@ -455,12 +455,12 @@ without_raw_content_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "mellon"}',
                     ),
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         args='{"password": "radiance"}',
                     ),
@@ -472,12 +472,12 @@ without_raw_content_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Welcome to Moria!",
                     ),
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="secret_retrieval_tool",
                         value="Life before Death",
                     ),

--- a/python/tests/e2e/snapshots/structured_output_with_tools/google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/google_snapshots.py
@@ -31,7 +31,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -60,7 +60,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -165,7 +165,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -194,7 +194,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -298,7 +298,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -310,7 +310,7 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -393,7 +393,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -405,7 +405,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )

--- a/python/tests/e2e/snapshots/structured_output_with_tools/tool_google_snapshots.py
+++ b/python/tests/e2e/snapshots/structured_output_with_tools/tool_google_snapshots.py
@@ -31,7 +31,7 @@ sync_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -60,7 +60,7 @@ sync_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -165,7 +165,7 @@ async_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -194,7 +194,7 @@ async_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -298,7 +298,7 @@ stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -310,7 +310,7 @@ stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )
@@ -393,7 +393,7 @@ async_stream_snapshot = snapshot(
             AssistantMessage(
                 content=[
                     ToolCall(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         args='{"isbn": "0-7653-1178-X"}',
                     )
@@ -405,7 +405,7 @@ async_stream_snapshot = snapshot(
             UserMessage(
                 content=[
                     ToolOutput(
-                        id="<unknown>",
+                        id="google_unknown_tool_id",
                         name="get_book_info",
                         value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                     )


### PR DESCRIPTION
Removes the `<>` symbols, which allows google-generated tool calls to be
replayed with anthropic provider, which uses a regex to validate tool
call ids and the regex does not allow <>