### PR TITLE
refactor: make model_id optional on FeatureNotSupportedError

### DIFF
--- a/python/mirascope/llm/clients/anthropic/_utils/encode.py
+++ b/python/mirascope/llm/clients/anthropic/_utils/encode.py
@@ -170,7 +170,7 @@ def encode_request(
     if format is not None:
         if format.mode == "strict":
             raise FormattingModeNotSupportedError(
-                formatting_mode="strict", provider="anthropic", model_id=model_id
+                formatting_mode="strict", provider="anthropic"
             )
         elif format.mode == "tool":
             format_tool_schema = _formatting_utils.create_tool_schema(format)

--- a/python/mirascope/llm/clients/google/_utils/encode.py
+++ b/python/mirascope/llm/clients/google/_utils/encode.py
@@ -200,7 +200,6 @@ def encode_request(
             raise FeatureNotSupportedError(
                 feature=f"formatting_mode:{format.mode} with tools",
                 provider="google",
-                model_id=model_id,
             )
 
         if format.mode == "strict":

--- a/python/mirascope/llm/exceptions.py
+++ b/python/mirascope/llm/exceptions.py
@@ -44,21 +44,25 @@ class ToolNotFoundError(MirascopeError):
 
 
 class FeatureNotSupportedError(MirascopeError):
-    """Raised if a Mirascope feature is unsupported by chosen provider and model."""
+    """Raised if a Mirascope feature is unsupported by chosen provider.
+
+    If compatibility is model-specific, then `model_id` should be specified.
+    If the feature is not supported by the provider at all, then it may be `None`."""
 
     provider: "Provider"
-    model_id: "ModelId"
+    model_id: "ModelId | None"
     feature: str
 
     def __init__(
         self,
         feature: str,
         provider: "Provider",
-        model_id: "ModelId",
+        model_id: "ModelId | None" = None,
         message: str | None = None,
     ) -> None:
         if message is None:
-            message = f"Feature '{feature}' is not supported by provider '{provider}' for model '{model_id}'"
+            model_msg = f" for model '{model_id}'" if model_id is not None else ""
+            message = f"Feature '{feature}' is not supported by provider '{provider}'{model_msg}"
         super().__init__(message)
         self.feature = feature
         self.provider = provider
@@ -74,11 +78,12 @@ class FormattingModeNotSupportedError(FeatureNotSupportedError):
         self,
         formatting_mode: "FormattingMode",
         provider: "Provider",
-        model_id: "ModelId",
+        model_id: "ModelId | None" = None,
         message: str | None = None,
     ) -> None:
         if message is None:
-            message = f"Formatting mode '{formatting_mode}' is not supported by provider '{provider}' for model '{model_id}'"
+            model_msg = f" for model '{model_id}'" if model_id is not None else ""
+            message = f"Formatting mode '{formatting_mode}' is not supported by provider '{provider}'{model_msg}"
         super().__init__(
             feature=f"formatting_mode:{formatting_mode}",
             provider=provider,

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_0_snapshots.py
@@ -4,10 +4,10 @@ test_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_0_snapshots.py
@@ -4,10 +4,10 @@ sync_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }
@@ -16,10 +16,10 @@ async_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }
@@ -28,10 +28,10 @@ stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }
@@ -40,10 +40,10 @@ async_stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/google_gemini_2_5_flash_snapshots.py
@@ -4,9 +4,9 @@ sync_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }
@@ -15,9 +15,9 @@ async_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }
@@ -26,9 +26,9 @@ stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }
@@ -37,9 +37,9 @@ async_stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0_snapshots.py
@@ -4,10 +4,10 @@ sync_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }
@@ -16,10 +16,10 @@ async_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }
@@ -28,10 +28,10 @@ stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }
@@ -40,10 +40,10 @@ async_stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FormattingModeNotSupportedError",
-            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic' for model 'claude-sonnet-4-0'\",)",
+            "args": "(\"Formatting mode 'strict' is not supported by provider 'anthropic'\",)",
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
-            "model_id": "claude-sonnet-4-0",
+            "model_id": "None",
             "provider": "anthropic",
         }
     }

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/google_gemini_2_5_flash_snapshots.py
@@ -4,9 +4,9 @@ sync_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }
@@ -15,9 +15,9 @@ async_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }
@@ -26,9 +26,9 @@ stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }
@@ -37,9 +37,9 @@ async_stream_snapshot = snapshot(
     {
         "exception": {
             "type": "FeatureNotSupportedError",
-            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google' for model 'gemini-2.5-flash'\",)",
+            "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
-            "model_id": "gemini-2.5-flash",
+            "model_id": "None",
             "provider": "google",
         }
     }


### PR DESCRIPTION
When the provider does not have support for a feature whatsoever
(regardless of model), I don't think model_id needs to be on the
FeatureNotSupportedError.