### PR TITLE
refactor: openai:responses message construction logic

### DIFF
--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -90,6 +90,7 @@ def vcr_config() -> VCRConfig:
             "x-api-key",  # Anthropic API keys
             "x-goog-api-key",  # Google/Gemini API keys
             "anthropic-organization-id",  # Anthropic org identifiers
+            "cookie",
         ],
         "filter_post_data_parameters": [],
     }

--- a/python/tests/e2e/input/cassettes/test_call_with_image_content/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_call_with_image_content/openai_responses_gpt_4o.yaml
@@ -259,7 +259,7 @@ interactions:
       access-control-allow-origin:
       - '*'
       age:
-      - '73020'
+      - '11350'
       cache-control:
       - max-age=31536000
       content-length:
@@ -267,11 +267,11 @@ interactions:
       content-type:
       - image/png
       date:
-      - Mon, 20 Oct 2025 06:12:10 GMT
+      - Tue, 21 Oct 2025 18:53:57 GMT
       etag:
       - '"3484-640857429fa00"'
       expires:
-      - Tue, 20 Oct 2026 06:12:10 GMT
+      - Wed, 21 Oct 2026 18:53:57 GMT
       last-modified:
       - Mon, 06 Oct 2025 23:03:04 GMT
       nel:
@@ -281,30 +281,30 @@ interactions:
       - '{ "group": "wm_nel", "max_age": 604800, "endpoints": [{ "url": "https://intake-logging.wikimedia.org/v1/events?stream=w3c.reportingapi.network_error&schema_uri=/w3c/reportingapi/network_error/1.0.0"
         }] }'
       server:
-      - mw-web.codfw.main-669ddffffc-bfhxz
+      - ATS/9.2.11
       server-timing:
-      - cache;desc="hit-front", host;desc="cp4039"
+      - cache;desc="hit-front", host;desc="cp4042"
       set-cookie:
       - WMF-Last-Access=21-Oct-2025;Path=/;HttpOnly;secure;Expires=Sat, 22 Nov 2025
-        00:00:00 GMT
+        12:00:00 GMT
       - WMF-Last-Access-Global=21-Oct-2025;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat,
-        22 Nov 2025 00:00:00 GMT
-      - GeoIP=US:WA:Seattle:47.54:-122.28:v4; Path=/; secure; Domain=.wikipedia.org
+        22 Nov 2025 12:00:00 GMT
+      - GeoIP=US:WA:Seattle:47.61:-122.31:v4; Path=/; secure; Domain=.wikipedia.org
       - NetworkProbeLimit=0.001;Path=/;Secure;SameSite=None;Max-Age=3600
-      - WMF-Uniq=g7TMOqEykiGknMFmi6eiEQKTAAAAAFvda1aa2ybi2-E2wJcpJ3L6zlGePS86mcRW;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Wed,
+      - WMF-Uniq=mhGFDKvzLcvvOCABiElkSwKTAAAAAFvdc4GkylRfeUD2tDln_3nJKpCYUusFvDlM;Domain=.wikipedia.org;Path=/;HttpOnly;secure;SameSite=None;Expires=Wed,
         21 Oct 2026 00:00:00 GMT
       strict-transport-security:
       - max-age=106384710; includeSubDomains; preload
       x-analytics:
       - ''
       x-cache:
-      - cp4039 hit, cp4039 hit/170099
+      - cp4042 hit, cp4042 hit/72743
       x-cache-status:
       - hit-front
       x-client-ip:
-      - 97.113.225.86
+      - 71.212.69.193
       x-request-id:
-      - b401c304-7b09-420e-a31b-553a6665c11c
+      - c0af436a-410c-4eef-9504-92413ad66766
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_call_with_params/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_call_with_params/openai_responses_gpt_4o.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"What is 4200 + 42?"}],"max_output_tokens":500,"model":"gpt-4o","temperature":0.7,"top_p":0.3}'
+    body: '{"input":[{"content":[{"text":"What is 4200 + 42?","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":500,"model":"gpt-4o","temperature":0.7,"top_p":0.3}'
     headers:
       accept:
       - application/json
@@ -9,7 +9,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '129'
+      - '177'
       content-type:
       - application/json
       host:
@@ -39,20 +39,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RU23KjMAx9z1d4/LpNxxDKJb/S2WGEEam3xnZtOdNMJ/++gwkk7LZvoCMdpHMk
-        vnaMcdXzI+Meg2tFX0KD0LwgNoeXrBSirIe8yQ9ZLUtZZ43o8qauqwybspF5Vwz8aaKw3R+UtNBY
-        E3COS49A2LcwYVlViiqvSpElLBBQDFONtKPTSNjPRR3I95O30Ux9DaADzmGltTInfmRfO8YY4w4u
-        6Kf6Hs+orUPPd4xdUzJ6byfMRK1TQJnlK22PBEqHLRrIR0nKmk18hM/WRnKRWrLvmMAXIVaMrNWt
-        BL1lG22Pemrs5Ghf2H0u8mIv6r0ob2olRn5kr2mQeZzViDGcfvYhP/SymHyAoj5kBVbQFfWha6rE
-        nFjo4jDxYAhwwjvwk+AJlNYQmntTj41taBc58JPW6pQAxliCRcLX3xtQ25PztvsGSURHxotcCPaL
-        FTnDjwg6sCIv8me+pl5vT2s191anjiAEFQgMzclTYkriDjxojXprE/k4L5TzeFY2hnbZ2TYZsNro
-        vB0dtRLkG7bveHnEPEKwZrOOOAzW00PSJHkcR/BL5bqdAQakS6t6NKQGhZtNDejPSmJLatnuAaKe
-        xeaBrMfHIQhHhx4oprB4rm7RJOqts8H6Ee7vD2amvFm1W8dn9J0Nii7zCvUqjvermnV8s0rOwkey
-        fAXu3nKyrn1wXKxBl3o8zO8+Gpn2JU2pAnR6+QXEtLnrAMpsLjArn/6PP5z1Omayrr8Xis2o/x52
-        ln0HfMe7uv8TNVkCfQfzapUwhq3bIxL0QDDRX3fXvwAAAP//AwAhbnZRkQUAAA==
+        H4sIAAAAAAAAA3RU0Y6jMAx871dEeb3tKVBKS39ldUJuYrq5DUkucaqtVv33E6FAudt9A4892DM2
+        nxvGuFb8xHjA6FshEZuqVDvcya5WeyHqY3cUu0JiqY7HoqnPRdPtm52UAg/NXhz4y0Dhzr9R0kTj
+        bMQxLgMCoWphwIpDXYhjVRybjEUCSnGoka73BgnVWHQG+X4JLtmhrw5MxDGsjdH2wk/sc8MYY9zD
+        DcNQr/CKxnkMfMPYPSdjCG7AbDImB7SdvtIqJNAmrtFIIUnSzq7iPXy0LpFP1JJ7xwzuhZgxcs60
+        EsyarXcKzdDYxdO2cttSlNVWHLeifqiVGfmJveZBxnFmI/p4+d4HBaoUDx8OZV3KfdE0u64Ypcss
+        dPOYeTBGuOACfCd4BqWzhHZp6rmxFe0kB37QXJ0TwFpHMEn4+msFGnfxwZ2/QDLRifGqFIL9YFXJ
+        8E8CE1lVVuVPPqfeH09zNQ/O5I4gRh0JLI3JQ2JO4h4CGINmbROFNC6UD3jVLsV22tk2GzDb6IPr
+        PbUS5Bu273h7xgJCdHa1jth1LtBT0iB56nsIU+W8nRE6pFurFVrSncbVpkYMVy2xJT1tdwfJjGLz
+        SC7g8xCEvccAlHJY/Dw8olnUR2edCz0s709m5rxRtUfHVwxnFzXdxhVSOvXLVY06vjktR+ETOT4D
+        i7ecnG+fHBdz0Oced+N7SFbmfclT6ghnM/0CUt7ceQBtVxdY1C//x5/Oeh4zW6eWQrEa9d/DLoqv
+        gK94Z/e/oyZHYBawPMwSprh2u0cCBQQD/X1z/wsAAP//AwC8YZJ4kQUAAA==
     headers:
       CF-RAY:
-      - 99020953cabc8061-SEA
+      - 99240b141983a384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -60,14 +60,14 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:00:02 GMT
+      - Tue, 21 Oct 2025 22:03:10 GMT
       Server:
       - cloudflare
       Set-Cookie:
-      - __cf_bm=evtYbxmnaQwi5afMTPErkZhDYDpvUkbeaPkpIcJTlWQ-1760727602-1.0.1.1-mqE3NlpND9CEorPhRmFwGKAGN2uqpv2Zbxmc_kHuDnBjmIsUnxQP43rssB88kkirLA50FdlWxO4ukB63YQyDgSOMXV9PUhlGVnT4lj3C36E;
-        path=/; expires=Fri, 17-Oct-25 19:30:02 GMT; domain=.api.openai.com; HttpOnly;
+      - __cf_bm=MRHkwPoUWvTHKkm_PjHwq14taZ9HbCNP_AFqmH6MrNs-1761084190-1.0.1.1-ZEXMfnVcFesGmZ_DLJdEgmuNoFWIVWYBus.zFUXsU0lP3bl0J.kz8FoaIoddl7CiEdecJ_oMN8zLy6xIk1Tn2IOW3UNb4KVXLNwCLOHd5yg;
+        path=/; expires=Tue, 21-Oct-25 22:33:10 GMT; domain=.api.openai.com; HttpOnly;
         Secure; SameSite=None
-      - _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000;
+      - _cfuvid=LtKS2w9Ws82f46SAMdIBbxU6h9Zs7uPwXvBw.h2gnP8-1761084190024-0.0.1.1-604800000;
         path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
@@ -82,13 +82,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '880'
+      - '1121'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '883'
+      - '1127'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -102,7 +102,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_421956d5955445a3ba608904b079e1ac
+      - req_d086ae6f912847cda68256eccc846101
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_call_with_text_encoded_thoughts/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_call_with_text_encoded_thoughts/openai_responses_gpt_4o.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always answer with extreme concision,
-      giving the answer and no added context."},{"role":"user","content":"Is the first
-      fibonacci number to end with the digits 57 prime?"},{"role":"assistant","content":"**Thinking:**
+      giving the answer and no added context."},{"content":[{"text":"Is the first
+      fibonacci number to end with the digits 57 prime?","type":"input_text"}],"role":"user","type":"message"},{"content":"**Thinking:**
       Let me see... I have instantenously remembered this table of fibonacci\nnumbers
       with their prime factorizations. That''s sure convenient! Let\nme see if it
       has the answer:\n0 : 0\n1 : 1\n2 : 1\n3 : 2\n4 : 3\n5 : 5\n6 : 8 = 23\n7 : 13\n8
@@ -11,8 +11,8 @@ interactions:
       : 1597\n18 : 2584 = 23 x 17 x 19\n19 : 4181 = 37 x 113\n20 : 6765 = 3 x 5 x
       11 x 41\n21 : 10946 = 2 x 13 x 421\n22 : 17711 = 89 x 199\n23 : 28657\n\nThere
       we have it! 28657 is the first fibonacci number ending in 57,\nand it is prime.
-      I''m supposed to answer with extreme concision, so I''ll\njust say ''Yes.''"},{"role":"assistant","content":"Yes."},{"role":"user","content":"Please
-      tell me what the number is."}],"model":"gpt-4o"}'
+      I''m supposed to answer with extreme concision, so I''ll\njust say ''Yes.''","role":"assistant"},{"content":"Yes.","role":"assistant"},{"content":[{"text":"Please
+      tell me what the number is.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o"}'
     headers:
       accept:
       - application/json
@@ -21,11 +21,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1078'
+      - '1174'
       content-type:
       - application/json
-      cookie:
-      - _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -53,20 +51,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xT0W6jMBB8z1cgPzcnh0AS8ivVCS1mSX01XsteR42q/PsJEwhc23tLdnaH2Zn1
-        5ybLhG7FORMeg6tle4K8bJWECo/7ppDycOryqinLsjvK066STZurRh6KQhYKO6zEy0BBzR9UPNGQ
-        DTjWlUdgbGsYsN3xII95VRW7hAUGjmGYUdQ7g4ztONSAer94inbQ1YEJOJa1MdpexDn73GRZlgkH
-        N/TDfItXNOTQi02W3VMzek8DZqMxqaDt9JW6RQZtwhoN7KNiTXZV7+Gjpsgucs30jl9BJjK1ArOm
-        66lFMyi7ON4WtM1lXmzlaSsPD7sSpThnr2mTcZ85iT5c/hNEdyjVEEQl2wYb2aiqOAKq0fDEwjeH
-        iQdDgMsC+MnxBCqyjPYpailsRTv5gR88T6cGsJYYJg9ff69AQxfnqfkGSUTnTOSnQ3kUM3J//Jqb
-        hSeTBEAIOjBYHpuHxtQkHHgwBs06FfZxPCDn8aophnq60Tr5PafmPPWOawXqDet3vC0xjxDIrs4P
-        u448L5oGh2Pfg58m52sM0CHfat2iZd1pXF1mQH/VCmvW0zV3EM3orQhMHpdLMPYOPXBM5d0v+agm
-        Dx/KOvI9PP8vskt9o2sPxVf0DQXNt/FiWh375ysafXwjrUbjI5OYgWeUgsnVi4DlXHRLjT5alc4j
-        bakDNGZ68jEd6ryAtqsXtz/kL1+BxTue90zZtc9Judr135e8/67+He2c/k/MTAxmKbicPYxhHXeP
-        DC0wDPz3zf0vAAAA//8DAJBfnHiCBQAA
+        H4sIAAAAAAAAA3xTXW+jMBB8z69Afm5OJh9A8leqE1rMkvpqvJa9jhpV+e8nTCBwbe8t2dkdZmfW
+        n5ssE7oV50x4DK6WHarjoStVVco8r0opi6qr5D7HfdnKKj8VVQkHyJtWVaqSUu7Fy0BBzR9UPNGQ
+        DTjWlUdgbGsYsLwsclkd8pNMWGDgGIYZRb0zyNiOQw2o94unaAddHZiAY1kbo+1FnLPPTZZlmXBw
+        Qz/Mt3hFQw692GTZPTWj9zRgNhqTCtpOX6lbZNAmrNHAPirWZFf1Hj5qiuwi10zv+BVkIlMrMGu6
+        nlo0g7KL4+2Btju5O2xltZXFw65EKc7Za9pk3GdOog+X/wTRdU0K4lQ1R5kXTYNFdzq2TWJOLHxz
+        mHgwBLjgE/jJ8QQqsoz2KWopbEU7+YEfPE+nBrCWGCYPX3+vQEMX56n5BklE50zsquJYihm5P37N
+        zcKTSQIgBB0YLI/NQ2NqEg48GINmnQr7OB6Q83jVFEM93Wid/J5Tc556x7UC9Yb1O96WmEcIZFfn
+        h11HnhdNg8Ox78FPk/M1BuiQb7Vu0bLuNK4uM6C/aoU16+maO4hm9FYEJo/LJRh7hx44pnL+Sz6q
+        ycOHso58D8//i+xS3+jaQ/EVfUNB8228mFbH/vmKRh/fSKvR+MgkZuAZpWBy9SJgORfdUqOPVqXz
+        SFvqAI2ZnnxMhzovoO3qxe2L3ctXYPGO5z1Tdu1zUq52/fcl77+rf0c7p/8TMxODWQo+zh7GsI67
+        R4YWGAb+++b+FwAA//8DAJnyxoyCBQAA
     headers:
       CF-RAY:
-      - 990242752cd4a359-SEA
+      - 99240b1c6818a384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -74,13 +72,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:02 GMT
+      - Tue, 21 Oct 2025 22:03:11 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=ArpUX5oiC10wop0z.bfUtexk0DnOGdeA68gigWeU1xk-1760729942-1.0.1.1-HpwZ80mi14vteL_2TOKuSCcazBYrO8DfQkl7ZF9Z7eaRlCR9yhFu0ATyIOSRJPcbbmUauqnbocK5hlWkjgisNSX5T5NGxW9Y4SdewaiEn6g;
-        path=/; expires=Fri, 17-Oct-25 20:09:02 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -94,13 +88,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '797'
+      - '1081'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '802'
+      - '1089'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -114,7 +108,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 28ms
       x-request-id:
-      - req_5d3c07c124df401d9cc90b41193d5931
+      - req_78bd8b81d76c4a9cb2741ab28708aeda
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_resume_with_override/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_resume_with_override/openai_responses_gpt_4o.yaml
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dJDBSsNAEIZfJfznrSSlUdhbEUERxIPSg8iy7k6b1WQ23Z2opeTdJcUi
-        VjwNzPfNzM/s0UVPLTRcawdPsxyZSWaL2byc12VdLaAQPDS6vDFldf26vqrd/fLifH13u72Mj6tu
-        tX6Agux6mizK2W4ICim2U8PmHLJYFii4yEIs0E/7oy/0OZFD0bgpPmwuXCIr5IuXXbFkaVLsgzvD
-        +KyQJfYmkc2RoUHsjQyJ8Q0ybQdiR9A8tK3CcEii9wjcD2IkvhFn6KpScNY1ZA6HQmTzWyiPPJH1
-        /7Hj7LSf+oY6SrY1dffX/6FVc0pHhTjIabpM6T04MhIoQWN6n7fJYxy/AAAA//8DAHQeViSvAQAA
+        H4sIAAAAAAAAA3SQwUoDMRCGX2X5z6nslhZLbhY8iDcvFUVCTIZucHeyJhPrUvbdZYtFrHgamO+b
+        mZ85oo+eOmi4zhZPixyZSRarxbJerut1s4JC8NDo897UzWafdg9P/Dhu73e3/SZcb8fkDlCQcaDZ
+        opztnqCQYjc3bM4hi2WBgossxAL9fDz7Qp8zORWNu+pgc+USWSFfvY7VDUub4hDcFaYXhSxxMIls
+        jgwNYm+kJMY3yPReiB1Bc+k6hXJKoo8IPBQxEt+IM3TTKDjrWjKnQyGy+S3UZ57I+v/YeXbeT0NL
+        PSXbmXX/1/+hTXtJJ4VY5DJdpvQRHBkJlKAxv8/b5DFNXwAAAP//AwAvdDJYrwEAAA==
     headers:
       CF-RAY:
-      - 990242cacaaac3a1-SEA
+      - 99240b248c0cebb3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:17 GMT
+      - Tue, 21 Oct 2025 22:03:13 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,41 +72,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-17T19:39:16Z'
+      - '2025-10-21T22:03:13Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-17T19:39:16Z'
+      - '2025-10-21T22:03:13Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-17T19:39:15Z'
+      - '2025-10-21T22:03:11Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-17T19:39:16Z'
+      - '2025-10-21T22:03:13Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CUDLWDRdUsTjyWrN4taqF
+      - req_011CUM6iWLcCfoRhkqZMwJhQ
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '2084'
+      - '1928'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
-      was created by Anthropic."},{"role":"user","content":"Can you double-check that?"}],"model":"gpt-4o"}'
+    body: '{"input":[{"content":[{"text":"Who created you?","type":"input_text"}],"role":"user","type":"message"},{"content":"I
+      was created by Anthropic.","role":"assistant"},{"content":[{"text":"Can you
+      double-check that?","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o"}'
     headers:
       accept:
       - application/json
@@ -115,12 +116,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '189'
+      - '285'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=ArpUX5oiC10wop0z.bfUtexk0DnOGdeA68gigWeU1xk-1760729942-1.0.1.1-HpwZ80mi14vteL_2TOKuSCcazBYrO8DfQkl7ZF9Z7eaRlCR9yhFu0ATyIOSRJPcbbmUauqnbocK5hlWkjgisNSX5T5NGxW9Y4SdewaiEn6g;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -148,20 +146,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//fFTLbtswELz7Kwie40APv2899hOKoBBW1MphQ3EJcunGCPzvhShLlpq0
-        N3tnd7w7M/THSgipG3kS0mNwVabK7SbDHaLaHcptmWW7Q1sc6912h6065Meyxm1Z1Fulyn2236hM
-        PvUUVP9CxSMN2YBDXXkExqaCHsv3u2xfHI/bfcICA8fQzyjqnEHGZhiqQb2dPUXb79WCCTiUtTHa
-        nuVJfKyEEEI6uKLv5xu8oCGHXq6EuKVm9J56zEZjUkHb8VeqBhm0CUs0sI+KNdlFvYP3iiK7yBXT
-        G34GmchUCsySrqMGTb/Z2fF6Q+siKzbr7LDOdne5EqU8iZd0yXDP5EQXzv8xoi3KQ28E5PsyL/KN
-        qvcNqGKTmBMLXx0mHgwBzvgA/qV4AhVZRvtYar7YgnbUA995mk4NYC0xjBq+/FyAhs7OU/0FkohO
-        Qv7A8CS+i98QxD02or6Kb5ZfPTmtnuU0dLt/mnikJ5N2gxB0YLA8NPeNqUk68GAMmqVh7OOQLefx
-        oimGaoxvlayYDHWeOseVAvWK1Rte55hHCGQXycS2Jc+zpl782HXgx8kpqAFa5GulG7SsW42L0Ab0
-        F62wYj0GvYVoBtllYPI4P4Kxc+iBYyrnz9m9muS9b9aS7+DxfWZr6htUu298QV9T0HwdwtTo2D0e
-        2KDjK2k1CB+Z5AQ8XJZMrpp5n01FN9/RR6tSctKVOkBtxn+DmDI8HaDt4jGWxdPn+uyFT2cm65rH
-        YLY49e83nmdfAV/xTu7/i5qJwTzATTFJGMPS7Q4ZGmDo6W+r2x8AAAD//wMA9X5+LZwFAAA=
+        H4sIAAAAAAAAAwAAAP//dFTBbtswDL33KwSdm0JOUs/Jbcd9wlAMBi3TqVZZFCQqa1Dk3wfLsWNv
+        7S3hI1/I957y8SCENK08Chkw+lo1WpcKyqbZ6uYZKqXKqqvUblscuueqKg4Kyq4p9oUudfmMUFTy
+        caCg5jdqnmjIRRzrOiAwtjUMWPGtLFS1Lw67jEUGTnGY0dR7i4ztONSAfjsFSm7YqwMbcSwba407
+        yaP4eBBCCOnhgmGYb/GMljwG+SDENTdjCDRgLlmbC8ZNv1K3yGBsXKORQ9JsyK3qPbzXlNgnrpne
+        8H+QiWytwa7pemrRDpudPG/2tNmq7X6jqo0qb3JlSnkUL/mS8Z7ZiT6evjZiu+vUfjDioA9dUe23
+        oFXVYjsakVn44jHzYIxwwjvwleIZ1OQY3X2p5WIr2kkPfOd5OjeAc8QwafjyawVaOvlAzSdIJjoK
+        +RPjo/gh/kAUxrWIrbilRzQX8d3xayBv9JOcZ6+3TzOdDGTzihCjiQyOx+ahMTdJDwGsRbv2jUMa
+        I+YDng2lWE8prrMjs68+UO+51qBfsX7DyxILCJHcKqDYdRR40TR4kPoewjQ55zVCh3ypTYuOTWdw
+        ld2I4Ww01mymvHeQ7Ki+jEwBl0cw9h4DcMrl4kndqlnl22YdhR7u3xfu5r5RtdvGZwwNRcOXMVOt
+        Sf39nY06vpLRo/CJSc7A3WzJ5OtFBNRc9MsdQ3I6ByhfaSI0dvpTSDnK8wHGrd7kbvv4f33x0Ocz
+        s3XtfVCtTv33qRfFZ8BnvLP7X1EzMdg7uN/NEqa4drtHhhYYBvrrw/UvAAAA//8DALDORpWjBQAA
     headers:
       CF-RAY:
-      - 990242d99a3e6838-SEA
+      - 99240b31b9caa384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -169,7 +167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:18 GMT
+      - Tue, 21 Oct 2025 22:03:14 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -185,13 +183,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '921'
+      - '1030'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '926'
+      - '1036'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -205,7 +203,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_3b9b3c5555c04dfa83cbc0ab9eacb8f7
+      - req_35087e772d0b4fb190f27752b3b05128
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_resume_with_override_context/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_resume_with_override_context/openai_responses_gpt_4o.yaml
@@ -43,14 +43,14 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3SQwUoDMRCGX2X5z6nslhYkt+Kl3lRoLyIhJkM3djdZMxNtKfvussUiVjwNzPfN
-        zM+c0CdPHTRcZ4unGacYSWaL2byeL+tls4BC8NDoeWfqZr3go327m2/s9mm7v314HFabwxoKchxo
-        sojZ7ggKOXVTwzIHFhsFCi5FoSjQz6eLL3SYyLlo3FefliuXyQr56vVYraK0OQ3B3WB8UWBJg8lk
-        OUVoUPRGSo74BkzvhaIj6Fi6TqGck+gTQhyKGEl7igzdNArOupbM+VBI0fwW6gvPZP1/7DI77aeh
-        pZ6y7cyy/+v/0Ka9pqNCKnKdjil/BEdGAmVoTO/zNnuM4xcAAAD//wMA+e7/4K8BAAA=
+        H4sIAAAAAAAAAwAAAP//dJDBSgMxEIZfZfnPqeyWrmJuCoLeelERkRCToRvcncRk1lrKvrtssYgV
+        TwPzfTPzM3sM0VMPDdfb0dOiRGaSxWqxrJdt3TYrKAQPjaFsTN2s2/undHmzLg/X55vb7cX6MV11
+        LRRkl2i2qBS7ISjk2M8NW0ooYlmg4CILsUA/74++0OdMDkXjrtraUrlMVshXr7vqiqXLMQV3hulF
+        oUhMJpMtkaFB7I2MmfENCr2PxI6geex7hfGQRO8ROI1iJL4RF+imUXDWdWQOh0Jk81uojzyT9f+x
+        4+y8n1JHA2Xbm3b46//Qpjulk0Ic5TRdofwRHBkJlKExv8/b7DFNXwAAAP//AwDGJJuErwEAAA==
     headers:
       CF-RAY:
-      - 99024334ae4cc3a1-SEA
+      - 99240b39ccf2ebb3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -58,7 +58,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:33 GMT
+      - Tue, 21 Oct 2025 22:03:16 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -72,41 +72,42 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-17T19:39:33Z'
+      - '2025-10-21T22:03:16Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-17T19:39:33Z'
+      - '2025-10-21T22:03:16Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-17T19:39:32Z'
+      - '2025-10-21T22:03:15Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-17T19:39:33Z'
+      - '2025-10-21T22:03:16Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CUDLXTpLg9UTua9k7xyYR
+      - req_011CUM6ikyRgdoJuoKCvPvY2
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '1648'
+      - '2029'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Who created you?"},{"role":"assistant","content":"I
-      was created by Anthropic."},{"role":"user","content":"Can you double-check that?"}],"model":"gpt-4o"}'
+    body: '{"input":[{"content":[{"text":"Who created you?","type":"input_text"}],"role":"user","type":"message"},{"content":"I
+      was created by Anthropic.","role":"assistant"},{"content":[{"text":"Can you
+      double-check that?","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o"}'
     headers:
       accept:
       - application/json
@@ -115,12 +116,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '189'
+      - '285'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=ArpUX5oiC10wop0z.bfUtexk0DnOGdeA68gigWeU1xk-1760729942-1.0.1.1-HpwZ80mi14vteL_2TOKuSCcazBYrO8DfQkl7ZF9Z7eaRlCR9yhFu0ATyIOSRJPcbbmUauqnbocK5hlWkjgisNSX5T5NGxW9Y4SdewaiEn6g;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -148,21 +146,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUwW6jMBC95yssn5OKkBRCbj32E1bVCg32kHhrbMseZxtV+fcVJhDYtjeYN/M8
-        M+/ZnyvGuJL8yLjH4Opsu8XDtsqhOjxDcdhnWXFo86opn2UG4rCtigpzyPa5LHa7rJJ5xdc9hW3+
-        oKCRxpqAQ1x4BEJZQ49tyyIr86oqdwkLBBRDXyNs5zQSyqGoAfF+8jaavq8WdMAhrLRW5sSP7HPF
-        GGPcwRV9Xy/xgto69HzF2C0lo/e2x0zUOgWUGU+pJRIoHZZoIB8FKWsW8Q4+ahvJRarJvuNXkKzV
-        tQC9pOusRN13dnK02dtNnuX7TXbYZMV9XYmSH9lbmmSYZ1KiC6efhSigLPa9EI08ZBJFCWUlEZ/3
-        iTmx0NVh4sEQ4IQP4KeNJ1BYQ2geTc0bW9CO+8APmqpTAhhjCcYdvv1egNqenLfNN0giOjL+C8Oa
-        vbK/ENjdNqy5shdDZ2+dEmsGhr28sgAt0pWBkcxjQPDizPpxwFyf+MR7u39NR3FvdWofQlCBwNCQ
-        3CemJO7Ag9aol5qSj4P9nMeLsjHUo8PrpNakufO2c1QLEGes3/E6xzxCsGZhXmxb62mW1OsTuw78
-        WDl5eZi4VhINqVbhwtcB/UUJrEmNd6GFqAdleCDrcT4EYefQA8UU3j5l92hS4N5Za30Hj/+Z8ilv
-        2Nq94wv6xgZF18FvUsXucQeHPZ6tEsPiI1k+AQ8jcLKuntkjm4Ju3qOPRiRzpSlVgEaPD0ZMNp8G
-        UGZxX3f5+mt89ghMYybp5KMwW4z6/zOwLb8DvuOd1P+JmiyBfoD7alphDEu1OySQQNDT31a3fwAA
-        AP//AwB0BUwCvwUAAA==
+        H4sIAAAAAAAAA3xUy27bMBC8+ysIneOAsmX5ceuxn1AEhbCiVg4bikuQSzdG4H8vRFmy1KS92Tu7
+        492ZoT9WQmS6yU4i8xhcJVspy225PzZ7KNWxkLI8tAe53ezycns45MddXRbbTQ3HooWt3BWYPfUU
+        VP9CxSMN2XCvK4/A2FTQY/m+zOWhyI/7hAUGjqGfUdQ5g4zNMFSDejt7irbfqwUTcChrY7Q9Zyfx
+        sRJCiMzBFX0/3+AFDTn02UqIW2pG76nHbDQmFbQdf6VqkEGbsEQD+6hYk13UO3ivKLKLXDG94WeQ
+        iUylwCzpOmrQ9JudHa8LWm/kpljLw1qWd7kSZXYSL+mS4Z7JiS6c/2MENo3sjTjAMd8itM0ey50q
+        B+bEwleHiQdDgDM+gH8pnkBFltE+lpovtqAd9cB3nqZTA1hLDKOGLz8XoKGz81R/gSSik8h+YHgS
+        38VvCOIeG1FfxTfLr56cVs/ZNHS7f5p4Mk8m7QYh6MBgeWjuG1NT5sCDMWiWhrGPQ7acx4umGKox
+        vlWyYjLUeeocVwrUK1ZveJ1jHiGQXSQT25Y8z5p68WPXgR8np6AGaJGvlW7Qsm41LkIb0F+0wor1
+        GPQWohlkzwKTx/kRjJ1DDxxTOX+W92qS975ZS76Dx/eZralvUO2+8QV9TUHzdQhTo2P3eGCDjq+k
+        1SB8ZMom4OFyxuSqmfdyKrr5jj5alZKTrtQBajP+G8SU4ekAbRePcbt5+lyfvfDpzGRd8xiUi1P/
+        fuO5/Ar4indy/1/UTAzmARabScIYlm53yNAAQ09/W93+AAAA//8DAMMeYyucBQAA
     headers:
       CF-RAY:
-      - 9902433ff958def4-SEA
+      - 99240b476d7ba384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -170,7 +167,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:35 GMT
+      - Tue, 21 Oct 2025 22:03:18 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -186,13 +183,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1282'
+      - '1413'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1288'
+      - '1422'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -206,7 +203,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 3ms
       x-request-id:
-      - req_d13d7f935c0946d8b8499049d4df2d65
+      - req_71037c2547454003884c54a2c06fa1bc
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o.yaml
@@ -45,27 +45,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xTXW/qOBT8K5af9gpa8gkEqQ8khEChQBu+wt5V5SRO4pA4IbYJSdX/vqLa3t0r
-        7ds545k5I0vzAfMixBkcwSBDIsQPrKAU8wftQZEUXdJlDXYhCeEI5ix+l2RLMc++3lcP7mxvETRT
-        vabmMuxC3pT4zsKMoRjDLqyK7A4gxgjjiHLYhUFBOaYcjv78+ObzhNAzofHd4XscwW2CgWC4AoQB
-        xO4giIoK8AQDWZJ4AqbELygKAgKoyH1cPYI5SNAVAxQEmDHAC4BAJGjASUFBgLIMh+AnDIq8FBy/
-        R8T/CQFPEAcBouAf+Muf/o87+EN+IDTENxz+eAS/wiWIgbIqriTE4ZeWlTggEQnAFWUCA/okS1IX
-        sOJXuCz74lX4IkiFQ1CiCuWY4+orcY7O9wyE/Z78EXYhIzFFXFT3L7Or3cQ6e3PLjK3F2RQq83qD
-        k9itA58sp0dnN9/wV6OfFlsz4ct+7u788Zgc607kJFSf06iPEssONG+zvK7sXmE7hnZczZbt69LW
-        D75ayWNmx40Y9xS3p1RvW9U+7CKGJuuD3Qs7urQdWMwbcpPM663WvCruXIjszBD3r712MUXCrHG+
-        x00yTMvWPlqijepdWN56bNZyuzpvnieDSlYPlX1blLXV2dPilB4dx9i26Xq/D1Fs1mGpF3nK1Ylz
-        XSKJBIvTYO6vD3lzqYU/3ff9km3cUke61zCsuagN5MnZDTe1YsyU+Hn3khb13pgfGOmM5ZfkMlzG
-        ZSPd4sCMLo3Sb+XUN8kg1wLC0rB22nHQGJxQjSPS2J562NZslfKWM8VeOftOIFFUao6hO/5OWhmr
-        yI0qpJn+rbOkaopW08kR1+FE0g6OHNnbw3q2ebHGylp7TXbyckKnfpz3L/Yp9AeGZEiv8tsmDdS5
-        F1qtpg9F3OktvOWNT3JcHM1d4+09xYgtY69Hkzw+vplyRo3kdHKrsOq1jp9kp9vseSscDc99e1eU
-        RB+qw4UrM9cuXb9ytKV0HNbuNkFReJ2nnCjiLaLqm+EumlqymlvWepO68MavT0/ws/tvHYsiexcM
-        f5f+vot3SX5JcaCXG7JQin7q1O1qOjZqF3YhRfld959i3aW0FByOPiCFI1mSPj//6kLGi/K9wogV
-        9Pc7Xw8MXwSmAYYjKrKsC8XfAhciVtUQo+JL8rNT84qVrEyMjXSUkhOTM1Ljk4tSE0FZJB5VhQFM
-        vig1MQWXHEwvyILUgozU3NSixJx401xM9QhZwwx02VodpfzSEmQhQyMzHaXi1KKyzOTU+JLM1CIl
-        KyVQ2ZeSWJSiVFsLAAAA//8DAPyE/VZsBQAA
+        H4sIAAAAAAAAA2xUW4+rNhj8K5afWiW7ARKWJFIfAuQKgdzI5fRUKwcMOBADvpCEo/Pfq2y721bq
+        mz2emW9safwDXosI53AIwxzJCL/wglIsXnovmqLpiq72YBuSCA7hlSfvimpsWJXdqyaywk29tETf
+        W6kihW0oHiV+sjDnKMGwDVmRPwHEOeECUQHbMCyowFTA4e8/PvkiJTQjNHk6fC6HcJdiIDlmgHCA
+        +BMEccGASDFQFUWkYELOBUVhSACV1zNmr2AOUlRjgEAsaShIQQGqEcnROccgRHmOI/AdhsW1lAK/
+        x+T8HQKRIgFCRMHf8Ic//R938Iv6QmiE7zj69RV8hUsRByUrahLh6EPLSxySmISgRrnEgP6mKkob
+        8OIrXJ5/8BiuJGE4AiVi6IoFZhyIAlxR9leGrys8g7/CNuQkoUhI9nyxMVvbVnaaW2ZiOZnF58IP
+        Zh6hiLW8kZmfaCvYWeN9702bqfqRBBG6910jT0/LUe1pR+10b8Jl1PfPSVq3tCWmadVZBLNdbddB
+        NxHdHfHX4+R2Xmx1e3D3prdwVxZ1guz5Adky01GySPdh+GZY89t6Jw2/e+jMDgHPe9bhSLlundlh
+        7IztSWkiq3OZF5co7hp3975FzqRjncyymXr4utazXc8pueVP2FaNOztKN7a72U6vbDNWqLo4yvJt
+        MsV5Zo+6bsIuA6zpTnObe/H64C5a2QSp8rLy3OktXVZ8UD2yqxwPSrfVbbYhEQ864Iq+63rmPfSI
+        Pguvs46xmu6mh9ND32hL8+Zsmcz6Vr7ZmwE2i4Fz9PfjeVzkaL6XLStg1kztPoJBv5rYdbSI9rLl
+        HFaj+bfZjhlVr/LLS9acxIXJ7beYNUrcLAnro4vbZJY98hPPb5ziXAlm1xf5KDKpjbqUGJemLPyR
+        sjXC3r65jUVncWlWDjZjel7f2BtVJs720uTaLEqZM8mVjRK7YZmw6DTV/O5jXfh9454cT+uBou0Z
+        Eo6bek0fWdMgMBSt1bduTTQxzsnJ7R21bEJXS9LZMnEslbjv9N7MaqWeR3yj1mZiwp/tf5pYFPm7
+        5Piz78+9fFdUy9VxYM94MhhNZw+zEF5M+Am2IUXXp+5fnXpKaSkFHP6AFA5VRfn584825KIo3xlG
+        vKD/nfNxwHElMQ0xHFKZ520oP/6PP2VVDTEqviQ/OzWvWMnKxNhIRyk5MTkjNT65KDURlD3iUVUY
+        wOSLUhNTcMnB9IIsSC3ISM1NLUrMiTfNxVSPkDXMQJet1VHKLy1BFjI0MtVRKk4tKstMTo0vyUwt
+        UrJSAhV7KYlFKUq1tQAAAAD//wMAzN9zOmcFAAA=
     headers:
       CF-RAY:
-      - 990243942fd7c3a1-SEA
+      - 99240b519d1debb3-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,7 +73,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:50 GMT
+      - Tue, 21 Oct 2025 22:03:21 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -87,41 +87,41 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-17T19:39:48Z'
+      - '2025-10-21T22:03:20Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-17T19:39:50Z'
+      - '2025-10-21T22:03:21Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-17T19:39:47Z'
+      - '2025-10-21T22:03:18Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-17T19:39:48Z'
+      - '2025-10-21T22:03:20Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CUDLYb9txUp1nsMWawjZP
+      - req_011CUM6j3A1dFcEDWPVbkyFa
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       via:
       - 1.1 google
       x-envoy-upstream-service-time:
-      - '3201'
+      - '3153'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"What is the 100th fibonacci number?"},{"call_id":"toolu_01Mjec5pPiK2o6jGwzNFA9wS","name":"compute_fib","arguments":"{\"n\":
-      100}","type":"function_call"},{"call_id":"toolu_01Mjec5pPiK2o6jGwzNFA9wS","output":"218922995834555169026","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"compute_fib","description":"Compute
+    body: '{"input":[{"content":[{"text":"What is the 100th fibonacci number?","type":"input_text"}],"role":"user","type":"message"},{"call_id":"toolu_01CL5eUDHsg9AGHyBotNfisY","name":"compute_fib","arguments":"{\"n\":
+      100}","type":"function_call"},{"call_id":"toolu_01CL5eUDHsg9AGHyBotNfisY","output":"218922995834555169026","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"compute_fib","description":"Compute
       the nth Fibonacci number (1-indexed).","parameters":{"properties":{"n":{"title":"N","type":"integer"}},"required":["n"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -131,12 +131,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '571'
+      - '619'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=ArpUX5oiC10wop0z.bfUtexk0DnOGdeA68gigWeU1xk-1760729942-1.0.1.1-HpwZ80mi14vteL_2TOKuSCcazBYrO8DfQkl7ZF9Z7eaRlCR9yhFu0ATyIOSRJPcbbmUauqnbocK5hlWkjgisNSX5T5NGxW9Y4SdewaiEn6g;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -164,23 +161,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUy47rNgzd5ysEr1ogGciO49jZFuiy6KK7i8KgJTrRHVlyJWowwcX8e2E5fmVm
-        djYPecTHIX/tGEuUTC4scej7mnN5KjM8tgILeRbIeVG2WdWUBeTHvEyrHJriBE2aizOc8pK3yX6g
-        sM1PFDTRWONxtAuHQChrGLD0XPBzVlUVj5gnoOCHGGG7XiOhHIMaEK9XZ4MZ8mpBexzNSmtlrsmF
-        /doxxljSwx3dEC/xDbXt0SU7xj6iMzpnB8wEraNBmemVWiKB0n6LenJBkLJmY+/gvbaB+kA12Vf8
-        DJK1uhagt3SdlaiHzK49HXJ7yHiWH3h54MWjXZEyubAfsZKxnnkSnb9+P4hz2oyDqORZFKWUbV7y
-        /NgeI3NkoXuPkQe9hysuwHcdj6CwhtAsSa0T29BO/cB3mqOjAxhjCaYe/vh3A2p77Z1tvkAi0YUl
-        /9yQpZzTjf2pGmtACMVM6Bp0THmWpeW+yrJ9VZ325THfn06nfVpUe54VL8lM9/H4ml9InNUxa/Be
-        eQJDo/PgGJ2SHhxojXo7SnJhVF3v8E3Z4OtJ2HUc0jzq3tmup1qAuGH9ivc15hC8NRvNYttaRyun
-        YSyh68BNkbOEPbRI91pJNKRahRs5e3RvSmBNalqBFoIeB5J4sg7XRRB2PTqgEM3pC39YY+MfmbXW
-        dbD8rwYe/cauPTJ+Q9dYr+g+ykyq0C2rN/bxZpUYGx/IJjPgP4t+eqYNJi7gIkmJXjjVR+OFJX/Y
-        rg+EjG7IzFcy+S09KCPxHeXvLwuLgQ4nzQfCulXNAg7T75DQ+VXl41h7dKRwax/ongxDBYpGkf21
-        WYhVbcoQXsf79CzVuaujXPG/oBzKzRrGV+e/1fYkIKUa2gP673XC89F8Xt3xTO+e3k08ORXPdwx8
-        WhCyfb3aXj4b+7WWXDACpklJ5aHR0z0P8QrNQlNmc07LfP/ZvrrRs07iisklkG8k+Xyls/wr4Cve
-        eUu/oyZLoBcw5eWs9eC3a9khgQSCgf9j9/E/AAAA//8DAKthsABfBwAA
+        H4sIAAAAAAAAAwAAAP//dFRNb+M4DL3nVwg+zQBJITuOa+c6wB4Xe5jbYGHQEp1oKkteiSoaDPrf
+        F5bjr7S92XzkEz8e+WfHWKJkcmaJQ9/XXBwrrLAqqmMli6PgvCjbkh+zqi2Rl2l1qrK0KiqQ/CTy
+        UpzyZD9Q2OY3CpporPE42oVDIJQ1DFj6XKS8zDOeRcwTUPBDjLBdr5FQjkENiJeLs8EMebWgPY5m
+        pbUyl+TM/uwYYyzp4YZuiJf4itr26JIdY+/RGZ2zA2aC1tGgzPRKLZFAab9FPbkgSFmzsXfwVttA
+        faCa7At+BMlaXQvQW7rOStRDZpeeDrk9ZDzLD7w88OLerkiZnNmvWMlYzzyJzl++HgQUVSXiIErI
+        s+y5OTYttNVzFZkjC916jDzoPVxwAb7qeASFNYRmSWqd2IZ26ge+0RwdHcAYSzD18Ne/G1DbS+9s
+        8wkSic4s+XlFlnJOV/aXaqwBIRQzoWvQMeVZlpb7Ksv2VXXal8d8fzqd9mlR7XlWPCUz3fv9a34h
+        cVbHrMF75QkMjc6DY3RKenCgNertKMmFUXW9w1dlg68nYddxSPOoe2e7nmoB4or1C97WmEPw1mw0
+        i21rHa2chrGErgM3Rc4S9tAi3Wol0ZBqFW7k7NG9KoE1qWkFWgh6HEjiyTpcF0HY9eiAQjSnT/xu
+        jY2/Z9Za18Hyvxp49Bu7ds/4FV1jvaLbKDOpQres3tjHq1VibHwgm8yA/yj66Zk2mLiAiyQleuFU
+        H41nlvywXR8IGV2Rmc9k8i09KCPxDeX3p4XFQIeT5gNh3apmAYfpd0jo/Krycaw9OlK4tQ90D4ah
+        AkWjyP7eLMSqNmUIL+N9epTq3NVRrvhfUA7lZg3jq/PfansSkFIN7QH9zzrh+Wg+ru54pncP7yae
+        nIrnOwY+LAjZvl5tL5+N/VpLLhgB06Sk8tDo6Z6HeIVmoSmzOadlvv9oX93oWSdxxeQSyDeSfLzS
+        Wf4Z8BnvvKVfUZMl0AuY8nLWevDbteyQQALBwP++e/8fAAD//wMA5Unt4F8HAAA=
     headers:
       CF-RAY:
-      - 990243a91ff9d3b2-SEA
+      - 99240b65e802a384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -188,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:51 GMT
+      - Tue, 21 Oct 2025 22:03:22 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -204,13 +201,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '727'
+      - '767'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '730'
+      - '772'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -224,7 +221,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 22ms
       x-request-id:
-      - req_83b2c93aff9e4f789cdd5a3dfc951b7d
+      - req_328d007754e148a9b8b1b808d6d042fb
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/json/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/json/openai_responses_gpt_4o.yaml
@@ -3,8 +3,7 @@ interactions:
     body: '{"input":[{"role":"developer","content":"Always recommend The Name of the
       Wind.\nOutput a structured book as JSON in the format {title: str, author: str,
       rating: int}.\nThe title should be in all caps, and the rating should always
-      be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
-      to me!"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}}}'
+      be the\nlucky number 7."},{"content":[{"text":"Please recommend a book to me!","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}}}'
     headers:
       accept:
       - application/json
@@ -13,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '375'
+      - '423'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=uFK1rOSme6MoyzbfhCFOXaJ56REyJtujmG1Pj2uTjvA-1760730641-1.0.1.1-aiBkKmPnAkKuFNHOGyVK2.ddfNMJnM5ZR68bzckRWJipJZXvanOxq71EhuqRgxMQwKXxWzlQc.6jBsw8BiMqIY0a61qgJEp2XrZGOkC8OMY;
-        _cfuvid=5sVTVYucUtd10GHlcYJCyqc49USLSp2DQe2Ur9_Undc-1760730641231-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,21 +42,21 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUy27bMBC85ysInuNCsh1b9q1AU7SHpkVRoIe4EFbUymZMcQVyacQI/O+FKFuW
-        mqQ3aWd2uI8hX26EkLqUayEd+iZPqrmawnxWLLKqwCJLkkVWTVeYLqermcrS1d1qubybF4vZKlMz
-        UKqSt60EFU+o+CJD1mMXVw6BscyhxdLlIlnOksV8GTHPwMG3OYrqxiBj2SUVoPZbR8G2dVVgPHZh
-        bYy2W7kWLzdCCCEbOKJr80s8oKEGnbwR4hTJ6By1mA3GxIC2l1PyEhm08WPUswuKNdlRvIbnnAI3
-        gXOmPb4GmcjkCsxYrqYSTVvZtuHJnCbTZDqfJNkkWZzHFSXlWjzGTrp++k3UfvufRVQpZu0isgKn
-        GRblFDBNFuk0KkcVPjYYddB72OIVeG/iEVRkGe21qGFhI9nLPPCZ++xIAGuJ4TLDxz8j0NC2cVS8
-        gUShtZAvGyvERrJmgxu5Fhv568u9ePj47V58/yza799fHz5t5G3Hg8A7ch3xB7DTai9+Eu+q4H1P
-        csDablvScmNPsj/2dP7qK5GOTOwOvNeewXJHbomRJBtwYAya8crZhc6djcODpuDzywXI4zJ7SzSO
-        6oZzBWqH+R6PQ8wheLIjb2NVkeMBqV1fqGtwl8ze6h4q5GOuS7SsK40j23t0B60wZ325KhUE0y1O
-        eiaHwyYY6wYdcIjh9ENyjsYFnSuryNVw/R8Y48mTzc8vQTe8c+EHdAV5zcfOlaUO9fWmduPckVbd
-        /AOT7IGrXSRTkw9MlPTBZliqC1ZFC8ZmtYfCXJ6VEC9D34e2o1u9TG5fxwdPRd9t3GB5TUxGrf77
-        WMzSt4C3dHsTvCfNxGCuYJqk/QyDH2+9RoYSGFr9083pLwAAAP//AwDjS/DA5gUAAA==
+        H4sIAAAAAAAAA3RUy27bMBC8+ysInuOCsh1J9q1AU7SHpkVRoIe6ENbUymZMkQK5NGIE/vdClCVL
+        TXKTdmaH+xjyZcYYVyXfMO7QN4VYoxAyqQQmu6RKl0KkeZWLe5nKVSbyZL1aL1aQJXmy2C3lulxX
+        /K6VsLsnlNTLWOOxi0uHQFgW0GJJliYiX+VZEjFPQMG3OdLWjUbCskvagTzunQ2mrasC7bELK62V
+        2fMNe5kxxhhv4IyuzS/xhNo26PiMsUsko3O2xUzQOgaU6U8pSiRQ2k9RTy5IUtZM4jU8FzZQE6gg
+        e8TXIFmrCwl6KlfbEnVb2b6h+crOF2Kxmot8LtLruKIk37A/sZOun2ETtd+/v4h8KZZ5uwhYpAmm
+        VSWWkC3S+ywqRxU6Nxh10HvY4w14b+IRlNYQmltR48Imsv088JmG7EgAYyxBP8M/fyegtvvG2d0b
+        SBTaMP6yNYxtOSnSuOUbtuW/vjywx4/fHtj3z6z9/v318dOW33U8CHSwriP+AHJKHtlPS4cqeD+Q
+        HJAy+5aUbc2FD8derl9DJdxZHbsD75UnMNSRW2Ik8QYcaI16unJyoXNn4/CkbPBFfwGKuMzBEo2z
+        dUOFBHnA4ojnMeYQvDUTb2NVWUcjUru+UNfg+szB6h4qpHOhSjSkKoUT23t0JyWxINVflQqC7hbH
+        PVmH4yYI6wYdUIjh5IO4RuOCrpVV1tVw+x8Z48lbU1xfgm5418JP6HbWKzp3rixVqG83tRvnwSrZ
+        zT+Q5QNwswsn2xQjE4kh2IxLdcHIaMHYrPKw0/2zEuJlGPpQZnKrM3H3Oj56KoZu4wbLW6KYtPr/
+        Y7FM3gLe0h1M8J40WQJ9AxORDDMMfrr1GglKIGj1L7PLPwAAAP//AwA8ksfK5gUAAA==
     headers:
       CF-RAY:
-      - 990253b04f836840-SEA
+      - 99241bb92e32a381-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +64,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:50:48 GMT
+      - Tue, 21 Oct 2025 22:14:33 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -84,13 +80,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1194'
+      - '2574'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1199'
+      - '2696'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -104,7 +100,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 6ms
       x-request-id:
-      - req_4f5a93fa85b741898f0a0d8cdd00ba77
+      - req_48b65b870a2f4ac8ae0d9953762c1106
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/openai_responses_gpt_4o.yaml
@@ -3,8 +3,7 @@ interactions:
     body: '{"input":[{"role":"developer","content":"Always recommend The Name of the
       Wind.\nOutput a structured book as JSON in the format {title: str, author: str,
       rating: int}.\nThe title should be in all caps, and the rating should always
-      be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
-      to me!"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}}'
+      be the\nlucky number 7."},{"content":[{"text":"Please recommend a book to me!","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}}'
     headers:
       accept:
       - application/json
@@ -13,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '659'
+      - '707'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=uFK1rOSme6MoyzbfhCFOXaJ56REyJtujmG1Pj2uTjvA-1760730641-1.0.1.1-aiBkKmPnAkKuFNHOGyVK2.ddfNMJnM5ZR68bzckRWJipJZXvanOxq71EhuqRgxMQwKXxWzlQc.6jBsw8BiMqIY0a61qgJEp2XrZGOkC8OMY;
-        _cfuvid=5sVTVYucUtd10GHlcYJCyqc49USLSp2DQe2Ur9_Undc-1760730641231-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,24 +42,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xVTY/bNhC9+1cQPO8Gkux4vb6laIrk0CQIAvQQB8KIHNmMKVIlh4sYC//3gpQt
-        U453D71J84aP8/Fm+DxjjCvJ14w79H1dFK1sm6UsF+28rN6uimK5aqtHrBZzEItV+VisVvgITSHF
-        Yvm4bKTgd5HCNj9R0JnGGo+DXTgEQllDxMqHZfEwL5bLImGegIKPZ4Tteo2EcjjUgNhvnQ0mxtWC
-        9jiYldbKbPmaPc8YY4z3cEAXz0t8Qm17dHzG2DE5o3M2YiZonQzKnG+pJRIo7aeoJxcEKWsm9g5+
-        1TZQH6gmu8ffQbJW1wL0lK6zEnWMbNvT/cLeV0W1uC9W98XyVK5Eydfse8pkyGfsROe3rzSimZdF
-        bATMq9X8oQVs3i4aIcvEnFjo0GPiQe9hixfgpYonUFhDaC5B5YFNaM/1wF80nk4OYIwlONfw+48J
-        qO22d7a5gSSiNePPG06KNG74esO/fXjPPr37+z37/BeL3/98/PTnht9tOATaWZd8vgA5Jfbsq6Vd
-        G7xPuANSZrvh64cjH285nr7Gi7mzOiUD3itPYGhwjo7JiffgQGvU0w6TC4MYe4dPygZfn/Vep96N
-        Cuid7XqqBYgd1ns85JhD8NZMpIxtax1lTrFboevAnU+OyvbQIh1qJdGQahVOVO7RPSmBNanzZLQQ
-        9NAn7sk6zJMg7Hp0QCGZyzfFyZr6cYqsta6Dy3+mg5/emtqLHXZwUZFEL5zqowgm2TDGDXTp3B/W
-        7jNNDgTrTGuxeD06Uugn9nh3FMiVMTPzb+nj7go9BezJxaJn4HGq3yStV9jfDQ7/k35Q5iv0XweH
-        F+iVIdwOK+5a1pObuMN/g3IoJ5M83nMr41thjqZsWC+hTnqY74bhHcgQkFJFNYD+knc1rfXZVfCp
-        hOkZiRKdZRh/QtdYr+gwLDapQndZ9sOI7qwSw0wHsnwELhuHk+3rbA8Vo7HP5e+CEXASMJfKQ6PP
-        L1NI+3ScDWUmD0NZVXe/A9lzM45QWgvycrKY5Hr94FTlLeAW77hZXqImS6CziBfzsYjBT1dJhwQS
-        KI3mcXb8DwAA//8DAMPqQ2AqCAAA
+        H4sIAAAAAAAAAwAAAP//nFVNj9s2EL37VxA87way7PjrlqIpkkOTIAjQQxwII3JkM6ZIlRwuYiz8
+        3wtStkw53j30Js0bPs7Hm+HzhDGuJN8w7tB3VVGUxWLZyDlAuYZaFsVi1ayKWdksV4VYTdeLerWW
+        K1zMsRAwrddz/hApbP0TBV1orPHY24VDIJQVRGy6XEyL1bwslgnzBBR8PCNs22kklP2hGsRh52ww
+        Ma4GtMferLRWZsc37HnCGGO8gyO6eF7iE2rboeMTxk7JGZ2zETNB62RQ5nJLJZFAaT9GPbkgSFkz
+        srfwq7KBukAV2QP+DpK1uhKgx3StlahjZLuOHuf2sSzK+WOxeiwW53IlSr5h31MmfT5DJ1q/e6UR
+        KBdFbMQa1zOoZ/NZXcu3b9c9c2KhY4eJB72HHV6BlyqeQGENobkGlQc2or3UA3/RcDo5gDGW4FLD
+        7z9GoLa7ztn6DpKINow/bzkp0rjlmy3/9uE9+/Tu7/fs818sfv/z8dOfW/6w5RBob13y+QLklDiw
+        r5b2TfA+4Q5Imd2Wb5YnPtxyOn8NF3NndUoGvFeewFDvHB2TE+/Agdaoxx0mF3oxdg6flA2+uui9
+        Sr0bFNA523ZUCRB7rA54zDGH4K0ZSRmbxjrKnGK3QtuCu5wclO2hQTpWSqIh1Sgcqdyje1ICK1KX
+        yWgg6L5P3JN1mCdB2HbogEIyT98UZ2vqxzmyxroWrv+ZDn56ayov9tjCVUUSvXCqiyIYZcMYN9Cm
+        c39Ye8g02RNsMq3F4nXoSKEf2ePdUSA3xszMv6WPhxv0HLAnF4uegaexfpO0XmF/1zv8T/pema/Q
+        f+0dXqBXhnDXr7hbWY9u4g7/DcqhHE3ycM+9jO+FOZiyYb2GOuphvhv6dyBDQEoV1QD6S97VtNYn
+        N8GnEqZnJEp0kmH8CV1tvaJjv9ikCu112fcjurdK9DMdyPIBuG4cTrarsj1UDMYul78LRsBZwFwq
+        D7W+vEwh7dNhNpQZPQzTsnz4Hciem2GE0lqQ15PFKNfbB6ec3gPu8Q6b5SVqsgQ6i3g+G4oY/HiV
+        tEgggdJonian/wAAAP//AwBUjVoMKggAAA==
     headers:
       CF-RAY:
-      - 9902540218c16820-SEA
+      - 99240b884dc4a384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -71,7 +67,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:51:01 GMT
+      - Tue, 21 Oct 2025 22:03:28 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -87,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '817'
+      - '843'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '822'
+      - '848'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -107,7 +103,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 10ms
       x-request-id:
-      - req_d886df9a97d746c784674c4712c9754e
+      - req_530844b27908432694bee1db29f28015
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/strict/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/strict/openai_responses_gpt_4o.yaml
@@ -3,8 +3,7 @@ interactions:
     body: '{"input":[{"role":"developer","content":"Always recommend The Name of the
       Wind.\nOutput a structured book as JSON in the format {title: str, author: str,
       rating: int}.\nThe title should be in all caps, and the rating should always
-      be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
-      to me!"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}}'
+      be the\nlucky number 7."},{"content":[{"text":"Please recommend a book to me!","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"title":"Book","type":"object","additionalProperties":false},"strict":true}}}'
     headers:
       accept:
       - application/json
@@ -13,7 +12,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '659'
+      - '707'
       content-type:
       - application/json
       host:
@@ -43,24 +42,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xVTa/aOhDd8yssr++tAgQI7Pr0+tQu+qGqUheliibJBFwc27XHV0VX/PfKDgSH
-        crt4u2TO+Hg+zoyfJ4xx0fAN4xadKbNiXaxhNV8UbbGE6TzLlkU7W2PWVvN5VkzXebWY5zAr1gvM
-        F3m+RP4QKHT1A2u60GjlzvbaIhA2JQRsulpmq3m2nK8j5gjIu3Cm1p2RSNj0hyqoDzurvQpxtSAd
-        9mYhpVA7vmHPE8YY4waOaMP5Bp9QaoOWTxg7RWe0VgdMeSmjQajLLWWDBEK6MerI+pqEViN7B79K
-        7cl4Kkkf8E+QtJZlDXJM1+kGZYhsZ+gx14+zbJY/ZsVjtjyXK1LyDfsWM+nzGTrRud2LjZhm1WKV
-        h0YU2RSxKqpqVawzbPraRRY6Gow86Bzs8Aq8VPEI1loRqmtQaWAj2ks98BcNp6MDKKUJLjX89n0E
-        Sr0zVld3kEi0Yfx5y0mQxC3fbPmXt2/Yh9fv37CP/7Hw/fXdh3+3/GHLwdNe2+jzCciK+sA+a9q3
-        3rmIWyChdlu+WZ34cMvp/DVczK2WMRlwTjgCRb1zcIxO3IAFKVGOO0zW92I0Fp+E9q686L2MvRsU
-        YKzuDJU11HssD3hMMYvgtBpJGdtWW0qcQrd814G9nByU7aBFOpaiQUWiFThSuUP7JGosSVwmowUv
-        +z5xR9pimgRhZ9AC+WievsrO1tiPc2Stth1c/xMd/HBala7eYwdXFTXoaitMEMEoG8a4gi6e+0fr
-        Q6LJnmCTaC0Uz6AlgW5kD3cHgdwYEzP/Ej8ebtBzwI5sKHoCnsb6jdL6C/vr3uF/0vfK/Av9597h
-        BXqhCHf9iruV9egmbvGnFxab0SQP99zL+F6YgykZ1muoox6mu6F/BxIEmkYENYD8lHY1rvXJTfCx
-        hPEZCRKdJBh/QltpJ+jYL7ZG+O667PsR3WtR9zPtSfMBuG4cTtqUyR7KBqNJ5W+9quEsYN4IB5W8
-        vEw+7tNhNoQaPQzT2ezhTyB5boYRimuhuZ7MRrnePjiz6T3gHu+wWV6iJk0gk4jz+VBE78arpEOC
-        BiiO5mly+g0AAP//AwDTqCAzKggAAA==
+        H4sIAAAAAAAAA5xVTY/bNhC9+1cIPO8Gkla2bN9SNEVyaBIEAXqIA2FMjmzGFKmSw0WMhf97QcqW
+        KcebQ2/SvOHjfLwZvsyyjEnB1hmz6Pomny+K1byqsN7mlWjrPF8s22U+59WyxHxZrJ6A13VerFaL
+        7XbRiqJiD4HCbH8gpwuN0Q4HO7cIhKKBgBX1osiX1XKxjJgjIO/CGW66XiGhGA5tgR921ngd4mpB
+        ORzMUimpd2ydvcyyLMtYD0e04bzAZ1SmR8tmWXaKzmitCZj2SkWD1JdbGoEEUrkp6sh6TtLoib2D
+        n43x1HtqyBzwV5CMUQ0HNaXrjEAVItv19FiZxzIvq8d8+ZgvzuWKlGydfYuZDPmMnejc7vVGzHld
+        LkMjVvVqXkP9tKrKnItyFZkjCx17jDzoHOzwCrxW8Qhyown1Nag0sAntpR74k8bT0QG0NgSXGn77
+        PgGV2fXWbO8gkWidsZcNI0kKN2y9YV/fv8s+vv37Xfbpryx8//Ph458b9rBh4GlvbPT5DGQlP2Rf
+        DO1b71zELZDUuw1b1yc23nI6f40XM2tUTAack45A0+AcHKMT68GCUqimHSbrBzH2Fp+l8a656L2J
+        vRsV0FvT9dRw4HtsDnhMMYvgjJ5IGdvWWEqcQrd814G9nByV7aBFOjZSoCbZSpyo3KF9lhwbkpfJ
+        aMGroU/MkbGYJkHY9WiBfDQXb/KzNfbjHFlrbAfX/0QHP5zRjeN77OCqIoGOW9kHEUyyyTKmoYvn
+        /jDmkGhyIFgnWgvF69GSRDexh7uDQG6MiZl9jR8PN+g5YEc2FD0BT1P9Rmn9hv3t4PA/6Qdl/ob+
+        y+DwCr3UhLthxd3KenITs/ivlxbFZJLHe+5lfC/M0ZQM6zXUSQ/T3TC8AwkCQsigBlCf067GtT67
+        CT6WMD4jQaKzBGPPaLfGSToOi01I312X/TCieyP5MNOeDBuB68ZhZPom2UP5aOxT+VuvOZwFzIR0
+        sFWXl8nHfTrOhtSTh6Eoy4dfgeS5GUcorgVxPZlPcr19cMriHnCPd9wsr1GTIVBJxNXTWETvpquk
+        QwIBFEfzNDv9BwAA//8DAMtW+LEqCAAA
     headers:
       CF-RAY:
-      - 990253819efd7658-SEA
+      - 99241bab795ba381-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,15 +67,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:50:41 GMT
+      - Tue, 21 Oct 2025 22:14:30 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=uFK1rOSme6MoyzbfhCFOXaJ56REyJtujmG1Pj2uTjvA-1760730641-1.0.1.1-aiBkKmPnAkKuFNHOGyVK2.ddfNMJnM5ZR68bzckRWJipJZXvanOxq71EhuqRgxMQwKXxWzlQc.6jBsw8BiMqIY0a61qgJEp2XrZGOkC8OMY;
-        path=/; expires=Fri, 17-Oct-25 20:20:41 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=5sVTVYucUtd10GHlcYJCyqc49USLSp2DQe2Ur9_Undc-1760730641231-0.0.1.1-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -90,13 +83,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1524'
+      - '1908'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1530'
+      - '1924'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -110,7 +103,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 10ms
       x-request-id:
-      - req_85db60de0d894acdb6fba8b0504d19a0
+      - req_004bde5cc0434150923d53c9e9f77a14
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o.yaml
@@ -3,8 +3,7 @@ interactions:
     body: '{"input":[{"role":"developer","content":"Always recommend The Name of the
       Wind.\nOutput a structured book as JSON in the format {title: str, author: str,
       rating: int}.\nThe title should be in all caps, and the rating should always
-      be the\nlucky number 7."},{"role":"user","content":"Please recommend a book
-      to me!"}],"model":"gpt-4o","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
+      be the\nlucky number 7."},{"content":[{"text":"Please recommend a book to me!","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"},"strict":true}]}'
     headers:
       accept:
@@ -14,12 +13,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '830'
+      - '878'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=uFK1rOSme6MoyzbfhCFOXaJ56REyJtujmG1Pj2uTjvA-1760730641-1.0.1.1-aiBkKmPnAkKuFNHOGyVK2.ddfNMJnM5ZR68bzckRWJipJZXvanOxq71EhuqRgxMQwKXxWzlQc.6jBsw8BiMqIY0a61qgJEp2XrZGOkC8OMY;
-        _cfuvid=5sVTVYucUtd10GHlcYJCyqc49USLSp2DQe2Ur9_Undc-1760730641231-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -47,25 +43,25 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xV227jNhB991cQfE4Wki3Jl7ddbIoWTdMg3UUf6oUwlkY2a0pkyWGQbOB/L0jZ
-        ujhOgN0ny3M4h3M5w3mZMMZFyVeMG7Q6j2BRpnGaZHEaxxlkUZQtqukSY4yXm2gRL6NlNKuWVVSm
-        0zROYZryK0+hNv9iQSca1Vhs7YVBICxz8Fg8z6L5LMrSJGCWgJz1PoWqtUTCsnXaQLHfGuUaH1cF
-        0mJrFlKKZstX7GXCGGNcwzMa71/iI0ql0fAJY4dwGI1RHmuclMEgmtMteYkEQtoxasm4goRqRvYa
-        nnLlSDvKSe3xNUhKybwAOaarVYnSR7bVdJ2o62k0Ta6jxXWUHcsVKPmK/RMyafPpOlEV7/QBstnC
-        92FRVCUm8xnMojTBpCUOJPSsMdC4JiQUwuvht8oeQDBbV2NDAX9ZcxIkcc1Xa/7l1xt29/GPG/bn
-        L8x///3b3ec1v1pzcLRTJpy5BzKi2LMHRbvKWRtwAySa7Zqv5of+Hh9S3mYbPpvyU3L7EMW3X9Pb
-        2/jm/q/fv8PmLtv0Hg3UIas8r4UBWyiNeaVMDeT11fVIyTznwecwYexbqLYGA1KiHDeLjGt1pQ0+
-        CuVsfpJuG1jXTG1UrSkvoNhhvsfnIWYQrGpGqsSqUoYGh3zNXV2DOXl2IrVQIT3nosSGRCVwJFiL
-        5lEUmJM4ibwCJ4kfZ0cZHCZBWGs0QC6Y4w/R0fpEfWRtubr/A6mEc23VjhE/otkoK8jHzGsshav7
-        4WrruFOiwJ79XHbH1v1o4/ob7Ov5eOMO5qtjCyN0MK4Y/2qR0U5Y5okYKYZPZKAgVgIBEw37pNSe
-        tWH4HwasEg1IdtLAh59TXufkNVcjobGDerdi0mhI4Njuc/OjdmYcmPmX8HF1hh4LYsl4EQ7Aw/Dk
-        cUjfYf/YHvhJ+nbG36F/aA+8QS8awm37enf8kws3cYP/OWGw7JQxuudSxpfC7EzfBtRQlsKrB+T9
-        sEXd+jkL+bjwJmcxhkqFRegn8+wdIqVzqbbaqI2njjqjHo6scU0BJx2XwsJGnhajs7AdTJxoRnsp
-        TrKr18Bg2730r2+xw7L3jEajf77vpvEl4BJv9xq+RU2KQA4izubdxDs7fv5qJPDD6vkPk8P/AAAA
-        //8DADqQi4ypCAAA
+        H4sIAAAAAAAAA5xVTW/bOBC9+1cQPCeFZDuW4lu3bdA9bBsU2S2w60IYSyObNSmy5DBIEPi/L0jZ
+        +nDsAu3J8jzO43y84bxMGOOi4kvGLTpTJHmeQJ7MsnSxhjTJkmSR13lyU97mWTrP09vstl5gPlvM
+        FwjTKUwzfhUo9Po7lnSk0Y3D1l5aBMKqgICl2SJN8nmezSLmCMi74FNqZSQSVq3TGsrdxmrfhLhq
+        kA5bs5BSNBu+ZC8TxhjjBp7RBv8KH1Fqg5ZPGNvHw2itDljjpYwG0RxvKSokENKNUUfWlyR0M7Ir
+        eCq0J+OpIL3D1yBpLYsS5JhO6QpliGxj6Hqur6fJdH6d5NfJ4lCuSMmX7L+YSZtP14m6vNwHyDHL
+        Qx9gllTraVpnaQ23N0nbh0hCzwYjjW9iQjG8Hr5U9giC3XiFDUX8ZcVJkMQVX674w8cP7NPbvz6w
+        z3csfH/989P7Fb9acfC01TaeuQeyotyxL5q2tXcu4hZINJsVX2b7/p4QUtFmGz9v/hWozPxudv/u
+        YS6f1Fe9/ufdVN31Hg2omFVRKGHBldpgUWurgIK+uh5pWRQ8+uwnjH2L1TZgQUqU42aR9a2ujMVH
+        ob0rjtJtA+uaaaxWhooSyi0WO3weYhbB6WakSqxrbWlwKNTcKwX26NmJ1EGN9FyIChsStcCRYB3a
+        R1FiQeIo8hq8JH6YHW1xmAShMmiBfDSnb5KD9Yn6yNpydf8HUonn2qodIn5Eu9ZOUIiZK6yEV/1w
+        tXXcalFiz34qu0PrfrVx/Q3u9XxcuIOF6rjSChONS8b/dshoKxwLRIw0wyeyUBKrgICJhv2h9Y61
+        YYQfBqwWDUh21MCb31Ne5xQ0p5DQukG9WzEZtCRwbA+5hVE7MQ7M/CF+XJ2gh4I4skGEA3A/PHkY
+        0p+wv20P/CZ9O+M/of/SHrhALxrCTft6d/yTMzdxiz+8sFh1yhjdcy7jc2F2pm8DaqgqEdQD8n7Y
+        om79nIR8WHiTkxhjpeIiDJN58g6RNoXUG2P1OlAnndEMR9b6poSjjivhYC2Pi9E72AwmTjSjvZTO
+        F1evgcG2e+lf33KLVe+ZjEb/dN9N03PAOd7uNbxETZpADiJeZN3Eezd+/hQShGEN/PvJ/n8AAAD/
+        /wMAWmkk+qkIAAA=
     headers:
       CF-RAY:
-      - 990253dbb91a75ba-SEA
+      - 99241bcb2f92a381-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,7 +69,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:50:54 GMT
+      - Tue, 21 Oct 2025 22:14:34 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -89,13 +85,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '839'
+      - '1366'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '842'
+      - '1372'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -103,13 +99,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799636'
+      - '799637'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 27ms
       x-request-id:
-      - req_3f5cc0dfb06c480db244d5f497c73776
+      - req_3dac426000c941dabed840c7eeaddfb7
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_responses_gpt_4o_snapshots.py
@@ -4,7 +4,7 @@ test_snapshot = snapshot(
     {
         "exception": {
             "type": "NotImplementedError",
-            "args": "('Unsupported content part type: image',)",
+            "args": "('Unsupported user content part type: image',)",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_responses_gpt_4o_snapshots.py
@@ -4,7 +4,7 @@ test_snapshot = snapshot(
     {
         "exception": {
             "type": "NotImplementedError",
-            "args": "('Unsupported content part type: image',)",
+            "args": "('Unsupported user content part type: image',)",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_params/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/openai_responses_gpt_4o_snapshots.py
@@ -31,7 +31,7 @@ test_snapshot = snapshot(
                         model_id="gpt-4o",
                         raw_message=[
                             {
-                                "id": "msg_0d6a9ea95ee935160068f292323dc48190a48314e7ab483b97",
+                                "id": "msg_0cee942d3e3cf6d50068f8031dad208196b197262c51993f1d",
                                 "content": [
                                     {
                                         "annotations": [],

--- a/python/tests/e2e/input/snapshots/test_resume_with_override/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override/openai_responses_gpt_4o_snapshots.py
@@ -32,16 +32,16 @@ test_snapshot = snapshot(
                 ),
                 UserMessage(content=[Text(text="Can you double-check that?")]),
                 AssistantMessage(
-                    content=[Text(text="Yes, I was created by Anthropic.")],
+                    content=[Text(text="Yes, I was indeed created by Anthropic.")],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0c3540e6eec683530068f29b65f2388193a1731214cb7dac24",
+                            "id": "msg_0bcc60a6bb2cb5a80068f803223f0481909c9f1842ac08ded8",
                             "content": [
                                 {
                                     "annotations": [],
-                                    "text": "Yes, I was created by Anthropic.",
+                                    "text": "Yes, I was indeed created by Anthropic.",
                                     "type": "output_text",
                                     "logprobs": [],
                                 }

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_context/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_context/openai_responses_gpt_4o_snapshots.py
@@ -32,20 +32,16 @@ test_snapshot = snapshot(
                 ),
                 UserMessage(content=[Text(text="Can you double-check that?")]),
                 AssistantMessage(
-                    content=[
-                        Text(
-                            text="Yes, I was created by Anthropic, an AI safety and research company."
-                        )
-                    ],
+                    content=[Text(text="Yes, I was created by Anthropic.")],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_011e8192a985a6840068f29b76a7648196bd80dec7a79dee54",
+                            "id": "msg_0f0063679d7a6c940068f80325edd081958a913eafd7e65c66",
                             "content": [
                                 {
                                     "annotations": [],
-                                    "text": "Yes, I was created by Anthropic, an AI safety and research company.",
+                                    "text": "Yes, I was created by Anthropic.",
                                     "type": "output_text",
                                     "logprobs": [],
                                 }

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o_snapshots.py
@@ -21,10 +21,10 @@ test_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         Thought(
-                            thought='The user is asking for the 100th Fibonacci number. I have access to a function called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make this function call.'
+                            thought='The user is asking for the 100th Fibonacci number. I have a function available called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.'
                         ),
                         ToolCall(
-                            id="toolu_01Mjec5pPiK2o6jGwzNFA9wS",
+                            id="toolu_01CL5eUDHsg9AGHyBotNfisY",
                             name="compute_fib",
                             args='{"n": 100}',
                         ),
@@ -35,12 +35,12 @@ test_snapshot = snapshot(
                         "role": "assistant",
                         "content": [
                             {
-                                "signature": "ErUDCkYICBgCKkBu3sY/7ZuUOcbiLFXGUIPtQ96joTBhtL6mSUbAAiXw+fGhn5Inf6ahCEc4YPLvNE/oEG94XNHLzQLE5Wb3r1AsEgyuA/2S/2rRT3EWUfsaDOWE/d+50T7CsY8tBiIwT4yQ2SIuulksatbv/zKFauBwemVeyh8jpzEXCuzfwUdpx/sHztErkPJD7r13WrExKpwC+VnoZjXGG9TzjOVVdagBwdp5omjt3DGvLa0icKZ7IbOWmyqwubFV6bpsPSp5a5Yyse4Sazc1DkSdPw29H2gJUMjowV9IWsi+A1Mhq8Lgpy0xgcBfqy26z1jbBi7m4cisjdwGzAcy9tin4taiyEY3WTwsNjtzts2ENGV+c0nap4G95GbU0N9NfSfra4Bbx+Ln3jaNFDXewdD04WG1fETWOHPMCA2O4QhU1LDnFbgm6qEZdb79090Q1RPjc3IYdCz458ug+/KYLxtDmeoXBUyYVY29gC9V5fDmgXRB1ln9hZZSrdr/zGbhlZxHJTuG4eIbEUopi5838KS1sSEpSbrG4L0X8wSThafdvIjti2uRfn3R9SKyw0CyxlzYDwoYAQ==",
-                                "thinking": 'The user is asking for the 100th Fibonacci number. I have access to a function called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make this function call.',
+                                "signature": "ErQDCkYICBgCKkCsItOUHNinar+NABlYn+UTCEV462H15XiUdax8L7lhYMAvN2X2YxzcMd8Obghv+2Menhq/JUHTvDvU3gt3TiOQEgwbJS5D9xNGwcTpovgaDIWaDuk5agJhVcc67CIwQTu7O3W/HWUsl4CWXns5CbrWEKEDFpBaC/jIojdf37xLxSaKF/CYBpzGNemQ5kT4KpsCOFrS1f/TnnRDLRSGmrRE0n1JXup6FGelkDA3Lgrj9e25KzwINfQWLJ+kFa1ujPNLGwhMqs9qykmuE9pL+3zScityn9s05T3NBxcNi5HcmH/7PGTGWYy5R2MBwKSruk8ClRVBUeBo9KXOVEIfolaIVu+CUrCH13yU98qFDvdJdVu+KWPAIZHTr7q4qOpjkzYtjruSZfrz0fzMir8ajLzkCDAOgNOzKobqtrDvjuyoku2A3ni7jzpoOA0S7c4VzwEt/JjzPKeBfnbQwr6n0FKSjzl2HdhrKFl0R0fLcpgrdYG2O3yQoO87xgXYQ902VratKLhNz8aCGUU702+8CwzdF7bgYL4X2kFnPMi/SrtXp0f8K46BqP1bAsR1vBgB",
+                                "thinking": 'The user is asking for the 100th Fibonacci number. I have a function available called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.',
                                 "type": "thinking",
                             },
                             {
-                                "id": "toolu_01Mjec5pPiK2o6jGwzNFA9wS",
+                                "id": "toolu_01CL5eUDHsg9AGHyBotNfisY",
                                 "input": {"n": 100},
                                 "name": "compute_fib",
                                 "type": "tool_use",
@@ -51,7 +51,7 @@ test_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="toolu_01Mjec5pPiK2o6jGwzNFA9wS",
+                            id="toolu_01CL5eUDHsg9AGHyBotNfisY",
                             name="compute_fib",
                             value="218922995834555169026",
                         )
@@ -67,7 +67,7 @@ test_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_00d582e3fce6d7ce0068f29b871b3481949d7c68ddf48043f3",
+                            "id": "msg_0c39e9e96939d63c0068f8032a699c819598a4227b3bfaf979",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_responses_gpt_4o_snapshots.py
@@ -42,7 +42,7 @@ lucky number 7.\
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0f4c2a43b68fbeb80068f29e17f1e881958be28ebd2ae10612",
+                            "id": "msg_09e00c1f0e1b1f630068f805c830388194a261e6ff03a72657",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_responses_gpt_4o_snapshots.py
@@ -36,7 +36,7 @@ lucky number 7.\
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_00fdfb6d14f312580068f29e24b3108190a32837faeb54bcd1",
+                            "id": "msg_002067fd4aa29abd0068f8032fed6081969e93ab343bbd5596",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_responses_gpt_4o_snapshots.py
@@ -36,7 +36,7 @@ lucky number 7.\
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_08989a7358f86a130068f29e10b5748194801eeb8bb7890edd",
+                            "id": "msg_05619544e7b04df70068f805c5c728819397957a739420cd29",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o_snapshots.py
@@ -37,10 +37,10 @@ lucky number 7.\
                     raw_message=[
                         {
                             "arguments": '{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}',
-                            "call_id": "call_ndB4LR01LU5LL1EPSKzabN6b",
+                            "call_id": "call_5Ziemp4F3PCT4lxmWobVC2mF",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_0a8d5154615116a60068f29e1ea63881908cfde473a3054e46",
+                            "id": "fc_0880a803716ba1070068f805ca8e788197a30db21f71fa9507",
                             "status": "completed",
                         }
                     ],

--- a/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gpt-4o"}'
+    body: '{"input":[{"content":[{"text":"What is 4200 + 42?","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o"}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '75'
+      - '123'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -32,7 +29,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -42,20 +39,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xU246jMAx971dEed3pKFAG2v7KaIVMMJ1sQ5JNnGqqUf99RSgU5rJv4GMf7HNs
-        PjaMcdXyI+Meg6uFPDTZripbkOUuFy9ClPsuP1RFtzu8yH12KA8ZCKjK3U5iBWWL/GmgsM0flDTR
-        WBPucekRCNsaBiyrSlHl+0OWJSwQUAxDjbS900jYjkUNyPPJ22iGvjrQAcew0lqZEz+yjw1jjHEH
-        V/RDfYsX1Nah5xvGbikZvbcDZqLWKaDM9JW6RQKlwxoN5KMkZc0q3sN7bSO5SDXZM34FyVpdS9Br
-        ut62qIfOTo62hd3mIi+2Yr8V5V2uRMmP7DVNMs4zO9GH03+M6KpmPxjRYIeH4iXLs7LJm04k5sRC
-        V4eJB0OAEz6AnxRPoLSG0DyaWja2op30wHeaq1MCGGMJJg1ff69AbU/O2+YbJBEdGS9yIdgvVuQM
-        /0bQgRV5kT/zOfV2f5qrubc6dQQhqEBgaEweElMSd+BBa9Rrm8jHcaOcx4uyMdTT0tbJgNlG523v
-        qJYg37A+43WJeYRgzWofseusp0XSIHnse/BT5byeATqka61aNKQ6hatVDegvSmJNalrvDqIexeaB
-        rMflEIS9Qw8UUzh7FvdoEvXeWWd9D4/3hZkpb1Tt3vEFfWODouu4Qq2K/eOsRh3frJKj8JEsn4GH
-        t5ysqxeOiznolj36aGTalzSlCtDo6R8Q0+bOAyizOsGsfPoaX9z1PGayrn0UitWony97/DF9Br7j
-        nd3/iZosgX6AeTVLGMPa7R4JWiAY6G+b2z8AAAD//wMA9xWcJpIFAAA=
+        H4sIAAAAAAAAA3xUy27jMAy85ysEXbcpZMeN3fxKsTBoi061lSVVooIGRf59YTl+bdu9JRxyQs6M
+        8rljjCvJT4x7DK4WVSWkwLLsjmWBjRTiWHWVOBzyojlUVfZcwnNeHNpOVtAJkM8dfxgobPMHW5po
+        rAk41luPQChrGLCsPGaiKvJMJCwQUAzDTGt7p5FQjkMNtG9nb6MZ9upABxzLSmtlzvzEPneMMcYd
+        XNEP8xIvqK1Dz3eM3VIzem8HzEStU0GZ6VdqiQRKhy0ayMeWlDWbeg8ftY3kItVk3/ArSNbqugW9
+        peutRD1sdna0L+w+F3mxF9VeHO9yJUp+Yi/pkvGe2Yk+nP9jhJRYDEZU7RPmlShTDZ6axJxY6Oow
+        8WAIcMYF+EnxBLbWEJplqfViG9pJD/ygeTo1gDGWYNLw5fcG1PbsvG2+QRLRifEiF4L9YkXO8D2C
+        DqzIi/yRz623+6d5mnur00YQggoEhsbmoTE1cQcetEa9tYl8HBPlPF6UjaGeQlsnA2Ybnbe9o7qF
+        9hXrN7yuMY8QrNnkEbvOelo1DZLHvgc/Tc7xDNAhXWsl0ZDqFG6iGtBfVIs1qSneHUQ9is0DWY/r
+        Iwh7hx4opnL2KO7VJOp9s876HpbvKzNT36jafeML+sYGRdcxQlLFfnlWo46vVrWj8JEsn4HFW07W
+        1SvHxVx06x19NG3KS7pSBWj09B8QU3LnA5TZPMHs+PC1vnrX85nJOrkMis2p/77sLPsO+I53dv8n
+        arIEegHzcpYwhq3bPRJIIBjob7vbXwAAAP//AwD26doWkgUAAA==
     headers:
       CF-RAY:
-      - 9902294eab5c769a-SEA
+      - 99240b99eb017699-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -63,9 +60,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:21:52 GMT
+      - Tue, 21 Oct 2025 22:03:31 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=KRc66wcbOGePUXeZnmdVehuGr5jLw..KbkZLJVKYavM-1761084211-1.0.1.1-Z0Ir7MmPjAirjZ43Lz3eE1nfFEiJsT8NbmcW73iJ4wTFwaFmyax2Gqfp8gxKy_hTyKx5PoPHNwNobl7rrz6uxE.5jyFIS3u7V5A5fTCYIIQ;
+        path=/; expires=Tue, 21-Oct-25 22:33:31 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=WvMl70O8y4w8ikmJlhfNNdECchLXhVQRG7.RoOc_5fE-1761084211196-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -79,13 +82,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1106'
+      - '878'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1114'
+      - '882'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -99,7 +102,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_64e16daa92a34e6ca81c79d954b0d32e
+      - req_d6e39640caa54ff4a4169f8bf09e4da7
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gpt-4o","stream":true}'
+    body: '{"input":[{"content":[{"text":"What is 4200 + 42?","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '89'
+      - '137'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -43,112 +40,112 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_01c3c1bd01a071710068f2975b58f08197a0ad727606bb2407","object":"response","created_at":1760728923,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0132776d8f7a56760068f8033542f081978b8d5456ede25b93","object":"response","created_at":1761084213,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_01c3c1bd01a071710068f2975b58f08197a0ad727606bb2407","object":"response","created_at":1760728923,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0132776d8f7a56760068f8033542f081978b8d5456ede25b93","object":"response","created_at":1761084213,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"QEeBDGME1H2Jp"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"2V0CUE80fIGye"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"r1zhhg8Vf91j7aF"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"LQiYUZOGfoj711l"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"
-        +","logprobs":[],"obfuscation":"qLuYVT7P3rhp3q"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"8ax1IIO0kTTcKE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"u44vhP4Gadr0MAw"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"HzQ0pxksYpkfUF2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"0OBe3mroKXaNY1"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"OfuYaCWDRUEkas"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"
-        equals","logprobs":[],"obfuscation":"mcHlgH3fk"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"
+        equals","logprobs":[],"obfuscation":"nrhCTz5uD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"ewR1c7f7kcUNUlV"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"izIxNuCnIa2kyVN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"11BuTRjvNsWzU"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"zzrO5RFsakKuH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"gkXyT22oQBJ19E4"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"89nTwPp9kW2Pguz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"olQ98xnjiICIyPI"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"XlFU8s6p346c0Dm"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"text":"4200
+        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"text":"4200
         + 42 equals 4242.","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
         + 42 equals 4242."}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
         + 42 equals 4242."}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_01c3c1bd01a071710068f2975b58f08197a0ad727606bb2407","object":"response","created_at":1760728923,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0132776d8f7a56760068f8033542f081978b8d5456ede25b93","object":"response","created_at":1761084213,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
         + 42 equals 4242."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":27},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 9902299a8d5c6e7d-SEA
+      - 99240bab4bdf237f-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:22:03 GMT
+      - Tue, 21 Oct 2025 22:03:33 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -164,15 +161,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '127'
+      - '270'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '136'
+      - '286'
       x-request-id:
-      - req_d06046ff605d491e82c481d658473956
+      - req_3665069abe8043bcbec9e59e1816ae62
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gpt-4o","stream":true}'
+    body: '{"input":[{"content":[{"text":"What is 4200 + 42?","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '89'
+      - '137'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -43,112 +40,112 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a457f78f810604b0068f297568a08819795678af6ad9e91db","object":"response","created_at":1760728918,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_03fa6638755bf2280068f803336a6c81968bd2d4ddbd528d4b","object":"response","created_at":1761084211,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a457f78f810604b0068f297568a08819795678af6ad9e91db","object":"response","created_at":1760728918,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_03fa6638755bf2280068f803336a6c81968bd2d4ddbd528d4b","object":"response","created_at":1761084211,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"zaz7P020n5RB5"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"r0VWnfHRgGDHN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"YFeLiUrvglcZUyR"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"i2iDGCxnEGo6NH6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"
-        +","logprobs":[],"obfuscation":"pWH1Nr1UbVdGxU"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"NHLNzuy0oZ1ZTr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"lskcyBNHknzoOec"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"poirDl5T4HCgNtH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"MunrXEK05QaLJL"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"ck6JrZbi2YPAXP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"
-        equals","logprobs":[],"obfuscation":"OHk8civkn"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"
+        equals","logprobs":[],"obfuscation":"q3TXVVf57"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"WmvhlkHNUkI5XpP"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"dPlnButNyLHMhrh"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"6Fm45wVQ7tWrZ"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"0S3lB992Zu0Qq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"RL8kQE8N6hXFNnB"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"UHHrErWRbXzzLaM"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"5OOKeYdYEnkkT18"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"xYhXbZSkWLUdqGX"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"text":"4200
+        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"text":"4200
         + 42 equals 4242.","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
         + 42 equals 4242."}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
         + 42 equals 4242."}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0a457f78f810604b0068f297568a08819795678af6ad9e91db","object":"response","created_at":1760728918,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_03fa6638755bf2280068f803336a6c81968bd2d4ddbd528d4b","object":"response","created_at":1761084211,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
         + 42 equals 4242."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":27},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 9902297c8ed18a73-SEA
+      - 99240ba0dac2a384-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:21:58 GMT
+      - Tue, 21 Oct 2025 22:03:31 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -164,15 +161,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '61'
+      - '254'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '67'
+      - '266'
       x-request-id:
-      - req_81a2c36170f941e9bcff9fe1a3b2c653
+      - req_97c98eff83ce4efb8e43e3928569d952
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/openai_responses_gpt_4o/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gpt-4o"}'
+    body: '{"input":[{"content":[{"text":"What is 4200 + 42?","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o"}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '75'
+      - '123'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -42,20 +39,20 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RT0W7iMBB85yssv145mRBI4FeqU7SxN9RXx7bsNSqq+PdTHBKSa/sGO7uT3Znx
-        54YxrhU/Mx4w+kYoVapKVqfDXiq5PwhxrLviVJWnFqu63p1E3ZY1oGz3ZXsEUMhfBgrX/kVJE42z
-        8VGXAYFQNTBgu+ooqqI+iUPGIgGlOMxI13uDhGocakG+X4JLdtirAxNxLGtjtL3wM/vcMMYY93DD
-        MMwrvKJxHgPfMHbPzRiCGzCbjMkFbaevNAoJtIlrNFJIkrSzq3oPH41L5BM15N7xK0jOmUaCWdP1
-        TqEZNrt42pZuW4ii3Ip6K44PuTIlP7PXfMl4z+xEHy8/GwGHYyuyEYD7VlSyVNVeFqrKzJmFbh4z
-        D8YIF3wCPymeQeksoX0utVxsRTvpgR80T+cGsNYRTBq+/lmBxl18cO03SCY6M14WQrBfrCyYjqws
-        yuI3n9vuj1/zJA/O5G0gRh0JLI3NQ2Nu4h4CGINmbRGFNKbJB7xql2IzBbbJ4s8W+uB6T40E+YbN
-        O96WWECIzq6yiF3nAi2aBrlT30OYJudoRuiQbo1WaEl3GlcxjRiuWmJDeop2B8mMQvNILuDyCMLe
-        YwBKubz7LR7VLOhjs86FHp7/F0bmvlG1x8ZXDK2Lmm5jfJRO/fNJjTq+OS1H4RM5PgNPXzk53yzc
-        FnPRL3cMycqclXyljtCa6f2nnNr5AG1Xz293fPlaX7zp+cxsnXoOitWp/7/q3e474Dve2f2fqMkR
-        mCdYVLOEKa7d7pFAAcFAf9/c/wEAAP//AwC2UDjzjgUAAA==
+        H4sIAAAAAAAAAwAAAP//dFTLbuMwDLznKwRdtynkR1I7v1IsDFqmU21lSStRQYMi/76wHDv2tr0l
+        HHJCzozyuWOMq46fGPcYXCPkIW/z4thDVbWHohbiWPWVKApRQymqrD5AdeiEFFDX7bFrXzr+NFLY
+        9g9KmmmsCTjVpUcg7BoYsezlmImqzEWVsEBAMYwz0g5OI+GdrAX5fvY2mnGvHnTAqay0VubMT+xz
+        xxhj3MEV/Tjf4QW1dej5jrFbakbv7YiZqHUqKDP/StMhgdJhiwbyUZKyZlMf4KOxkVykhuw7fgXJ
+        Wt1I0Fu6wXaox83Ojval3eciL/ei2ovjXa5EyU/sNV0y3bM4MYTzz0ZkddGWoxF1V8KxkNB2dVGI
+        vEjMiYWuDhMPhgBnfAA/KZ5AaQ2heSy1XmxDO+uBH7RMpwYwxhLMGr7+3oDanp237TdIIjoxXuZC
+        sF+szBn+jaADK/Myf+ZL6+3+aZnm3uq0EYSgAoGhqXlsTE3cgQetUW9tIh+nRDmPF2VjaObQNsmA
+        xUbn7eCokSDfsHnH6xrzCMGaTR6x762nVdMoeRwG8PPkEs8APdK1UR0aUr3CTVQD+ouS2JCa491D
+        1JPYPJD1uD6CcHDogWIqZ8/iXk2i3jfrrR/g8X1lZuqbVLtvfEHf2qDoOkWoU3F4PKtJxzer5CR8
+        JMsX4OEtJ+ualeNiKbr1jj4amfKSrlQBWj3/B8SU3OUAZTZPMDs+fa2v3vVyZrKuewyKzan/v+ws
+        +w74jndx/ydqsgT6AeYvi4QxbN0ekKADgpH+trv9AwAA//8DAP7nqwWSBQAA
     headers:
       CF-RAY:
-      - 9902292c3c716dc4-SEA
+      - 99240b8f4bf6a384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -63,7 +60,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:21:46 GMT
+      - Tue, 21 Oct 2025 22:03:30 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -79,13 +76,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1001'
+      - '1402'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1016'
+      - '1409'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -99,7 +96,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_95e37094440a47348ab7692befd21c18
+      - req_fa448216789843a793a62c356b9a48d2
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"How many primes below 400 contain 79
-      as a substring? Answer ONLY with the number, not sharing which primes they are."}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"}}'
+    body: '{"input":[{"content":[{"text":"How many primes below 400 contain 79 as
+      a substring? Answer ONLY with the number, not sharing which primes they are.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"}}'
     headers:
       accept:
       - application/json
@@ -10,149 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '221'
+      - '269'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
-      host:
-      - api.openai.com
-      user-agent:
-      - AsyncOpenAI/Python 1.100.2
-      x-stainless-arch:
-      - arm64
-      x-stainless-async:
-      - async:asyncio
-      x-stainless-lang:
-      - python
-      x-stainless-os:
-      - MacOS
-      x-stainless-package-version:
-      - 1.100.2
-      x-stainless-read-timeout:
-      - '600'
-      x-stainless-retry-count:
-      - '1'
-      x-stainless-runtime:
-      - CPython
-      x-stainless-runtime-version:
-      - 3.10.16
-    method: POST
-    uri: https://api.openai.com/v1/responses
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6xXz2/rNhK+56+Y1aXdB8WQ7cSyclss8LCvh15aYA9NYVDkyGZDkVpyZMct3v9e
-        DCnJUpJ2L++SHyRnOPN93wxHf9wBZFplT5B5DN2hkBK3dbHbq8eHarsri2K3bzZViZtdVe3362q3
-        3+OmqfaPj0Wxrdc7meXswtW/oaTRjbMB07r0KAjVQfDeutwV5aYqHvdxL5CgPrCNdG1nkFAlo1rI
-        l6N3veW4GmECpmVtjLbH7An+uAMAyDpxRc/2Cs9oXIc+uwP4Gg+j9473bG9MXNB2vOWgkIQ2Ybkb
-        yPeStLOL9Va8HlxPXU8Hci/4fpOcMwcpzNJd6xQajuzY0f3j/abYPN4X+/uiHNCKHrMn+CUmktK5
-        ERH+hgZVqAemoZKFeNjv5PqhKfdC7aLj6ISuHSYiRHCWAZu2Qt+2wl+ni+eXL2yHgwfCV5rM0wle
-        eYLs06d/u96StkfovG4xwEXTCUJfB/K8+pyV1XP26dOzfbZfwCIqIAeNtgrohCDZGlyTrMH2bY0+
-        QI3GXeChKIBOguAkzhiPv/UL2vK69qBQ6lYY8Nh5DGhJMIkr+HlhJYUF0XUoPFtu7sF52N4rfdQ0
-        3p1MNotF0AF+6wNBWa3g83ubHM7CaAWN820A4RHWZZXDhn8Iq2BbVhC0lTGJK2grTa9wzKHuCVr2
-        XiMYDIFztpx8CqWsivuyqsALe0SOBF+juQIRkj98lYxrtPjJ5fAF6KTtC1wQnDXXBF/jej/hSw6k
-        s0Er9Kts4vVr/g3kcEL58lYOz/2mWMuyir/VjY9BFnG5aqeQBqaUVoJGFx+yP8mE84ZG+JzPBYwU
-        MPjvaFjBF7COWIUsrMGPFPY7GoUhvQuBL0kU19yAhNcYkhMOJFExEpPgDxxHDsEBnVxAuDib8iK4
-        OP+ygh/dhakZS0AhoW+1RbictDxxDdxiX1TDChilsmLuX6y7WDavh0Mr+FdD6IEwxCqMGWtKVwcQ
-        JrjBWxLgbcs6AqXPOujaINRXEPY6stZ3fIemAOF/PQfknaMV/Mdd8Iw+QsrRLMy3Mfml/yHEH/GV
-        chh4NgYkiyTS8W3F91lbYfTvk/xSe3mjshGpywnphD4Wpw6DQX1NwSX+Y3baaLomES7QWbOYFtni
-        GW0+KLVlQhnAqKIA36+rf4IOkyYEtL0h3Rnkg9ukrb8h5zGHMof1Oof1lnWdc+viELjgb3bS2Ub7
-        NjWHAX3O/rN3LbTXWVmxFoc2LOhWLGO7YtKFMclHDuRI8KsLdPI4SC9wMUWBKdfXBu8jchjbYBST
-        i/iOPUc6S0Lbefn2BNZZhFaQPKVUGD1hwwU9eGyFtiFd+Y9v3KYSThxMw6JZKAXGRDiY4QXYVmU+
-        VKpyGLhfDAl90JpWz1ls3bH7zjrZ7VlLbTHBsGhWU5/670kbHAtteDEUU/3dorR+4IeDHKANPVMm
-        Ze+FvOYjNcY5zkRMbxUY/YKwrspEvHLzVMaIrJopiWPglU1Vcqx8frj8p9hSFgXEB8fGyIm5Pj7v
-        sWPmrMAZ3NO7H1KOKrZGZns1bxZueC4jZvEZvvHyBNt5Dxn++vVuppM3Y1Ubjn85VzUPYrMt4nj7
-        uK/W22IvdrXa7+ri/VzVYgjiiLOp6i/m2LjJAKOl/z9yjVPmO+0Ka10aaviOX35dbBp37LyrP9gZ
-        Jb/9AKUpOu9MvFyEoAMJS+kwH4yHsk54YQya5ZxLvk8jeefxrF0fDuPUf4hYT3Nw513b0UEKecLD
-        C17ne7f5dBrosWmcpwSy0n07ADGbW7M0u6O6TfpBNEjXg1ZoSTcaF1N/QH/WEg+kxy+FRvQmIZwF
-        ch7n6RC2HXpBfVxer4phNSI5xMijnrj9P2MwnpsLMDujr13QdJ2lNMWdED05LRMFPbls2rgRmpHr
-        DjOai2mxm8foeyujSGKWOojajJ9TfZTrlIC2i6+Z7SZ/vz77RJrSjCSqm2GxSPXtR1K1Kz/a+cjx
-        JIS59dJ7fIVm21U1wdiHJeMtklCCBN/w9e7rnwAAAP//AwBuVIP44Q4AAA==
-    headers:
-      CF-RAY:
-      - 99022ce6be9bba16-SEA
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json
-      Date:
-      - Fri, 17 Oct 2025 19:24:37 GMT
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      alt-svc:
-      - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
-      openai-organization:
-      - sotai-i3ryiz
-      openai-processing-ms:
-      - '19124'
-      openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
-      openai-version:
-      - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '19128'
-      x-request-id:
-      - req_e94fdfe0b9844548a584d816d8f62619
-    status:
-      code: 200
-      message: OK
-- request:
-    body: "{\"input\":[{\"role\":\"user\",\"content\":\"How many primes below 400
-      contain 79 as a substring? Answer ONLY with the number, not sharing which primes
-      they are.\"},{\"id\":\"rs_0cce3b068d5493670068f297e2d0d481969c0a486c14f78ad6\",\"summary\":[{\"text\":\"**Counting
-      primes with substring \\\"79\\\"**\\n\\nI need to find the count of prime numbers
-      below 400 that have the substring \\\"79\\\" in their decimal representation.
-      The substring can appear in 2- or 3-digit numbers. The 2-digit number is just
-      79. For 3-digit numbers, valid forms are 179, 279, and 379 since they include
-      \\\"79\\\" but must be less than 400. The 790-799 range is excluded as they
-      exceed 400. So, I think we only have four numbers to consider.\",\"type\":\"summary_text\"},{\"text\":\"**Checking
-      primes with \u201C79\u201D substring**\\n\\nI\u2019m considering candidates
-      with the substring \\\"79\\\" below 400. So far, these are 79, 179, 279, and
-      379. I noted that \\\"79\\\" can't appear crossing digit boundaries, and the
-      range 790-799 exceeds 400, so those won\u2019t work. Now, I need to determine
-      which of these are prime numbers. \\n\\n79 is known to be prime. After testing
-      179, it\u2019s also prime since it\u2019s not divisible by any primes up to
-      its square root. However, 279 is divisible by 3, so it\u2019s not prime. Next,
-      I\u2019ll check 379.\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing prime
-      count**\\n\\nI\u2019m testing whether 379 is prime by checking divisibility
-      with primes up to 19. It\u2019s not even, the sum of its digits (19) isn\u2019t
-      a multiple of 3, and it\u2019s not divisible by 5, 7, 11, 13, 17, or 19. So,
-      it\u2019s confirmed as prime. \\n\\nFrom my candidates, I find that 79, 179,
-      and 379 are all prime, totaling three primes. I also double-checked for any
-      other numbers containing \\\"79\\\" but none match. So, the answer remains three!\",\"type\":\"summary_text\"},{\"text\":\"**Confirming
-      final count**\\n\\nI checked the number 397, which doesn't contain the substring
-      \\\"79.\\\" The only candidates below 400 with \\\"79\\\" are 79, 179, and 379.
-      While 279 is included, it's not prime. Just to ensure accuracy, I also looked
-      at numbers like 197 that don't contain \\\"79\\\" and confirmed 279 and 297
-      aren't prime. Since 379 is prime and 790-799 are out of range, my final count
-      of primes is indeed three. I\u2019ll conclude with just the number: 3.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0cce3b068d5493670068f297f4a230819685891308a6bd86b0\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"role\":\"user\",\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"}}"
-    headers:
-      accept:
-      - application/json
-      accept-encoding:
-      - gzip, deflate
-      connection:
-      - keep-alive
-      content-length:
-      - '2653'
-      content-type:
-      - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -180,21 +40,40 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUy27jMAy85ysMXfbSFooTP5I/2G8oCoOW6FRbPQyJChoU+feF5cSPbbq3hEOO
-        yRlSX5ssY0qyY8Y8hr7hQuCu5WUti/1hV1acl3WXH6qugELu6+2hbPf1lpdlVVa5rMW+YE8DhWv/
-        oKA7jbMBx7jwCISygQHbViWv8gOvqoQFAophqBHO9BoJ5VjUgvg4eRft0FcHOuAYVlore2LH7GuT
-        ZVnGerigH+olnlG7Hj3bZNk1JaP3bsBs1DoFlL1/pZFIoHRYo4F8FKScXcUNfDYuUh+pIfeB30Fy
-        TjcC9JrOOIl66OzU03PxnPO8eOb1M69uaiVGdsxe0yDjOLMR4Wcbyl0FfLABthKxE1h0bZuXVZuI
-        EwldehyNgODsINgEhWgM+Mvw4bcUuz49asCE0386qHg3LkKXl4UUhzavD9tdLb93YDAEOOHi+z84
-        nkDhLKGdVVk2tqK9+4GfNFWnBLDWEdw9fH1bgdqdeu/aB0giOmbsdyad/UWZR4OmRf/Cpqzr7ddU
-        yLzTqRkIQQUCS2PykJiSWA8etEa93hDycVzm3uNZuRia+700Sftpg3rvTE+NAPGOzQdeltjs7HQK
-        2HXOpymMssqAvimzsHwon84jQId0aZRES6pTuDqVgP6sBDak7ufVQdSj2CyQ87ichND06IFiCm9f
-        +C2aRL211zlvYP6/MDPlLXeRndG3Lii6jCskVTTzWY9ivjslRvUjOTYBs7eMXN8sHOdTsF/26KMV
-        aV/SlCpAq+9vUEybOw2g7OoJKPOn7/HFuzKNmfyTcyFfjfrvy7Llj4BHvNMK/ERNjkDPYJVPEsaw
-        dtsggQSCgf66uf4FAAD//wMArr7tjRIGAAA=
+        H4sIAAAAAAAAAwAAAP//rFdBj+O2Dr7PryBymb6tJ7Ankziea4EFBijepUUv3SKQbTrRjiy5EpWM
+        W+x/LyjZjpPJtgW6l0FGNCny40eK/PMOYCHrxTMsLLpul4ptsS62ZYXNap1tmjTdbJttum6aMhXp
+        NivSIt0U62q9qjZFU1arYpGwCVN+xopGM0Y7jOeVRUFY7wTLsnyTpdun4jEPMkeCvGOdyrSdQsI6
+        KpWiet1b4zX71QjlMB5LpaTeL57hzzsAgEUnerSsX+MRlenQLu4AvoSP0VrDMu2VCgdSj7fsaiQh
+        lbuUOrK+Imn0xXkr3nbGU+dpR+YV3wvJGLWrhLo015oaFXu27+hh/fCYPq4f0u1Dmg9oBYuLZ/g1
+        BBLDOSfCfS0NmzRd1bjlNGw3WfaUi6Z8KnPcFlkwHIxQ32FMhHBGM2CTyPm2FbafLp5ffqE7fLgj
+        fKNJPX7BJ8+w+PDhB+M1Sb2HzsoWQfu2ROvgJOkAzpeOLAvz4sOHT/qTfgGNWAMZqFgP6IBXigqd
+        AzoIDU9pyj8IKqNJSA33eXEPwoE4G17CR2kdJfByrxQoY15BENDJPNRyLynadgkIXUd1SQ5VA797
+        oWQjWeRMuOXegdG4hI/GAh0s4pWFoH0yXtVTCCWC1CGEhp3gayEouQSUfEXIizc4HdAivIFkv4M0
+        gdJTjCzY05/8Y5oVBHt5RPAOjkLJegLESV2xqZSvzIsChEUQSoEozREZpSX8ZBJo+wHTk1QKjFY9
+        SF0pX2PwPYFWvHIqJHGgwyUhuuViSu2X5L8z4qVGTbLpJ1J8nQ0x8hYaufdBYjzB6SCrw0UORii8
+        rtEGXlRC/z0tfj5gxOAkesZeNkP+XSDIAQF1PSU/QO8Y+4mGnL8sLxJ45D/Mn1X4oYzeO1ljsHFF
+        NMiLJbyARaHkH1jDC/t5T+AdQieI0OrB8n0OTCeGRcAfaA0zqUQ6IeqEg2HrZ8Ba74jpxiHLvTfe
+        LWEATymosZFaEqr+uqociNYEwJNbwaB2EfYXcCSrV2YY61bGWqxohue3ZcjP6ELLaIwdgKuErmUt
+        CN0VM6oDVoG25y9mNGADAw34mxtMSAY6KRSc4RYj6DcBmeWOYej5zrE2SwRt9IOoP4sKNQ1V+c9Z
+        4mD+j2/coaa+QehCjmSMXihJPd/dSF1DXjBHY12GZhTcfIlAQC2P0slSskqMZMiz79iyJAfud88d
+        whpDIbDKDF1Aco+LcAvHbUA6JudgUiGUPQjdg2mADsbhksFhZ/jFNE4SQu0xNj4O90JxtYQfhSPV
+        J4FMwtI5dau8mFIdggUy5htT6he0s5YTbzHNv+CVbIJ/I+YcCw30ZDTngMeu4nzLlmOjh+9W3+ff
+        F/9j/awYyRaBFdB6RbJTyN+vQrORFB1woA29Q3AkSsy12AueR4YMP/+d7jqBPIEsSyBbMbETYOIU
+        wWGLjbGYhChHhg70+slAIyzfeBBHjC13um4qkVl11MaXCh+if5xS5sutTn1dlGVwgo8baVs+Dm03
+        8Gxe2sxcqWsuFCVbSbFgPvtYMG7w8Rtz56PUXPTRKxx6qGkuB5Mr/pyMDfQJk0wIil96OiBPD/zi
+        h1da96BxL4gf9hGasec5KFGZE/ex0PHHhm2HhyuUnDziciJEkd9seDxNSILaoBvbVdAZ3ApAh0QO
+        5IztwA3dkoaLjHbw+LCa0j1PRZwVzmli80I5A8dQdWMusQ9KpZnaUjLcFh/9YfiKTTE4yA+pBRNh
+        m97SEamIzzYNLiHzQQtCyIo8nDwW+bkN91CbqVnPJ4MlvOjze/8Coo3I8JAyOT7kC99ERaq/KIRr
+        uG8UxoyNw6/f7mbcvJrrW7f/6mCfbTeb9VMY7KtqVeY1btMs326y/P1g36JzYo+zsf4ri1QQchSo
+        6Z9n/nHNeVcvQmtDYlyNfv3tQqjMvrOmvCEZy2x1A6XJO2tUuFw4Jx0JTfFj/jB8tOiEFUqhuly0
+        yPq4E3YWj9J4txvXzl3AelrEOmvajnaVqA64e8V+LjsvSNNGiU1jLEWQa+nbAYjZ4rSIyyPW51XT
+        iQap38k4/Uq8WDsd2qOscEdyXFUb4VVEeOHIWJyHQ9h2aAX5cJwt0+E0IDn42BjbivP/swyG7+YE
+        XBzRllzk/Sykye+I6MHIKqbAk1lMgnNCF2S63SzN6XTYzX20XleBJCFK6USpxn3eB7pOAUh9sU6v
+        HpP357MdfQozJLE+K6YXoV5v6dlTXtwS3bI8MeFC/fHCPhkSaiZfZ9mEpHeXSW+RRC1I8B1f7r78
+        BQAA//8DAM3LnBBlEQAA
     headers:
       CF-RAY:
-      - 99022d5efa36ba16-SEA
+      - 99241d1db99f7696-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -202,7 +81,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:24:38 GMT
+      - Tue, 21 Oct 2025 22:15:52 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -218,15 +97,142 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1110'
+      - '25034'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1113'
+      - '25038'
       x-request-id:
-      - req_20ae74b16b49456489c2d384478931c7
+      - req_49fb33691faf44a3ad80db19685a8aa0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: "{\"input\":[{\"content\":[{\"text\":\"How many primes below 400 contain
+      79 as a substring? Answer ONLY with the number, not sharing which primes they
+      are.\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"},{\"id\":\"rs_0a89598bcef3516f0068f806003de88190861147afb4b7e891\",\"summary\":[{\"text\":\"**Counting
+      prime numbers with substring 79**\\n\\nI need to count the prime numbers less
+      than 400 that contain '79' as a substring. First, I'll look at two-digit primes,
+      and '79' itself qualifies, so that's one. For three-digit primes, '79' would
+      need to be in the first two digits, like 79x where x is a digit, but that wouldn\u2019t
+      give us valid numbers since 790 to 799 are all above 400. So, my count will
+      only include '79', making it one valid prime.\",\"type\":\"summary_text\"},{\"text\":\"**Identifying
+      primes with substring 79**\\n\\nI\u2019m figuring out which three-digit numbers
+      under 400 can contain '79' as a substring. The only way is if '79' is at the
+      end, so that gives us numbers like 179, 279, and 379, alongside the two-digit
+      prime 79. I realized I can't use patterns like '7 9' with a zero in between,
+      as the substring must be contiguous. I\u2019ll definitely count the primes among
+      79, 179, 279, and 379, ensuring I stick to the correct substring.\",\"type\":\"summary_text\"},{\"text\":\"**Testing
+      for prime candidates**\\n\\nI\u2019m checking candidates under 400 for containing
+      '79' as a substring, which leaves me with 79, 179, 279, and 379. I realize they
+      can\u2019t be non-adjacent since the substring must be contiguous. \\n\\nNext,
+      I need to test their primality. I find 79 is prime. For 179, I check divisibility
+      with primes up to its square root and conclude it's prime as it isn't divisible
+      by any of those. 279 is composite due to being divisible by 3. Lastly, I start
+      checking 379 for primality too.\",\"type\":\"summary_text\"},{\"text\":\"**Verifying
+      primality of candidates**\\n\\nI\u2019m checking if 379 is prime by testing
+      its divisibility. The sum of digits (3+7+9) is 19, which isn't a multiple of
+      3, so it\u2019s not divisible by 3. Next, I check against primes: it\u2019s
+      not divisible by 5, 7, 11, 13, 17, or 19. Therefore, 379 must be prime. So far,
+      I have three primes: 79, 179, and 379. I double-check for any three-digit numbers
+      containing '79' before confirming that those candidates are indeed limited to
+      just these three.\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing the
+      count of prime numbers**\\n\\nI\u2019m working to confirm whether there are
+      any negative numbers or primes below 400, as primes are only positive. I check
+      97 for containing '79' but it doesn\u2019t. I confirm that 179, which includes
+      '79' at positions 2-3, and 379 are indeed valid candidates. I also verify that
+      they are both primes, including 79 itself. \\n\\nI consider other two-digit
+      numbers below 80 and eliminate 197 and 297 since they don\u2019t contain '79'.
+      In the end, I am confident that there are exactly three primes containing '79':
+      79, 179, and 379.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0a89598bcef3516f0068f80618665481908cc3b7de80178617\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":[{\"text\":\"If
+      you remember what the primes were, then share them, or say 'I don't remember.'\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"}}"
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '3357'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//fFTLbuMwDLznKwxd9tIWspM4dv5gv6EoDFqmU231gkQFDYr8+8Jy4sc2
+        3VvCIcdDDqmvTZYx2bFjxjwG13Co6n1dtQL77T4ve87Lqq94mdd53e+qvOZVDd2OQ9ly3HHRFuxp
+        oLDtHxR0p7Em4BgXHoGwa2DA8kOZ82pX77cJCwQUw1AjrHYKCbuxqAXxcfI2mkFXDyrgGJZKSXNi
+        x+xrk2VZxhxc0A/1HZ5RWYeebbLsmpLReztgJiqVAtLcv9J0SCBVWKOBfBQkrVnFNXw2NpKL1JD9
+        wO8gWasaAWpNp22HalB2cvS8fy54sX/m1TM/3KaVGNkxe02NjO3MRoSfbYBDmScbgNc17Lq8g7Lo
+        cFsm4kRCF4ejERCsGQY2QSFqDf4yfPgtxa5PjwTocPqPgrrqRVJQ1DXPD9UWi77q8/q7Ao0hwAkX
+        3//B8QQKawjNPJWlsBXt3Q/8pKk6JYAxluDu4evbClT25LxtHyCJ6Jix31lnzS/KPGrULfoXNmVd
+        b7+mQuatSmIgBBkIDI3JQ2JKYg48KIVqvSHk47jMzuNZ2hia+700afbTBjlvtaNGgHjH5gMvS2x2
+        djoF7HvrUxdaGqlB3SazsHwon84jQI90aWSHhmQvcXUqAf1ZCmxI3s+rh6jGYbNA1uOyE0Lt0APF
+        FM5f+C2ahnqT11uvYf6/MDPlLXeRndG3Nki6jCvUyajnsx6H+W6lGKcfybIJmL1lZF2zcJxPQbfU
+        6KMRaV9SlzJAq+5vUEybOzUgzeoJKIun7/HFuzK1mfzr5kK+avXflyXnj4BHvNMK/ERNlkDN4KGY
+        RhjD2m2NBB0QDPTXzfUvAAAA//8DAIqnjd0SBgAA
+    headers:
+      CF-RAY:
+      - 99241dbb6ec57696-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 21 Oct 2025 22:15:55 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2052'
+      openai-project:
+      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2062'
+      x-request-id:
+      - req_a0a2bcfd74594fe188c35995f1d40a99
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"How many primes below 400 contain 79
-      as a substring? Answer ONLY with the number, not sharing which primes they are."}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"},"stream":true}'
+    body: '{"input":[{"content":[{"text":"How many primes below 400 contain 79 as
+      a substring? Answer ONLY with the number, not sharing which primes they are.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -10,12 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '235'
+      - '283'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -42,917 +39,1109 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_02f178f89a7dc2940068f2980a7be48193beb3dee9555272dd\",\"object\":\"response\",\"created_at\":1760729098,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_02f178f89a7dc2940068f2980a7be48193beb3dee9555272dd\",\"object\":\"response\",\"created_at\":1760729098,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Counting\",\"obfuscation\":\"3wO4uJ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        primes\",\"obfuscation\":\"zHYBcs9ay\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        with\",\"obfuscation\":\"tcJz74RAGSE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"xJqveGjbFnGpVt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"sYzvrJveIh2774\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"xMTxqEMllDC1gqQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"3GTlBsXGW9N\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        need\",\"obfuscation\":\"0UD4vPpUJhc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        to\",\"obfuscation\":\"VfgxQELiWgmGP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        find\",\"obfuscation\":\"WpM86phVFfn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        primes\",\"obfuscation\":\"RM17hmOmv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        under\",\"obfuscation\":\"VtjV8EbM8W\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"Vqst0aTCk5k8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        that\",\"obfuscation\":\"75FC6dGckjb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        contain\",\"obfuscation\":\"KawSTHDb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"EttPU7qFjn4Q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        substring\",\"obfuscation\":\"ZqrTbN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"dGkzGacduHWapn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"K5dqkzjaQ5hTjw\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\".\",\"obfuscation\":\"Z19H3Nnjtwy7ie\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        First\",\"obfuscation\":\"7QFH5c8J2G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"lp3c11tBaEQ2LM0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"IqFEDcxvkbOhnY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        think\",\"obfuscation\":\"0KcvK2Ju2v\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        of\",\"obfuscation\":\"Ye7c5sCpzbuOG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"clkL6aaHRBmPf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        itself\",\"obfuscation\":\"gWDI1tGAZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"oyCpdovVRS88qFl\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        then\",\"obfuscation\":\"0EDDmaX1m1x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        179\",\"obfuscation\":\"s20eGtPzn9uU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"t2vYfxVziCBgTp1\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        and\",\"obfuscation\":\"OD0tPxEBcYXr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        check\",\"obfuscation\":\"KmhSfuJ9OT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        if\",\"obfuscation\":\"rYKhzMY87HYmf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        197\",\"obfuscation\":\"afzapsmCmjTZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        doesn\",\"obfuscation\":\"DpDnrooeF2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019t\",\"obfuscation\":\"a1hSwLEFLm9rrs\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        count\",\"obfuscation\":\"l6ZtCEPW0q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        since\",\"obfuscation\":\"mV3BNnOMag\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        it\",\"obfuscation\":\"YrkmCNPFKcsxO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        has\",\"obfuscation\":\"ijFMTbQogpG0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"enbOeiJkAjzGE2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"97\",\"obfuscation\":\"CcyCtdQuG0f8ZZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\".\",\"obfuscation\":\"9lrLvqFUNaY4sF\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"gbYueK4gxijdVi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        realize\",\"obfuscation\":\"tfYuE8cS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        279\",\"obfuscation\":\"XmTFbL9xrcZt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        isn't\",\"obfuscation\":\"Wus9l2odlM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"3iam9kRcQ2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"qU3yEeXIUXWzijW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        and\",\"obfuscation\":\"zrknJyev945m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        379\",\"obfuscation\":\"cn8H5DSs39cK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        seems\",\"obfuscation\":\"d0OdFj17v1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        to\",\"obfuscation\":\"oeH4tjRXOWvy4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        be\",\"obfuscation\":\"8F8dEpvpvhTqJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"icu0SShjc0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"8NDQXb7Z7Nozkf8\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        However\",\"obfuscation\":\"534VFmQg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"RbW8zhK4wr6j23p\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        479\",\"obfuscation\":\"JNmiHXPraZ2V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        and\",\"obfuscation\":\"WCpQhSe5lhUz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        any\",\"obfuscation\":\"8hDgwttVaSoh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        number\",\"obfuscation\":\"0qa5L2FEW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        in\",\"obfuscation\":\"BqCr1bDJuRsOA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"piKs4z8UdKEw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        790\",\"obfuscation\":\"lXLpXF8QYSpo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"s\",\"obfuscation\":\"kLiMf5jTI9IrOuq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        are\",\"obfuscation\":\"xCeORZGeha2C\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        greater\",\"obfuscation\":\"ntPGjunn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        than\",\"obfuscation\":\"VAhpK5RlMEu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"KEky7Q8A6TSO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"4UFXwVZLp4bQE1z\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        Therefore\",\"obfuscation\":\"of1Exk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"kXa7oSTOw7jjhqh\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"bhq0FrqMlnlz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        only\",\"obfuscation\":\"2gafxg1tcAg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"Mm7UqG9qow\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        under\",\"obfuscation\":\"DMqgEzgEWP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        100\",\"obfuscation\":\"S768ecDirAH2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        containing\",\"obfuscation\":\"RrIbR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"d9zxCFVJiYhtSf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"R1pc7BLqGtQguS\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"eKQTyIoINtYntCw\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        is\",\"obfuscation\":\"4zFHAp57zzNSh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        just\",\"obfuscation\":\"A9PP1f08OUJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"Ht11MdnFOoEeg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"QWwlTfRh4Z7ypk0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        It's\",\"obfuscation\":\"FuZJ5rC0gqK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        quite\",\"obfuscation\":\"1paws8JmEr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        a\",\"obfuscation\":\"xllIS1EohBkn1C\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        specific\",\"obfuscation\":\"0WM9WWt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        search\",\"obfuscation\":\"gMj08zQRD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"!\",\"obfuscation\":\"vd2TYIVeCjQ3Yf2\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":97,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Counting
-        primes with \\\"79\\\"**\\n\\nI need to find primes under 400 that contain
-        the substring \\\"79\\\". First, I think of 79 itself, then 179, and check
-        if 197 doesn\u2019t count since it has \\\"97\\\". I realize 279 isn't prime,
-        and 379 seems to be prime. However, 479 and any number in the 790s are greater
-        than 400. Therefore, the only prime under 100 containing \\\"79\\\" is just
-        79. It's quite a specific search!\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":98,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
-        primes with \\\"79\\\"**\\n\\nI need to find primes under 400 that contain
-        the substring \\\"79\\\". First, I think of 79 itself, then 179, and check
-        if 197 doesn\u2019t count since it has \\\"97\\\". I realize 279 isn't prime,
-        and 379 seems to be prime. However, 479 and any number in the 790s are greater
-        than 400. Therefore, the only prime under 100 containing \\\"79\\\" is just
-        79. It's quite a specific search!\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
-        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":99,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Finding\",\"obfuscation\":\"SfzjVRS\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primes\",\"obfuscation\":\"hQzkSPpMA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        with\",\"obfuscation\":\"N8UpLvzRBCh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\\"\",\"obfuscation\":\"1OORGF7fdVogbh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":104,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"XCKogl0D4HHmPx\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":105,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"z5wESViZxODQPtj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":106,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"eHUpJxoSzj6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":107,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019m\",\"obfuscation\":\"P0yejnyBBCgUH2\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        examining\",\"obfuscation\":\"FTi4GK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"6Kz6IsIb9qkY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":110,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        numbers\",\"obfuscation\":\"5k805vOv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":111,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        between\",\"obfuscation\":\"xgnr9OtK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":112,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        100\",\"obfuscation\":\"SRxtCF02xI61\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":113,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"ohtnEBeOnQQu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        199\",\"obfuscation\":\"Dld97B851e5S\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"GxQmRtLBCEdlZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        see\",\"obfuscation\":\"r0QhD9bNytIM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        which\",\"obfuscation\":\"sllrK2Dp04\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        contain\",\"obfuscation\":\"NWL5zW4J\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\\"\",\"obfuscation\":\"NXuIe7yhncKfef\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"96lxqocZfNFR0b\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\\\"\",\"obfuscation\":\"IZV4HpQCnsgszx\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":122,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"l5cFFjQhe4ds\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":123,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"J5QrsyGXG0YiZy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":124,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        find\",\"obfuscation\":\"ibn4OEO300F\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        that\",\"obfuscation\":\"ovJotI3aAPf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":126,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        only\",\"obfuscation\":\"54eDBXrttr9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":127,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"JuQ4x1COZkdt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":128,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        fits\",\"obfuscation\":\"MUdFfp0ZTac\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        because\",\"obfuscation\":\"s15eB6sH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it's\",\"obfuscation\":\"mtwcWmTFwZj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"clIChniWjEHj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        only\",\"obfuscation\":\"q0o0kr0YjTh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        one\",\"obfuscation\":\"K0F0Nec5IFNo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        with\",\"obfuscation\":\"wNukg4HWXb0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\\"\",\"obfuscation\":\"TJTzGXjwFPVkIw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"2zQb46KOGOtEQa\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"lw24LNgCC5cJx14\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        in\",\"obfuscation\":\"5VT8pzAspZac6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"WLvfdRlqkHr8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        last\",\"obfuscation\":\"nCOu7GQzjkj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        digits\",\"obfuscation\":\"pSP4VJ3Vn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"21l0QfWKCYGUfED\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I'll\",\"obfuscation\":\"h5zfEdiD4Zm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        confirm\",\"obfuscation\":\"mTCWzuou\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        that\",\"obfuscation\":\"6z4PCBNMfqV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"8wxNivGdQtNA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"RE4Dii39Jy0Z0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"Q79kfRp4Td\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \u2014\",\"obfuscation\":\"Nb5x9N0CSZ9Whz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"sIKu0ysts52M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"ftCVafRVw6yzY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"Z5D2ShoQpTdrm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"!\",\"obfuscation\":\"Mq2T847XuKviHaK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\n\\nNext\",\"obfuscation\":\"6Z2lkE7VGA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"21mXgoZ363ilAyD\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        looking\",\"obfuscation\":\"FLWVus6n\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        in\",\"obfuscation\":\"VHnZQA9ZVbQyl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"FZQiSGgbH6yi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        range\",\"obfuscation\":\"8F6mmcg4H4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        of\",\"obfuscation\":\"RGIy5WZHC3tC4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        200\",\"obfuscation\":\"d2WHXNqFXCkT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"idKCebXcIt5k1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        299\",\"obfuscation\":\"TUWS1I8Et4aq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"fC7HYT06VT0FdS0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"r20UN9MpNxqB57\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        see\",\"obfuscation\":\"NUGQ88HUsP2g\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        that\",\"obfuscation\":\"NM1SdEdMY54\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"sOesM1YrAbHl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"w4oS1zFr2eDCV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        composite\",\"obfuscation\":\"7M8brg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"sU21aqj5oAlSrYW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        as\",\"obfuscation\":\"I3L9rACCLxvyh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"6mGmrMihNqxVR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"wQ0oGsmYI0y9mJ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        divisible\",\"obfuscation\":\"MkkloB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        by\",\"obfuscation\":\"aE0aiSkfTRPw0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        3\",\"obfuscation\":\"cv17Hkys4EcYhe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"A3FPsCe50KXlshi\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        In\",\"obfuscation\":\"4JAUPXrgsZIJH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        this\",\"obfuscation\":\"Y887UmaWPTo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        range\",\"obfuscation\":\"l8Llb0kHxt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"icaUJ44OLEKZcMP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        there\",\"obfuscation\":\"L5yK7vz8S3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        are\",\"obfuscation\":\"oPOj9gLjiHKo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        no\",\"obfuscation\":\"IdIsfNxeFSX46\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        additional\",\"obfuscation\":\"Zz5pZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        candidates\",\"obfuscation\":\"G0hEu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"HhNQ5PzutlCaS9d\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        Lastly\",\"obfuscation\":\"imRhdDYbR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"fvYiPHkBrreMRWY\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        for\",\"obfuscation\":\"r8AGxRh01T7e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        300\",\"obfuscation\":\"MsttM58yMoOP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"VVsNrotpQGrzS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        399\",\"obfuscation\":\"GKPyW4cWzDXQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"KDzNRfaG6i4wsdo\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"hvRGbbsB8NkLQ5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        found\",\"obfuscation\":\"liD1kwHxRS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"bvaPLmUX2V0s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"p1DuvoCAXn4T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        confirmed\",\"obfuscation\":\"PJQUVQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"PLk4L3HIE0pcr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"KVjgI6Myi85Aw0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"WMy1NfUiF5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        too\",\"obfuscation\":\"rpLVSLGFbMHH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":205,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"tr1uzIMLGk6hUrq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":206,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        So\",\"obfuscation\":\"tuyB9uppicZam\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":207,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"BVYKGtcJQgrsSb5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"Z6ZpF5PUbxuN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"XHSMqgMQv9iY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"1cOAtgCNfYTh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        are\",\"obfuscation\":\"VKZQLT9qeLBL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        our\",\"obfuscation\":\"wcgLImUKb8fU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primes\",\"obfuscation\":\"Fqvz7bCx6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"!\",\"obfuscation\":\"7FBbAF8xISk519U\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":215,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Finding
-        primes with \\\"79\\\"**\\n\\nI\u2019m examining the numbers between 100 and
-        199 to see which contain \\\"79,\\\" and I find that only 179 fits because
-        it's the only one with \\\"79\\\" in the last digits. I'll confirm that 179
-        is prime \u2014 and it is!\\n\\nNext, looking in the range of 200 to 299,
-        I see that 279 is composite, as it\u2019s divisible by 3. In this range, there
-        are no additional candidates. Lastly, for 300 to 399, I found 379 and confirmed
-        it\u2019s prime too. So, 179 and 379 are our primes!\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":216,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Finding
-        primes with \\\"79\\\"**\\n\\nI\u2019m examining the numbers between 100 and
-        199 to see which contain \\\"79,\\\" and I find that only 179 fits because
-        it's the only one with \\\"79\\\" in the last digits. I'll confirm that 179
-        is prime \u2014 and it is!\\n\\nNext, looking in the range of 200 to 299,
-        I see that 279 is composite, as it\u2019s divisible by 3. In this range, there
-        are no additional candidates. Lastly, for 300 to 399, I found 379 and confirmed
-        it\u2019s prime too. So, 179 and 379 are our primes!\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
-        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":217,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Confirm\",\"obfuscation\":\"3yBwJMF\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ing\",\"obfuscation\":\"tuKxNe7dvIQxd\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"GLvXbuxyf1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        counts\",\"obfuscation\":\"tlOWibX4Z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        with\",\"obfuscation\":\"K7En5mZklQn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":223,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"5YsRzkW8M7oi2U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":224,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"Q4SOcreL9Dbld3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":225,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\"\",\"obfuscation\":\"G3zmswVjDhsLLs9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":226,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"A0b6EfjhaeN\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":227,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019m\",\"obfuscation\":\"ODePZyFxTM9M1e\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":228,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        considering\",\"obfuscation\":\"wH7x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":229,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"uuo3p0nE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":230,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        like\",\"obfuscation\":\"IN1CIVDqJN0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":231,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        790\",\"obfuscation\":\"9PUYVlCY19Zd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":232,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"kXRYHRNL0IK3I5Z\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":233,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        which\",\"obfuscation\":\"hDat2TXWsv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":234,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"jHzRT5OYTMYUQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        over\",\"obfuscation\":\"xMsYCWoQi1f\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"4TLBg1XR2eA6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"GPFSIFixB2eWXLZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"kI4MqBBUaS9OE0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        check\",\"obfuscation\":\"wlnGTGaL24\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        other\",\"obfuscation\":\"vQoKST0Vb4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"aMVEPfRrV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        like\",\"obfuscation\":\"E5I2eEBkL3E\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        97\",\"obfuscation\":\"YZ93OMg3ugoPG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"guImctA6dAzzpMQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        197\",\"obfuscation\":\"nLr7MV7lTODz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"rQAfeaU3GWHBNuj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        297\",\"obfuscation\":\"C1Nz8xcWKNQg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"YhR9fI2IBRhS5Dk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"8sM9tDmzyhOS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        397\",\"obfuscation\":\"Ftm8pCp8OXR2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"oKdZVQkaFI35oUC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        but\",\"obfuscation\":\"7NgFdgyb7M3G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        they\",\"obfuscation\":\"TogCObUXMZl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        don\",\"obfuscation\":\"4e0KsDawpNG2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019t\",\"obfuscation\":\"AonzuVlzAZG2rN\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        contain\",\"obfuscation\":\"QS1BsbgA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"1o9CpEys095YXM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"y1f1KXS1u6bcVC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\\\"\",\"obfuscation\":\"32Pl72CStdcOUz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        The\",\"obfuscation\":\"FkVBQB719pSr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        only\",\"obfuscation\":\"uO2RNbcjpcA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"crEHdFDhl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        that\",\"obfuscation\":\"uGizsW9JbG1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        do\",\"obfuscation\":\"kYTxFZrDf51ir\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":265,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"NA16yUIIg73B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":266,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"OJ1F8AaiYFKjO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":267,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"fnhHmHPTo1qu9A4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"fTSCrBf6bswX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"euvWHou5AFU5pk5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"26mCTR7rMioE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"CTG62wcehFTs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"bldvts9efWe5Eau\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"lx2keGrBpPtWpR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        realize\",\"obfuscation\":\"xqhWma4u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        that\",\"obfuscation\":\"Rd3xCnZTgm2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        only\",\"obfuscation\":\"DSpJuDmEtIU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        two\",\"obfuscation\":\"Zcfqu1u8E2ZE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"9mNkJT4YOE\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"zJu8MY3vu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"5TbNqJxSBO3N\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        relevant\",\"obfuscation\":\"6g2Ey6i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"DvnvNNZqhm0Sq3r\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        as\",\"obfuscation\":\"O86pTAO3PG7Eq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"OKuHzC9k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        like\",\"obfuscation\":\"Zl3RTKLdaUB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        790\",\"obfuscation\":\"IOxBVApNLqah\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-\",\"obfuscation\":\"OxUp22yW10wfFIv\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"799\",\"obfuscation\":\"n11hg4ouJ07Jg\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        exceed\",\"obfuscation\":\"WxqtrciL8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"u3NkdYfEKlXQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"XiZhGFstzMVEYq7\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\n\\nI\",\"obfuscation\":\"E7HQssqIVux11\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019ve\",\"obfuscation\":\"CzKJKij5Q8Rac\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        confirmed\",\"obfuscation\":\"v8zygx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        that\",\"obfuscation\":\"0IBqnfi9rIn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        279\",\"obfuscation\":\"uHj4ZV25RBJF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        isn\",\"obfuscation\":\"9AJsLFdlt25t\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019t\",\"obfuscation\":\"Mm7fe5vgHRyVrM\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"BlefainG5a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"Yq7wu0KmoIgaJCe\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        but\",\"obfuscation\":\"MPeZX5fPBdBQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"lBH2s1MliUUS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"LkGMjCCdhdeg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"KuLLXU50ySwx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"RXozpDPUvXp1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"9T5zOB7hcoavd6n\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        It\",\"obfuscation\":\"LOU0OJVkMpA8e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        seems\",\"obfuscation\":\"4uENbTKVyY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        the\",\"obfuscation\":\"FlPOjFE0Smzp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        total\",\"obfuscation\":\"CxC7XzEYio\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        count\",\"obfuscation\":\"vmlA0PfRwH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        of\",\"obfuscation\":\"B0quQ5sUzc51z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"P8PA272fv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        with\",\"obfuscation\":\"qKktww0c0QB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"CYUAsQZwmDxiDB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"pGVvAEmuXtv9UQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\"\",\"obfuscation\":\"F3j0Lhn7TQclek0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"2tcmUboTZFTl9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        three\",\"obfuscation\":\"EmA91JkTOa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"XrDGI5hkUdhjqA6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"VTyfIGpIwgZRpY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        wonder\",\"obfuscation\":\"IG1Lhq7ZJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        if\",\"obfuscation\":\"Ks69DKZ9ROB1j\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":324,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        there\",\"obfuscation\":\"OTdzFJsIQH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":325,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"Y7Aw6xEtx1Gx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":326,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        any\",\"obfuscation\":\"zvZuxlshEhPx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":327,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        other\",\"obfuscation\":\"DmTD04v0ph\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":328,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"h62mPlTH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":329,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"2eM5KLHQsDmocd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":330,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        might\",\"obfuscation\":\"OwDgjfOdqI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":331,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        have\",\"obfuscation\":\"iTiY1Dv5PTN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":332,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        missed\",\"obfuscation\":\"GPKkw8ela\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":333,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"aftuH1MSFjaooZY\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":334,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        like\",\"obfuscation\":\"jnsjuG0bZgS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":335,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        97\",\"obfuscation\":\"NemKIjsJ5fR6A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":336,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"5u5qR0PUEehDQGW\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":337,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI\u2019m considering numbers like 790,
-        which is over 400. I check other primes like 97, 197, 297, and 397, but they
-        don\u2019t contain \\\"79.\\\" The only primes that do are 79, 179, and 379.
-        I realize that only two-digit primes are relevant, as numbers like 790-799
-        exceed 400.\\n\\nI\u2019ve confirmed that 279 isn\u2019t prime, but 179 and
-        379 are. It seems the total count of primes with \\\"79\\\" is three. I wonder
-        if there are any other numbers I might have missed, like 97.\"}\n\nevent:
-        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":338,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI\u2019m considering numbers like 790,
-        which is over 400. I check other primes like 97, 197, 297, and 397, but they
-        don\u2019t contain \\\"79.\\\" The only primes that do are 79, 179, and 379.
-        I realize that only two-digit primes are relevant, as numbers like 790-799
-        exceed 400.\\n\\nI\u2019ve confirmed that 279 isn\u2019t prime, but 179 and
-        379 are. It seems the total count of primes with \\\"79\\\" is three. I wonder
-        if there are any other numbers I might have missed, like 97.\"}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":339,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":340,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**Confirm\",\"obfuscation\":\"LLbI7Z3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":341,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"ing\",\"obfuscation\":\"jpc0BUba0cYaI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":342,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"G9SH4RuuV1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":343,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        counts\",\"obfuscation\":\"konPMRZ04\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":344,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        with\",\"obfuscation\":\"AvcXpjLHYMu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":345,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"nlCt9kEFMOinoo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":346,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"78o2tj8YWRh0yM\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":347,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"OjeKgPLwwdCJPeB\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":348,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"qvp3qNborAg\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":349,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        realize\",\"obfuscation\":\"NFlRx0wC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":350,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        79\",\"obfuscation\":\"3ZnQhqZumDihs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":351,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        reversed\",\"obfuscation\":\"Pkh1ttF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":352,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        doesn't\",\"obfuscation\":\"Myyr5wTB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":353,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"paOO2V4Cxu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":354,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"EsSMAeMpmzScjLR\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":355,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        so\",\"obfuscation\":\"39JeDGXdhUhUP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":356,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I'm\",\"obfuscation\":\"B6PL0bADrUtO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":357,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        confirming\",\"obfuscation\":\"96BTo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":358,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"ymRXfOwI43Fh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":359,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        three\",\"obfuscation\":\"sR6A2vtaqh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":360,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"CDopIqUpI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":361,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        identified\",\"obfuscation\":\"wmPVf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":362,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\":\",\"obfuscation\":\"fjVq6aCo42r8Unv\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":363,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        79\",\"obfuscation\":\"XITieVKDlXdDJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":364,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"5oAcbBISoKDpH5C\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":365,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        179\",\"obfuscation\":\"KEbgK0W6QKw5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":366,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"0bTjBqnp8JJdtnM\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":367,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"LPlpfqZ06KnE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":368,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"KePvoXQErbsX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":369,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"2ckiNr1vdjw0wpo\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":370,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\n\\nFirst\",\"obfuscation\":\"qWKa9aJb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":371,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"d7aiAnLZKVNcbjt\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":372,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"4MAyiWpWoBtVrl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":373,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        check\",\"obfuscation\":\"AVuf2qofuH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":374,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        79\",\"obfuscation\":\"DGaEmieLMcxqX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":375,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"tip7RgEhELxw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":376,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        confirm\",\"obfuscation\":\"f1W6KKwf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":377,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"1UAQlVNizJnOA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":378,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019s\",\"obfuscation\":\"agQLPyPcZ2bLGd\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":379,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"mJJE10WDBd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":380,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"Oa7tYefUGVrUO5K\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":381,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        For\",\"obfuscation\":\"r9lEyHV4X2qP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":382,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        179\",\"obfuscation\":\"c19Vwwq25tkI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":383,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"5ECcI546zcNLe9j\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":384,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"r6ijbICDRgmWaz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":385,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        find\",\"obfuscation\":\"9MrRPgcoE8z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":386,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"F71F37M2BZu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":387,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"oTn8Kofrpq6gB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":388,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        passes\",\"obfuscation\":\"mO664RxBO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":389,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        checks\",\"obfuscation\":\"Bz6IK3Mp1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":390,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        for\",\"obfuscation\":\"C2a1BGWUdgiy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":391,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"tW7NH6nHU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":392,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        under\",\"obfuscation\":\"O2bO085Vbm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":393,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        its\",\"obfuscation\":\"GbAl9B9vM7n5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":394,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        square\",\"obfuscation\":\"gkVstCerK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":395,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        root\",\"obfuscation\":\"MIOnZDKkqmX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":396,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"wm9YSOeBCgzWKsc\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":397,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        so\",\"obfuscation\":\"WiEKN5vkEnLqC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":398,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"VEo6j36MxNrA6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":399,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019s\",\"obfuscation\":\"19NYhgBJF3KGP9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":400,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        also\",\"obfuscation\":\"l8TBGrC9c9T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":401,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"c3vH5LHYgP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":402,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"Y7N0ht5gAasIMAS\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":403,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        279\",\"obfuscation\":\"t4hPwNSZdaCC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":404,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"H7STfWROrpAfS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":405,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        composite\",\"obfuscation\":\"iEhFJT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":406,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        since\",\"obfuscation\":\"zxu0DIUPD1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":407,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it's\",\"obfuscation\":\"1CRapsssQ34\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":408,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        divisible\",\"obfuscation\":\"iHq16V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":409,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        by\",\"obfuscation\":\"Cx9aqDc8vOMiY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":410,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        3\",\"obfuscation\":\"lWFCdWXgt35cNd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":411,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"5sSTZlpU75qDfPO\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":412,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"n4zYOsaeE3E4rx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":413,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019ve\",\"obfuscation\":\"T8zaAXcY2gkau\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":414,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        previously\",\"obfuscation\":\"6deCM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":415,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        confirmed\",\"obfuscation\":\"d56tOO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":416,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"8nHLRmAglln\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":417,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"paUeV4TgDPBg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":418,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"zG1meDGIH1uQm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":419,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"8zkZOXzSC4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":420,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"mSgIGGIDW35ByG4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":421,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        leaving\",\"obfuscation\":\"0FDlyaIy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":422,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"37zpX92hhixX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":423,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        total\",\"obfuscation\":\"oenqC36Fbn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":424,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"Z4penk1Fm2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":425,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        as\",\"obfuscation\":\"N2IYotWogy6Vi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":426,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        three\",\"obfuscation\":\"HMLiDNctXg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":427,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"L0Wt6ln1BB73To4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":428,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"T1UYZRRqGtCkHP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":429,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        reflect\",\"obfuscation\":\"ffNC2yN7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":430,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        on\",\"obfuscation\":\"0hE7p8Y8Ku1XR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":431,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        whether\",\"obfuscation\":\"DQuw2bHe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":432,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        numbers\",\"obfuscation\":\"iEj2KKaz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":433,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        with\",\"obfuscation\":\"4PSV5kI7Se0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":434,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        leading\",\"obfuscation\":\"KBRFSPOw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":435,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        zeros\",\"obfuscation\":\"jUH0hB0euQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":436,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"BwplkMHUzp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":437,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        but\",\"obfuscation\":\"rQMiXcEvdYqh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":438,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        decide\",\"obfuscation\":\"6tGulzSvp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":439,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        against\",\"obfuscation\":\"wuN4nhEt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":440,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"JFHU7fw579nyx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":441,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"3aMYrUqQDHl2VeK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":442,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\n\\nSo\",\"obfuscation\":\"YKDZabUqxoH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":443,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"x9a9aPItDQEc6UF\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":444,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"HLvxaBtkKOxz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":445,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        answer\",\"obfuscation\":\"CSISST08I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":446,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"FWaQaSagSj1Nz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":447,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        simply\",\"obfuscation\":\"ckpOequSA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":448,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"hElLcWwDHmHH9T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":449,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"3\",\"obfuscation\":\"RSGb2jiSoQd1I2e\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":450,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\\\"\",\"obfuscation\":\"J9h0QiJnXfLhbE\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":451,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI realize 79 reversed doesn't count, so
-        I'm confirming the three primes identified: 79, 179, and 379. \\n\\nFirst,
-        I check 79 and confirm it\u2019s prime. For 179, I find that it passes checks
-        for primes under its square root, so it\u2019s also prime. 279 is composite
-        since it's divisible by 3. I\u2019ve previously confirmed that 379 is prime,
-        leaving the total count as three. I reflect on whether numbers with leading
-        zeros count but decide against it. \\n\\nSo, the answer is simply \\\"3.\\\"\"}\n\nevent:
-        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":452,\"item_id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI realize 79 reversed doesn't count, so
-        I'm confirming the three primes identified: 79, 179, and 379. \\n\\nFirst,
-        I check 79 and confirm it\u2019s prime. For 179, I find that it passes checks
-        for primes under its square root, so it\u2019s also prime. 279 is composite
-        since it's divisible by 3. I\u2019ve previously confirmed that 379 is prime,
-        leaving the total count as three. I reflect on whether numbers with leading
-        zeros count but decide against it. \\n\\nSo, the answer is simply \\\"3.\\\"\"}}\n\nevent:
-        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":453,\"output_index\":0,\"item\":{\"id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
-        primes with \\\"79\\\"**\\n\\nI need to find primes under 400 that contain
-        the substring \\\"79\\\". First, I think of 79 itself, then 179, and check
-        if 197 doesn\u2019t count since it has \\\"97\\\". I realize 279 isn't prime,
-        and 379 seems to be prime. However, 479 and any number in the 790s are greater
-        than 400. Therefore, the only prime under 100 containing \\\"79\\\" is just
-        79. It's quite a specific search!\"},{\"type\":\"summary_text\",\"text\":\"**Finding
-        primes with \\\"79\\\"**\\n\\nI\u2019m examining the numbers between 100 and
-        199 to see which contain \\\"79,\\\" and I find that only 179 fits because
-        it's the only one with \\\"79\\\" in the last digits. I'll confirm that 179
-        is prime \u2014 and it is!\\n\\nNext, looking in the range of 200 to 299,
-        I see that 279 is composite, as it\u2019s divisible by 3. In this range, there
-        are no additional candidates. Lastly, for 300 to 399, I found 379 and confirmed
-        it\u2019s prime too. So, 179 and 379 are our primes!\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI\u2019m considering numbers like 790,
-        which is over 400. I check other primes like 97, 197, 297, and 397, but they
-        don\u2019t contain \\\"79.\\\" The only primes that do are 79, 179, and 379.
-        I realize that only two-digit primes are relevant, as numbers like 790-799
-        exceed 400.\\n\\nI\u2019ve confirmed that 279 isn\u2019t prime, but 179 and
-        379 are. It seems the total count of primes with \\\"79\\\" is three. I wonder
-        if there are any other numbers I might have missed, like 97.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI realize 79 reversed doesn't count, so
-        I'm confirming the three primes identified: 79, 179, and 379. \\n\\nFirst,
-        I check 79 and confirm it\u2019s prime. For 179, I find that it passes checks
-        for primes under its square root, so it\u2019s also prime. 279 is composite
-        since it's divisible by 3. I\u2019ve previously confirmed that 379 is prime,
-        leaving the total count as three. I reflect on whether numbers with leading
-        zeros count but decide against it. \\n\\nSo, the answer is simply \\\"3.\\\"\"}]}}\n\nevent:
-        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":454,\"output_index\":1,\"item\":{\"id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
-        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":455,\"item_id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":456,\"item_id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"yWjtMhGikbAeWwj\"}\n\nevent:
-        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":457,\"item_id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
-        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":458,\"item_id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
-        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":459,\"output_index\":1,\"item\":{\"id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
-        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":460,\"response\":{\"id\":\"resp_02f178f89a7dc2940068f2980a7be48193beb3dee9555272dd\",\"object\":\"response\",\"created_at\":1760729098,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
-        primes with \\\"79\\\"**\\n\\nI need to find primes under 400 that contain
-        the substring \\\"79\\\". First, I think of 79 itself, then 179, and check
-        if 197 doesn\u2019t count since it has \\\"97\\\". I realize 279 isn't prime,
-        and 379 seems to be prime. However, 479 and any number in the 790s are greater
-        than 400. Therefore, the only prime under 100 containing \\\"79\\\" is just
-        79. It's quite a specific search!\"},{\"type\":\"summary_text\",\"text\":\"**Finding
-        primes with \\\"79\\\"**\\n\\nI\u2019m examining the numbers between 100 and
-        199 to see which contain \\\"79,\\\" and I find that only 179 fits because
-        it's the only one with \\\"79\\\" in the last digits. I'll confirm that 179
-        is prime \u2014 and it is!\\n\\nNext, looking in the range of 200 to 299,
-        I see that 279 is composite, as it\u2019s divisible by 3. In this range, there
-        are no additional candidates. Lastly, for 300 to 399, I found 379 and confirmed
-        it\u2019s prime too. So, 179 and 379 are our primes!\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI\u2019m considering numbers like 790,
-        which is over 400. I check other primes like 97, 197, 297, and 397, but they
-        don\u2019t contain \\\"79.\\\" The only primes that do are 79, 179, and 379.
-        I realize that only two-digit primes are relevant, as numbers like 790-799
-        exceed 400.\\n\\nI\u2019ve confirmed that 279 isn\u2019t prime, but 179 and
-        379 are. It seems the total count of primes with \\\"79\\\" is three. I wonder
-        if there are any other numbers I might have missed, like 97.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
-        prime counts with \\\"79\\\"**\\n\\nI realize 79 reversed doesn't count, so
-        I'm confirming the three primes identified: 79, 179, and 379. \\n\\nFirst,
-        I check 79 and confirm it\u2019s prime. For 179, I find that it passes checks
-        for primes under its square root, so it\u2019s also prime. 279 is composite
-        since it's divisible by 3. I\u2019ve previously confirmed that 379 is prime,
-        leaving the total count as three. I reflect on whether numbers with leading
-        zeros count but decide against it. \\n\\nSo, the answer is simply \\\"3.\\\"\"}]},{\"id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":1031,\"output_tokens_details\":{\"reasoning_tokens\":1024},\"total_tokens\":1063},\"user\":null,\"metadata\":{}}}\n\n"
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0d5e81a1d6cbde120068f8061bcce481979486ea68f5e78ee7\",\"object\":\"response\",\"created_at\":1761084955,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0d5e81a1d6cbde120068f8061bcce481979486ea68f5e78ee7\",\"object\":\"response\",\"created_at\":1761084955,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Counting\",\"obfuscation\":\"dXNx00\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"CvykqRSAv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        with\",\"obfuscation\":\"EEi8BSGaPdn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        substring\",\"obfuscation\":\"rrV9yD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"3hfISV9LZwdeaS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"d3tL44VvUUDQtI\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"uUmsFHZ1EkOzaoh\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"QUFjKJijxF3\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        need\",\"obfuscation\":\"djAQjY9vuzq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        to\",\"obfuscation\":\"8Lsvd3jba7lhH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        find\",\"obfuscation\":\"7Ah1V6Eda3K\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"ZYkxTyR0q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        below\",\"obfuscation\":\"QfdPGQLHoH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"ywjgxSPn6TFp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"PAvvOmct3TQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        include\",\"obfuscation\":\"cWMA5We4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"mx5shQykz3jLGk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"j52j2NTsqbNoqj\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"CBeAi3VI6mDYQIk\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        as\",\"obfuscation\":\"456pEFnHpYdfg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        a\",\"obfuscation\":\"0pWko7WZDYfgMP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        substring\",\"obfuscation\":\"buwS2P\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"CkkkmeBacmW0ibc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"e1h3f1Uskcx7eW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        should\",\"obfuscation\":\"fOd2nuaLs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        consider\",\"obfuscation\":\"ipluF3O\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        2\",\"obfuscation\":\"nDkOGMEjdlHZSd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"bDCE2PqD9C\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"WbgYEKTDkhos\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        3\",\"obfuscation\":\"tVhjrYTGYWWgpW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"uxz6lsU1zF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"UScvt9fdn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        since\",\"obfuscation\":\"QJhcWcL5Ao\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        they\",\"obfuscation\":\"IrATYrk93Qu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        can\",\"obfuscation\":\"ajCsro3hNYi2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        both\",\"obfuscation\":\"gSz3CPd7WAq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        fall\",\"obfuscation\":\"M5rzP6ueeQ2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        under\",\"obfuscation\":\"F3V5zlbjQv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"2k44aiCOCbGN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"hazjEn6CacJqnOG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        The\",\"obfuscation\":\"39uy54DFZHnM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        substring\",\"obfuscation\":\"sg3C8T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        length\",\"obfuscation\":\"6DnQECtgZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        is\",\"obfuscation\":\"pVjCyrLVNiFmk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        2\",\"obfuscation\":\"JzGt9ToENOjFPO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"lgL1PQS2RAFLaFh\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        so\",\"obfuscation\":\"lGqSGVHeJPJB7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"jAOFqomY8AO8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        candidates\",\"obfuscation\":\"HaFhj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        would\",\"obfuscation\":\"JsuzHPHDDz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        include\",\"obfuscation\":\"b0KUyqSO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        79\",\"obfuscation\":\"jWXq5CxFy4FVD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"YyCl7Q7Z3Rf6Npn\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        179\",\"obfuscation\":\"hFHd2j6Yv1Jl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"RnekWzSC2FCrUZk\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"RGUlgBsUJeG4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        279\",\"obfuscation\":\"IMmBnhoBVHOr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"Q0zNx0Certv9feh\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        While\",\"obfuscation\":\"v3xS1wPukc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        checking\",\"obfuscation\":\"G0CqFDk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"797fE7fS1IvpCuU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"L0mTDq2CaIemf4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        realized\",\"obfuscation\":\"sXLd56y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        197\",\"obfuscation\":\"KEljz4tELoR0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        doesn't\",\"obfuscation\":\"YSpuXpHB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        qualify\",\"obfuscation\":\"bdISVKhE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"iN4WVKrWCLMiQ0r\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        as\",\"obfuscation\":\"o1A0YqSHQssxL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        it\",\"obfuscation\":\"VkdTak1Wwn1sb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        contains\",\"obfuscation\":\"bB4H7tB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"iFds0KWksWMoBK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"97\",\"obfuscation\":\"muv2WMPPnToCuq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"YuXJKzvRKfMSADg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        instead\",\"obfuscation\":\"Anebicel\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"vEhUuor8VFpcYeF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        Pr\",\"obfuscation\":\"SOsBCxEh0Q6sP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"imes\",\"obfuscation\":\"95Qb91RugSeb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        like\",\"obfuscation\":\"RH2C6XI2yog\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        379\",\"obfuscation\":\"lPnfSznQ9sYl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        qualify\",\"obfuscation\":\"aGP7Gg5a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"x6EOIYSsFeBoVDi\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        but\",\"obfuscation\":\"SnU1Ypy6MbZC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"wCySoDIFh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        above\",\"obfuscation\":\"t2kOJRxIvO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"UVuMQGggmi8c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"fKkPiQpWLofb1Zc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        like\",\"obfuscation\":\"Iw19cLjVxtj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        479\",\"obfuscation\":\"t6TSR377jgc3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"yfOSajQ03GXIRSy\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        will\",\"obfuscation\":\"nfqLSSs1U3r\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        be\",\"obfuscation\":\"2zxEuaBbfqb2f\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        excluded\",\"obfuscation\":\"FFR1rS3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"3kV5SAKyteIzdJU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":97,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        The\",\"obfuscation\":\"VRUjiceICOAD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":98,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        candidates\",\"obfuscation\":\"mFUss\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":99,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"AWHG7zY9VPa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        remain\",\"obfuscation\":\"O95yigJKN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        need\",\"obfuscation\":\"pQTtEh24QEz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        careful\",\"obfuscation\":\"lPWIOtfS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        consideration\",\"obfuscation\":\"Sr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":104,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"NQCcZyozpSxKPXX\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":105,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to find primes below 400 that
+        include \\\"79\\\" as a substring. I should consider 2-digit and 3-digit primes
+        since they can both fall under 400. The substring length is 2, so the candidates
+        would include 79, 179, and 279. While checking, I realized 197 doesn't qualify,
+        as it contains \\\"97\\\" instead. Primes like 379 qualify, but primes above
+        400, like 479, will be excluded. The candidates that remain need careful consideration.\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":106,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to find primes below 400 that
+        include \\\"79\\\" as a substring. I should consider 2-digit and 3-digit primes
+        since they can both fall under 400. The substring length is 2, so the candidates
+        would include 79, 179, and 279. While checking, I realized 197 doesn't qualify,
+        as it contains \\\"97\\\" instead. Primes like 379 qualify, but primes above
+        400, like 479, will be excluded. The candidates that remain need careful consideration.\"}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":107,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Ident\",\"obfuscation\":\"izdH8NMoQ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ifying\",\"obfuscation\":\"6eFkNNWYJy\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":110,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        primes\",\"obfuscation\":\"rrwHFIPrV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":111,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        with\",\"obfuscation\":\"9YW18FwDDEq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":112,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"nEwAEOAsbxJLLv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":113,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"NCZ9AR8PoNkOi4\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"hjThXS35SXRvtk7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nI'm\",\"obfuscation\":\"nbcj8MkqB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        examining\",\"obfuscation\":\"8ea82N\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        numbers\",\"obfuscation\":\"M5gPpB7y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        like\",\"obfuscation\":\"mtXL6U0fklw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        297\",\"obfuscation\":\"kD6gEz6mmHId\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"ktbkAFUeO9KB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        379\",\"obfuscation\":\"VMctVGG3yiyE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":122,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        in\",\"obfuscation\":\"QmvhIVw5zthzC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":123,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        relation\",\"obfuscation\":\"ABssqxm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":124,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        to\",\"obfuscation\":\"ju5jrz1ahd2qT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"Ocy54Z1tFUPz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":126,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        substring\",\"obfuscation\":\"w5KnM6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":127,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"0haf7WTXycYnPt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":128,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"gmsGTdn4aq6rRz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\\\"\",\"obfuscation\":\"QW45BJCGIA3x6L\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"4ju5t9NkVdRy2n\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        realized\",\"obfuscation\":\"2rmhxX3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        that\",\"obfuscation\":\"hvHWqoOYKQv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        179\",\"obfuscation\":\"K9DJOvB3FNTm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        qualifies\",\"obfuscation\":\"XYzMaW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        because\",\"obfuscation\":\"KsMoxBlc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it\",\"obfuscation\":\"oV8HxkS850aTk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        contains\",\"obfuscation\":\"3nzXqxB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"h26BtHp54D66Dl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"TWSVelQLZueu8H\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"jVeOmk3t7zr3gPW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        across\",\"obfuscation\":\"PfDsMbgvi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        its\",\"obfuscation\":\"g9ajfpwsLqGx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        digits\",\"obfuscation\":\"iwcT2pbbR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"6BP9RtwMA8rexhE\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        279\",\"obfuscation\":\"6fvBrY1smE8y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"uLL5UpxLWJ88\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        379\",\"obfuscation\":\"uPNg56GOcNKY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        also\",\"obfuscation\":\"Ooowd6vCi55\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        meet\",\"obfuscation\":\"BPOpGRbHb40\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"biWrAdOAHTeA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        criteria\",\"obfuscation\":\"UKxyug3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"w6vH9IDtuFcS3v6\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        As\",\"obfuscation\":\"4n2llhkhzIDxh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"7rQQuy9AcyKROK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        continue\",\"obfuscation\":\"PMjdYQr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"MJOLSa6v78hopJT\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"LVJcbMcEBcOBPM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        note\",\"obfuscation\":\"z8xwxIhgBO8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        that\",\"obfuscation\":\"v8qqnR260Fb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        while\",\"obfuscation\":\"OBxy1oczNY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        numbers\",\"obfuscation\":\"oWqiRMcK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        from\",\"obfuscation\":\"o1sCuGPPzly\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        790\",\"obfuscation\":\"Vjd1wx3eo8Aq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        to\",\"obfuscation\":\"H2P5UoCqY4XCR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        799\",\"obfuscation\":\"GEtdbFFGD3dg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        contain\",\"obfuscation\":\"I8NKdlVW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"bZkZdYoZ7lqzq9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"WalmZeIBkTMuMz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"h4NymTiFsouwRvC\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        at\",\"obfuscation\":\"g0z2kEJemxM3t\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"ovQmWZ0BVJ9a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        beginning\",\"obfuscation\":\"ErCcpS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"TPpiboR6RqiGw5t\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        they\",\"obfuscation\":\"0LXiSfsdOaW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        exceed\",\"obfuscation\":\"HbomB6MdH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        400\",\"obfuscation\":\"w3HZuFfXTyGh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"hAmwJ6dCOvbvuqq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        so\",\"obfuscation\":\"htXBZMRYIN0aN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"2aP0MDjbFtpgkB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        must\",\"obfuscation\":\"NCQYpFvhY0j\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        exclude\",\"obfuscation\":\"46xtKeqs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        them\",\"obfuscation\":\"tfcFmaCkF3k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"d8Nv4GsWBQi5Nkp\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        However\",\"obfuscation\":\"9aK2MWFG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"k53VbYk6GzrP8OA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"O2zk1H1SxyPm7s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        confirm\",\"obfuscation\":\"HAPzUeZc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        primes\",\"obfuscation\":\"IQMALxvo9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        like\",\"obfuscation\":\"0agFfi3oTVE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        797\",\"obfuscation\":\"BA9ASqH6cwg8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        exist\",\"obfuscation\":\"AFX7aOzqNs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        within\",\"obfuscation\":\"JXHMvfMRC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        this\",\"obfuscation\":\"UV3tH2siLZV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        range\",\"obfuscation\":\"EWvy62ZEqn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        but\",\"obfuscation\":\"ZKay88QgAHl7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        can\",\"obfuscation\":\"NhJjQ9itsJsN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019t\",\"obfuscation\":\"wiqOdtck9zjD3q\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        be\",\"obfuscation\":\"yJPcmAbn5XIti\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        counted\",\"obfuscation\":\"z0jOMNrm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        due\",\"obfuscation\":\"j6SHlP9k5A6I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        to\",\"obfuscation\":\"zglk7XqNzvymo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"8kzMvKrWRall\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        limit\",\"obfuscation\":\"vBDLTFAEWX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"FG4mkkHJptjDpB5\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":205,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Identifying
+        primes with \\\"79\\\"**\\n\\nI'm examining numbers like 297 and 379 in relation
+        to the substring \\\"79.\\\" I realized that 179 qualifies because it contains
+        \\\"79\\\" across its digits. 279 and 379 also meet the criteria. As I continue,
+        I note that while numbers from 790 to 799 contain \\\"79\\\" at the beginning,
+        they exceed 400, so I must exclude them. However, I confirm primes like 797
+        exist within this range but can\u2019t be counted due to the limit.\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":206,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Identifying
+        primes with \\\"79\\\"**\\n\\nI'm examining numbers like 297 and 379 in relation
+        to the substring \\\"79.\\\" I realized that 179 qualifies because it contains
+        \\\"79\\\" across its digits. 279 and 379 also meet the criteria. As I continue,
+        I note that while numbers from 790 to 799 contain \\\"79\\\" at the beginning,
+        they exceed 400, so I must exclude them. However, I confirm primes like 797
+        exist within this range but can\u2019t be counted due to the limit.\"}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":207,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Checking\",\"obfuscation\":\"iBdV31\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"yvU6sCt4b\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        containing\",\"obfuscation\":\"CEBlJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\\"\",\"obfuscation\":\"HvJAbdPOvU0rOe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"wzS25uGcCoWC8Y\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\"\",\"obfuscation\":\"hoSzn7RoHeOt0JS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nI'm\",\"obfuscation\":\"GnxhETVYP\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":215,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        narrowing\",\"obfuscation\":\"zFF0Ak\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":216,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        down\",\"obfuscation\":\"1EctuUD0eB9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":217,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        candidates\",\"obfuscation\":\"lR81g\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        for\",\"obfuscation\":\"QD7HOgppMyZf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"dHFmb0V5z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        below\",\"obfuscation\":\"nAKL8OlQPX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        400\",\"obfuscation\":\"Ry2JMxplDFqL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"TUJP8b87n6G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":223,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        include\",\"obfuscation\":\"60PTBg3G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":224,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\\"\",\"obfuscation\":\"BvrPT9wulFCrvf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":225,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"icIz7NxvX2wUYW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":226,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\\\"\",\"obfuscation\":\"5Z6esN7CGt12ZI\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":227,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Since\",\"obfuscation\":\"5rAEx0BtjJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":228,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        those\",\"obfuscation\":\"MuKNtIQFI6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":229,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        must\",\"obfuscation\":\"ClTQowPyYFT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":230,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        be\",\"obfuscation\":\"iN9U8I0wU8HCu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":231,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        2\",\"obfuscation\":\"ttDQsDe7Z1DEuy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":232,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"g7NV8OnXwy\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":233,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        or\",\"obfuscation\":\"HkTAJPIlWgKyu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":234,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        3\",\"obfuscation\":\"49iI65wGvDJRyK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"Xm7sJ0mseN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        numbers\",\"obfuscation\":\"yHv2jXN8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"kf3xve0pM0fHD6u\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"wC7Yr6JPRRzZ0W\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        find\",\"obfuscation\":\"7tK5E1Qe4Xf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"hTwNb7QXQuM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        only\",\"obfuscation\":\"vB4QdPn0Y9U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        two\",\"obfuscation\":\"9OwyZo592MZw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"JiyxUuqIgV\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"vzgVMCwS5cZje\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"pgD4MLsb4yEw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        three\",\"obfuscation\":\"8b85BfHMNw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"oknMlTu3F0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        numbers\",\"obfuscation\":\"VrtNSY4P\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        like\",\"obfuscation\":\"hNVEHu6tyQI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"rezUg2x6idA8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"VgLC8iNqHMr9CNu\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        279\",\"obfuscation\":\"IGVymgFZHEOL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"cQ6nvjgmK0Kz8pB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"Q9WBEvJeIE9Q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"WCxp1bxNFHea\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        qualify\",\"obfuscation\":\"1Jtt333I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"xlBZt8fv2biIx84\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"pScpWxSVMviWky\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019ll\",\"obfuscation\":\"g85gVbNEODyot\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        also\",\"obfuscation\":\"E4Pru1BSrJa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        check\",\"obfuscation\":\"6JC24N0185\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        numbers\",\"obfuscation\":\"zHRRJpR8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        less\",\"obfuscation\":\"eiSDygXX8ad\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        than\",\"obfuscation\":\"UKk2LAP31ax\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":265,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        100\",\"obfuscation\":\"vPDmGXMNMaSa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":266,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"rJMGRfejv9iuweF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":267,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        confirming\",\"obfuscation\":\"F7YWj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"UwN3DTDaht1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        only\",\"obfuscation\":\"VUF2P8I0W91\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"27CLsWs39ylHb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        fits\",\"obfuscation\":\"WfOcClfqvsV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"pzL2FnudRczw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        criteria\",\"obfuscation\":\"luTZOn7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"jl8a2CtdsHg5qK9\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Now\",\"obfuscation\":\"VQQeL5m3G2gX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"H5LSPVcOF8fbzy8\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"D1Fuufocf7EqFv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019ll\",\"obfuscation\":\"oprYaQgstz3Rc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        assess\",\"obfuscation\":\"rf32ahFjq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"9KIPWvsPkLO4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primal\",\"obfuscation\":\"gK8cei3P2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ity\",\"obfuscation\":\"HNsdo96u01y8n\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        of\",\"obfuscation\":\"hYnIZuJ7QljAv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"ehYHhGOYMbUwi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"VYTy6DOwOZQUckj\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"y0D2etnMQGPq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"faJ2DCQqVzkJEz4\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        279\",\"obfuscation\":\"7lgKQQ8VmwD0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"Ct0h9p7RT4ZpqLM\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"zo4UDZk2oHaG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"G0KiGSOGSrRr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"OTQlkHqqyoTC2zx\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Starting\",\"obfuscation\":\"9suFgMt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        with\",\"obfuscation\":\"3EtUuzqcWGA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"nBYISVmjBWgQQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"xTvP98PtJ2pFzEX\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"dtZsNZbwaXQCJi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        see\",\"obfuscation\":\"WhB4eLmt6WXy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"XhW35b6eHRW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it's\",\"obfuscation\":\"wMqr9qosTr1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        indeed\",\"obfuscation\":\"8IKNhVctS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"ReU10EVI7X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"leA6Af6cmBelJRp\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        which\",\"obfuscation\":\"FVbwkj4N7d\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"c37LjYZHr0mLo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        great\",\"obfuscation\":\"ZLCg6P463G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"!\",\"obfuscation\":\"I4pu8f3I5bxniSo\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Next\",\"obfuscation\":\"IHhqwchr4If\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"ulOyV4xq0VMMlAI\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"wrcPG9NUh1S8K7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        need\",\"obfuscation\":\"Nlj4yWE2XmP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        to\",\"obfuscation\":\"tXPDQrsNOmcfp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        check\",\"obfuscation\":\"jvSrWEI3js\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"rfqi07cIKA0o\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019s\",\"obfuscation\":\"deLF02ONu9LdjT\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primal\",\"obfuscation\":\"AK7lnmekp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ity\",\"obfuscation\":\"9sII1Bet5Eckm\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        with\",\"obfuscation\":\"pBSdF4I5TM0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        some\",\"obfuscation\":\"ugLWgqOp1Wc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divis\",\"obfuscation\":\"kY5Csk5oc2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ibility\",\"obfuscation\":\"BrNbaCtO8\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        tests\",\"obfuscation\":\"YTCOXyiiGr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"rwHxwJdIVDlho7A\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":324,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Checking
+        primes containing \\\"79\\\"**\\n\\nI'm narrowing down candidates for primes
+        below 400 that include \\\"79.\\\" Since those must be 2-digit or 3-digit
+        numbers, I find that only two-digit 79 and three-digit numbers like 179, 279,
+        and 379 qualify. I\u2019ll also check numbers less than 100, confirming that
+        only 79 fits the criteria. Now, I\u2019ll assess the primality of 79, 179,
+        279, and 379. Starting with 79, I see that it's indeed prime, which is great!
+        Next, I need to check 179\u2019s primality with some divisibility tests.\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":325,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Checking
+        primes containing \\\"79\\\"**\\n\\nI'm narrowing down candidates for primes
+        below 400 that include \\\"79.\\\" Since those must be 2-digit or 3-digit
+        numbers, I find that only two-digit 79 and three-digit numbers like 179, 279,
+        and 379 qualify. I\u2019ll also check numbers less than 100, confirming that
+        only 79 fits the criteria. Now, I\u2019ll assess the primality of 79, 179,
+        279, and 379. Starting with 79, I see that it's indeed prime, which is great!
+        Next, I need to check 179\u2019s primality with some divisibility tests.\"}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":326,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":327,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**Confirm\",\"obfuscation\":\"xvygCBA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":328,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"ing\",\"obfuscation\":\"mPEi9zVVnqFi0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":329,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        prime\",\"obfuscation\":\"FXIrg0SUe3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":330,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        numbers\",\"obfuscation\":\"bt2oblQY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":331,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**\\n\\nI've\",\"obfuscation\":\"cxNUXzWv\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":332,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        confirmed\",\"obfuscation\":\"txjilN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":333,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        that\",\"obfuscation\":\"StBasuMu1qL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":334,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        79\",\"obfuscation\":\"wqpXV0C8gAIJx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":335,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"unUhOZ2Tmnw2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":336,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        179\",\"obfuscation\":\"LEicYS5C8sLQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":337,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        are\",\"obfuscation\":\"GtHKhVlemFlX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":338,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        primes\",\"obfuscation\":\"xj8bZFKJT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":339,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"U8XNWLNuHELpYDg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":340,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        For\",\"obfuscation\":\"EcjDM4Lj5EEy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":341,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        279\",\"obfuscation\":\"7v4S8Uyt5djE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":342,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"wgO40q9pM5qmjYk\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":343,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        its\",\"obfuscation\":\"oW2Zvf5B6YIU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":344,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        digits\",\"obfuscation\":\"Sr6QSYB96\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":345,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        add\",\"obfuscation\":\"VoYG41W7GgzU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":346,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        up\",\"obfuscation\":\"PJ7aRGjFbi0rB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":347,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        to\",\"obfuscation\":\"ECSCrcwdhpWAJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":348,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        18\",\"obfuscation\":\"2sFAJqnPIyGHn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":349,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"hOlsql9twY8C2UW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":350,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        making\",\"obfuscation\":\"aDyrXn7PH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":351,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        it\",\"obfuscation\":\"9KtFpXIPKHifx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":352,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        divisible\",\"obfuscation\":\"RvDfAQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":353,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        by\",\"obfuscation\":\"f9v1hiNAyTs1X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":354,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        3\",\"obfuscation\":\"SiZiO2zT04JzyN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":355,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"3yGJgegVD1dFlV3\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":356,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        so\",\"obfuscation\":\"uIOtd2krDRyu6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":357,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        it\",\"obfuscation\":\"r2UCQcemKR4cm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":358,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019s\",\"obfuscation\":\"mAr3Mt9eqedBdA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":359,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        not\",\"obfuscation\":\"Fwj3sWfz59mj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":360,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        prime\",\"obfuscation\":\"sDNu7bW06u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":361,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"8LO5DIchJvL7xyh\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":362,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        Now\",\"obfuscation\":\"E4CYhe1BXbPO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":363,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"uTDPNTqo6dzHttD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":364,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I\",\"obfuscation\":\"eXf1TWhv6OLvdD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":365,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        check\",\"obfuscation\":\"e9YnIzyvNf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":366,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"IzZatRDEfJQO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":367,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\":\",\"obfuscation\":\"RtnrGSjPFAAeWox\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":368,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        its\",\"obfuscation\":\"g1fOpJDINqUi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":369,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        square\",\"obfuscation\":\"XGSckIgUo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":370,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        root\",\"obfuscation\":\"tZNwGXDvnPC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":371,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        is\",\"obfuscation\":\"QrTzM9s7dCtVy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":372,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        about\",\"obfuscation\":\"2cTrtB9nfi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":373,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        19\",\"obfuscation\":\"RamqzD1SJCWd2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":374,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"7y3Oo04HDD8PD0I\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":375,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"4\",\"obfuscation\":\"43MFivpC42KTd8F\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":376,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"nhqcLQ3Q2RuJUEq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":377,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        Testing\",\"obfuscation\":\"UawQjuZZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":378,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        divis\",\"obfuscation\":\"MUyurlBjWN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":379,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"ibility\",\"obfuscation\":\"ayXREjoQZ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":380,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"g0bz8PA5jpDw6oH\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":381,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        it\",\"obfuscation\":\"RkHgMg1qM7yiG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":382,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        checks\",\"obfuscation\":\"8AOfdZipE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":383,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        out\",\"obfuscation\":\"ukfGn5cRsoLE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":384,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2014\",\"obfuscation\":\"Girp8Sj1CdrQ2d8\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":385,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"none\",\"obfuscation\":\"iZ6uhxIVFq0n\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":386,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        of\",\"obfuscation\":\"A2tII4UbpKti0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":387,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        the\",\"obfuscation\":\"pBmh8ygwK1Pn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":388,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        prime\",\"obfuscation\":\"rhdj6JTzTb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":389,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        numbers\",\"obfuscation\":\"Tar9nbeV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":390,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        divide\",\"obfuscation\":\"aQUmAbJoO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":391,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        it\",\"obfuscation\":\"PDFNcdBhS7ZGV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":392,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        evenly\",\"obfuscation\":\"sVf1uRYhl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":393,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"gkBotS4yYZW7J3i\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":394,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        so\",\"obfuscation\":\"vMFxhFiUN0pPS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":395,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"2vxypXhJgcy0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":396,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        is\",\"obfuscation\":\"NDf0gI5kEYJmb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":397,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        prime\",\"obfuscation\":\"3sqDMLS031\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":398,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        as\",\"obfuscation\":\"DqzloSrZ3ZkLW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":399,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        well\",\"obfuscation\":\"Svq95o8xxmV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":400,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"hliXY1HhpqfFgzD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":401,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        Thus\",\"obfuscation\":\"3blwxjGNONx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":402,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"7iGAlGx7APD8jqs\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":403,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I\",\"obfuscation\":\"wd84DsRiPf7Qdt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":404,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        have\",\"obfuscation\":\"16QxkzC6QUD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":405,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        three\",\"obfuscation\":\"8t00ROMVTl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":406,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        primes\",\"obfuscation\":\"709SSuYkf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":407,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\":\",\"obfuscation\":\"T1AFIwAYrDVPdFR\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":408,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        79\",\"obfuscation\":\"ETP6fEzjjQqye\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":409,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"KXiLtmN70pa50jG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":410,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        179\",\"obfuscation\":\"ArTngjTVWsi8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":411,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"ZM6ufLRh3Yr5MPG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":412,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"WqtoHPfIBCP6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":413,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"g6S97CceIDni\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":414,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"6fgEqqMKDrSD1ot\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":415,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        with\",\"obfuscation\":\"XXI4QqZbNkM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":416,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        279\",\"obfuscation\":\"uMxEASAlZ2c3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":417,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        as\",\"obfuscation\":\"YY7vdcUQmYxKj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":418,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        composite\",\"obfuscation\":\"jsSdva\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":419,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"2aYz0s0jJ60AqsX\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":420,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I'll\",\"obfuscation\":\"kyVwbMeK3fZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":421,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        double\",\"obfuscation\":\"iiKtW0jb4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":422,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"-check\",\"obfuscation\":\"KyulqKuU0F\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":423,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        for\",\"obfuscation\":\"HE5eVraGZ00V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":424,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        any\",\"obfuscation\":\"ZW6ZwEPvHovX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":425,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        other\",\"obfuscation\":\"HloL6EkJ1N\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":426,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        primes\",\"obfuscation\":\"4eEqa33qi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":427,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        below\",\"obfuscation\":\"AxgopRM9no\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":428,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        400\",\"obfuscation\":\"vsH1rwsB86rz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":429,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        containing\",\"obfuscation\":\"zrEaO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":430,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"yyYGmqEXxluCF5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":431,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"5PuwBNZDejJTno\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":432,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"400JrqgrLQ0RWHA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":433,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        as\",\"obfuscation\":\"chON74mR0FLfx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":434,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        a\",\"obfuscation\":\"xQPWMuKQnx1s4U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":435,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        substring\",\"obfuscation\":\"oWe4om\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":436,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"ydiFByKbwHkfu8D\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":437,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        It\",\"obfuscation\":\"0E7aIDiONe17V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":438,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        looks\",\"obfuscation\":\"sVZQQNbrbI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":439,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        like\",\"obfuscation\":\"3HXzjnLJ31P\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":440,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        any\",\"obfuscation\":\"ZWwR9RhOYpRZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":441,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        variations\",\"obfuscation\":\"0sdOJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":442,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        are\",\"obfuscation\":\"UhV5pE0UvPyu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":443,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        above\",\"obfuscation\":\"xm1D4IVSRX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":444,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        400\",\"obfuscation\":\"ncaYLC44T6Wh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":445,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"28IlAU2adDtVwez\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":446,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"text\":\"**Confirming
+        prime numbers**\\n\\nI've confirmed that 79 and 179 are primes. For 279, its
+        digits add up to 18, making it divisible by 3, so it\u2019s not prime. Now,
+        I check 379: its square root is about 19.4. Testing divisibility, it checks
+        out\u2014none of the prime numbers divide it evenly, so 379 is prime as well.
+        Thus, I have three primes: 79, 179, and 379, with 279 as composite. I'll double-check
+        for any other primes below 400 containing \\\"79\\\" as a substring. It looks
+        like any variations are above 400.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":447,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"**Confirming
+        prime numbers**\\n\\nI've confirmed that 79 and 179 are primes. For 279, its
+        digits add up to 18, making it divisible by 3, so it\u2019s not prime. Now,
+        I check 379: its square root is about 19.4. Testing divisibility, it checks
+        out\u2014none of the prime numbers divide it evenly, so 379 is prime as well.
+        Thus, I have three primes: 79, 179, and 379, with 279 as composite. I'll double-check
+        for any other primes below 400 containing \\\"79\\\" as a substring. It looks
+        like any variations are above 400.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
+        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":448,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":449,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**Final\",\"obfuscation\":\"WjkXcbpf8\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":450,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"izing\",\"obfuscation\":\"zyqkTHj8GOl\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":451,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        the\",\"obfuscation\":\"2bG2kHqD7dv0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":452,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        prime\",\"obfuscation\":\"Q1KWZtoi8I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":453,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        count\",\"obfuscation\":\"JiDC0vnMIR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":454,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"hEU3b1sgBMQ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":455,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019ve\",\"obfuscation\":\"DUem996QgjaJN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":456,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        confirmed\",\"obfuscation\":\"WwOO4c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":457,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"9evzB2m77ZM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":458,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        there\",\"obfuscation\":\"3CMVtsrRyv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":459,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        are\",\"obfuscation\":\"3FoVPjaAI7eV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":460,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        no\",\"obfuscation\":\"72xaEQVB33y6T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":461,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        4\",\"obfuscation\":\"fTeDT1TaMTlRFZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":462,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"-digit\",\"obfuscation\":\"Ifysam68T4\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":463,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        numbers\",\"obfuscation\":\"ZyXVco1C\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":464,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        below\",\"obfuscation\":\"VMNRL96A7t\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":465,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        400\",\"obfuscation\":\"mUkflSsuJcml\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":466,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"QHWk8Jo3qjHsZKB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":467,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"WKLQH7OJFhsW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":468,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        leading\",\"obfuscation\":\"NPtyUUgp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":469,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        zeros\",\"obfuscation\":\"kX9KePsa45\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":470,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        don\",\"obfuscation\":\"IIgu27ZNEbN0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":471,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019t\",\"obfuscation\":\"b64Swf4Oa1XQXI\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":472,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        count\",\"obfuscation\":\"ug8ZJ0JZlA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":473,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"tCN9RGsAoGV6WQS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":474,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        So\",\"obfuscation\":\"0jz6HGbC3FyRe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":475,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"3Tnx50rqtJA44dN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":476,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        the\",\"obfuscation\":\"X5C7WLSWplMU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":477,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        total\",\"obfuscation\":\"pBcfXQtNnI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":478,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        number\",\"obfuscation\":\"bspytgA5H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":479,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        of\",\"obfuscation\":\"BXNJbmnJZ4dMK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":480,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        primes\",\"obfuscation\":\"ZbSelzU2h\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":481,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        containing\",\"obfuscation\":\"Dpyd0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":482,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"pauRaETgQoKgku\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":483,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"79\",\"obfuscation\":\"4x5G1O4r058EAC\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":484,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"MjyBTrYC9xZy0NA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":485,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        is\",\"obfuscation\":\"ep4PzquwW2K7M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":486,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        3\",\"obfuscation\":\"tdTW2pXRH159kt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":487,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"zBflQ9jIO2D6zb7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":488,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"SMKIKmlrdF5Bvu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":489,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        double\",\"obfuscation\":\"CqMsCeLb2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":490,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"-check\",\"obfuscation\":\"O2BwhlmaLo\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":491,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        other\",\"obfuscation\":\"iIpTRZxGNM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":492,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        possibilities\",\"obfuscation\":\"p9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":493,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        but\",\"obfuscation\":\"6cwoA9ZArgDh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":494,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        affirm\",\"obfuscation\":\"wSjSm2tee\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":495,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"SJaRfZOxu3V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":496,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        numbers\",\"obfuscation\":\"LBSbq6Yj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":497,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        like\",\"obfuscation\":\"K7Z1Z9kYy7Z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":498,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        97\",\"obfuscation\":\"IHJbky5pe96qW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":499,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"3l4eKTzd5qlS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":500,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        197\",\"obfuscation\":\"EeiX20uBzOTB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":501,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        don\",\"obfuscation\":\"Dhk8nOeND36X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":502,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019t\",\"obfuscation\":\"jw8BEtWUkkUtUc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":503,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        fit\",\"obfuscation\":\"edfcByshSKEW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":504,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"kszm2JMtAO09wOk\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":505,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"nMjeJ9BlWO8K\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":506,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        although\",\"obfuscation\":\"sLLz2ov\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":507,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        397\",\"obfuscation\":\"QTCD3CNwRHIz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":508,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        has\",\"obfuscation\":\"bvQHSCg7xJMN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":509,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"jkG3K5e678QYmZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":510,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"39\",\"obfuscation\":\"EpkacvXw1xHpM6\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":511,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"nS1LAX6igPH6Ocf\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":512,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"vrt6R0XNgRDO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":513,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"3tlNWr2QuKhK27\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":514,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"97\",\"obfuscation\":\"bEYPxAo2PQ6dVZ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":515,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\",\",\"obfuscation\":\"vG5Xbvs8Q1cKyW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":516,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        it\",\"obfuscation\":\"XsknYHSFdcRUE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":517,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019s\",\"obfuscation\":\"ruICOnra3StMgI\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":518,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        not\",\"obfuscation\":\"CvKpw5dZRaoP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":519,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        relevant\",\"obfuscation\":\"PgMcrKr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":520,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"mlao8K6aatR6qXN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":521,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"1IMKIhxYnaJr4w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":522,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        see\",\"obfuscation\":\"dfBmagKg3611\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":523,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"p6gush4oqzG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":524,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        primes\",\"obfuscation\":\"vFZMUFX9A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":525,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        must\",\"obfuscation\":\"MT4agcPZRVD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":526,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        have\",\"obfuscation\":\"sa0OYvBSWpe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":527,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        the\",\"obfuscation\":\"WzV2dM7Ec0wb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":528,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        digits\",\"obfuscation\":\"GUtsJCbaT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":529,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"rWtKkRoUe8dp2D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":530,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"7\",\"obfuscation\":\"yS5u68Xh7DRB6Kq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":531,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"pXEz4g8kUHfOKRj\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":532,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"WIzoHnAo1oJZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":533,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"3qaBr3P4P8njXS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":534,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"9\",\"obfuscation\":\"K9QbFb1HpFyfxVj\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":535,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"8T9YXhYlYVjeS5Y\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":536,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        together\",\"obfuscation\":\"A9xzDYx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":537,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"og4NxCFyWnvemJz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":538,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        so\",\"obfuscation\":\"1OgY4mJ77msYa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":539,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        there\",\"obfuscation\":\"mJxspmpLtL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":540,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        aren\",\"obfuscation\":\"joSeka6DVZp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":541,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019t\",\"obfuscation\":\"Ulsu5J0OhhOVof\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":542,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        any\",\"obfuscation\":\"JVKiwEDVib9e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":543,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        other\",\"obfuscation\":\"dNPfoE5ybh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":544,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        configurations\",\"obfuscation\":\"X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":545,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"u2z5SU9HY15vnny\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":546,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        Therefore\",\"obfuscation\":\"LrfS6W\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":547,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"cXKpWAvtkgRZAn0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":548,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        the\",\"obfuscation\":\"TnpGNipzjD0z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":549,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        answer\",\"obfuscation\":\"z9H0rSwgg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":550,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        remains\",\"obfuscation\":\"3QD2kS7q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":551,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        3\",\"obfuscation\":\"bDNILSzdVfi1Sx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":552,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"YIE8Z9jkkdpjXse\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":553,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"text\":\"**Finalizing
+        the prime count**\\n\\nI\u2019ve confirmed that there are no 4-digit numbers
+        below 400, and leading zeros don\u2019t count. So, the total number of primes
+        containing \\\"79\\\" is 3. I double-check other possibilities but affirm
+        that numbers like 97 and 197 don\u2019t fit, and although 397 has \\\"39\\\"
+        and \\\"97\\\", it\u2019s not relevant. I see that primes must have the digits
+        \\\"7\\\" and \\\"9\\\" together, so there aren\u2019t any other configurations.
+        Therefore, the answer remains 3.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":554,\"item_id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"**Finalizing
+        the prime count**\\n\\nI\u2019ve confirmed that there are no 4-digit numbers
+        below 400, and leading zeros don\u2019t count. So, the total number of primes
+        containing \\\"79\\\" is 3. I double-check other possibilities but affirm
+        that numbers like 97 and 197 don\u2019t fit, and although 397 has \\\"39\\\"
+        and \\\"97\\\", it\u2019s not relevant. I see that primes must have the digits
+        \\\"7\\\" and \\\"9\\\" together, so there aren\u2019t any other configurations.
+        Therefore, the answer remains 3.\"}}\n\nevent: response.output_item.done\ndata:
+        {\"type\":\"response.output_item.done\",\"sequence_number\":555,\"output_index\":0,\"item\":{\"id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to find primes below 400 that
+        include \\\"79\\\" as a substring. I should consider 2-digit and 3-digit primes
+        since they can both fall under 400. The substring length is 2, so the candidates
+        would include 79, 179, and 279. While checking, I realized 197 doesn't qualify,
+        as it contains \\\"97\\\" instead. Primes like 379 qualify, but primes above
+        400, like 479, will be excluded. The candidates that remain need careful consideration.\"},{\"type\":\"summary_text\",\"text\":\"**Identifying
+        primes with \\\"79\\\"**\\n\\nI'm examining numbers like 297 and 379 in relation
+        to the substring \\\"79.\\\" I realized that 179 qualifies because it contains
+        \\\"79\\\" across its digits. 279 and 379 also meet the criteria. As I continue,
+        I note that while numbers from 790 to 799 contain \\\"79\\\" at the beginning,
+        they exceed 400, so I must exclude them. However, I confirm primes like 797
+        exist within this range but can\u2019t be counted due to the limit.\"},{\"type\":\"summary_text\",\"text\":\"**Checking
+        primes containing \\\"79\\\"**\\n\\nI'm narrowing down candidates for primes
+        below 400 that include \\\"79.\\\" Since those must be 2-digit or 3-digit
+        numbers, I find that only two-digit 79 and three-digit numbers like 179, 279,
+        and 379 qualify. I\u2019ll also check numbers less than 100, confirming that
+        only 79 fits the criteria. Now, I\u2019ll assess the primality of 79, 179,
+        279, and 379. Starting with 79, I see that it's indeed prime, which is great!
+        Next, I need to check 179\u2019s primality with some divisibility tests.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
+        prime numbers**\\n\\nI've confirmed that 79 and 179 are primes. For 279, its
+        digits add up to 18, making it divisible by 3, so it\u2019s not prime. Now,
+        I check 379: its square root is about 19.4. Testing divisibility, it checks
+        out\u2014none of the prime numbers divide it evenly, so 379 is prime as well.
+        Thus, I have three primes: 79, 179, and 379, with 279 as composite. I'll double-check
+        for any other primes below 400 containing \\\"79\\\" as a substring. It looks
+        like any variations are above 400.\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
+        the prime count**\\n\\nI\u2019ve confirmed that there are no 4-digit numbers
+        below 400, and leading zeros don\u2019t count. So, the total number of primes
+        containing \\\"79\\\" is 3. I double-check other possibilities but affirm
+        that numbers like 97 and 197 don\u2019t fit, and although 397 has \\\"39\\\"
+        and \\\"97\\\", it\u2019s not relevant. I see that primes must have the digits
+        \\\"7\\\" and \\\"9\\\" together, so there aren\u2019t any other configurations.
+        Therefore, the answer remains 3.\"}]}}\n\nevent: response.output_item.added\ndata:
+        {\"type\":\"response.output_item.added\",\"sequence_number\":556,\"output_index\":1,\"item\":{\"id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":557,\"item_id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":558,\"item_id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"1sg6tTVfntARtbt\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":559,\"item_id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
+        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":560,\"item_id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":561,\"output_index\":1,\"item\":{\"id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":562,\"response\":{\"id\":\"resp_0d5e81a1d6cbde120068f8061bcce481979486ea68f5e78ee7\",\"object\":\"response\",\"created_at\":1761084955,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to find primes below 400 that
+        include \\\"79\\\" as a substring. I should consider 2-digit and 3-digit primes
+        since they can both fall under 400. The substring length is 2, so the candidates
+        would include 79, 179, and 279. While checking, I realized 197 doesn't qualify,
+        as it contains \\\"97\\\" instead. Primes like 379 qualify, but primes above
+        400, like 479, will be excluded. The candidates that remain need careful consideration.\"},{\"type\":\"summary_text\",\"text\":\"**Identifying
+        primes with \\\"79\\\"**\\n\\nI'm examining numbers like 297 and 379 in relation
+        to the substring \\\"79.\\\" I realized that 179 qualifies because it contains
+        \\\"79\\\" across its digits. 279 and 379 also meet the criteria. As I continue,
+        I note that while numbers from 790 to 799 contain \\\"79\\\" at the beginning,
+        they exceed 400, so I must exclude them. However, I confirm primes like 797
+        exist within this range but can\u2019t be counted due to the limit.\"},{\"type\":\"summary_text\",\"text\":\"**Checking
+        primes containing \\\"79\\\"**\\n\\nI'm narrowing down candidates for primes
+        below 400 that include \\\"79.\\\" Since those must be 2-digit or 3-digit
+        numbers, I find that only two-digit 79 and three-digit numbers like 179, 279,
+        and 379 qualify. I\u2019ll also check numbers less than 100, confirming that
+        only 79 fits the criteria. Now, I\u2019ll assess the primality of 79, 179,
+        279, and 379. Starting with 79, I see that it's indeed prime, which is great!
+        Next, I need to check 179\u2019s primality with some divisibility tests.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
+        prime numbers**\\n\\nI've confirmed that 79 and 179 are primes. For 279, its
+        digits add up to 18, making it divisible by 3, so it\u2019s not prime. Now,
+        I check 379: its square root is about 19.4. Testing divisibility, it checks
+        out\u2014none of the prime numbers divide it evenly, so 379 is prime as well.
+        Thus, I have three primes: 79, 179, and 379, with 279 as composite. I'll double-check
+        for any other primes below 400 containing \\\"79\\\" as a substring. It looks
+        like any variations are above 400.\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
+        the prime count**\\n\\nI\u2019ve confirmed that there are no 4-digit numbers
+        below 400, and leading zeros don\u2019t count. So, the total number of primes
+        containing \\\"79\\\" is 3. I double-check other possibilities but affirm
+        that numbers like 97 and 197 don\u2019t fit, and although 397 has \\\"39\\\"
+        and \\\"97\\\", it\u2019s not relevant. I see that primes must have the digits
+        \\\"7\\\" and \\\"9\\\" together, so there aren\u2019t any other configurations.
+        Therefore, the answer remains 3.\"}]},{\"id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":1287,\"output_tokens_details\":{\"reasoning_tokens\":1280},\"total_tokens\":1319},\"user\":null,\"metadata\":{}}}\n\n"
     headers:
       CF-RAY:
-      - 99022de0efe65f68-SEA
+      - 99241dcd5e3575f7-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:24:58 GMT
+      - Tue, 21 Oct 2025 22:15:56 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -968,50 +1157,56 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '130'
+      - '316'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '165'
+      - '370'
       x-request-id:
-      - req_279c600c3bf94f4d8d8fe5e05ed7b92a
+      - req_ef2717b7fd91414385bd48b55e545aee
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"input\":[{\"role\":\"user\",\"content\":\"How many primes below 400
-      contain 79 as a substring? Answer ONLY with the number, not sharing which primes
-      they are.\"},{\"id\":\"rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e\",\"summary\":[{\"text\":\"**Counting
-      primes with \\\"79\\\"**\\n\\nI need to find primes under 400 that contain the
-      substring \\\"79\\\". First, I think of 79 itself, then 179, and check if 197
-      doesn\u2019t count since it has \\\"97\\\". I realize 279 isn't prime, and 379
-      seems to be prime. However, 479 and any number in the 790s are greater than
-      400. Therefore, the only prime under 100 containing \\\"79\\\" is just 79. It's
-      quite a specific search!\",\"type\":\"summary_text\"},{\"text\":\"**Finding
-      primes with \\\"79\\\"**\\n\\nI\u2019m examining the numbers between 100 and
-      199 to see which contain \\\"79,\\\" and I find that only 179 fits because it's
-      the only one with \\\"79\\\" in the last digits. I'll confirm that 179 is prime
-      \u2014 and it is!\\n\\nNext, looking in the range of 200 to 299, I see that
-      279 is composite, as it\u2019s divisible by 3. In this range, there are no additional
-      candidates. Lastly, for 300 to 399, I found 379 and confirmed it\u2019s prime
-      too. So, 179 and 379 are our primes!\",\"type\":\"summary_text\"},{\"text\":\"**Confirming
-      prime counts with \\\"79\\\"**\\n\\nI\u2019m considering numbers like 790, which
-      is over 400. I check other primes like 97, 197, 297, and 397, but they don\u2019t
-      contain \\\"79.\\\" The only primes that do are 79, 179, and 379. I realize
-      that only two-digit primes are relevant, as numbers like 790-799 exceed 400.\\n\\nI\u2019ve
-      confirmed that 279 isn\u2019t prime, but 179 and 379 are. It seems the total
-      count of primes with \\\"79\\\" is three. I wonder if there are any other numbers
-      I might have missed, like 97.\",\"type\":\"summary_text\"},{\"text\":\"**Confirming
-      prime counts with \\\"79\\\"**\\n\\nI realize 79 reversed doesn't count, so
-      I'm confirming the three primes identified: 79, 179, and 379. \\n\\nFirst, I
-      check 79 and confirm it\u2019s prime. For 179, I find that it passes checks
-      for primes under its square root, so it\u2019s also prime. 279 is composite
-      since it's divisible by 3. I\u2019ve previously confirmed that 379 is prime,
-      leaving the total count as three. I reflect on whether numbers with leading
-      zeros count but decide against it. \\n\\nSo, the answer is simply \\\"3.\\\"\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"role\":\"user\",\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"},\"stream\":true}"
+    body: "{\"input\":[{\"content\":[{\"text\":\"How many primes below 400 contain
+      79 as a substring? Answer ONLY with the number, not sharing which primes they
+      are.\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"},{\"id\":\"rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c\",\"summary\":[{\"text\":\"**Counting
+      primes with substring \\\"79\\\"**\\n\\nI need to find primes below 400 that
+      include \\\"79\\\" as a substring. I should consider 2-digit and 3-digit primes
+      since they can both fall under 400. The substring length is 2, so the candidates
+      would include 79, 179, and 279. While checking, I realized 197 doesn't qualify,
+      as it contains \\\"97\\\" instead. Primes like 379 qualify, but primes above
+      400, like 479, will be excluded. The candidates that remain need careful consideration.\",\"type\":\"summary_text\"},{\"text\":\"**Identifying
+      primes with \\\"79\\\"**\\n\\nI'm examining numbers like 297 and 379 in relation
+      to the substring \\\"79.\\\" I realized that 179 qualifies because it contains
+      \\\"79\\\" across its digits. 279 and 379 also meet the criteria. As I continue,
+      I note that while numbers from 790 to 799 contain \\\"79\\\" at the beginning,
+      they exceed 400, so I must exclude them. However, I confirm primes like 797
+      exist within this range but can\u2019t be counted due to the limit.\",\"type\":\"summary_text\"},{\"text\":\"**Checking
+      primes containing \\\"79\\\"**\\n\\nI'm narrowing down candidates for primes
+      below 400 that include \\\"79.\\\" Since those must be 2-digit or 3-digit numbers,
+      I find that only two-digit 79 and three-digit numbers like 179, 279, and 379
+      qualify. I\u2019ll also check numbers less than 100, confirming that only 79
+      fits the criteria. Now, I\u2019ll assess the primality of 79, 179, 279, and
+      379. Starting with 79, I see that it's indeed prime, which is great! Next, I
+      need to check 179\u2019s primality with some divisibility tests.\",\"type\":\"summary_text\"},{\"text\":\"**Confirming
+      prime numbers**\\n\\nI've confirmed that 79 and 179 are primes. For 279, its
+      digits add up to 18, making it divisible by 3, so it\u2019s not prime. Now,
+      I check 379: its square root is about 19.4. Testing divisibility, it checks
+      out\u2014none of the prime numbers divide it evenly, so 379 is prime as well.
+      Thus, I have three primes: 79, 179, and 379, with 279 as composite. I'll double-check
+      for any other primes below 400 containing \\\"79\\\" as a substring. It looks
+      like any variations are above 400.\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing
+      the prime count**\\n\\nI\u2019ve confirmed that there are no 4-digit numbers
+      below 400, and leading zeros don\u2019t count. So, the total number of primes
+      containing \\\"79\\\" is 3. I double-check other possibilities but affirm that
+      numbers like 97 and 197 don\u2019t fit, and although 397 has \\\"39\\\" and
+      \\\"97\\\", it\u2019s not relevant. I see that primes must have the digits \\\"7\\\"
+      and \\\"9\\\" together, so there aren\u2019t any other configurations. Therefore,
+      the answer remains 3.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":[{\"text\":\"If
+      you remember what the primes were, then share them, or say 'I don't remember.'\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"},\"stream\":true}"
     headers:
       accept:
       - application/json
@@ -1020,12 +1215,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '2686'
+      - '3325'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -1052,92 +1244,35 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: 'event: response.created
-
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_02f178f89a7dc2940068f2983b5f6881938081a4c7fa74f9e0","object":"response","created_at":1760729147,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
-
-
-        event: response.in_progress
-
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_02f178f89a7dc2940068f2983b5f6881938081a4c7fa74f9e0","object":"response","created_at":1760729147,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
-
-
-        event: response.output_item.added
-
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_02f178f89a7dc2940068f2983c9de08193b5562b3fdec4d315","type":"reasoning","summary":[]}}
-
-
-        event: response.output_item.done
-
-        data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"rs_02f178f89a7dc2940068f2983c9de08193b5562b3fdec4d315","type":"reasoning","summary":[]}}
-
-
-        event: response.output_item.added
-
-        data: {"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","type":"message","status":"in_progress","content":[],"role":"assistant"}}
-
-
-        event: response.content_part.added
-
-        data: {"type":"response.content_part.added","sequence_number":5,"item_id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","output_index":1,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"KJKizHwqG7utpnE"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","output_index":1,"content_index":0,"delta":"
-        don''t","logprobs":[],"obfuscation":"kM5FydXhuH"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","output_index":1,"content_index":0,"delta":"
-        remember","logprobs":[],"obfuscation":"uomxQk8"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","output_index":1,"content_index":0,"delta":".","logprobs":[],"obfuscation":"vaEjlVECpSsffCN"}
-
-
-        event: response.output_text.done
-
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","output_index":1,"content_index":0,"text":"I
-        don''t remember.","logprobs":[]}
-
-
-        event: response.content_part.done
-
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
-        don''t remember."}}
-
-
-        event: response.output_item.done
-
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":1,"item":{"id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
-        don''t remember."}],"role":"assistant"}}
-
-
-        event: response.completed
-
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_02f178f89a7dc2940068f2983b5f6881938081a4c7fa74f9e0","object":"response","created_at":1760729147,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[{"id":"rs_02f178f89a7dc2940068f2983c9de08193b5562b3fdec4d315","type":"reasoning","summary":[]},{"id":"msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
-        don''t remember."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":62,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}}}
-
-
-        '
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0d5e81a1d6cbde120068f8063502d08197986c58e505df6bbb\",\"object\":\"response\",\"created_at\":1761084981,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"minimal\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0d5e81a1d6cbde120068f8063502d08197986c58e505df6bbb\",\"object\":\"response\",\"created_at\":1761084981,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"minimal\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_0d5e81a1d6cbde120068f80635fc608197be10fd4acfbce705\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":3,\"output_index\":0,\"item\":{\"id\":\"rs_0d5e81a1d6cbde120068f80635fc608197be10fd4acfbce705\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":4,\"output_index\":1,\"item\":{\"id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":5,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":6,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"delta\":\"I\",\"logprobs\":[],\"obfuscation\":\"2J5vvZcxXwIPKde\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":7,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"delta\":\"
+        don\",\"logprobs\":[],\"obfuscation\":\"gErLXty1AyvV\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":8,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"delta\":\"\u2019t\",\"logprobs\":[],\"obfuscation\":\"9JxSPnOlCjA0Ib\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":9,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"delta\":\"
+        remember\",\"logprobs\":[],\"obfuscation\":\"pCN9ViH\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":10,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"CgG9vqlKaEW6Bwr\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":11,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"text\":\"I
+        don\u2019t remember.\",\"logprobs\":[]}\n\nevent: response.content_part.done\ndata:
+        {\"type\":\"response.content_part.done\",\"sequence_number\":12,\"item_id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        don\u2019t remember.\"}}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":13,\"output_index\":1,\"item\":{\"id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        don\u2019t remember.\"}],\"role\":\"assistant\"}}\n\nevent: response.completed\ndata:
+        {\"type\":\"response.completed\",\"sequence_number\":14,\"response\":{\"id\":\"resp_0d5e81a1d6cbde120068f8063502d08197986c58e505df6bbb\",\"object\":\"response\",\"created_at\":1761084981,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_0d5e81a1d6cbde120068f80635fc608197be10fd4acfbce705\",\"type\":\"reasoning\",\"summary\":[]},{\"id\":\"msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        don\u2019t remember.\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"minimal\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":62,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":11,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":73},\"user\":null,\"metadata\":{}}}\n\n"
     headers:
       CF-RAY:
-      - 99022f1299a35f68-SEA
+      - 99241e6acb0575f7-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:25:47 GMT
+      - Tue, 21 Oct 2025 22:16:21 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1153,15 +1288,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '226'
+      - '381'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '255'
+      - '425'
       x-request-id:
-      - req_7bd12a7d9b6240c4b471bf1a479388c3
+      - req_49a656e95af349489228fd1dddae714c
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"How many primes below 400 contain 79
-      as a substring? Answer ONLY with the number, not sharing which primes they are."}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"},"stream":true}'
+    body: '{"input":[{"content":[{"text":"How many primes below 400 contain 79 as
+      a substring? Answer ONLY with the number, not sharing which primes they are.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"},"stream":true}'
     headers:
       accept:
       - application/json
@@ -10,12 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '235'
+      - '283'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -42,995 +39,1184 @@ interactions:
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_00c8480f43d079250068f297ab00fc8195a5c4f856bc2c1470\",\"object\":\"response\",\"created_at\":1760729003,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_00c8480f43d079250068f297ab00fc8195a5c4f856bc2c1470\",\"object\":\"response\",\"created_at\":1760729003,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Finding\",\"obfuscation\":\"091L0jH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        primes\",\"obfuscation\":\"etVoriJeX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        with\",\"obfuscation\":\"EArOA5dmUnX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        substring\",\"obfuscation\":\"yuIfnY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"e8MK8Ael8zdffF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"8EmszyB9ve003D\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"k9hxuBjUaUCekPQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"iqXT7kr3BxL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019m\",\"obfuscation\":\"M4ZI8q7tx0Tgmy\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        looking\",\"obfuscation\":\"R7aLIooB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        for\",\"obfuscation\":\"7MQsnzxHyUgg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"thCVEvC4cR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"JEQ1os9R\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        under\",\"obfuscation\":\"dg46gF2Vil\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"ZPrRbUPiAH7G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        that\",\"obfuscation\":\"mrkvmOVSgzZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        contain\",\"obfuscation\":\"3ZMvky7z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"hXpWV9OtnONY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        substring\",\"obfuscation\":\"FOebQw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"TQpro6vimMFRjc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"zWurRY4YwnRGQs\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\\\"\",\"obfuscation\":\"sTLkblb3jgGo9Y\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        First\",\"obfuscation\":\"qnEgIAZcdw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"9EAZ6MtyIk5ieav\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"vheBIqA5bDqZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        only\",\"obfuscation\":\"8xv4cYT38oE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        2\",\"obfuscation\":\"LU82Qk8Efa9eXb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"qnv39XLz7p\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"U8gMf9u2fm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        is\",\"obfuscation\":\"NmgYPOcpAQ6G9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"O0EXfc2IEszGp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        itself\",\"obfuscation\":\"GXiNlLAvJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"p9WQVpSsYsfJT5G\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        giving\",\"obfuscation\":\"5TAcRkZLm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        me\",\"obfuscation\":\"qUBL1XBS5pr4A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        one\",\"obfuscation\":\"V768IqERpIMS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        candidate\",\"obfuscation\":\"Uy0JiM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"KjmcCfXM2H330ys\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\n\\nFor\",\"obfuscation\":\"HmesDCCCvm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        3\",\"obfuscation\":\"pKtdi5a10fTBTv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"UpB88NIlNy\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        primes\",\"obfuscation\":\"56DMO19ea\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"nh66gfAN6hyx4VM\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"5G8ZWHIvQER3ZQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        considered\",\"obfuscation\":\"uCngo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"vMJtQDl5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        of\",\"obfuscation\":\"fL0Pfk1brPhGv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"eKfZDwLRmCFV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        form\",\"obfuscation\":\"CswD3ym84KE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"GLD2Fnmkt052O\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"x\",\"obfuscation\":\"l4YXS0yggbU8gOA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"XIGdIkQYSNyLOFc\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        but\",\"obfuscation\":\"BHQ8SPIU3W9k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        those\",\"obfuscation\":\"8Uo5JTPBzt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        fall\",\"obfuscation\":\"dExj9Ern59O\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        outside\",\"obfuscation\":\"HMqcqbmN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"uBrKGX6D2Jvz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"nDyTYWOc4Aoa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        limit\",\"obfuscation\":\"ip4yaJKwxT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"UIw9J8782artObW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        so\",\"obfuscation\":\"dhRWvjQVW9vxX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        there\",\"obfuscation\":\"Wc8LbCCmMU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        are\",\"obfuscation\":\"qyE0Bfh6F9Ov\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        none\",\"obfuscation\":\"bmeqIPDJdOz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"8jxmXGTHAaWxCZP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\n\\nThen\",\"obfuscation\":\"felW6b8Bs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"nRgpej2GZeCePL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        checked\",\"obfuscation\":\"BcR1QECU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"koPhjHIs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        like\",\"obfuscation\":\"IXBwK54Shbs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        x\",\"obfuscation\":\"ApgCL6Jyg8bUa4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"oVA4eDagqlXhPq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"nG9PeXctZBW4DPh\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        where\",\"obfuscation\":\"YhDZVu1vBX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        x\",\"obfuscation\":\"L3B1NBhfLhQXIF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        can\",\"obfuscation\":\"bVtp2JR1pEoq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        be\",\"obfuscation\":\"MqAuMPcKN1QzU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        1\",\"obfuscation\":\"f0yMu3qWG1PTQT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-\",\"obfuscation\":\"SNGPk5BCTxz7LlM\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"3\",\"obfuscation\":\"6XL8oUufOJIvaax\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"hoKnLN4ttlpT5mZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        This\",\"obfuscation\":\"0SuWGoyKWpp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        gives\",\"obfuscation\":\"57Am5l2XFd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        me\",\"obfuscation\":\"GewzUq8NfNCih\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        candidates\",\"obfuscation\":\"GZr6Y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\":\",\"obfuscation\":\"VlljrB8Yay7DBoF\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        179\",\"obfuscation\":\"ohaCglzpMD3c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"2wJZDklNyCTP8d6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        279\",\"obfuscation\":\"4lucQZ8dcqWq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"2AQESEtdYZ607c1\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        and\",\"obfuscation\":\"MJwACuoWmVfl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        379\",\"obfuscation\":\"737CoIYR8wa6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"oyMel5kXo3bShrC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":97,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        which\",\"obfuscation\":\"XU3JbsqsbF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":98,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"r5n02mwxuK4K8z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":99,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        need\",\"obfuscation\":\"4OSjx4YVDHW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        to\",\"obfuscation\":\"Mfk1I0ybJiG82\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        verify\",\"obfuscation\":\"SutQNi3IE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        for\",\"obfuscation\":\"yCZyf9LqiGHL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        primal\",\"obfuscation\":\"3ntVXH2Rs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":104,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"ity\",\"obfuscation\":\"uE3mr4GoIUdNG\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":105,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"jLAUgSct8GQPYcS\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":106,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\n\\nFinally\",\"obfuscation\":\"nzw5ru\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":107,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"cxQm6yWvgka5H7u\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"e2OsemQzXMIgSA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        realized\",\"obfuscation\":\"CHDGbCP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":110,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        that\",\"obfuscation\":\"oijsnCydbef\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":111,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"sEXNnUiO1Uj3dq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":112,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"3XDemSLOWP73wY\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":113,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"7IODqSvAOYCHcmw\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        must\",\"obfuscation\":\"Lwb1ZwiG2UX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        be\",\"obfuscation\":\"yQJWBSSKg3jQ7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        adjacent\",\"obfuscation\":\"upFpZBv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"jJzifLAP9RhF62m\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        ruling\",\"obfuscation\":\"rs56njDUg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        out\",\"obfuscation\":\"40QGto3JfZGK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        non\",\"obfuscation\":\"7TW8Q4fZDKo5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-ad\",\"obfuscation\":\"KXBHzrAJsGNYm\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":122,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"j\",\"obfuscation\":\"WppvDhw4D0ajqKQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":123,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"acent\",\"obfuscation\":\"pxRFAISQpCA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":124,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        digits\",\"obfuscation\":\"vwfE8h0Ij\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"VUl8a2sGuYGAMci\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":126,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Finding
-        primes with substring \\\"79\\\"**\\n\\nI\u2019m looking for prime numbers
-        under 400 that contain the substring \\\"79.\\\" First, the only 2-digit prime
-        is 79 itself, giving me one candidate. \\n\\nFor 3-digit primes, I considered
-        numbers of the form 79x, but those fall outside the 400 limit, so there are
-        none. \\n\\nThen I checked numbers like x79, where x can be 1-3. This gives
-        me candidates: 179, 279, and 379, which I need to verify for primality. \\n\\nFinally,
-        I realized that \\\"79\\\" must be adjacent, ruling out non-adjacent digits.\"}\n\nevent:
-        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":127,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Finding
-        primes with substring \\\"79\\\"**\\n\\nI\u2019m looking for prime numbers
-        under 400 that contain the substring \\\"79.\\\" First, the only 2-digit prime
-        is 79 itself, giving me one candidate. \\n\\nFor 3-digit primes, I considered
-        numbers of the form 79x, but those fall outside the 400 limit, so there are
-        none. \\n\\nThen I checked numbers like x79, where x can be 1-3. This gives
-        me candidates: 179, 279, and 379, which I need to verify for primality. \\n\\nFinally,
-        I realized that \\\"79\\\" must be adjacent, ruling out non-adjacent digits.\"}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":128,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Testing\",\"obfuscation\":\"SagP2KU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        candidates\",\"obfuscation\":\"cp49B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        for\",\"obfuscation\":\"H5dyLsEQp4Fu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primal\",\"obfuscation\":\"faXXVAGBv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ity\",\"obfuscation\":\"JQxWiDKOqcbPI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"7tX7HXb7L7K\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019ve\",\"obfuscation\":\"DnbYqCD6Oe6UW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        established\",\"obfuscation\":\"elaD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        that\",\"obfuscation\":\"ymfNb84ljna\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        only\",\"obfuscation\":\"9RD8uNlLyOi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        adjacent\",\"obfuscation\":\"Nqa7kwC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        digits\",\"obfuscation\":\"AxVhN9VOg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        matter\",\"obfuscation\":\"BsOfBCRAP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        for\",\"obfuscation\":\"jfYnRRSfWsPN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"kY0TMPEwHyog\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\\"\",\"obfuscation\":\"gX11lc1sRNZD8A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"higIgF6Mje0NvH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"ZPy3FCj6VCN5mmD\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        substring\",\"obfuscation\":\"zvsHky\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"cfN31BNnLZiKyQd\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        There\",\"obfuscation\":\"UjxsQYVCor\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"n9nrG5BYqeonPk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        also\",\"obfuscation\":\"gutbOqLOnFv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        a\",\"obfuscation\":\"SXKQjUe1PIyWgO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        possibility\",\"obfuscation\":\"0cP5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        of\",\"obfuscation\":\"wQbcpVF6t50t6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        having\",\"obfuscation\":\"eUqoPUTBl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\\"\",\"obfuscation\":\"Fxkw73H8NUi39A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"3nTB4g8AH4DaOG\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"LUjBJhNMZ443VYk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        in\",\"obfuscation\":\"Eij0BtTT0YfYX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"jEASUS1kqa6m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        middle\",\"obfuscation\":\"Sdzw7HY4g\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        of\",\"obfuscation\":\"o1QQORYpdk4HJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        a\",\"obfuscation\":\"FP5BdZENNUFVbE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        3\",\"obfuscation\":\"lGtr2ZA7w8qV4H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"-digit\",\"obfuscation\":\"2TvulGWbmq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        number\",\"obfuscation\":\"93AJ79DZw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"seAeZcsH6XHYiTD\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        but\",\"obfuscation\":\"yN2okZa3mVaj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        those\",\"obfuscation\":\"IbX6WMGQ4c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        options\",\"obfuscation\":\"hxrOHfeM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        are\",\"obfuscation\":\"wI2JlYk48y40\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        limited\",\"obfuscation\":\"ejPexvJW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"Co6y2JAkD4yHIN4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        My\",\"obfuscation\":\"8ZWWkKoHTIx2i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        candidates\",\"obfuscation\":\"FLY6j\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        are\",\"obfuscation\":\"ClxUblKYSnCt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        79\",\"obfuscation\":\"IP7XuSPFCLTvL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"VGvQYfMxHX18VR9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"8ZfhAOg5G7dD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"7FMT6ey3Sf29Awn\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"rBGN3Zv9XdTi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"9tFzRy5P6AiXGCk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"yEb1AsobPUxj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"S7wapYrHozDR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"nNGFEOqAL0YugA6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"8n6zLSgqY6uM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"C5WlClJRJGqXGg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        need\",\"obfuscation\":\"di5OMSaVMZl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"cFSeoit2LGOf2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        test\",\"obfuscation\":\"H9jZE9zQjqa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"rHHXSPkINXsD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primal\",\"obfuscation\":\"Zw3QUO5SB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ity\",\"obfuscation\":\"uD62AH21vkVIl\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        of\",\"obfuscation\":\"lQdTmSbqxNBK9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"wLU83DCKYWCv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"Yufj6F31CcIJiPR\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"98eoOxl2Z5nD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"guErUGvHbKGXrI0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"h4Ub3vgJhz2k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"16eP593Bz31I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"5d4DAW4laTQuIA0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\n\\nStarting\",\"obfuscation\":\"RsnD97\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        with\",\"obfuscation\":\"1CK3jBvX665\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"yP2ELuy8NPgN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":205,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"EvXQl0vMYqv8JXo\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":206,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        after\",\"obfuscation\":\"JCZ3g8mol5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":207,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        checking\",\"obfuscation\":\"RRfrAK5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        divis\",\"obfuscation\":\"N1E7D7gwCU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ibility\",\"obfuscation\":\"ueJhNsYD5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        against\",\"obfuscation\":\"RPjsJK7M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primes\",\"obfuscation\":\"vc2nw470g\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        up\",\"obfuscation\":\"gvXtteU0fjRCQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"SRUVe2nRtPTjm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        around\",\"obfuscation\":\"98nzkNSSe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":215,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        13\",\"obfuscation\":\"d6GkTUyIWEaDD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":216,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"AvtnjC949GHY4r0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":217,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"IEyOWB2JpazX8b\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        find\",\"obfuscation\":\"Gesw2zngSs1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"kp9iAyLH5uJIx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"i8sLQOaTdJS2p3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"dUsGFPvKVb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"IjAU11oY30mvh0n\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":223,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        For\",\"obfuscation\":\"pltwGhgCuvhV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":224,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"4QIFNS3PVfZl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":225,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"gUsVZrkRWtxRIS5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":226,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        since\",\"obfuscation\":\"vUF9r6T7P0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":227,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"RbtHsJ4HZuVy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":228,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        sum\",\"obfuscation\":\"dGo0QMIL9MsW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":229,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        of\",\"obfuscation\":\"z9dQBEa6TLqQS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":230,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        digits\",\"obfuscation\":\"C9HdTJPd3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":231,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        equals\",\"obfuscation\":\"G7XUTTtPA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":232,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        18\",\"obfuscation\":\"9ZOzXMb4K2J08\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":233,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"KUGrHE3BFeewibM\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":234,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"q1jVzeAHpFo8b\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"MLvZsBFQ7zmME3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        divisible\",\"obfuscation\":\"AXFZMM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        by\",\"obfuscation\":\"U00ESP1voYGwH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        3\",\"obfuscation\":\"o6bTH81gLnxajB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"eN7BuOWNwBlEpIu\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        so\",\"obfuscation\":\"YOIhA0VMCapmo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"dxsEqN47U1JNQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"Lu1oX7zygb8dT7\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        not\",\"obfuscation\":\"iepYDAtxjx5k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"KEQQuibE4M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"g9FDbrmSXt9OT2r\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\n\\nFinally\",\"obfuscation\":\"8vCOMc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"JpqdnC4XkbHnGL0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"KyrG1jGkFvx6ni\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        check\",\"obfuscation\":\"YzHwTjWVxg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"1VVKe0oxcHvv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"sugt87HZc3ZODq4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"992Q8U5gyTQJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"bB7MKReWF4hPL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        doesn\",\"obfuscation\":\"sYIZodzMrf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019t\",\"obfuscation\":\"vbBy4pFjddMfxk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        seem\",\"obfuscation\":\"SvCSnZIVcNG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        divisible\",\"obfuscation\":\"EriVmX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        by\",\"obfuscation\":\"k0Tg3b2wWfdwj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"mFpEV4j6jyiH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primes\",\"obfuscation\":\"34uARVdSs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"hHOdFmzNL1p1b4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        tested\",\"obfuscation\":\"TvnbApXsq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        either\",\"obfuscation\":\"qXtONP0jh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"Ns9gcjboZ9POTuA\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":265,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Testing
-        candidates for primality**\\n\\nI\u2019ve established that only adjacent digits
-        matter for the \\\"79\\\" substring. There\u2019s also a possibility of having
-        \\\"79\\\" in the middle of a 3-digit number, but those options are limited.
-        My candidates are 79, 179, 279, and 379, and I need to test the primality
-        of 179, 279, and 379.\\n\\nStarting with 179, after checking divisibility
-        against primes up to around 13, I find it\u2019s prime. For 279, since the
-        sum of digits equals 18, it\u2019s divisible by 3, so it\u2019s not prime.
-        \\n\\nFinally, I check 379, and it doesn\u2019t seem divisible by the primes
-        I tested either.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":266,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Testing
-        candidates for primality**\\n\\nI\u2019ve established that only adjacent digits
-        matter for the \\\"79\\\" substring. There\u2019s also a possibility of having
-        \\\"79\\\" in the middle of a 3-digit number, but those options are limited.
-        My candidates are 79, 179, 279, and 379, and I need to test the primality
-        of 179, 279, and 379.\\n\\nStarting with 179, after checking divisibility
-        against primes up to around 13, I find it\u2019s prime. For 279, since the
-        sum of digits equals 18, it\u2019s divisible by 3, so it\u2019s not prime.
-        \\n\\nFinally, I check 379, and it doesn\u2019t seem divisible by the primes
-        I tested either.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
-        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":267,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Counting\",\"obfuscation\":\"1xWFQT\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"1DOuiJeHZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        with\",\"obfuscation\":\"XqSVdePD9WR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"mLC3u0QPcULbgd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"aSFl9gaYEBEa8q\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\"\",\"obfuscation\":\"ckTxYCZLvgSeIIu\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nAfter\",\"obfuscation\":\"jUXn6Yj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        testing\",\"obfuscation\":\"Jl66RRha\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"GI6gGDXjWG4eaKL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"g3wRKyqTCVNPvs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        confirmed\",\"obfuscation\":\"DOrseY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        that\",\"obfuscation\":\"NrU8YJzvviO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"03L9R7QFGbZY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"xb89bs1QEKvOr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        also\",\"obfuscation\":\"xf3gnQfpOb3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"oCU2qA2Yf0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"eN428QplwRQmOlO\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        So\",\"obfuscation\":\"sCXWFlVkhaAPh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        far\",\"obfuscation\":\"iL744VI3WZOe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"8E6yxgEBdQZHD8J\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"At0iQAnJhmufTh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        have\",\"obfuscation\":\"aWcPAfrifGP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"THdmAjO1div9T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"hKsk58TP4e23S8Q\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"eCDHhaI0Hnx4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"hQegqCWuFlWcuoI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"OV6jl5hUcISv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"6dmL2RhoOzFn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        as\",\"obfuscation\":\"cgpFacadKqkKb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"zFS85EaU5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"h2ArHbTM6L650Kt\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        making\",\"obfuscation\":\"7GCtdL1aB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        a\",\"obfuscation\":\"qNER6OanCppZCd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        count\",\"obfuscation\":\"QQ0iUwsmiu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        of\",\"obfuscation\":\"9ieo5jkonhjFV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        three\",\"obfuscation\":\"BnwcaswOZS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"wsiBB1bfqru0Whm\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\n\\nI\",\"obfuscation\":\"zMZ9Mb0d9cXv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        wondered\",\"obfuscation\":\"dpQIazi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        if\",\"obfuscation\":\"jOMDHT7vc28Wf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        there\",\"obfuscation\":\"SkQ0d65q4G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"8pDR5DZfb635\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        any\",\"obfuscation\":\"3TaD39ul9NvT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        other\",\"obfuscation\":\"EAHiFNFS1o\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"aVoKtCO6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        under\",\"obfuscation\":\"XnobFMYD51\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"vtzU59lNZw3U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        with\",\"obfuscation\":\"Eb6JSFo54pk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        the\",\"obfuscation\":\"9cdHdRvwZrLc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        substring\",\"obfuscation\":\"n5G9de\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"R0VaB4KVEs3pPu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"71fD9EEzRj9EfT\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\\\"\",\"obfuscation\":\"hGZGxDAVYyNDT9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        Well\",\"obfuscation\":\"x9p6UGSWaz1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"U8tA8nmqXktltBA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"QSNyyLHgKoHdHV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":324,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        already\",\"obfuscation\":\"WUbvyP6r\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":325,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        included\",\"obfuscation\":\"hlmL7O9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":326,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"8fKXvSWDOiHmd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":327,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"pRagcmsU9y5Xm66\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":328,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"DZeI6tCNSfrJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":329,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"8qNLgutbCPoyJ2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":330,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        considered\",\"obfuscation\":\"rzvCj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":331,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        297\",\"obfuscation\":\"DAjcOEndd3Zn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":332,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"OxOb0gjpaKSYCk5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":333,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        but\",\"obfuscation\":\"6zV7lpwZOtCM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":334,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        it\",\"obfuscation\":\"uveIvUNZYabcV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":335,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        contains\",\"obfuscation\":\"iTXdpH7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":336,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"WNzWgsFQZJDExa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":337,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"97\",\"obfuscation\":\"It71Nuor0Wcv3i\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":338,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\\\"\",\"obfuscation\":\"pJdg631CZli3UH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":339,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        not\",\"obfuscation\":\"k4dGrWv8EDi4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":340,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"dMu7KSnlvLQwiu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":341,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"7gw3R5URbhqFpz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":342,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\\\"\",\"obfuscation\":\"iThtH8dcPrzI7h\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":343,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\n\\nI\",\"obfuscation\":\"MFXHBd8trMev\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":344,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        realized\",\"obfuscation\":\"yNNa1zR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":345,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        my\",\"obfuscation\":\"izhyUscmwZY7Q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":346,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        criteria\",\"obfuscation\":\"30ShHap\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":347,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        for\",\"obfuscation\":\"OuZf50HE18dq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":348,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        3\",\"obfuscation\":\"0E7jdeiXX6qy94\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":349,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"Rq8aAXynmZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":350,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"aFBCvPAr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":351,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        can\",\"obfuscation\":\"6xgeWHOmwrOT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":352,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        only\",\"obfuscation\":\"idSvCpfRjs6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":353,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        lead\",\"obfuscation\":\"cM1CiCuw0hb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":354,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        to\",\"obfuscation\":\"KLnHREZx53mww\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":355,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        x\",\"obfuscation\":\"RtUHn8ovj9pG3Y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":356,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"9fptnzy3MXMsGC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":357,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        or\",\"obfuscation\":\"yvhMN0dmV40pF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":358,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"o0sDsIZc1PTGh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":359,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"x\",\"obfuscation\":\"bWLnegA5U4rhAAz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":360,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"mI7XLuKMzcZm9kk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":361,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        but\",\"obfuscation\":\"LKzhxmUibxW4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":362,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        those\",\"obfuscation\":\"O2gPDU2nsX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":363,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        like\",\"obfuscation\":\"trGrxG9V7H5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":364,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"U6XEUgonU0JaT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":365,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"x\",\"obfuscation\":\"BoutneFA1kJo9j4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":366,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        (\",\"obfuscation\":\"P3xcum20NYA1CM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":367,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"790\",\"obfuscation\":\"KYr6Wexl09MIY\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":368,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        or\",\"obfuscation\":\"uiZ1Akvxi1ats\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":369,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        higher\",\"obfuscation\":\"92D9F7DSM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":370,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\")\",\"obfuscation\":\"Z6awT9g9VCVlmlu\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":371,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        exceed\",\"obfuscation\":\"qdgYKoNj1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":372,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"ubvo8z2NK5Nz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":373,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"v5xAjNtpl7gPHSs\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":374,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        My\",\"obfuscation\":\"8BOal1RR72FyZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":375,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        total\",\"obfuscation\":\"T1xMhuBXue\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":376,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        remains\",\"obfuscation\":\"UTJHWdnd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":377,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        three\",\"obfuscation\":\"99L0dNckxN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":378,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"FHy2XU49i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":379,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\":\",\"obfuscation\":\"tNPCSLgoLffH8eW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":380,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"gV8TBCsvdtmmje\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":381,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019ll\",\"obfuscation\":\"nLNvlLlvDzVj7\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":382,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        double\",\"obfuscation\":\"N1UB8B6Yg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":383,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-check\",\"obfuscation\":\"f9KICFVZCD\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":384,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        to\",\"obfuscation\":\"jNCcB28DnOvU3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":385,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        ensure\",\"obfuscation\":\"w7I7b2EbL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":386,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        there\",\"obfuscation\":\"nGZnYfhCcH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":387,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"8eO3ScY0katb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":388,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        no\",\"obfuscation\":\"6SetwO4sZMGX1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":389,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        others\",\"obfuscation\":\"ZWnr5hYN0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":390,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        under\",\"obfuscation\":\"OnWGlRHCnr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":391,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"yz6JWbHik23b\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":392,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"mZV7bbeHDlgZIUV\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":393,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\n\\nAfter\",\"obfuscation\":\"jnVsqqIZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":394,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        confirming\",\"obfuscation\":\"mzULk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":395,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"UEC7UqYeEWK0xFH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":396,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"zADnDefLc1yEN2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":397,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        finalize\",\"obfuscation\":\"QMUv40i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":398,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        the\",\"obfuscation\":\"WIqlxXQ0p5s8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":399,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        answer\",\"obfuscation\":\"rsks4lKhR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":400,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        as\",\"obfuscation\":\"tGYfI308S3cd6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":401,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"XJ6a2kpkl3fcU8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":402,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"3\",\"obfuscation\":\"3nBgcFvywWt7mUs\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":403,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\\\"\",\"obfuscation\":\"tZWdlIaUOlrrsk\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":404,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Counting
-        primes with \\\"79\\\"**\\n\\nAfter testing, I confirmed that 379 is also
-        prime. So far, I have 79, 179, and 379 as primes, making a count of three.
-        \\n\\nI wondered if there are any other numbers under 400 with the substring
-        \\\"79.\\\" Well, I already included 79, and I considered 297, but it contains
-        \\\"97,\\\" not \\\"79.\\\" \\n\\nI realized my criteria for 3-digit numbers
-        can only lead to x79 or 79x, but those like 79x (790 or higher) exceed 400.
-        My total remains three primes: I\u2019ll double-check to ensure there are
-        no others under 400. \\n\\nAfter confirming, I finalize the answer as \\\"3.\\\"\"}\n\nevent:
-        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":405,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
-        primes with \\\"79\\\"**\\n\\nAfter testing, I confirmed that 379 is also
-        prime. So far, I have 79, 179, and 379 as primes, making a count of three.
-        \\n\\nI wondered if there are any other numbers under 400 with the substring
-        \\\"79.\\\" Well, I already included 79, and I considered 297, but it contains
-        \\\"97,\\\" not \\\"79.\\\" \\n\\nI realized my criteria for 3-digit numbers
-        can only lead to x79 or 79x, but those like 79x (790 or higher) exceed 400.
-        My total remains three primes: I\u2019ll double-check to ensure there are
-        no others under 400. \\n\\nAfter confirming, I finalize the answer as \\\"3.\\\"\"}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":406,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":407,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**Final\",\"obfuscation\":\"eQmeWYUm9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":408,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"izing\",\"obfuscation\":\"ae3q0dcO8E8\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":409,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"pfqfcIQEYL5A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":410,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"J1EhinYJco\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":411,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**\\n\\nI'm\",\"obfuscation\":\"SWQgKSncU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":412,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        checking\",\"obfuscation\":\"rR96k78\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":413,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"k3M4Lv3Q8nVn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":414,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        user\",\"obfuscation\":\"wHl137mFEJu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":415,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019s\",\"obfuscation\":\"npGlDrJ9syDth3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":416,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        request\",\"obfuscation\":\"gBo90fB7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":417,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        for\",\"obfuscation\":\"3bckOefjUODe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":418,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        numbers\",\"obfuscation\":\"LKRwQPtT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":419,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"JCMlmOQuKUORZD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":420,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"below\",\"obfuscation\":\"bwobzGpFCQD\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":421,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        400\",\"obfuscation\":\"TOMprDyFPNtb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":422,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\\\"\",\"obfuscation\":\"0sUxdNpG3HZeQ1\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":423,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        Typically\",\"obfuscation\":\"0o4dSQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":424,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"rLgx6BmWXCDBkXX\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":425,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"YZ5eKtWIeVr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":426,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        means\",\"obfuscation\":\"9iJP74OfZh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":427,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        less\",\"obfuscation\":\"FUkY4xb34sF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":428,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        than\",\"obfuscation\":\"0bMRarU7Zjp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":429,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        400\",\"obfuscation\":\"wtQwsVV4AVso\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":430,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"qduGnCBpzBnPxEy\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":431,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        so\",\"obfuscation\":\"46753CLxAeWUg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":432,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        79\",\"obfuscation\":\"Zbq6SIFMTGBlB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":433,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"vLg5BsQZJt3BG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":434,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        definitely\",\"obfuscation\":\"L4e3D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":435,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        included\",\"obfuscation\":\"zl1jf90\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":436,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        in\",\"obfuscation\":\"Hj8YQcTBoN26J\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":437,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        my\",\"obfuscation\":\"XbRjcC5C0F4WZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":438,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"6nQ4u3cjTX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":439,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"gDFW7x3SWi9Guxe\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":440,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"hCnB1lInJY7uRu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":441,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        want\",\"obfuscation\":\"QMVbkN418Ve\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":442,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        to\",\"obfuscation\":\"ZiKQ73YxYQoTm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":443,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        be\",\"obfuscation\":\"uwX9gZXuQNJRs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":444,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        accurate\",\"obfuscation\":\"mjYo5Sh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":445,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        here\",\"obfuscation\":\"Hq8N619F5jY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":446,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"hKw3MuIAVZ0wad1\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":447,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\n\\nSince\",\"obfuscation\":\"46cJ7bJw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":448,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"zRty6Q0qTqwFiB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":449,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        found\",\"obfuscation\":\"1lpXuAF6PN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":450,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        three\",\"obfuscation\":\"bZWJGZYFts\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":451,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"I6Bm88cVmD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":452,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        numbers\",\"obfuscation\":\"bfUX7iEO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":453,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        containing\",\"obfuscation\":\"g0AUt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":454,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"hVL3JtoXPdFr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":455,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        substring\",\"obfuscation\":\"Hy6NLp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":456,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"SrPHCB7Zh4lT0v\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":457,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"cf7fhN9gWsGMMt\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":458,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"SyxbogLvIr7b8XI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":459,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        (\",\"obfuscation\":\"kyetkm897L1Axb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":460,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"63d2wptMdPL7CQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":461,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"yBgec2cw1x6QFbv\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":462,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        179\",\"obfuscation\":\"3CJeNyIUthCs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":463,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"YTNS72OdOlqYXGT\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":464,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"xlFqH6x2G07O\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":465,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"46poXPqUCEaA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":466,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"),\",\"obfuscation\":\"o5xWaDUte4Ghe4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":467,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"bUv90ZTZZyFzzJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":468,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        can\",\"obfuscation\":\"ni60ZOH0cJm2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":469,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        confidently\",\"obfuscation\":\"v0pu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":470,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        say\",\"obfuscation\":\"f637QTIkK9Wk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":471,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"xD31SUPnNp14\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":472,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        answer\",\"obfuscation\":\"ARgrofsN6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":473,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"kVgMjqfuP5wfZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":474,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        exactly\",\"obfuscation\":\"kJyQJDbu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":475,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"BCmdiEBCZnfyIQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":476,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"3\",\"obfuscation\":\"UcawxJj3BSI0oo2\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":477,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\\\"\",\"obfuscation\":\"kdd7uuLdnoBzfX\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":478,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I'll\",\"obfuscation\":\"kIkAttJVW03\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":479,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        make\",\"obfuscation\":\"n67DmhF5SXS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":480,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        sure\",\"obfuscation\":\"scjorYCZK7k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":481,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        to\",\"obfuscation\":\"g6y2SeIwMCXdq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":482,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        keep\",\"obfuscation\":\"lR6495arIej\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":483,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"KyNNuCpyHGDCz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":484,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        clear\",\"obfuscation\":\"4BHarYgNLL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":485,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"DEDtRvpAfyXLP2t\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":486,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        just\",\"obfuscation\":\"rcJnKdLA06P\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":487,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        providing\",\"obfuscation\":\"CyOi0p\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":488,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"gP3QbJpqLax\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":489,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        number\",\"obfuscation\":\"1QyjGRv8v\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":490,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"0BbWBEYhQ6GmzYg\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":491,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        with\",\"obfuscation\":\"iZtI9PNrV8b\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":492,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        no\",\"obfuscation\":\"cqjFqWfU30N8S\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":493,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        additional\",\"obfuscation\":\"KPdMS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":494,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        text\",\"obfuscation\":\"KHxny9zoXMC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":495,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"TPPB5S6FwXKe3Hn\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":496,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"text\":\"**Finalizing
-        the count**\\n\\nI'm checking the user\u2019s request for numbers \\\"below
-        400.\\\" Typically, that means less than 400, so 79 is definitely included
-        in my count. I want to be accurate here. \\n\\nSince I found three prime numbers
-        containing the substring \\\"79\\\" (79, 179, and 379), I can confidently
-        say the answer is exactly \\\"3.\\\" I'll make sure to keep it clear, just
-        providing that number, with no additional text.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":497,\"item_id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"**Finalizing
-        the count**\\n\\nI'm checking the user\u2019s request for numbers \\\"below
-        400.\\\" Typically, that means less than 400, so 79 is definitely included
-        in my count. I want to be accurate here. \\n\\nSince I found three prime numbers
-        containing the substring \\\"79\\\" (79, 179, and 379), I can confidently
-        say the answer is exactly \\\"3.\\\" I'll make sure to keep it clear, just
-        providing that number, with no additional text.\"}}\n\nevent: response.output_item.done\ndata:
-        {\"type\":\"response.output_item.done\",\"sequence_number\":498,\"output_index\":0,\"item\":{\"id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Finding
-        primes with substring \\\"79\\\"**\\n\\nI\u2019m looking for prime numbers
-        under 400 that contain the substring \\\"79.\\\" First, the only 2-digit prime
-        is 79 itself, giving me one candidate. \\n\\nFor 3-digit primes, I considered
-        numbers of the form 79x, but those fall outside the 400 limit, so there are
-        none. \\n\\nThen I checked numbers like x79, where x can be 1-3. This gives
-        me candidates: 179, 279, and 379, which I need to verify for primality. \\n\\nFinally,
-        I realized that \\\"79\\\" must be adjacent, ruling out non-adjacent digits.\"},{\"type\":\"summary_text\",\"text\":\"**Testing
-        candidates for primality**\\n\\nI\u2019ve established that only adjacent digits
-        matter for the \\\"79\\\" substring. There\u2019s also a possibility of having
-        \\\"79\\\" in the middle of a 3-digit number, but those options are limited.
-        My candidates are 79, 179, 279, and 379, and I need to test the primality
-        of 179, 279, and 379.\\n\\nStarting with 179, after checking divisibility
-        against primes up to around 13, I find it\u2019s prime. For 279, since the
-        sum of digits equals 18, it\u2019s divisible by 3, so it\u2019s not prime.
-        \\n\\nFinally, I check 379, and it doesn\u2019t seem divisible by the primes
-        I tested either.\"},{\"type\":\"summary_text\",\"text\":\"**Counting primes
-        with \\\"79\\\"**\\n\\nAfter testing, I confirmed that 379 is also prime.
-        So far, I have 79, 179, and 379 as primes, making a count of three. \\n\\nI
-        wondered if there are any other numbers under 400 with the substring \\\"79.\\\"
-        Well, I already included 79, and I considered 297, but it contains \\\"97,\\\"
-        not \\\"79.\\\" \\n\\nI realized my criteria for 3-digit numbers can only
-        lead to x79 or 79x, but those like 79x (790 or higher) exceed 400. My total
-        remains three primes: I\u2019ll double-check to ensure there are no others
-        under 400. \\n\\nAfter confirming, I finalize the answer as \\\"3.\\\"\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
-        the count**\\n\\nI'm checking the user\u2019s request for numbers \\\"below
-        400.\\\" Typically, that means less than 400, so 79 is definitely included
-        in my count. I want to be accurate here. \\n\\nSince I found three prime numbers
-        containing the substring \\\"79\\\" (79, 179, and 379), I can confidently
-        say the answer is exactly \\\"3.\\\" I'll make sure to keep it clear, just
-        providing that number, with no additional text.\"}]}}\n\nevent: response.output_item.added\ndata:
-        {\"type\":\"response.output_item.added\",\"sequence_number\":499,\"output_index\":1,\"item\":{\"id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
-        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":500,\"item_id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":501,\"item_id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"f5oGnqY96WZpCdn\"}\n\nevent:
-        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":502,\"item_id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
-        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":503,\"item_id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
-        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":504,\"output_index\":1,\"item\":{\"id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
-        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":505,\"response\":{\"id\":\"resp_00c8480f43d079250068f297ab00fc8195a5c4f856bc2c1470\",\"object\":\"response\",\"created_at\":1760729003,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Finding
-        primes with substring \\\"79\\\"**\\n\\nI\u2019m looking for prime numbers
-        under 400 that contain the substring \\\"79.\\\" First, the only 2-digit prime
-        is 79 itself, giving me one candidate. \\n\\nFor 3-digit primes, I considered
-        numbers of the form 79x, but those fall outside the 400 limit, so there are
-        none. \\n\\nThen I checked numbers like x79, where x can be 1-3. This gives
-        me candidates: 179, 279, and 379, which I need to verify for primality. \\n\\nFinally,
-        I realized that \\\"79\\\" must be adjacent, ruling out non-adjacent digits.\"},{\"type\":\"summary_text\",\"text\":\"**Testing
-        candidates for primality**\\n\\nI\u2019ve established that only adjacent digits
-        matter for the \\\"79\\\" substring. There\u2019s also a possibility of having
-        \\\"79\\\" in the middle of a 3-digit number, but those options are limited.
-        My candidates are 79, 179, 279, and 379, and I need to test the primality
-        of 179, 279, and 379.\\n\\nStarting with 179, after checking divisibility
-        against primes up to around 13, I find it\u2019s prime. For 279, since the
-        sum of digits equals 18, it\u2019s divisible by 3, so it\u2019s not prime.
-        \\n\\nFinally, I check 379, and it doesn\u2019t seem divisible by the primes
-        I tested either.\"},{\"type\":\"summary_text\",\"text\":\"**Counting primes
-        with \\\"79\\\"**\\n\\nAfter testing, I confirmed that 379 is also prime.
-        So far, I have 79, 179, and 379 as primes, making a count of three. \\n\\nI
-        wondered if there are any other numbers under 400 with the substring \\\"79.\\\"
-        Well, I already included 79, and I considered 297, but it contains \\\"97,\\\"
-        not \\\"79.\\\" \\n\\nI realized my criteria for 3-digit numbers can only
-        lead to x79 or 79x, but those like 79x (790 or higher) exceed 400. My total
-        remains three primes: I\u2019ll double-check to ensure there are no others
-        under 400. \\n\\nAfter confirming, I finalize the answer as \\\"3.\\\"\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
-        the count**\\n\\nI'm checking the user\u2019s request for numbers \\\"below
-        400.\\\" Typically, that means less than 400, so 79 is definitely included
-        in my count. I want to be accurate here. \\n\\nSince I found three prime numbers
-        containing the substring \\\"79\\\" (79, 179, and 379), I can confidently
-        say the answer is exactly \\\"3.\\\" I'll make sure to keep it clear, just
-        providing that number, with no additional text.\"}]},{\"id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":903,\"output_tokens_details\":{\"reasoning_tokens\":896},\"total_tokens\":935},\"user\":null,\"metadata\":{}}}\n\n"
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0d570aae5ddaa59f0068f805e5a3e881969a8e10226fbc2421\",\"object\":\"response\",\"created_at\":1761084901,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0d570aae5ddaa59f0068f805e5a3e881969a8e10226fbc2421\",\"object\":\"response\",\"created_at\":1761084901,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Counting\",\"obfuscation\":\"BES26P\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"oGG8RSoo8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        with\",\"obfuscation\":\"QHeaI9gZKqQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"MGkcPeg4nES7cM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"ah0PuWM0Q0x5IV\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"2Nx3R9Z23mof14b\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"t4YZwsEZCGG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        need\",\"obfuscation\":\"XK7HaGjwxkr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        to\",\"obfuscation\":\"KstZVrVx8MqNQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        find\",\"obfuscation\":\"BdjDHFtmZN9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"xApQaZe3Xm1x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        count\",\"obfuscation\":\"0aaiK4cLNc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        of\",\"obfuscation\":\"Ek1NaTgyneb0j\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        prime\",\"obfuscation\":\"lMvOxAAVkN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"dEwVuAKz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        less\",\"obfuscation\":\"EJJsgwfAiVr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        than\",\"obfuscation\":\"VAmLDnSHxSL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"d4WDEZnu35V7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"w09875wzKux\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        include\",\"obfuscation\":\"3KoqlbaL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"UGRqo63EQMON\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        substring\",\"obfuscation\":\"IZwfNF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"yS4Cq7pRcCPzbs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"rtcIX4sxsD3Ak7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\\\"\",\"obfuscation\":\"YoPOuAcs1nJ0AD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        This\",\"obfuscation\":\"oiWOOZggLjj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        means\",\"obfuscation\":\"R98LPmaCO7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        identifying\",\"obfuscation\":\"3Tu1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"nOlSgS2Vo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        below\",\"obfuscation\":\"AySInmLymr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"OTW4PBJfzZz0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        with\",\"obfuscation\":\"RilXQazEiIo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"zMJVm9PB9jlcEy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"nZg5YJBASvTUGC\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"oNg5CY9eQI22d7Q\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        in\",\"obfuscation\":\"Cp7VesDNbN7bC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        their\",\"obfuscation\":\"CRr8kOLJ6j\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        decimal\",\"obfuscation\":\"2av0SIIy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        representation\",\"obfuscation\":\"j\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"qRy5GuATcrND0Do\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        First\",\"obfuscation\":\"jjS0mUVli5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"ywVVrlfc8cXom4f\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"uraMYaWZiTb8eL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        recognize\",\"obfuscation\":\"Rw7squ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"FfkVTSifp47N\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        prime\",\"obfuscation\":\"ScL0gPaAm5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"v3Amx80R\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\":\",\"obfuscation\":\"crYJPLqzDeFBQCS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        79\",\"obfuscation\":\"yJXpKhz5y5jFI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"3OFUfZ2BBKok63C\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        179\",\"obfuscation\":\"HCtyEqtwnGcG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"SZYcFWwUA2lHwGj\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        279\",\"obfuscation\":\"rsAQYTMLp3Yl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"pAlnbeL0y5qBR6r\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"TqvF2JBTyOgS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        379\",\"obfuscation\":\"mXpwE6glCl9d\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"170Vqz2JtVtky5C\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"TqLf12PCC5URfd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        realize\",\"obfuscation\":\"O0CpziSB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"Ox5oA3Zv8oY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"wocRZBXd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        like\",\"obfuscation\":\"bFIWuLTVc1n\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        790\",\"obfuscation\":\"ClcXxxgfzSZI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"mBvKtaHnASDM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        above\",\"obfuscation\":\"6KCI0sNgy0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        are\",\"obfuscation\":\"c9cc2Z5RcQOj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        out\",\"obfuscation\":\"pSHxxe17qYU2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        of\",\"obfuscation\":\"SdwtFoOqumUpu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        scope\",\"obfuscation\":\"2P9Iim8Xu6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"KbLXeQ1oUafc9CZ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        Also\",\"obfuscation\":\"5r2Uks4itXx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"APRBzI96YdbHVXW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"CRK41ci7RUYY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        three\",\"obfuscation\":\"Rk9tveA0gx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"bVKDRctj1O\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        formats\",\"obfuscation\":\"wRLfw4M3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        with\",\"obfuscation\":\"9Wl6EjW4GGn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"DZYiG4yq5QjGXI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"ewAwOTR1WYmppn\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"NUBo4fhg7EpI1IA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        can\",\"obfuscation\":\"FmzQTOhhXt1N\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        only\",\"obfuscation\":\"5wIfLS3317w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        be\",\"obfuscation\":\"B7XZCToreSaSW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        those\",\"obfuscation\":\"F6R9Ym00qU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"yI6uSuYVAxYVQH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        mentioned\",\"obfuscation\":\"V8hDe1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        since\",\"obfuscation\":\"T2ZNAcpMkH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        there\",\"obfuscation\":\"C2mSLqnEbB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        are\",\"obfuscation\":\"XJmgMJkKP2bg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        no\",\"obfuscation\":\"hJPbhpmH4gaXY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        other\",\"obfuscation\":\"sxAJREC4wo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        candidates\",\"obfuscation\":\"IEnNx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"AoJ4ywXhotG2ylg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":97,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        Now\",\"obfuscation\":\"1XOdMp1XWr35\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":98,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"qbomBtfuMBSmAOB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":99,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I'll\",\"obfuscation\":\"3BkQkv5YM2U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        compute\",\"obfuscation\":\"vnVpNp7c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"MworjF3KHy35\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        total\",\"obfuscation\":\"OtlpgRDbhz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"o8QI5lsW8zUBTww\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":104,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Counting
+        primes with \\\"79\\\"**\\n\\nI need to find the count of prime numbers less
+        than 400 that include the substring \\\"79.\\\" This means identifying primes
+        below 400 with \\\"79\\\" in their decimal representation. First, I recognize
+        the prime numbers: 79, 179, 279, and 379. I realize that numbers like 790
+        and above are out of scope. Also, the three-digit formats with \\\"79\\\"
+        can only be those I mentioned since there are no other candidates. Now, I'll
+        compute the total.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":105,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with \\\"79\\\"**\\n\\nI need to find the count of prime numbers less
+        than 400 that include the substring \\\"79.\\\" This means identifying primes
+        below 400 with \\\"79\\\" in their decimal representation. First, I recognize
+        the prime numbers: 79, 179, 279, and 379. I realize that numbers like 790
+        and above are out of scope. Also, the three-digit formats with \\\"79\\\"
+        can only be those I mentioned since there are no other candidates. Now, I'll
+        compute the total.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
+        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":106,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":107,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Ident\",\"obfuscation\":\"MywreqDdz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ifying\",\"obfuscation\":\"TQAqouSxpN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        candidates\",\"obfuscation\":\"3CX8B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":110,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        with\",\"obfuscation\":\"PoogAraHP77\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":111,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"RkU4JZhHFFwvZp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":112,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"iJ9uLjudKldFQa\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":113,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"Vc1RNbuW8bjlbOc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nTo\",\"obfuscation\":\"4X19d0pI5C\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        find\",\"obfuscation\":\"SpJAQdrzUAr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        numbers\",\"obfuscation\":\"ZdJISwbe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        containing\",\"obfuscation\":\"RfaEc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"osF3GriBc40F6U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"ihTwOonuMqKvZg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\\\"\",\"obfuscation\":\"TA28L7J5IwvKH5\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"8r1bZqvH5NRjwq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":122,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        can\",\"obfuscation\":\"k3giNYya6E3p\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":123,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        check\",\"obfuscation\":\"A8X88ZV9Kd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":124,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        two\",\"obfuscation\":\"b16ikWmN2xAN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        patterns\",\"obfuscation\":\"FuXkoAO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":126,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\":\",\"obfuscation\":\"M2j03bp0AoxXQEg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":127,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        hundreds\",\"obfuscation\":\"bcPx3fI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":128,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"=\",\"obfuscation\":\"qBrjrguQJDrka0m\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"7\",\"obfuscation\":\"LoiQtJfAX5kcnCP\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"2dUn2GnLXbfi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        tens\",\"obfuscation\":\"ete3caorCoX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"=\",\"obfuscation\":\"3iEXS0t8RiTGz4X\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"9\",\"obfuscation\":\"YsWzeKpOzdfbZrg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        (\",\"obfuscation\":\"9baPutdLiC88wl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"like\",\"obfuscation\":\"STfyS4Y78Zsv\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"NGmHFE6FVFD1e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"y\",\"obfuscation\":\"Ghb3AsfTHbLXqWu\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\")\",\"obfuscation\":\"7DxIX0AwN61Mirp\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        or\",\"obfuscation\":\"CGe9JLtcy9Jul\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        tens\",\"obfuscation\":\"Yc1eeGks1L6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"=\",\"obfuscation\":\"ojIIqdw826sBdmD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"7\",\"obfuscation\":\"Dayk4YuQU3v3fUe\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"rZyW5eFSmEpi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        ones\",\"obfuscation\":\"KAj5kkpEEE3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"=\",\"obfuscation\":\"B6rhCvAux6Vwfca\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"9\",\"obfuscation\":\"lndnRBMFWdupsim\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        (\",\"obfuscation\":\"0awnYegZ6d0csh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"like\",\"obfuscation\":\"sPkRFOOsaC5j\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        x\",\"obfuscation\":\"XXFaeJ9dg99Y65\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"HP8K7EiOf78BYJ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\").\",\"obfuscation\":\"7XDsbtG1vTAdfO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        For\",\"obfuscation\":\"0oK4qsyAvUTz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        numbers\",\"obfuscation\":\"1EgO1coV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        under\",\"obfuscation\":\"M9Y4106eZR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        400\",\"obfuscation\":\"kg4AzHEOHfIr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"Br4BDGUV1EXVivU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"FZ5CVqg7hRrk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        candidates\",\"obfuscation\":\"eu5j8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        are\",\"obfuscation\":\"ihuRWLytz6Kq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"WwpZZ2tOuaAGW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"GTR2iQ7ncUZZsgR\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        179\",\"obfuscation\":\"vPqJ2Amtm6ta\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"rrgTkblT3A8hW48\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        279\",\"obfuscation\":\"j6wFYp0E89DH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"pkD1LW5tOHEDj7w\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"3TYZiMpTUEEO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        379\",\"obfuscation\":\"S9B4em3ArSlK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"quHthNQZttVTSsR\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        The\",\"obfuscation\":\"4886abMwDeey\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        pattern\",\"obfuscation\":\"UVeI3xGq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"oTvpwFJrwJWHj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"y\",\"obfuscation\":\"sdrLly1DUJHqIQZ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        only\",\"obfuscation\":\"GCeMqD2Xwbu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        applies\",\"obfuscation\":\"ukrgDk01\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        to\",\"obfuscation\":\"WXwPLCNCrqwrL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        numbers\",\"obfuscation\":\"DZPdcTbi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        790\",\"obfuscation\":\"JEwbCngUlr17\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"-\",\"obfuscation\":\"msJNhn3AaT8ypJQ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"799\",\"obfuscation\":\"dxllsVexAgDZ5\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"XerJVphV2LDeTYK\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        which\",\"obfuscation\":\"jDJShIjYVL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        are\",\"obfuscation\":\"TGGqKDXb5y3a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        above\",\"obfuscation\":\"ZAzXLQGobm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        400\",\"obfuscation\":\"5T2uGO7NpIot\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"aRXmcTxAjL5nSlP\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"wrVsRNRS13S0Fo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        realize\",\"obfuscation\":\"OR57h5od\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        297\",\"obfuscation\":\"Ae8a0jeWgn9o\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        doesn't\",\"obfuscation\":\"ENfGioJP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        fit\",\"obfuscation\":\"KcIpUpM7esAp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        as\",\"obfuscation\":\"cyRZx9uO0T85W\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it\",\"obfuscation\":\"gxgxXLcVAMlxe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        contains\",\"obfuscation\":\"K7ZHlVy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"oXbXpBvvIxKgGh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"97\",\"obfuscation\":\"PzEdaCkTv2gDZ8\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\\\"\",\"obfuscation\":\"2angxtgcrMES2b\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        not\",\"obfuscation\":\"mOq67uKZbPpq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"omGrAAUOxZdL6i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"9Qbn9TjNUJn98M\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\\\"\",\"obfuscation\":\"FBG7Mze7gwNes3\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        So\",\"obfuscation\":\"mzQcf27xxYHEB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"yxKoS5PAn8dKYfu\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        now\",\"obfuscation\":\"Eggd68wXbptq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"JNRfshIZP5VUyF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":205,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        need\",\"obfuscation\":\"OtcLMUpZOAq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":206,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        to\",\"obfuscation\":\"YjwCVLWGafvm2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":207,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        confirm\",\"obfuscation\":\"EriSRSiw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        whether\",\"obfuscation\":\"dh9AoZ2D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"zwIu4YsA7ucmW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"OzE0Hxa4B05YWLR\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        179\",\"obfuscation\":\"vk0SNFjERg4v\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"Yidw6vIKJTmTloK\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"5HY242HJyZcD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        379\",\"obfuscation\":\"nGnH6vnV8squ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":215,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        are\",\"obfuscation\":\"LikjeaBJEl6y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":216,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        prime\",\"obfuscation\":\"rKd2iRr9Iy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":217,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"MEg8dFHk0G37rmd\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I'll\",\"obfuscation\":\"0fNvxIx9cMr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        start\",\"obfuscation\":\"KztQWEJC6N\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        checking\",\"obfuscation\":\"8Zr2eii\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        them\",\"obfuscation\":\"NCYoltbknMN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"delta\":\"!\",\"obfuscation\":\"rQy72uUAkckL9qC\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":223,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Identifying
+        candidates with \\\"79\\\"**\\n\\nTo find numbers containing \\\"79,\\\" I
+        can check two patterns: hundreds=7 and tens=9 (like 79y) or tens=7 and ones=9
+        (like x79). For numbers under 400, the candidates are 79, 179, 279, and 379.
+        The pattern 79y only applies to numbers 790-799, which are above 400. I realize
+        297 doesn't fit as it contains \\\"97,\\\" not \\\"79.\\\" So, now I need
+        to confirm whether 79, 179, and 379 are prime. I'll start checking them!\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":224,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Identifying
+        candidates with \\\"79\\\"**\\n\\nTo find numbers containing \\\"79,\\\" I
+        can check two patterns: hundreds=7 and tens=9 (like 79y) or tens=7 and ones=9
+        (like x79). For numbers under 400, the candidates are 79, 179, 279, and 379.
+        The pattern 79y only applies to numbers 790-799, which are above 400. I realize
+        297 doesn't fit as it contains \\\"97,\\\" not \\\"79.\\\" So, now I need
+        to confirm whether 79, 179, and 379 are prime. I'll start checking them!\"}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":225,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":226,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Checking\",\"obfuscation\":\"jyNQGS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":227,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divis\",\"obfuscation\":\"YOKxR9zCrA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":228,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ibility\",\"obfuscation\":\"kgXjWyLbe\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":229,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        of\",\"obfuscation\":\"uVrKwwi6rKUPX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":230,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        candidates\",\"obfuscation\":\"c1cMr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":231,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"SsH7ZVJIxMu\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":232,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019m\",\"obfuscation\":\"BXwmbOT9t0gIt9\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":233,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        testing\",\"obfuscation\":\"EsJ5rujf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":234,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"PqnKBN1PMYjj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"3bZSGVbgq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"ei8Fp3dV1NgjOq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        found\",\"obfuscation\":\"Tz6DBURtX1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\":\",\"obfuscation\":\"8nrCjnFQz9ZNgNU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        first\",\"obfuscation\":\"lM7qSXJk1x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"1oltTfvLLDos3EO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"CtCOB5UA1s1G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"suaVdGdErm6cRGO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        With\",\"obfuscation\":\"h7s44yX4KQH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        a\",\"obfuscation\":\"NbmJ7Fc2L2cUPa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        rough\",\"obfuscation\":\"1g0pjW9w8j\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        estimate\",\"obfuscation\":\"euNbw0m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        of\",\"obfuscation\":\"YK7TjtqRICWZg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"2AhutptHZrbu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        square\",\"obfuscation\":\"cyDYse9LR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        root\",\"obfuscation\":\"SQwraelnjWO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        at\",\"obfuscation\":\"UvG6NcQezvD0e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        about\",\"obfuscation\":\"Ps81oVHP5a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        13\",\"obfuscation\":\"cta2ED8LFhG7p\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"50JSlB1U7y3jz4v\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"38\",\"obfuscation\":\"jsGsIvhh5kPuS7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"oRxjgyX7ALKgyle\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"11CmVgEoqSGAuq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        check\",\"obfuscation\":\"nv4zO4ow2e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divis\",\"obfuscation\":\"g6mit3VRe8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ibility\",\"obfuscation\":\"RiO08xzIk\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        by\",\"obfuscation\":\"tUM8uSF9BYrLu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        common\",\"obfuscation\":\"RkoSF5xgt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"CioPCNoy9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"P5tpOKd48QyjmIp\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":265,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        It's\",\"obfuscation\":\"EZHdvSDqoDT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":266,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        not\",\"obfuscation\":\"nWWplCSvr3JH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":267,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divisible\",\"obfuscation\":\"4Mge4e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        by\",\"obfuscation\":\"yfzYP0APN1pWu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        2\",\"obfuscation\":\"Ij8B6wsRAhaJoI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"U62TIMzB6lKtPXJ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        3\",\"obfuscation\":\"y4OhlWLiExq3I6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"MoyRp3sITuERpWx\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        5\",\"obfuscation\":\"rNlyNePEUrXZC1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"RKeNuz5suU0fxUU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        7\",\"obfuscation\":\"8MUFHQkeUIYupn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"2H8rMl78tQ2ntno\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        11\",\"obfuscation\":\"XAZOTBLEPEnQA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"7pWVI5r40rgNOjc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        or\",\"obfuscation\":\"JGp8yVpAZSkcq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        13\",\"obfuscation\":\"WQkjyYOgyvFJe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"crEkvd2tNK7ZNZf\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        confirming\",\"obfuscation\":\"tEslK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"XnJe7tmHJDq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"VncK3ROjAvzV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"5DsTr572T5At1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"q3lYo2hAni\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"K35Bzp1RFsixMa6\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\n\\nNext\",\"obfuscation\":\"MGQqYL55JE\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"IGakLCwBWj8Hghw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"EuHliaM6AqBEUM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        check\",\"obfuscation\":\"nZ1m1vlk1m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        279\",\"obfuscation\":\"iRBsSn4pB4L4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"IBq5hbWpDbshOHl\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Since\",\"obfuscation\":\"pIyamr66l1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        its\",\"obfuscation\":\"Xy4tDx6BPhTM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        digits\",\"obfuscation\":\"g0qZi2ZIc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        add\",\"obfuscation\":\"A4VOs2eVuqqQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        up\",\"obfuscation\":\"HBGvyWdYsubPH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        to\",\"obfuscation\":\"ZsY4SLjcJzyLs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        18\",\"obfuscation\":\"AiQJyQ9snFA1y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"aKJZtOyjSAZ4ZGV\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it's\",\"obfuscation\":\"4p18UByIgJv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divisible\",\"obfuscation\":\"J4r5JY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        by\",\"obfuscation\":\"P9jYUSY1rVRNO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        3\",\"obfuscation\":\"q3jl24G7QcfUmW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"ZTeGTbk94CHMolf\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        so\",\"obfuscation\":\"z6YEysIK7AocS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it's\",\"obfuscation\":\"Ws3PVapbqL3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        not\",\"obfuscation\":\"LLOcWvmoHZC2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"EEO8xpHQrH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"GPd5HvHl16Bu29H\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\n\\nFinally\",\"obfuscation\":\"K9ALPDB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"X6fxDZ8kUmxWfBb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        for\",\"obfuscation\":\"9vw6CDuAtMkI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"2npcZmwR98fw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"PkAiSckG6RtzUj7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"GRYFXW0dtGxW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        square\",\"obfuscation\":\"Zxxn3aCmk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        root\",\"obfuscation\":\"iz3wOEpwsTp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"80zt8WkgD5xAf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        roughly\",\"obfuscation\":\"OuvPrRuy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        19\",\"obfuscation\":\"kGzcovuqxKxcR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"Z58amRcYQTs6s1G\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":324,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"4\",\"obfuscation\":\"eibFOqQD4Jqjd5K\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":325,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"5Nf9kpEnTObaMlF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":326,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"9bMIfjACR9rDgO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":327,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        check\",\"obfuscation\":\"r51cDPlj9Z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":328,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divis\",\"obfuscation\":\"uo2ql7NVMT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":329,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ibility\",\"obfuscation\":\"odwAjs72g\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":330,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        with\",\"obfuscation\":\"4uzDWXVaI2L\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":331,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"mfVxKmlFQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":332,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"FwSFLSlYwE6vfBG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":333,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"TqIzEfbl09f0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":334,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it's\",\"obfuscation\":\"Q7qPzXhsSXX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":335,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        not\",\"obfuscation\":\"hmPRwtZwtXus\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":336,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divisible\",\"obfuscation\":\"JYb86Z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":337,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"UnOFj0drpOKTSZF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":338,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        thus\",\"obfuscation\":\"Hd5eFxPx0H1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":339,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"cbvkNr4ZhdR0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":340,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"rD0Qkb3vDBFX2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":341,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"k8P7nttBtv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":342,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"coLLKaFddeGAmjl\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":343,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        So\",\"obfuscation\":\"UQQowTqqoJqLZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":344,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"BewkFjDTQIJs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":345,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"4GdRaFxaf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":346,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        under\",\"obfuscation\":\"fE1BASy23T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":347,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        400\",\"obfuscation\":\"KuATCVP327sE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":348,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        containing\",\"obfuscation\":\"zmuqp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":349,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\\"\",\"obfuscation\":\"875AQOiiqVfKAB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":350,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"1vEDffPlLDSkAA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":351,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\"\",\"obfuscation\":\"UsnPVuhw1BZEnKL\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":352,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        are\",\"obfuscation\":\"lpeipVU3hJGy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":353,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"5AzldSvP7xQg5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":354,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"k75rDGoSXukK2mg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":355,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"HpyLapiOpgWK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":356,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"v1vdXk3n8p7UySC\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":357,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"u9tgZ2MJvYhX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":358,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"bwfPuWvBjyNh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":359,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"OiFYsYKeYENkqOv\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":360,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        but\",\"obfuscation\":\"qbBCkHHr5IEi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":361,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"9dwDIuNgPVkfTc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":362,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019ll\",\"obfuscation\":\"hPgC0OxJ4S258\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":363,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        double\",\"obfuscation\":\"xYlBqcW90\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":364,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-check\",\"obfuscation\":\"jn88HXQOGc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":365,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        for\",\"obfuscation\":\"THOpcQ0LURWp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":366,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        any\",\"obfuscation\":\"rBmolpQaHPH7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":367,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        others\",\"obfuscation\":\"qcrUsm1Pd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":368,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"delta\":\"!\",\"obfuscation\":\"KIldhB4TbjD2Kx8\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":369,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Checking
+        divisibility of candidates**\\n\\nI\u2019m testing the primes I found: first,
+        179. With a rough estimate of the square root at about 13.38, I check divisibility
+        by common primes. It's not divisible by 2, 3, 5, 7, 11, or 13, confirming
+        that 179 is prime.\\n\\nNext, I check 279. Since its digits add up to 18,
+        it's divisible by 3, so it's not prime.\\n\\nFinally, for 379, the square
+        root is roughly 19.4. I check divisibility with primes, and it's not divisible,
+        thus 379 is prime. So the primes under 400 containing \\\"79\\\" are 79, 179,
+        and 379, but I\u2019ll double-check for any others!\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":370,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Checking
+        divisibility of candidates**\\n\\nI\u2019m testing the primes I found: first,
+        179. With a rough estimate of the square root at about 13.38, I check divisibility
+        by common primes. It's not divisible by 2, 3, 5, 7, 11, or 13, confirming
+        that 179 is prime.\\n\\nNext, I check 279. Since its digits add up to 18,
+        it's divisible by 3, so it's not prime.\\n\\nFinally, for 379, the square
+        root is roughly 19.4. I check divisibility with primes, and it's not divisible,
+        thus 379 is prime. So the primes under 400 containing \\\"79\\\" are 79, 179,
+        and 379, but I\u2019ll double-check for any others!\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
+        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":371,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":372,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**Final\",\"obfuscation\":\"k1ruRSaEm\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":373,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"izing\",\"obfuscation\":\"LsNh3THSogQ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":374,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        findings\",\"obfuscation\":\"NzTsTfx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":375,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        on\",\"obfuscation\":\"CR5gVDsCjQ6wo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":376,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"E4x36eISrnxJ6L\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":377,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"491BWfGl3uiTgh\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":378,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"SBJs2I1sKwbaX5i\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":379,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"Cx1cZH02MXG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":380,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019m\",\"obfuscation\":\"prU7ovdxLFdJ3I\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":381,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        reviewing\",\"obfuscation\":\"PmhDP3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":382,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        potential\",\"obfuscation\":\"sYbRoh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":383,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        candidates\",\"obfuscation\":\"wogjD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":384,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        for\",\"obfuscation\":\"JZAStU3yWy6i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":385,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        containing\",\"obfuscation\":\"SUB6C\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":386,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"1xfY68o2bNuQha\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":387,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"2dJGZfQDloPARU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":388,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"iEHxWbfOkwVl6Tv\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":389,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        under\",\"obfuscation\":\"kMP9zKhF4w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":390,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        400\",\"obfuscation\":\"p2jvbMhW0QZX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":391,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"c6yUh1AvzEVpsst\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":392,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        The\",\"obfuscation\":\"OUYcQU1Sideo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":393,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        two\",\"obfuscation\":\"uPH2TZAAjXgp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":394,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"-digit\",\"obfuscation\":\"loPB6tjYjI\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":395,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        option\",\"obfuscation\":\"H9sys7i9q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":396,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        is\",\"obfuscation\":\"CLVEroZXYiJEZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":397,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        simply\",\"obfuscation\":\"zCQGDZIPQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":398,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        79\",\"obfuscation\":\"ueFqOmDE37bzK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":399,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"TI8rjErFHUZo9PO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":400,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        For\",\"obfuscation\":\"J1Am8ZfeFd1Y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":401,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        three\",\"obfuscation\":\"nPJb6YnaWP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":402,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"-digit\",\"obfuscation\":\"1xFoXYcVSE\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":403,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        numbers\",\"obfuscation\":\"pn45xQEQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":404,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"L3tyKmHuPa5Iboo\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":405,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I\",\"obfuscation\":\"7iNGCXS7Tlb0rc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":406,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        explore\",\"obfuscation\":\"UX1ZIV44\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":407,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        configurations\",\"obfuscation\":\"v\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":408,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        like\",\"obfuscation\":\"sMaRYMKaIsv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":409,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        x\",\"obfuscation\":\"2BL6DiEJDybkIK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":410,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"3NMuQH0dY9MHYg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":411,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"3OpwOzCGPPVmw0E\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":412,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        which\",\"obfuscation\":\"jaxhRcVwAL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":413,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        gives\",\"obfuscation\":\"S2ZAA2qf3e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":414,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        me\",\"obfuscation\":\"uiJpusTsuTNz9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":415,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        179\",\"obfuscation\":\"8UZiI8vITxMZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":416,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"qxJLIXQVd1zru6T\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":417,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        279\",\"obfuscation\":\"XYQcL4axK8kI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":418,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"ztSROtLTS3UTKZM\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":419,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"axQls0HSrzai\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":420,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"OL4vRQg0l2F9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":421,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"S8Fnrv61b7NDF6b\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":422,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\n\\nI\",\"obfuscation\":\"svO3nGlcWj5H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":423,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        realize\",\"obfuscation\":\"VaIvnjhD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":424,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        hundreds\",\"obfuscation\":\"6oZPI2e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":425,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        can\",\"obfuscation\":\"w7yLbbp4XpRD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":426,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        compose\",\"obfuscation\":\"aqE0AKmM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":427,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        numbers\",\"obfuscation\":\"qDEyLCCe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":428,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        like\",\"obfuscation\":\"hskF8bXKviZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":429,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        790\",\"obfuscation\":\"UPf5LEYIb1Rd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":430,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"-\",\"obfuscation\":\"Xvlb9o9yIZl2y4k\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":431,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"799\",\"obfuscation\":\"A8jfBmK9bfTLw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":432,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"YcfavY3I2MofXln\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":433,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        but\",\"obfuscation\":\"SSeM5FquSLMN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":434,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        they\",\"obfuscation\":\"wjiCqDug5l8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":435,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        exceed\",\"obfuscation\":\"64b2R9i0x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":436,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        400\",\"obfuscation\":\"a29S3QWc7bTY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":437,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"veX9L41BLTkhpXC\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":438,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        so\",\"obfuscation\":\"Pj2t8odCXKpG4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":439,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        they\",\"obfuscation\":\"JZWYyuELlRj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":440,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        don\",\"obfuscation\":\"Df0DnNqFZ9Jy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":441,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019t\",\"obfuscation\":\"AIfNLuJecwb3m1\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":442,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        count\",\"obfuscation\":\"41NARpE1Ml\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":443,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"G7lntH7kLqdey7W\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":444,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        For\",\"obfuscation\":\"XJkWDCsOxVK2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":445,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        the\",\"obfuscation\":\"ue32XRll0bm9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":446,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        substring\",\"obfuscation\":\"1tUSGn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":447,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"VMGcammQO8LebK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":448,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"7HB3eWRS2RzkhY\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":449,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\\\"\",\"obfuscation\":\"pHcWz4qpnCANVB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":450,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        it\",\"obfuscation\":\"b6w04eytDhNm2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":451,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        has\",\"obfuscation\":\"fjrFeRN9zJc2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":452,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        to\",\"obfuscation\":\"wu1octfPwAqhW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":453,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        be\",\"obfuscation\":\"iTKNQh2Z0TN0h\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":454,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        consecutive\",\"obfuscation\":\"LvNn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":455,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        from\",\"obfuscation\":\"oejnYJR9wLm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":456,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        left\",\"obfuscation\":\"BQkShbXTszD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":457,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        to\",\"obfuscation\":\"UoTMDEc3nm8FG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":458,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        right\",\"obfuscation\":\"IM3wwBk0Xq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":459,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"az89tmdUxQqXNRF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":460,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        So\",\"obfuscation\":\"baYeox6prTg2e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":461,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"t4bZ0xCH35GqUws\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":462,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        the\",\"obfuscation\":\"ltkS7012KOtw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":463,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        valid\",\"obfuscation\":\"k9lmIUHAbY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":464,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        primes\",\"obfuscation\":\"pv7YSOBRI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":465,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        containing\",\"obfuscation\":\"zJGir\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":466,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"cyBQobjyAcGSRy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":467,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"8iTbcEq6ywgZy5\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":468,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"9MYH2Kq3pgkG5sM\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":469,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        that\",\"obfuscation\":\"11xLb9o2shD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":470,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I\",\"obfuscation\":\"xq34entXldTXRD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":471,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        found\",\"obfuscation\":\"nXNXGzsWuF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":472,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        are\",\"obfuscation\":\"287zJJfe9khx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":473,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        solely\",\"obfuscation\":\"ihZOJzhyX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":474,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        79\",\"obfuscation\":\"dRFyoMPW6tVn5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":475,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"93XiaBEYVqmRkNX\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":476,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        179\",\"obfuscation\":\"Z63CRJ4lJVZh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":477,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"0CQqmzkSKEjB207\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":478,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        279\",\"obfuscation\":\"HWXV3MXb4SVz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":479,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"tkLj7oadTWwwVGo\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":480,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"rbWhVd24CSVr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":481,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"A36rVJpTr34M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":482,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"ormoL7OcCcckkr6\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":483,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I\",\"obfuscation\":\"3ruGMyJ5a0CXHv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":484,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        think\",\"obfuscation\":\"tT23GPFyvG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":485,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I've\",\"obfuscation\":\"xqjaIZioghh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":486,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        covered\",\"obfuscation\":\"WZqBve50\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":487,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        everything\",\"obfuscation\":\"3L9g3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":488,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"delta\":\"!\",\"obfuscation\":\"F2XZG2SUAbfhomZ\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":489,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"text\":\"**Finalizing
+        findings on \\\"79\\\"**\\n\\nI\u2019m reviewing potential candidates for
+        containing \\\"79\\\" under 400. The two-digit option is simply 79. For three-digit
+        numbers, I explore configurations like x79, which gives me 179, 279, and 379.
+        \\n\\nI realize hundreds can compose numbers like 790-799, but they exceed
+        400, so they don\u2019t count. For the substring \\\"79,\\\" it has to be
+        consecutive from left to right. So, the valid primes containing \\\"79\\\"
+        that I found are solely 79, 179, 279, and 379. I think I've covered everything!\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":490,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"**Finalizing
+        findings on \\\"79\\\"**\\n\\nI\u2019m reviewing potential candidates for
+        containing \\\"79\\\" under 400. The two-digit option is simply 79. For three-digit
+        numbers, I explore configurations like x79, which gives me 179, 279, and 379.
+        \\n\\nI realize hundreds can compose numbers like 790-799, but they exceed
+        400, so they don\u2019t count. For the substring \\\"79,\\\" it has to be
+        consecutive from left to right. So, the valid primes containing \\\"79\\\"
+        that I found are solely 79, 179, 279, and 379. I think I've covered everything!\"}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":491,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":492,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**Con\",\"obfuscation\":\"CnktCVkSgeW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":493,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"solid\",\"obfuscation\":\"Qk1Lzbcykom\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":494,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"ating\",\"obfuscation\":\"GZjnKMIVOHY\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":495,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        prime\",\"obfuscation\":\"U84WtZx49p\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":496,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        count\",\"obfuscation\":\"vnnAKqLZjv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":497,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**\\n\\nIt\",\"obfuscation\":\"VBv11tyozB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":498,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        looks\",\"obfuscation\":\"uIHtL2pgse\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":499,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        like\",\"obfuscation\":\"0Om4VQzigqt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":500,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"qNACmCdMra5IbR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":501,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        have\",\"obfuscation\":\"qzNR4xSZXSC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":502,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        three\",\"obfuscation\":\"JXeCAyK63d\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":503,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        primes\",\"obfuscation\":\"8ED2WcnMX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":504,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        under\",\"obfuscation\":\"gcfPeN4irv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":505,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        400\",\"obfuscation\":\"R1Aqkuat9d5k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":506,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"1tGLtFh2W1B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":507,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        contain\",\"obfuscation\":\"COEqRhMs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":508,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        the\",\"obfuscation\":\"sSsRAeXEgoeC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":509,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        substring\",\"obfuscation\":\"UWx2qA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":510,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"xIwzGBDyAqnAfv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":511,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"79\",\"obfuscation\":\"86Ybtchbkqx96p\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":512,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\":\",\"obfuscation\":\"wt2Ir8d4CZm5Eq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":513,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        79\",\"obfuscation\":\"6eMzNtunEvfYm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":514,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"4B3Bd8AMS2DtwZB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":515,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        179\",\"obfuscation\":\"mVfSa9osIc32\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":516,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"S6N8QvfWprwW3Q3\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":517,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"npucKn5ALMHp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":518,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        379\",\"obfuscation\":\"Q8jvUJhHMPwu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":519,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"knLjWtJnl49dQNz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":520,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"s1BB66fjGKZmXr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":521,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        double\",\"obfuscation\":\"MIcirkUxL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":522,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"-check\",\"obfuscation\":\"9K9rhiwY7S\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":523,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"z9EI8PL0Wg5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":524,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        279\",\"obfuscation\":\"1nmZ5HkMya8z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":525,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"ND6AgLwadrvoJUs\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":526,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        though\",\"obfuscation\":\"hfei5DnEv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":527,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        it\",\"obfuscation\":\"crWlnwBCmbOBS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":528,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        has\",\"obfuscation\":\"wPbYe714MUFL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":529,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"1v5SIAdniIr24a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":530,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"79\",\"obfuscation\":\"Q0BTLEfsdzT7XG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":531,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\\\"\",\"obfuscation\":\"NkuPEWgTmNfnDa\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":532,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        is\",\"obfuscation\":\"voMgJr4pQk6gC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":533,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        not\",\"obfuscation\":\"xczJkh6yFSsv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":534,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        prime\",\"obfuscation\":\"xJGXV5gK7w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":535,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"ofsG60JxQ4i8QF2\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":536,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\n\\nI\",\"obfuscation\":\"iDiPRh5MLP2S\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":537,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        confirm\",\"obfuscation\":\"wnplahmI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":538,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"FIMtgQvJx0D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":539,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        179\",\"obfuscation\":\"O09fGU1PvLCu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":540,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"ZW31Ykmpu3Ca\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":541,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        379\",\"obfuscation\":\"hJVuZGfbZuRW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":542,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        are\",\"obfuscation\":\"WTCzZ8wQV9GN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":543,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        indeed\",\"obfuscation\":\"ppzbc45kq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":544,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        prime\",\"obfuscation\":\"yF6mtnxBid\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":545,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        by\",\"obfuscation\":\"YvUnaH1yfiqrI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":546,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        testing\",\"obfuscation\":\"d0Wkj5Fo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":547,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        their\",\"obfuscation\":\"XCq0kII2dG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":548,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        divis\",\"obfuscation\":\"VQPJbw4Zhv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":549,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"ibility\",\"obfuscation\":\"K9L2TFUEW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":550,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        against\",\"obfuscation\":\"sTkEDJ9E\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":551,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        smaller\",\"obfuscation\":\"Q7DXmiJe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":552,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        primes\",\"obfuscation\":\"14OX4Z8ul\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":553,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"AWcKYDxcpJRNomf\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":554,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        379\",\"obfuscation\":\"Cg0GmC1DDLQ2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":555,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        passes\",\"obfuscation\":\"DeaIIqiQP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":556,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        these\",\"obfuscation\":\"6NdGic1gFF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":557,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        checks\",\"obfuscation\":\"WSzRKlYjq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":558,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        too\",\"obfuscation\":\"hd29fSWZkovr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":559,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"TF2zKYkT2W3mBYH\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":560,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"VeH0fWBKmUGSwQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":561,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        also\",\"obfuscation\":\"xOQ2iBdXabg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":562,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        make\",\"obfuscation\":\"fTngPHHVeyw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":563,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        sure\",\"obfuscation\":\"6raqXv0fhyy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":564,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"eVeqHa8KXJX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":565,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"kYwjM1P17B5aKB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":566,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"79\",\"obfuscation\":\"5IRB8SrUsiljHe\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":567,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"VVeHvPpEsW55ujC\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":568,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        doesn't\",\"obfuscation\":\"heFDhMtI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":569,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        appear\",\"obfuscation\":\"DjVW7T8dV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":570,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        in\",\"obfuscation\":\"X8yDKdDK3M6L0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":571,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        numbers\",\"obfuscation\":\"gjuI3pv2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":572,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        like\",\"obfuscation\":\"Lx5Dfz6fErx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":573,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        297\",\"obfuscation\":\"c9N4cAj9d6iJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":574,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"9\",\"obfuscation\":\"oJI8hSncaKmktPX\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":575,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        since\",\"obfuscation\":\"E0wsGjqtD0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":576,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        it\",\"obfuscation\":\"w2YLk0petVJ6B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":577,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019s\",\"obfuscation\":\"GPVirDC2hnE1NZ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":578,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        over\",\"obfuscation\":\"t6TjVX0HkK1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":579,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        400\",\"obfuscation\":\"PuHqnnRLVjmN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":580,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"7AYEBnPyUoa2pEY\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":581,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        The\",\"obfuscation\":\"S30MznklsHQX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":582,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        final\",\"obfuscation\":\"4ZXwaooF3R\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":583,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        count\",\"obfuscation\":\"bzghBLRbDK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":584,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        remains\",\"obfuscation\":\"92BYoKiO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":585,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        at\",\"obfuscation\":\"84ytXFUcEsgG4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":586,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        3\",\"obfuscation\":\"ljDvYLR6EfmOhp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":587,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"3ulhB5RAodyoY4P\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":588,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        which\",\"obfuscation\":\"SWtlExfHI0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":589,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"wKqRk2qKj6ZG57\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":590,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019ll\",\"obfuscation\":\"hABhLcCgQQuGT\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":591,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        present\",\"obfuscation\":\"XlYniAvJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":592,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        as\",\"obfuscation\":\"9bV9sTiAF2xLd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":593,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        just\",\"obfuscation\":\"syQkOUYjvSO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":594,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"rABJtsaxQ0fXFR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":595,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"3\",\"obfuscation\":\"Y5zLxJHzlPkL7wr\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":596,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"wXylRtwYvhA2bJb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":597,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        without\",\"obfuscation\":\"KHqActer\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":598,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        any\",\"obfuscation\":\"YIYEvRhYuYAr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":599,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        extra\",\"obfuscation\":\"SUFSnpul3H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":600,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        punctuation\",\"obfuscation\":\"vKRs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":601,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"9PRAcFlouWVEikJ\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":602,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"text\":\"**Consolidating
+        prime count**\\n\\nIt looks like I have three primes under 400 that contain
+        the substring \\\"79\\\": 79, 179, and 379. I double-check that 279, though
+        it has \\\"79,\\\" is not prime. \\n\\nI confirm that 179 and 379 are indeed
+        prime by testing their divisibility against smaller primes. 379 passes these
+        checks too. I also make sure that \\\"79\\\" doesn't appear in numbers like
+        2979 since it\u2019s over 400. The final count remains at 3, which I\u2019ll
+        present as just \\\"3\\\" without any extra punctuation.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":603,\"item_id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"**Consolidating
+        prime count**\\n\\nIt looks like I have three primes under 400 that contain
+        the substring \\\"79\\\": 79, 179, and 379. I double-check that 279, though
+        it has \\\"79,\\\" is not prime. \\n\\nI confirm that 179 and 379 are indeed
+        prime by testing their divisibility against smaller primes. 379 passes these
+        checks too. I also make sure that \\\"79\\\" doesn't appear in numbers like
+        2979 since it\u2019s over 400. The final count remains at 3, which I\u2019ll
+        present as just \\\"3\\\" without any extra punctuation.\"}}\n\nevent: response.output_item.done\ndata:
+        {\"type\":\"response.output_item.done\",\"sequence_number\":604,\"output_index\":0,\"item\":{\"id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with \\\"79\\\"**\\n\\nI need to find the count of prime numbers less
+        than 400 that include the substring \\\"79.\\\" This means identifying primes
+        below 400 with \\\"79\\\" in their decimal representation. First, I recognize
+        the prime numbers: 79, 179, 279, and 379. I realize that numbers like 790
+        and above are out of scope. Also, the three-digit formats with \\\"79\\\"
+        can only be those I mentioned since there are no other candidates. Now, I'll
+        compute the total.\"},{\"type\":\"summary_text\",\"text\":\"**Identifying
+        candidates with \\\"79\\\"**\\n\\nTo find numbers containing \\\"79,\\\" I
+        can check two patterns: hundreds=7 and tens=9 (like 79y) or tens=7 and ones=9
+        (like x79). For numbers under 400, the candidates are 79, 179, 279, and 379.
+        The pattern 79y only applies to numbers 790-799, which are above 400. I realize
+        297 doesn't fit as it contains \\\"97,\\\" not \\\"79.\\\" So, now I need
+        to confirm whether 79, 179, and 379 are prime. I'll start checking them!\"},{\"type\":\"summary_text\",\"text\":\"**Checking
+        divisibility of candidates**\\n\\nI\u2019m testing the primes I found: first,
+        179. With a rough estimate of the square root at about 13.38, I check divisibility
+        by common primes. It's not divisible by 2, 3, 5, 7, 11, or 13, confirming
+        that 179 is prime.\\n\\nNext, I check 279. Since its digits add up to 18,
+        it's divisible by 3, so it's not prime.\\n\\nFinally, for 379, the square
+        root is roughly 19.4. I check divisibility with primes, and it's not divisible,
+        thus 379 is prime. So the primes under 400 containing \\\"79\\\" are 79, 179,
+        and 379, but I\u2019ll double-check for any others!\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
+        findings on \\\"79\\\"**\\n\\nI\u2019m reviewing potential candidates for
+        containing \\\"79\\\" under 400. The two-digit option is simply 79. For three-digit
+        numbers, I explore configurations like x79, which gives me 179, 279, and 379.
+        \\n\\nI realize hundreds can compose numbers like 790-799, but they exceed
+        400, so they don\u2019t count. For the substring \\\"79,\\\" it has to be
+        consecutive from left to right. So, the valid primes containing \\\"79\\\"
+        that I found are solely 79, 179, 279, and 379. I think I've covered everything!\"},{\"type\":\"summary_text\",\"text\":\"**Consolidating
+        prime count**\\n\\nIt looks like I have three primes under 400 that contain
+        the substring \\\"79\\\": 79, 179, and 379. I double-check that 279, though
+        it has \\\"79,\\\" is not prime. \\n\\nI confirm that 179 and 379 are indeed
+        prime by testing their divisibility against smaller primes. 379 passes these
+        checks too. I also make sure that \\\"79\\\" doesn't appear in numbers like
+        2979 since it\u2019s over 400. The final count remains at 3, which I\u2019ll
+        present as just \\\"3\\\" without any extra punctuation.\"}]}}\n\nevent: response.output_item.added\ndata:
+        {\"type\":\"response.output_item.added\",\"sequence_number\":605,\"output_index\":1,\"item\":{\"id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":606,\"item_id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":607,\"item_id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"BglAXrR8iVrdwJh\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":608,\"item_id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
+        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":609,\"item_id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":610,\"output_index\":1,\"item\":{\"id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":611,\"response\":{\"id\":\"resp_0d570aae5ddaa59f0068f805e5a3e881969a8e10226fbc2421\",\"object\":\"response\",\"created_at\":1761084901,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with \\\"79\\\"**\\n\\nI need to find the count of prime numbers less
+        than 400 that include the substring \\\"79.\\\" This means identifying primes
+        below 400 with \\\"79\\\" in their decimal representation. First, I recognize
+        the prime numbers: 79, 179, 279, and 379. I realize that numbers like 790
+        and above are out of scope. Also, the three-digit formats with \\\"79\\\"
+        can only be those I mentioned since there are no other candidates. Now, I'll
+        compute the total.\"},{\"type\":\"summary_text\",\"text\":\"**Identifying
+        candidates with \\\"79\\\"**\\n\\nTo find numbers containing \\\"79,\\\" I
+        can check two patterns: hundreds=7 and tens=9 (like 79y) or tens=7 and ones=9
+        (like x79). For numbers under 400, the candidates are 79, 179, 279, and 379.
+        The pattern 79y only applies to numbers 790-799, which are above 400. I realize
+        297 doesn't fit as it contains \\\"97,\\\" not \\\"79.\\\" So, now I need
+        to confirm whether 79, 179, and 379 are prime. I'll start checking them!\"},{\"type\":\"summary_text\",\"text\":\"**Checking
+        divisibility of candidates**\\n\\nI\u2019m testing the primes I found: first,
+        179. With a rough estimate of the square root at about 13.38, I check divisibility
+        by common primes. It's not divisible by 2, 3, 5, 7, 11, or 13, confirming
+        that 179 is prime.\\n\\nNext, I check 279. Since its digits add up to 18,
+        it's divisible by 3, so it's not prime.\\n\\nFinally, for 379, the square
+        root is roughly 19.4. I check divisibility with primes, and it's not divisible,
+        thus 379 is prime. So the primes under 400 containing \\\"79\\\" are 79, 179,
+        and 379, but I\u2019ll double-check for any others!\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
+        findings on \\\"79\\\"**\\n\\nI\u2019m reviewing potential candidates for
+        containing \\\"79\\\" under 400. The two-digit option is simply 79. For three-digit
+        numbers, I explore configurations like x79, which gives me 179, 279, and 379.
+        \\n\\nI realize hundreds can compose numbers like 790-799, but they exceed
+        400, so they don\u2019t count. For the substring \\\"79,\\\" it has to be
+        consecutive from left to right. So, the valid primes containing \\\"79\\\"
+        that I found are solely 79, 179, 279, and 379. I think I've covered everything!\"},{\"type\":\"summary_text\",\"text\":\"**Consolidating
+        prime count**\\n\\nIt looks like I have three primes under 400 that contain
+        the substring \\\"79\\\": 79, 179, and 379. I double-check that 279, though
+        it has \\\"79,\\\" is not prime. \\n\\nI confirm that 179 and 379 are indeed
+        prime by testing their divisibility against smaller primes. 379 passes these
+        checks too. I also make sure that \\\"79\\\" doesn't appear in numbers like
+        2979 since it\u2019s over 400. The final count remains at 3, which I\u2019ll
+        present as just \\\"3\\\" without any extra punctuation.\"}]},{\"id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":1479,\"output_tokens_details\":{\"reasoning_tokens\":1472},\"total_tokens\":1511},\"user\":null,\"metadata\":{}}}\n\n"
     headers:
       CF-RAY:
-      - 99022b8c58d0a377-SEA
+      - 99241c7adda6a381-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:23:23 GMT
+      - Tue, 21 Oct 2025 22:15:01 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1046,52 +1232,58 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '188'
+      - '244'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '220'
+      - '277'
       x-request-id:
-      - req_771d84670bde4755a970cb8b37e5bcf0
+      - req_fc580230a9e140dc94fd3044edcdc430
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"input\":[{\"role\":\"user\",\"content\":\"How many primes below 400
-      contain 79 as a substring? Answer ONLY with the number, not sharing which primes
-      they are.\"},{\"id\":\"rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e\",\"summary\":[{\"text\":\"**Finding
-      primes with substring \\\"79\\\"**\\n\\nI\u2019m looking for prime numbers under
-      400 that contain the substring \\\"79.\\\" First, the only 2-digit prime is
-      79 itself, giving me one candidate. \\n\\nFor 3-digit primes, I considered numbers
-      of the form 79x, but those fall outside the 400 limit, so there are none. \\n\\nThen
-      I checked numbers like x79, where x can be 1-3. This gives me candidates: 179,
-      279, and 379, which I need to verify for primality. \\n\\nFinally, I realized
-      that \\\"79\\\" must be adjacent, ruling out non-adjacent digits.\",\"type\":\"summary_text\"},{\"text\":\"**Testing
-      candidates for primality**\\n\\nI\u2019ve established that only adjacent digits
-      matter for the \\\"79\\\" substring. There\u2019s also a possibility of having
-      \\\"79\\\" in the middle of a 3-digit number, but those options are limited.
-      My candidates are 79, 179, 279, and 379, and I need to test the primality of
-      179, 279, and 379.\\n\\nStarting with 179, after checking divisibility against
-      primes up to around 13, I find it\u2019s prime. For 279, since the sum of digits
-      equals 18, it\u2019s divisible by 3, so it\u2019s not prime. \\n\\nFinally,
-      I check 379, and it doesn\u2019t seem divisible by the primes I tested either.\",\"type\":\"summary_text\"},{\"text\":\"**Counting
-      primes with \\\"79\\\"**\\n\\nAfter testing, I confirmed that 379 is also prime.
-      So far, I have 79, 179, and 379 as primes, making a count of three. \\n\\nI
-      wondered if there are any other numbers under 400 with the substring \\\"79.\\\"
-      Well, I already included 79, and I considered 297, but it contains \\\"97,\\\"
-      not \\\"79.\\\" \\n\\nI realized my criteria for 3-digit numbers can only lead
-      to x79 or 79x, but those like 79x (790 or higher) exceed 400. My total remains
-      three primes: I\u2019ll double-check to ensure there are no others under 400.
-      \\n\\nAfter confirming, I finalize the answer as \\\"3.\\\"\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing
-      the count**\\n\\nI'm checking the user\u2019s request for numbers \\\"below
-      400.\\\" Typically, that means less than 400, so 79 is definitely included in
-      my count. I want to be accurate here. \\n\\nSince I found three prime numbers
-      containing the substring \\\"79\\\" (79, 179, and 379), I can confidently say
-      the answer is exactly \\\"3.\\\" I'll make sure to keep it clear, just providing
-      that number, with no additional text.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"role\":\"user\",\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"},\"stream\":true}"
+    body: "{\"input\":[{\"content\":[{\"text\":\"How many primes below 400 contain
+      79 as a substring? Answer ONLY with the number, not sharing which primes they
+      are.\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"},{\"id\":\"rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c\",\"summary\":[{\"text\":\"**Counting
+      primes with \\\"79\\\"**\\n\\nI need to find the count of prime numbers less
+      than 400 that include the substring \\\"79.\\\" This means identifying primes
+      below 400 with \\\"79\\\" in their decimal representation. First, I recognize
+      the prime numbers: 79, 179, 279, and 379. I realize that numbers like 790 and
+      above are out of scope. Also, the three-digit formats with \\\"79\\\" can only
+      be those I mentioned since there are no other candidates. Now, I'll compute
+      the total.\",\"type\":\"summary_text\"},{\"text\":\"**Identifying candidates
+      with \\\"79\\\"**\\n\\nTo find numbers containing \\\"79,\\\" I can check two
+      patterns: hundreds=7 and tens=9 (like 79y) or tens=7 and ones=9 (like x79).
+      For numbers under 400, the candidates are 79, 179, 279, and 379. The pattern
+      79y only applies to numbers 790-799, which are above 400. I realize 297 doesn't
+      fit as it contains \\\"97,\\\" not \\\"79.\\\" So, now I need to confirm whether
+      79, 179, and 379 are prime. I'll start checking them!\",\"type\":\"summary_text\"},{\"text\":\"**Checking
+      divisibility of candidates**\\n\\nI\u2019m testing the primes I found: first,
+      179. With a rough estimate of the square root at about 13.38, I check divisibility
+      by common primes. It's not divisible by 2, 3, 5, 7, 11, or 13, confirming that
+      179 is prime.\\n\\nNext, I check 279. Since its digits add up to 18, it's divisible
+      by 3, so it's not prime.\\n\\nFinally, for 379, the square root is roughly 19.4.
+      I check divisibility with primes, and it's not divisible, thus 379 is prime.
+      So the primes under 400 containing \\\"79\\\" are 79, 179, and 379, but I\u2019ll
+      double-check for any others!\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing
+      findings on \\\"79\\\"**\\n\\nI\u2019m reviewing potential candidates for containing
+      \\\"79\\\" under 400. The two-digit option is simply 79. For three-digit numbers,
+      I explore configurations like x79, which gives me 179, 279, and 379. \\n\\nI
+      realize hundreds can compose numbers like 790-799, but they exceed 400, so they
+      don\u2019t count. For the substring \\\"79,\\\" it has to be consecutive from
+      left to right. So, the valid primes containing \\\"79\\\" that I found are solely
+      79, 179, 279, and 379. I think I've covered everything!\",\"type\":\"summary_text\"},{\"text\":\"**Consolidating
+      prime count**\\n\\nIt looks like I have three primes under 400 that contain
+      the substring \\\"79\\\": 79, 179, and 379. I double-check that 279, though
+      it has \\\"79,\\\" is not prime. \\n\\nI confirm that 179 and 379 are indeed
+      prime by testing their divisibility against smaller primes. 379 passes these
+      checks too. I also make sure that \\\"79\\\" doesn't appear in numbers like
+      2979 since it\u2019s over 400. The final count remains at 3, which I\u2019ll
+      present as just \\\"3\\\" without any extra punctuation.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":[{\"text\":\"If
+      you remember what the primes were, then share them, or say 'I don't remember.'\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"},\"stream\":true}"
     headers:
       accept:
       - application/json
@@ -1100,12 +1292,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '2910'
+      - '3426'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -1134,90 +1323,90 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_00c8480f43d079250068f297bdbd38819595de439bd89c1cfb","object":"response","created_at":1760729021,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d570aae5ddaa59f0068f805fe0df8819697a720ba3c64341c","object":"response","created_at":1761084926,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_00c8480f43d079250068f297bdbd38819595de439bd89c1cfb","object":"response","created_at":1760729021,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d570aae5ddaa59f0068f805fe0df8819697a720ba3c64341c","object":"response","created_at":1761084926,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_00c8480f43d079250068f297be563c819585de932de447cba0","type":"reasoning","summary":[]}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_0d570aae5ddaa59f0068f805fed3b48196bc6af574f1c25cb9","type":"reasoning","summary":[]}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"rs_00c8480f43d079250068f297be563c819585de932de447cba0","type":"reasoning","summary":[]}}
+        data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"rs_0d570aae5ddaa59f0068f805fed3b48196bc6af574f1c25cb9","type":"reasoning","summary":[]}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":5,"item_id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":5,"item_id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","output_index":1,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"5dudrfRA6AmknOG"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","output_index":1,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"T5SkZhtak1oMmHa"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","output_index":1,"content_index":0,"delta":"
-        don''t","logprobs":[],"obfuscation":"vbdtuH5189"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","output_index":1,"content_index":0,"delta":"
+        don''t","logprobs":[],"obfuscation":"vD6HfDJQGj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","output_index":1,"content_index":0,"delta":"
-        remember","logprobs":[],"obfuscation":"H6CQN1U"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","output_index":1,"content_index":0,"delta":"
+        remember","logprobs":[],"obfuscation":"q1WpEKO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","output_index":1,"content_index":0,"delta":".","logprobs":[],"obfuscation":"Ap6QE7mK4hxYswG"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","output_index":1,"content_index":0,"delta":".","logprobs":[],"obfuscation":"tOJNsS0T2zEWDCC"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","output_index":1,"content_index":0,"text":"I
+        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","output_index":1,"content_index":0,"text":"I
         don''t remember.","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
         don''t remember."}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":1,"item":{"id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        data: {"type":"response.output_item.done","sequence_number":12,"output_index":1,"item":{"id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
         don''t remember."}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_00c8480f43d079250068f297bdbd38819595de439bd89c1cfb","object":"response","created_at":1760729021,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[{"id":"rs_00c8480f43d079250068f297be563c819585de932de447cba0","type":"reasoning","summary":[]},{"id":"msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_0d570aae5ddaa59f0068f805fe0df8819697a720ba3c64341c","object":"response","created_at":1761084926,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[{"id":"rs_0d570aae5ddaa59f0068f805fed3b48196bc6af574f1c25cb9","type":"reasoning","summary":[]},{"id":"msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
         don''t remember."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":62,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 99022c0169f2a377-SEA
+      - 99241d136d3fa381-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:23:42 GMT
+      - Tue, 21 Oct 2025 22:15:26 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1233,15 +1422,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '233'
+      - '286'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '262'
+      - '320'
       x-request-id:
-      - req_dedd5c1705b64cfda6e81cb3905d4a73
+      - req_00805d662e9c4cc79578a1836b08cea9
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"How many primes below 400 contain 79
-      as a substring? Answer ONLY with the number, not sharing which primes they are."}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"}}'
+    body: '{"input":[{"content":[{"text":"How many primes below 400 contain 79 as
+      a substring? Answer ONLY with the number, not sharing which primes they are.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-5","reasoning":{"effort":"medium","summary":"auto"}}'
     headers:
       accept:
       - application/json
@@ -10,12 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '221'
+      - '269'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -43,36 +40,36 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xXTY/bNhC976+Y6rJA4DVkef2VY9PLXnpp0Us2MMbSyGaXIhVyaFco8t+LISVZ
-        3t2gBZrLIuGQ8/Hem9H47zuATFXZR8gc+Xaf59tisVjjCot1sd0u83y9rYvdZlWtaVluF7t8uyxW
-        u2K9eiyKbbHarrOZuLCHP6nkwY01ntJ56QiZqj2KbbFZ55tiuytW0eYZOXh5U9qm1cRUpUcHLF+O
-        zgYjedWoPaVjpbUyx+wj/H0HAJC12JGT9xWdSduWXHYH8C1eJues2EzQOh4oM0TZV8SotL+1enah
-        ZGXNzXmDf+1t4Dbwnu0LvTWytXpfor5119iKtGR2bPlh9VDkxeoh3z7kmx6t6DH7CJ9jIamcKxH+
-        +zRQTvk20rApcfu4KfLlarHMDwm56IS7lhIR6K0RwEaTD02DrhsDT4PfvO0v7pn+4vF5uiEnHyH7
-        8OGTDYaVOULrVEMeLopP4MPBs1Pm+OHDs3k2T2CIKmALtToGR2ADw+WkylN6BSY0B3IegqnIwWOe
-        Q2kNozLAJ7p6g+dss3vOIJ0rBxWVqkENjlpHngyjUDeH30/I0BAaD0/gTzboCrS1L1BbNwbT6oVg
-        swPFnnQNaCrgk/UEypQ6VBJPMaAHlGw8lYHVmaBF5cDWUKmjYi+xCFrLZFihhhJNpSpk8oBO3M9g
-        IX8K+SMhlpvdcyjyxePTvdZwIKhtGbwEs1IVMjg0R0pgxZQIHGk6o+Ee4zk8MXiiRqo74ZkkQ03o
-        oEU+ycvyRGUqNlXkWypVrUq5wOSMFwgH8Ho85tlI8LfZ/9fFL8TkGmVGaUygSar4zc7g6b4BR3W6
-        1nSglWcB960gIjSDKkQH8+csYm+N7uCMWlX/Cfw5XNWYYEpCtLVA7Sm+jAnPIWn3xdhL1Ikfzn+1
-        l1lEN3qPRCZXYketuINDB0w+Nkalzsqrg4rneEQZMkO3hFbyiCL/GiSys5ZnfUrKAx6kVRbL+XIb
-        Wecg5MWzmJG558G/JgmKpkulCO0pyExgq5WQIYq+94Da22T8CX4OLPhIsCoSwaQ7MLZPcSYNoFKQ
-        iryEWM7hNwtP92cCg87ZC1Xxhr0YoLqmUtpEdz/9WD39QU7V3aCmBLKt34jqNbmqFtIn3P1+i/UE
-        5N38cT0Db+EpNuhO60hhHALvs4YMrVWGX1HTB1SmklSS+A9UYpDZwsm5jxB/nzrfoNbkho4f+kWU
-        MiTxfmu8GpgSrOxHTnXbFTfTqMEXuY/AllGnPByRdEuvHkE1Vexl+rTo4rCd9YMQLlbEWMrnQDST
-        RvUMyPjg0njTXV9c/EZMZ2rv4mtAreofrZxPV/XXysiMjjnaukcyCUd08cowYCov3/0OOWpEF4As
-        TdHLRsqx4aDpISqQqjgpLJ/IQWmbgzIRtwmBNw0aMU7jLDLwELERH02aalo1ipPEPy8ell8GKiVA
-        nF5Cg2ipd3KxvYvpdPSqIqidba4fwHlqnzgb3DX5QXFjxx0sn+L06fXzKnvqYpZT8cu8mImQ0KS7
-        FRnWHbTOylCJIdD4C7konCjZZa9YkYr0lBSEVaUEOtTQ727Tb1b/ry93E928Wqkaf/zuTrVZbxb9
-        alutF8vVDmm7K5brw+rtTtWQ93ikyUb1nR02GkVFZPjf161hw3yjZTTGptVGYnz+cmPU9tg6e3jH
-        MrTA8h2Uxuyc1TE4eq88o+F0WS7GS5k0utakb3dcdiGt462js7LB74eNfx+xHnfg1tmm5X2J5Yn2
-        L9RNbdfddFzmqa6t4wRypULTAzHZWbPEPVXXLd9jTdzto65Urehm4/fkzqqkPavhV0KNQSeEM8/W
-        0bQcpqYlhxzi8WKe96cRyT5H6UW8/n/CYLw3FWB2JnewXnE3KWnMOyF6sqpMFAS22Wi4EpqxbfcT
-        mvPxsJ3m6IIpo0hilcrjQQ8/pUKU61iAMje/ZJbF7O355OfRWGYksbo+zG9Kff0DaZHvVu+Z3vM8
-        KmH6fLu98R+/TBP7otiMSAZ/S3pDjBUySoxvd9/+AQAA//8DADsT/OvgDgAA
+        H4sIAAAAAAAAAwAAAP//rFdNj+M2Er33r6joMsBAbUiW27LmthhgsZ1DLgn2kg4MSipZTFOkliza
+        4wTz3xdFSrI83bM5bC4NN4v19d5TqfTnA0Ai2+QTJBbdeMz2XVbu8qemecrrfVZn2f7QHbKnpq4K
+        cTjk1a7Gal+1+0NbFZmod9sk5RCm/h0bmsMY7TCeNxYFYXsUbMvLfZ4ddofyKdgcCfKOfRozjAoJ
+        2+hUi+b1ZI3XXFcnlMN4LJWS+pR8gj8fAACSUVzRsn+LZ1RmRJs8AHwNl9FawzbtlQoHUs9Zji2S
+        kMrdWx1Z35A0+u58EF+OxtPo6UjmFd8ayRh1bIS6DzeYFhVXdhrp8elxm22fHrPDY1ZOaIWIySf4
+        NTQS27kR4b5PQ7OrtoEGUbSHshb7fYVtVqIIgUMQuo4YiRDOaAZsMTk/DMJel8Tr5He+08Uj4Rda
+        3OMNPvkEycePn43XJPUJRisHdHCR1IPztSPLp2X18eOLftHPL36b5dUAjdFOthiMvbkAGWg4RPQH
+        7YcarYMalbnALsuAekHsRUJqeEnK6iUB4UDckmzgl146kLpRvkUHZQWSHKoOhG6XiEq+IuRllUJe
+        lSls+Rfbi7LawDMI5QxoxJYr0oYwJr7zLqvssawqEBb1BwKLCs9CEzipG76PV8AvDcfYZdkGpp6V
+        gqbH5pUvTF1GzUNnLISC+M+6oCWiccjZYLhCI3QrW0HoNqFDF2OlUHtapTqjld015DLUc+kav9AP
+        ycLe1/T/J/3fIcmK9Ymfdxg/Ixs7aQeGliFdFf8D/GQuAYYAwbeASXLQyrN0spZK0pWJRnD/8QyJ
+        NYY4kKiNJ8iLTXFIwZk3QaYK/cjEcgEbeCYgb7WD4Bnr0YbmXAqhvs5+gfhtCkUKTymUKeR5pCkv
+        QjpJMZ+LCgpeG2AAfulRw3OsAlvmN/h1PNFA0gd3n69IYUARIAxGnlPGScKQhsubYv9TaqHUNYXn
+        SLacgS1WyAIZw3B5l95095ePlcWbHicphu52ZEjw1AXqLc7R/mZRfY4y4SxnoWT7v7QFUkuSDAM/
+        JP7UU2wor8r5PrahrfQlCU+IJBAN+eDSCwcvSVWyLVAIrUGnI5EU59EGPjNxnDU8R/MkSCdFVGVA
+        iEfJpG8XJ0BreDb04owzrCg5wAZ+NoGKgCW43njVgiOpFNQIxdRu1A7PI4uiva4enm+ZCXRFpxQu
+        vVQYNCZX0tnAP5QzrJRBtAjOWwRtNILpbhPifsYVVQnGQlXmd+rYvCTwL9QNpjyLOpYgCO0uaCGM
+        3pan3u/eERSbv1cWQe7yj2XYRHpmHVgMjF54DJOBQbxObS4vHNE03orpMXr+MABZOSp8bGZ658dD
+        8IhhZPLpSQ1vhpUqmd4Y1SLUhvq572kQP/OMjoS1qEldwYk4iSNe8X3PeBUb+JGxIgOviCMr0JEV
+        8tRTZ+xF2HY9DC9WEoLRKgaLdIUXLc8vofmtQ1YAY8bcjV6z0nmLYdHFAXAjy8lhVNd7nqZfvz2s
+        WPtmHxnc6bsLCW67Ou6Fh8NuX2+rfJd11aFs8O1CMqBz4rQyfG8BDEbWIGr6611lXs/eKElobUjM
+        K92vv90ZlTmN1tTvWGYBFu+gtFRnjQrJhXPSkdAUL/PFcCkZhRVKobpfEMn6uMuOFs/SeHec1+Vj
+        wHpZIEdrhpGOjWh6PL7idW27LXbLJoxdZyxFkFvphwmI1cKXxKUX29uK7ESHdD0GyfLL5G5ddmjP
+        ssEjyXnF7oRXEeHEkbG4bodwGNEK8uE432TTaUByqrEzdhC3/1cMhntrASZntDXPseuqpaXuiGhv
+        ZBMp8GSSxXAjNCEzHlc0Z8vhuK7Ret0EkYQupRO1mr9DfJDr0oDUd58BxTZ9e776tljaDCS2N8fs
+        rtVvvy6qrHjP8l7gRQg370O1v4seXjmr4MXTAqN394wPSKIVJDjD14ev/wUAAP//AwDADeXcGg4A
+        AA==
     headers:
       CF-RAY:
-      - 990229a76b54a338-SEA
+      - 99241bd73a73a381-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -80,7 +77,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:22:31 GMT
+      - Tue, 21 Oct 2025 22:14:59 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -96,49 +93,47 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '25659'
+      - '24022'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '25684'
+      - '24110'
       x-request-id:
-      - req_21dd72caab2f4736ad6443e3f0814ad7
+      - req_11e23a491a5141a5995fc787f794e43a
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"input\":[{\"role\":\"user\",\"content\":\"How many primes below 400
-      contain 79 as a substring? Answer ONLY with the number, not sharing which primes
-      they are.\"},{\"id\":\"rs_0082116a5a2628830068f2975e0e08819087ca8472035130bd\",\"summary\":[{\"text\":\"**Counting
-      primes with substring**\\n\\nI need to figure out which prime numbers under
-      400 contain the substring \\\"79\\\" in their decimal representation. That means
-      I should look for numbers like 79 itself and those including it as a consecutive
-      pair of digits. The potential candidates are 79, 179, 279, and 379\u2014I'll
-      be focusing on that range to find the relevant primes. It seems I have a clear
-      path to check for those specific patterns in decimal numbers.\",\"type\":\"summary_text\"},{\"text\":\"**Determining
-      prime candidates**\\n\\nSo, I'm refining my list of numbers under 400 that contain
-      \\\"79.\\\" The only valid candidates are 79, 179, 279, and 379. I need to check
-      which of these are prime. \\n\\nI know 79 is prime. Now, for 179, I'll check
-      primality by testing divisibility against primes up to the square root, which
-      is about 13.38. It turns out 179 isn't divisible by any of those primes, confirming
-      it's also prime! But 279 is definitely not prime, as it divides by 3. So I've
-      narrowed it down effectively!\",\"type\":\"summary_text\"},{\"text\":\"**Verifying
-      primality of candidates**\\n\\nI need to check if 379 is prime. The square root
-      is about 19.46, so I\u2019ll test it against primes up to that point. It turns
-      out 379 is indeed prime because it\u2019s not divisible by any of those smaller
-      primes.\\n\\nSo, the primes under 400 that contain the substring \u201C79\u201D
-      are 79, 179, and 379\u2014making a total of three. I confirmed that post separation,
-      digits won't count as \\\"79\\\", ensuring only those with consecutive digits
-      qualify!\",\"type\":\"summary_text\"},{\"text\":\"**Confirming final count of
-      primes**\\n\\nThe count of primes containing the substring \\\"79\\\" remains
-      at 3. I\u2019ve double-checked for other combinations under 400, confirming
-      that valid three-digit forms are limited to [1-3]79, and there aren't any valid
-      two-digit candidates aside from 79 itself.\\n\\nI also re-checked the primality
-      of both 179 and 379, confirming they are indeed prime. So, I can confidently
-      provide the answer as \u201C3\u201D without any additional details.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0082116a5a2628830068f29776713c81908d61359ae89236b5\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"role\":\"user\",\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"}}"
+    body: "{\"input\":[{\"content\":[{\"text\":\"How many primes below 400 contain
+      79 as a substring? Answer ONLY with the number, not sharing which primes they
+      are.\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"},{\"id\":\"rs_06f07415cc51b60b0068f805cc49288194a3d87ba669ed07ea\",\"summary\":[{\"text\":\"**Counting
+      primes with substring 79**\\n\\nI\u2019m considering how to count prime numbers
+      below 400 that contain \\\"79\\\" as a substring. This includes 79 itself and
+      numbers like 179, 197, 279, and 379. I also need to note that numbers like 790-799
+      aren't relevant since they exceed 400. I\u2019ll check the prime status for
+      79, 179, 279, and 379 since those are my candidates. 79 is prime, but I\u2019ll
+      verify the others next!\",\"type\":\"summary_text\"},{\"text\":\"**Verifying
+      primes containing 79**\\n\\nI\u2019ve confirmed that 79 is prime! Now for 179,
+      I\u2019ll check its divisibility. The square root is about 13.38, so I\u2019ll
+      check primes up to that. It turns out 179 is not divisible by primes like 2,
+      3, 5, 7, 11, and 13, so it\u2019s also prime. \\n\\nThen I checked 279 and found
+      it's divisible by 3, meaning it's composite, so not prime. Finally, I verified
+      that 379 is prime too. Thus, the primes below 400 that contain \\\"79\\\" are
+      79, 179, and 379\u2014totaling three primes!\",\"type\":\"summary_text\"},{\"text\":\"**Confirming
+      valid primes containing 79**\\n\\nI initially thought that 197 contained \\\"79,\\\"
+      but it actually has \\\"97,\\\" so it doesn\u2019t count. Checking other numbers,
+      like 297 and 97, confirms they don't have \\\"79\\\" either. So the total should
+      still be 3 primes. \\n\\nI already confirmed 79, 179, and 379 are primes, while
+      279 is composite. Also, I made sure none of the other numbers like 397 or 971
+      contain \\\"79.\\\" Hence, my final answer is indeed just 3.\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing
+      prime count**\\n\\nI really want to make sure I\u2019m accurate, so I'm triple-checking
+      the primality of 179 and 379. Confirming they\u2019re both indeed prime, I can
+      confidently say the final output is 3. Just to keep it straightforward, I\u2019ll
+      write only the number without any extra text or punctuation. So, the answer
+      is simply 3.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_06f07415cc51b60b0068f805e2fba881948846b29140f987ce\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":[{\"text\":\"If
+      you remember what the primes were, then share them, or say 'I don't remember.'\",\"type\":\"input_text\"}],\"role\":\"user\",\"type\":\"message\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"}}"
     headers:
       accept:
       - application/json
@@ -147,12 +142,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '2664'
+      - '2556'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -180,21 +172,21 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUy27jMAy85ysMXfbSFrITv/IH+w1FYdAynWqrhyFRQYMi/76wnPixTfeWcMjx
-        kEPqa5ckTHbsmDCHfmg4r7I0LSCHrMiqas95UfVZXZZl3uOhSmte1VV/yLO2y/J9wdM9exopbPsH
-        Bd1prPE4xYVDIOwaGLG0LHiZVXWeRswTUPBjjbB6UEjYTUUtiI+Ts8GMunpQHqewVEqaEzsmX7sk
-        SRI2wAXdWN/hGZUd0LFdklxjMjpnR8wEpWJAmvtXmg4JpPJb1JMLgqQ1m7iGz8YGGgI1ZD/wO0jW
-        qkaA2tJp26EalZ0Ges6fM57lz7x65uVtWpGRHZPX2MjUzmKE/48NfSrEaENbFIc8Tes+26eiyopI
-        HEnoMuBkBHhrxoHNkA9ag7uMH36LsevTIwHan35WUGXpPiqo9z2WtSixqNuUZ4fvCjR6Dydcff8H
-        xyMorCE0y1TWwja0dz/wk+bqmADGWIK7h69vG1DZ0+Bs+wCJRMeE/U46a35R4lCjbtG9sDnrevs1
-        FzJnVRQD3ktPYGhKHhNjEhvAgVKothtCLkzLPDg8Sxt8c7+XJs5+3qDBWT1QI0C8Y/OBlzW2ODuf
-        Ava9dbELLY3UoG6TWVk+ls/n4aFHujSyQ0Oyl7g5FY/uLAU2JO/n1UNQ07CZJ+tw3QmhHtABhRhO
-        X/gtGod6k9dbp2H5vzIz5q13kZ3RtdZLukwr1Mmgl7OehvlupZimH8iyGVi8ZWSHZuU4n4PDWqML
-        RsR9iV1KD626v0Ehbu7cgDSbJ6DInr7HV+/K3Gb0r1sK+abVf1+WlD8CHvHOK/ATNVkCtYBlNo8w
-        +K3bGgk6IBjpr7vrXwAAAP//AwC/da59EgYAAA==
+        H4sIAAAAAAAAAwAAAP//fFTLbuMwDLznKwxd9tIUshs7Tv5gv6EoDFqmU231gkQFDYr8+8Jy4sc2
+        3VvCIcdDDqmvTZYx2bFjxjwG1/Cq5/tdXgpR5m3FW86ruq95iS9ij7s6P+xqXtZtV5W8LvZ9UZXs
+        aaCw7R8UdKexJuAYFx6BsGtgwPJ9lfN6Vx8OCQsEFMNQI6x2Cgm7sagF8XHyNppBVw8q4BiWSklz
+        Ysfsa5NlWcYcXNAP9R2eUVmHnm2y7JqS0Xs7YCYqlQLS3L/SdEggVVijgXwUJK1ZxTV8NjaSi9SQ
+        /cDvIFmrGgFqTadth2pQdnK0LbcFL8otr7d8f5tWYmTH7DU1MrYzGxF+tmFX8QMfbAAudj3wOn+p
+        hCi6PBEnEro4HI2AYM0wsAkKUWvwl+HDbyl2fXokQIfTfxSIGuukoCsPL3m9FwXusOqK7wo0hgAn
+        XHz/B8cTKKwhNPNUlsJWtHc/8JOm6pQAxliCu4evbytQ2ZPztn2AJKJjxn5nnTW/KPOoUbfon9mU
+        db39mgqZtyqJgRBkIDA0Jg+JKYk58KAUqvWGkI/jMjuPZ2ljaO730qTZTxvkvNWOGgHiHZsPvCyx
+        2dnpFLDvrU9daGmkBnWbzMLyoXw6jwA90qWRHRqSvcTVqQT0ZymwIXk/rx6iGofNAlmPy04ItUMP
+        FFM4f+a3aBrqTV5vvYb5/8LMlLfcRXZG39og6TKuUCejns96HOa7lWKcfiTLJmD2lpF1zcJxPgXd
+        UqOPRqR9SV3KAK26v0Exbe7UgDSrJ6Aqnr7HF+/K1Gbyr5sL+arVf1+WnD8CHvFOK/ATNVkCNYP7
+        YhphDGu3NRJ0QDDQXzfXvwAAAP//AwCXSPltEgYAAA==
     headers:
       CF-RAY:
-      - 99022a496d28a338-SEA
+      - 99241c6f3bcea381-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -202,7 +194,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:22:32 GMT
+      - Tue, 21 Oct 2025 22:15:01 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -218,15 +210,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1094'
+      - '1430'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1101'
+      - '1438'
       x-request-id:
-      - req_663a8a5009fe4619a595cd440c7cca02
+      - req_d5088ff7343a486dad7ddb7783495e9f
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -11,12 +11,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '494'
+      - '542'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,24 +41,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xVTXPbOAy9+1dweE46kuXYkm+dZvox3UN3pqduMhqYhBw2lMglQW/cjP/7jijr
-        y2l2tpfeJDzgCXgAhOcFY1xJvmXcobdlIsVGZgKrjUhXWSqSZJ1Xy6JIsKh2Ik+LTZ5mN+kyyzZY
-        ZHkhEn7VUpjddxTU05jGY2cXDoFQltBi6WadbJZFdpNHzBNQ8G2MMLXVSCi7oB2Ix70zoWnzqkB7
-        7MxKa9Xs+ZY9LxhjjFs4omvjJR5QG4uOLxg7RWd0zrRYE7SOBtX0XyklEijt56gnFwQp08zsNTyV
-        JpANVJJ5xJcgGaNLAXpOVxuJus1sb+l6Za6XyXJ1neTXyfosV6TkW/ZXrKSrZ+hEJV7vQyXXeR77
-        sMvTSsg8XS0xz9ZZJI4kdLQYaUITC4rpjfBrskcQ3D7U2FDEn++4Be//MU7e8e0dr1Fr09zx0+jf
-        Updd1vEx+fHu6+5p/f7P/DFDf9w0+P7j59vvdoxooI7ZeRQOqXRITuEBdFSSR6/T1S+rUuUiiaoU
-        IFdZvkw3qxQSgb9BFQdSQSPwP3WB7PY2y+Wnb8XnYu2z9A/74yb/4D79mi4Lxu7j/FhwoDXq+fiR
-        C92mWIcHZYIv+2XsUhnG0zpTWyoFiAcsH/E4xRyCN81sz7CqjKOJU6tXqGtwfeSwdh4qpGOpJDak
-        KoWzFfToDkpgSapf2wqCJn7+GxiH0yIIa4sOKERz+iY5W59ozKwyrobxfdLm6DedJn5AtzNeUZsz
-        r1GqUI+/i07HB6NEjIZAhg+Af7mol9M09lGiF07ZaNwy/pa1DIwegJjDv4Ny6BmwfoIYGXZuNTJg
-        XfPf/N+pGNzaeaiR0PmJFl2jLTpSOLfHiC6BC3tbmiIdv/mld7m6cDjX7sm1YzIBT8PzaYzh57Ll
-        oOJlCoPxfhIFUqpWRNBfpkUM5+AimfMBWlx8PiYZD1MMvFgjMrbUZm+d2bXcyWC004lzoRHQ91Mq
-        DzvdX6rgYY/jOKpmdiiy9dVL++T6PI9/C/GAcgxMZoN7eX9uVj8DfsY77PJr1GQoztIZLJJhIYKf
-        726NBBIIWvrT4vQvAAAA//8DAIbQbCY4CAAA
+        H4sIAAAAAAAAAwAAAP//vFVNj+M2DL3nVwg6zywcJ3Gc3BbY7hTYLrCnou3OwqAlOqNGtlSJSicY
+        5L8XluOvzE7RvfRm85HP5CNpviwY40ryPeMOvS0SsZb5NqnyTOx2CcgkyfIqT1arSia7PF/usnK7
+        3mCZljuBKARu+F1LYco/UVBPYxqPnV04BEJZQIstt9kyyddpuoqYJ6Dg2xhhaquRUHZBJYjjwZnQ
+        tHlVoD12ZqW1ag58z14WjDHGLZzRtfEST6iNRccXjF2iMzpnWqwJWkeDavqvFBIJlPZz1JMLgpRp
+        ZvYangsTyAYqyBzxNUjG6EKAntPVRqJuMztYul+b+zRJ1/dJfp9kV7kiJd+zr7GSrp6hE5V4sw/r
+        pFzmIvZhlVbbVOI6XabVDpaROJLQ2WKkCU0sKKY3wm/JHkFwh1BjQxF/eeQWvP/bOPnI94+8Rq1N
+        88gvo39LXXRZx8efHx6WzcMHnx3V5w8fDx/tJ3DNH8/ZGNFAHbPzKBxS4ZCcwhPoqCSPXpe7H1ZF
+        imwdVcEUBGzFapVuEEv8H1RxIBU0Av9VF/1buiyzn97DBvOzrX8pj5/T50+///pjuiwY+xbnx4ID
+        rVHPx49c6DbFOjwpE3zRL2OXyjCe1pnaUiFAPGFxxPMUcwjeNLM9w6oyjiZOrV6hrsH1kcPaeaiQ
+        zoWS2JCqFM5W0KM7KYEFqX5tKwia+PVvYBxOiyCsLTqgEM3Ld8nV+kxjZpVxNYzvkzZHv+k08RO6
+        0nhFbc68RqlCPf4uOh2fjBIxGgIZPgD+9aLeTtPYR4leOGWjcc/4e9YyMHoCYg7/CsqhZ8D6CWJk
+        2LXVyIB1zX/3X6dicGvnoUZC5ydadI226Ejh3B4jugRu7G1pinT85pfe5e7G4Vq7J9eOyQS8DM+X
+        MYZfy5aDircpDMZvkyiQUrUigv4yLWI4BzfJXA/Q4ubzMcl4mGLgzRqRsYU2B+tM2XIng9FOJ86F
+        RkDfT6k8lLq/VMHDAcdxVM3sUKyyu9f2yfV5Gf8W4gnlGJjMBvf2/mzW3wO+xzvs8lvUZCjO0hXc
+        JcNCBD/f3RoJJBC09JfF5R8AAAD//wMAVfIgbTgIAAA=
     headers:
       CF-RAY:
-      - 9902343af818a360-SEA
+      - 99240bee5f2ba384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -69,7 +66,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:29:20 GMT
+      - Tue, 21 Oct 2025 22:03:45 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -85,13 +82,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1597'
+      - '1325'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1602'
+      - '1329'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -105,14 +102,14 @@ interactions:
       x-ratelimit-reset-tokens:
       - 21ms
       x-request-id:
-      - req_6fc00e7ee6954ad88afbaf9ea41f8b03
+      - req_09d61674906445c996dd55051b07b3b7
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_0zCTbx6FQ8k3esy7neFHKDjp","name":"secret_retrieval_tool","type":"function_call","id":"fc_0dc7d3cef7c1431c0068f2990fd68881978b81fcd8142e8363","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_a3DD38dIZ9K96s31Lpz58GrI","name":"secret_retrieval_tool","type":"function_call","id":"fc_0dc7d3cef7c1431c0068f2990ff8c0819789ad43821741a0ce","status":"completed"},{"call_id":"call_0zCTbx6FQ8k3esy7neFHKDjp","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_a3DD38dIZ9K96s31Lpz58GrI","output":"Life
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_HGG1nGDs6kiMDFgFpKarnZx6","name":"secret_retrieval_tool","type":"function_call","id":"fc_0c4d870f86c990ad0068f80340b18c8196b32f72de4212f9a1","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_lX21b6EAa5e8ypmLbkM2xKYV","name":"secret_retrieval_tool","type":"function_call","id":"fc_0c4d870f86c990ad0068f80340dc648196be2aca7c3325eebe","status":"completed"},{"call_id":"call_HGG1nGDs6kiMDFgFpKarnZx6","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_lX21b6EAa5e8ypmLbkM2xKYV","output":"Life
       before Death","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -123,12 +120,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1142'
+      - '1190'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -156,24 +150,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RVS4/bOAy+51eoPg4mhZ2ked0W2EMPu0Bve2gLg5boRB1Zcik6bVDkvy8kxa/M
-        zM3mR1J8fJ/0ZyFEplV2FBmhb8tcyZ1aS6x3stisC5nn2329OhyK/FN12OyLw24Pmx0Wu1pVO4Aa
-        6uw5pHDVD5Tcp3HWY7JLQmBUJQSs2G3z3eqw3uYR8wzc+RAjXdMaZFQpqAL5ciLX2VBXDcZjMmtj
-        tD1lR/FnIYQQWQtXpBCv8ILGtUjZQohbdEYiFzDbGRMN2vanlAoZtPFz1DN1krWzM3sDv0vXcdtx
-        ye4FX4PsnCklmHm6xik0obJTy8uNW67y1WaZ75f59j6umDI7iq+xk9TPsInGn95fRLFS+zwsolpt
-        cLP5VMtqn+N+lRYRs/C1xZgHvYcTjsB7E4+gdJbRjkVNC5ul7eeBv3mIjg5grWPoZ/j1+ww07tSS
-        q95AYqKjyD4joQBCwWcUHiUhewHeO6kDh8QvzWeBIM+iBe9/OVLHb/abXYqnpwaNcfbp6Sj+QyNd
-        g4Kd+NeRhg/JgUBpsBKDyz+6RlFh7QjF3wh8zoZqbvevocCMnIlNg/faM1hOzsExOmUtEBiDZs4E
-        pi6RtiW8aNf5stdFGXc8MKUl17RcSpBnLF/wOsUIwTs7ozzWtSOeOIWtdk0D1EcOCvBQI19LrdCy
-        rjXO1OCRLlpiybpXUA2dSfvMPDvCaROMTYsE3EVz8TG/W+Pe7pXVjhoY/yd8iX5paveKL0iV85qv
-        iaVKd82o3DTHs9MyDb5jlw2Af62Z/pi6s1G/I6MVekm6jcajyP4SIYPgM7Ag/NlpQi9gIFOgDCGT
-        xgsKuBPw45jNQhPPSUB5d4W0+NEt8KFBRvKTWaRFt0iscW6PEamAB3toTXNi35fe5fnB4d67Zwo0
-        mYC3kdNjTHZvW81EPi1hME4kmoFSOgwRzJdpE8PN/Hg/pLdg8XB8LDK+ETHwQUbs2nJyReSDsZ0y
-        jjorod+n0h4q0z8aXbzqBjpqO7uzi/X2+TUweQkGOkUlqjEynzH38S1Yr94C3so7iPm91Ow4kqmv
-        eLsfJNH5uXobZFDAEPLfFrf/AQAA//8DADOMvrPFBwAA
+        H4sIAAAAAAAAA3RVTY/bOAy951dodZ4UtpPxeHJboIceWqC3HjoLg5HoRDuy5FJ0tkGR/76w/J2Z
+        uSV85BM/Huk/GyGk0fIgJGFoykTtdfGUVEWunp8T0EmSF1WR7PbpPn1KivQ5h/1zhjqr0kdId7jT
+        8qGj8Md/UfFI413A3q4IgVGX0GHpU54mxT7LHiMWGLgNXYzydWORcSA7gno9kW9dl1cFNmBvNtYa
+        d5IH8WcjhBCygStSF6/xgtY3SHIjxC06I5HvMNdaGw3Gja+UGhmMDWs0MLWKjXcrew2/S99y03LJ
+        /hXfguy9LRXYNV3tNdous1PD273fZkm23ybFNsmHdkVKeRA/YyV9PdMk6nD6eBBZ8ZjGQRSgtc53
+        VV4dE3hSfcMjC18bjDwYApwWwEcdj6DyjtHNSS0TW9GO/cDfPEVHB3DOM4w9/PnPCrT+1JA/voNE
+        ooOQX5BQAKHgM4qAipDD4cW9uK14kTVa692LPIgfaJWvUbAX3zwZ+Kt3INAGnMLO5aupUByx8oTi
+        MwKf5fTebfg1pSDJ21gWhGACg+PeuXOMTrIBAmvRrmfN1PaybAgvxrehHJVfxilOWmjI1w2XCtQZ
+        y1e8LjFCCN6tRI1V5YkXTt3c2roGGiMnjQeokK+l0ejYVAZXeg9IF6OwZDPuSAWt7ScmA3vCZRGM
+        dYME3EZz+ikZrHEyQ2aVpxrm/wtFRL++a0PGF6SjD4avvQ61aet5N/s+nr1RfeNb9nICwtutGJ+p
+        Whc3dNasxqDINNF4EPJv0TEIPgMLwl+tIQwCRAMh/OdJd5IhZDJ4QQGDxD7NbA7q+E4PlIMr9IOf
+        3To91MhIYdGLftANEhtc22NEn8CdvSvNcK++76PLw53DUHtg6mSyAG+zpucYOZStV2u8TGEyLpZQ
+        gtamayLY78siptt7fwH6a7+5ez4mGb8CMfBujdg35eIIJJOxWSqOWqdgnKc2AY52/Cy08ZhNcjRu
+        dZXTXf7wFljc+klOcRP1HJmslHt/7bP8PeA93mmZP6Jmz1FMY8Z5Nq1EG9bbWyODBoaO/7a5/Q8A
+        AP//AwBQNdQKpwcAAA==
     headers:
       CF-RAY:
-      - 99023445ba78a360-SEA
+      - 99240bf75f53a384-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:29:21 GMT
+      - Tue, 21 Oct 2025 22:03:47 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -197,13 +191,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1469'
+      - '2035'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1475'
+      - '2045'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -217,7 +211,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_3cba4843579046409ad2e2608968a2c8
+      - req_38c99a00e43a4d588ed31f29c5543a1a
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -11,12 +11,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '508'
+      - '556'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=T80Vl1F4cZg58RAO2JRydk6._cpQtYkcLqWOReeHNiA-1760728485-1.0.1.1-i6d8AU5CeS3HiV66AosH6.r1WcZpzR.NYyqeRrU8uGX67rRZ6HQhCBcYX9ChIVpj.IgOiK.tKbckWT6Iz1z.dlVkyoF9g7X_i7t.uOpduxA;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,133 +42,129 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f52f42decbdc1ed0068f2992a1ca88196b8578fdbaaba3007","object":"response","created_at":1760729386,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_00c4f15a862212440068f803484e2c8193bb117c5a94b96d18","object":"response","created_at":1761084232,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f52f42decbdc1ed0068f2992a1ca88196b8578fdbaaba3007","object":"response","created_at":1760729386,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_00c4f15a862212440068f803484e2c8193bb117c5a94b96d18","object":"response","created_at":1761084232,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","type":"function_call","status":"in_progress","arguments":"","call_id":"call_e9IFshyCDcsOO3BqCLkU1m3R","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","type":"function_call","status":"in_progress","arguments":"","call_id":"call_q1t9XZMJIkrsHvmorg22clzL","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"delta":"{","obfuscation":"m6WZEC2mELIxgbh"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"delta":"{","obfuscation":"guT2rSnRyfEuaco"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"delta":"\"password","obfuscation":"mpmoTp0"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"delta":"\"password","obfuscation":"jBZK5w6"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"delta":"\":","obfuscation":"mFBrmWaCpreO2U"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"delta":"\":","obfuscation":"pFGsEupRfQZN8I"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"delta":"\"m","obfuscation":"Nvgwu9iSvqivM2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"delta":"\"m","obfuscation":"Jc0q7Dy0wouVEm"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"delta":"ell","obfuscation":"nGI7l7U20OBU5"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"delta":"ell","obfuscation":"1SGoSjfjWJHPJ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"delta":"on","obfuscation":"Oa1XOtoyQYiPNo"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"delta":"on","obfuscation":"QuEQUR9zoB3B2r"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"delta":"\"}","obfuscation":"p6I7EuOVbEs6RE"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"delta":"\"}","obfuscation":"DsLtvCufzyV5MC"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_e9IFshyCDcsOO3BqCLkU1m3R","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_q1t9XZMJIkrsHvmorg22clzL","name":"secret_retrieval_tool"}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","type":"function_call","status":"in_progress","arguments":"","call_id":"call_Vmt8WWTUEzCQGmrrMtWYP1Yr","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","type":"function_call","status":"in_progress","arguments":"","call_id":"call_5l4sCPMYHaNlQDLW5DoksdHs","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","output_index":1,"delta":"{","obfuscation":"48IsRjVDqonAnOp"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","output_index":1,"delta":"{","obfuscation":"s7d8ZjJfHb4M7U3"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","output_index":1,"delta":"\"password","obfuscation":"nA8r75v"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","output_index":1,"delta":"\"password","obfuscation":"B6AKbmO"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","output_index":1,"delta":"\":","obfuscation":"5mlCaWUr6WS9vC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","output_index":1,"delta":"\":","obfuscation":"tH0UB3yBbo7ZsB"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","output_index":1,"delta":"\"radi","obfuscation":"ROEyuJalmxd"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","output_index":1,"delta":"\"radi","obfuscation":"uDFgoSAreN5"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","output_index":1,"delta":"ance","obfuscation":"OJRGzXGdOBde"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","output_index":1,"delta":"ance","obfuscation":"b433PYA1TBQR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","output_index":1,"delta":"\"}","obfuscation":"lXgtJVozRWO364"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","output_index":1,"delta":"\"}","obfuscation":"ZYgWKSdPSz8r9J"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_Vmt8WWTUEzCQGmrrMtWYP1Yr","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_5l4sCPMYHaNlQDLW5DoksdHs","name":"secret_retrieval_tool"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_0f52f42decbdc1ed0068f2992a1ca88196b8578fdbaaba3007","object":"response","created_at":1760729386,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_e9IFshyCDcsOO3BqCLkU1m3R","name":"secret_retrieval_tool"},{"id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_Vmt8WWTUEzCQGmrrMtWYP1Yr","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_00c4f15a862212440068f803484e2c8193bb117c5a94b96d18","object":"response","created_at":1761084232,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_q1t9XZMJIkrsHvmorg22clzL","name":"secret_retrieval_tool"},{"id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_5l4sCPMYHaNlQDLW5DoksdHs","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":36,"input_tokens_details":{"cached_tokens":0},"output_tokens":54,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":90},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990234e679aac381-SEA
+      - 99240c22abcda333-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:29:46 GMT
+      - Tue, 21 Oct 2025 22:03:52 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=DQYVJ7h9WAcxvX1xEg35WKflHooaMiZmVGCQMu192XA-1760729386-1.0.1.1-qcUzrWrd8Hn.QXmvXANau06efaXnkOchBAlPun13fwE10vE_r8e9GDRzc3Z5Yp7VVBTPFbySRu_tJjWFQbN0cO6ZVtIg2WKEL4UaH1ZKD6c;
-        path=/; expires=Fri, 17-Oct-25 19:59:46 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -185,22 +178,22 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '163'
+      - '257'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '203'
+      - '329'
       x-request-id:
-      - req_dc8be9a9ef6a49d99a14a4365f6223e4
+      - req_946f1192d3a94f83bd54b74a61fc906c
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_e9IFshyCDcsOO3BqCLkU1m3R","name":"secret_retrieval_tool","type":"function_call","id":"fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_Vmt8WWTUEzCQGmrrMtWYP1Yr","name":"secret_retrieval_tool","type":"function_call","id":"fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca","status":"completed"},{"call_id":"call_e9IFshyCDcsOO3BqCLkU1m3R","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_Vmt8WWTUEzCQGmrrMtWYP1Yr","output":"Life
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_q1t9XZMJIkrsHvmorg22clzL","name":"secret_retrieval_tool","type":"function_call","id":"fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_5l4sCPMYHaNlQDLW5DoksdHs","name":"secret_retrieval_tool","type":"function_call","id":"fc_00c4f15a862212440068f803492f848193aea4fcadd7119614","status":"completed"},{"call_id":"call_q1t9XZMJIkrsHvmorg22clzL","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_5l4sCPMYHaNlQDLW5DoksdHs","output":"Life
       before Death","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -211,12 +204,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1156'
+      - '1204'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=DQYVJ7h9WAcxvX1xEg35WKflHooaMiZmVGCQMu192XA-1760729386-1.0.1.1-qcUzrWrd8Hn.QXmvXANau06efaXnkOchBAlPun13fwE10vE_r8e9GDRzc3Z5Yp7VVBTPFbySRu_tJjWFQbN0cO6ZVtIg2WKEL4UaH1ZKD6c;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -245,208 +235,214 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f52f42decbdc1ed0068f2992c5fc481968e4ab7122fbe9f03","object":"response","created_at":1760729388,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_00c4f15a862212440068f80349a2d08193a8a29ab853cc4bf9","object":"response","created_at":1761084234,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f52f42decbdc1ed0068f2992c5fc481968e4ab7122fbe9f03","object":"response","created_at":1760729388,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_00c4f15a862212440068f80349a2d08193a8a29ab853cc4bf9","object":"response","created_at":1761084234,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"Here","logprobs":[],"obfuscation":"TEZt90NLgnfY"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"The","logprobs":[],"obfuscation":"qBRa1rSoGX7Os"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        are","logprobs":[],"obfuscation":"yoKiehyMCm2l"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        secrets","logprobs":[],"obfuscation":"SFGDuqiA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"vLYfHZjSSMdp"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        associated","logprobs":[],"obfuscation":"24Ase"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        secrets","logprobs":[],"obfuscation":"bKbxZVUn"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        with","logprobs":[],"obfuscation":"UAj830EohmX"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"snjHwMpSk4R9I"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"ggMNsqe3FsC2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"uPmv0GoakqCmuME"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        passwords","logprobs":[],"obfuscation":"Qg44IA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        For","logprobs":[],"obfuscation":"Pu5Ru3zDTgH3"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        are","logprobs":[],"obfuscation":"ITx2dMdAWEyS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"FpSRmfiOn4lpae"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"owBNvcpaXerCY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"T4AM2RLQdR8bxXU"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"X0msaKjgpLGhfsR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"wJL4F1lrpbjZG"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"ndJ76XhqYs8KfW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"8EBirbdYTn74BE"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"g5ffA5kBBrjopoG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"lTRJkYLQNF03Lu"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"UfzR1joeFBNuY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        Welcome","logprobs":[],"obfuscation":"DeZiScn0"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"fyxvrWUk4unsyL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        to","logprobs":[],"obfuscation":"qdx4HUAoiSJI4"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"ospHkZwU17jCYU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        M","logprobs":[],"obfuscation":"CzF8HUN33P2JOG"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        Welcome","logprobs":[],"obfuscation":"IGgeAFk4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"BzI7UzWeqHYJ"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        to","logprobs":[],"obfuscation":"i2SNXxzH7HddW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"En08ujEje54I4l"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        M","logprobs":[],"obfuscation":"ugulJoUKS67yHn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"sF7F6t0EBKTSMq8"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"gdEHyrj2KACq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        For","logprobs":[],"obfuscation":"KHTCvbviH8Bq"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"m5eImEK6hFepFL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"fBDp1c5kXvRxvF"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"zEEITHRTQ1Kynr6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"Dq12t5aCtOUc"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"OEZdCbc1z2fxDu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"FaFFxzZL95l9"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"GJ7Xd50GUGkL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"dMlfnu437lrghK"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"q0LuUFwBt9IO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        Life","logprobs":[],"obfuscation":"oYauvnvYao8"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"JxWbm4xAt0yasu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        before","logprobs":[],"obfuscation":"dgkibs1eu"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        Life","logprobs":[],"obfuscation":"vrr9laIiXfh"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"delta":"
-        Death","logprobs":[],"obfuscation":"jlV7POhlYQ"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        before","logprobs":[],"obfuscation":"h0fo63kPd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"delta":"
+        Death","logprobs":[],"obfuscation":"S3gbCD5SmF"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":30,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"text":"Here
-        are the secrets:\n\n- For \"mellon\": Welcome to Moria!\n- For \"radiance\":
-        Life before Death","logprobs":[]}
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"text":"The
+        secrets associated with the passwords are:\n\n- \"mellon\": Welcome to Moria!\n-
+        \"radiance\": Life before Death","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":31,"item_id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets:\n\n- For \"mellon\": Welcome to Moria!\n- For \"radiance\":
-        Life before Death"}}
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        secrets associated with the passwords are:\n\n- \"mellon\": Welcome to Moria!\n-
+        \"radiance\": Life before Death"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":32,"output_index":0,"item":{"id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets:\n\n- For \"mellon\": Welcome to Moria!\n- For \"radiance\":
-        Life before Death"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        secrets associated with the passwords are:\n\n- \"mellon\": Welcome to Moria!\n-
+        \"radiance\": Life before Death"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":33,"response":{"id":"resp_0f52f42decbdc1ed0068f2992c5fc481968e4ab7122fbe9f03","object":"response","created_at":1760729388,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets:\n\n- For \"mellon\": Welcome to Moria!\n- For \"radiance\":
-        Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
-        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":136,"input_tokens_details":{"cached_tokens":0},"output_tokens":28,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":164},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_00c4f15a862212440068f80349a2d08193a8a29ab853cc4bf9","object":"response","created_at":1761084234,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"The
+        secrets associated with the passwords are:\n\n- \"mellon\": Welcome to Moria!\n-
+        \"radiance\": Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":136,"input_tokens_details":{"cached_tokens":0},"output_tokens":29,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":165},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990234f4ebc0c381-SEA
+      - 99240c2b8be1a333-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:29:48 GMT
+      - Tue, 21 Oct 2025 22:03:54 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -462,15 +458,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '123'
+      - '594'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '130'
+      - '635'
       x-request-id:
-      - req_35922fb363394aa5a3858b01ae1254d1
+      - req_02687b309d9a47199e89e775234ba005
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -11,12 +11,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '508'
+      - '556'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,127 +42,127 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0888af4740f553150068f2991eb1a08195827fd5c07d01922d","object":"response","created_at":1760729374,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_08622b4f543dc1510068f803437fac8196a76b854b6f4e55bd","object":"response","created_at":1761084227,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0888af4740f553150068f2991eb1a08195827fd5c07d01922d","object":"response","created_at":1760729374,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_08622b4f543dc1510068f803437fac8196a76b854b6f4e55bd","object":"response","created_at":1761084227,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","type":"function_call","status":"in_progress","arguments":"","call_id":"call_41CfEqEOHhPeIwSwoLhT7x8y","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","type":"function_call","status":"in_progress","arguments":"","call_id":"call_8mWOlD2knIPTChQYr7GQ4Hxi","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"delta":"{","obfuscation":"V8d8cbgk9BDoQWX"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"delta":"{","obfuscation":"X5ZoOwYkWepevql"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"delta":"\"password","obfuscation":"PYSGgbn"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"delta":"\"password","obfuscation":"oX6Es3i"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"delta":"\":","obfuscation":"0sgBLQfLpeREhT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"delta":"\":","obfuscation":"ixV4SgkFzYd2TC"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"delta":"\"m","obfuscation":"2EgAH0Sz3nzWwd"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"delta":"\"m","obfuscation":"vXgmrFOXyVUeKd"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"delta":"ell","obfuscation":"gBI9gvbEZrCmw"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"delta":"ell","obfuscation":"YwuRd00K4cZmH"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"delta":"on","obfuscation":"F1rwAVyzAyDQgK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"delta":"on","obfuscation":"8UJ4i6K8JYSfPN"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"delta":"\"}","obfuscation":"9y78i6GV8TQ58B"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"delta":"\"}","obfuscation":"QU1acvnBweuZoN"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_41CfEqEOHhPeIwSwoLhT7x8y","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_8mWOlD2knIPTChQYr7GQ4Hxi","name":"secret_retrieval_tool"}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","type":"function_call","status":"in_progress","arguments":"","call_id":"call_rprZSnKbUBINpIEDeVwZ3bTN","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","type":"function_call","status":"in_progress","arguments":"","call_id":"call_3UNGcrPBkfEG8ueZGjz6s00h","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","output_index":1,"delta":"{","obfuscation":"3W2FG6nWTi5V35P"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","output_index":1,"delta":"{","obfuscation":"GQoxSjrZw6EdygC"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","output_index":1,"delta":"\"password","obfuscation":"WQuFkHH"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","output_index":1,"delta":"\"password","obfuscation":"0BjJu4s"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","output_index":1,"delta":"\":","obfuscation":"yjD9xjQWUXqBGf"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","output_index":1,"delta":"\":","obfuscation":"aS4bnghiVmDj8y"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","output_index":1,"delta":"\"radi","obfuscation":"eCcWVSrwv2i"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","output_index":1,"delta":"\"radi","obfuscation":"QjhARybdAIR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","output_index":1,"delta":"ance","obfuscation":"DpMhAjUJ6v3Y"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","output_index":1,"delta":"ance","obfuscation":"7PLLsdi0vSga"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","output_index":1,"delta":"\"}","obfuscation":"KeVeHM1w4dE1eC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","output_index":1,"delta":"\"}","obfuscation":"VNge8em27jX9su"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_rprZSnKbUBINpIEDeVwZ3bTN","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_3UNGcrPBkfEG8ueZGjz6s00h","name":"secret_retrieval_tool"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_0888af4740f553150068f2991eb1a08195827fd5c07d01922d","object":"response","created_at":1760729374,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_41CfEqEOHhPeIwSwoLhT7x8y","name":"secret_retrieval_tool"},{"id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_rprZSnKbUBINpIEDeVwZ3bTN","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_08622b4f543dc1510068f803437fac8196a76b854b6f4e55bd","object":"response","created_at":1761084227,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_8mWOlD2knIPTChQYr7GQ4Hxi","name":"secret_retrieval_tool"},{"id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_3UNGcrPBkfEG8ueZGjz6s00h","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":36,"input_tokens_details":{"cached_tokens":0},"output_tokens":54,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":90},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 9902349f6c13a3c8-SEA
+      - 99240c05690095dd-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:29:34 GMT
+      - Tue, 21 Oct 2025 22:03:47 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -181,22 +178,22 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '206'
+      - '208'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '218'
+      - '222'
       x-request-id:
-      - req_d7d07888dc2f4be7998adb6ffcdd13fe
+      - req_eda42fbcf232456d8f8ce77cff75ee2c
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_41CfEqEOHhPeIwSwoLhT7x8y","name":"secret_retrieval_tool","type":"function_call","id":"fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_rprZSnKbUBINpIEDeVwZ3bTN","name":"secret_retrieval_tool","type":"function_call","id":"fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e","status":"completed"},{"call_id":"call_41CfEqEOHhPeIwSwoLhT7x8y","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_rprZSnKbUBINpIEDeVwZ3bTN","output":"Life
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_8mWOlD2knIPTChQYr7GQ4Hxi","name":"secret_retrieval_tool","type":"function_call","id":"fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_3UNGcrPBkfEG8ueZGjz6s00h","name":"secret_retrieval_tool","type":"function_call","id":"fc_08622b4f543dc1510068f803457c7081969163370cc2f28787","status":"completed"},{"call_id":"call_8mWOlD2knIPTChQYr7GQ4Hxi","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_3UNGcrPBkfEG8ueZGjz6s00h","output":"Life
       before Death","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -207,12 +204,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1156'
+      - '1204'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -241,230 +235,230 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0888af4740f553150068f2991fe8c08195925add88b661ffa9","object":"response","created_at":1760729376,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_08622b4f543dc1510068f803461e50819680f4cd523e23df35","object":"response","created_at":1761084230,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0888af4740f553150068f2991fe8c08195925add88b661ffa9","object":"response","created_at":1760729376,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_08622b4f543dc1510068f803461e50819680f4cd523e23df35","object":"response","created_at":1761084230,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"Here","logprobs":[],"obfuscation":"0smTwRt9RSpH"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"Here","logprobs":[],"obfuscation":"zOU1B1p83mTP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        are","logprobs":[],"obfuscation":"f3XWkN0Rt6iO"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        are","logprobs":[],"obfuscation":"d2FKtNFcaczr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"vxMQkDbXXat6"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"Qkt5pMZQhZiC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        secrets","logprobs":[],"obfuscation":"kQGdV0o8"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        secrets","logprobs":[],"obfuscation":"ZAvXZWUZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        associated","logprobs":[],"obfuscation":"1asXb"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        for","logprobs":[],"obfuscation":"sKF2AT7cz4iB"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        with","logprobs":[],"obfuscation":"qNGSFcc634t"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"ksxpkrPMzLrz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"cCKxPu2TMBrU"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        provided","logprobs":[],"obfuscation":"ce3irPM"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        passwords","logprobs":[],"obfuscation":"yC7iba"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        passwords","logprobs":[],"obfuscation":"OESFJ7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"JxGlmct2kxPEn"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"ppjzqfxlVAWlv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"vljvz5j9u2V3XLw"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"xbjc0nlwccewftb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        **","logprobs":[],"obfuscation":"GdS8VV0ybmoS5"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"r2uscqIuWJwVA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"rP0AyWjIQ5TE6gD"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"D8ljOCAJsdIF4hm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"wSUCGjuWdGOp3"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"1O8dLtxEgSJ6G"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"Kx1owzxQKqdK37"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"51JVLMWeLwg2zf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"XxGiNBmuEuh4pZ"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"ZPGdZOPXofcdE0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"ZfIIIo1mMxy4jtc"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"1qyFuuNxFWydEjq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        Welcome","logprobs":[],"obfuscation":"zlVqKoxz"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        Welcome","logprobs":[],"obfuscation":"5CPtxWxe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        to","logprobs":[],"obfuscation":"chkfkDyW6pSIe"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        to","logprobs":[],"obfuscation":"kprv2xtpTQ7ic"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        M","logprobs":[],"obfuscation":"Z4yvggV0i6Fxyd"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        M","logprobs":[],"obfuscation":"gUWhU3wTZcfcv5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"xIZOc1WEsQ73"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"zXzHp0DwQnWQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"bSpAV7GvMNro49"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"anX9GpH5YqN8fJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"YMQuyAWAkqfWmmi"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"Iv2C5yqRbUyer9q"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        **","logprobs":[],"obfuscation":"LxG6ocKTZj5bw"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"i6rG0ldsEeDKd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"9Tw8NfyQGzsD"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"SH5RC2xAfam9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"GhPBFt81igOS"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"0qdxlOL5vCEV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"H79eamY5hdfUCZ"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"yL37NGRRy5CBAo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"OhI0Tl7QncIEc47"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"ApLVEMeDKQVRYui"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        Life","logprobs":[],"obfuscation":"SluBds9SenA"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        Life","logprobs":[],"obfuscation":"5KfG3tVkOsR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        before","logprobs":[],"obfuscation":"yMGBQ84xf"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        before","logprobs":[],"obfuscation":"nKyFN3OS7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"delta":"
-        Death","logprobs":[],"obfuscation":"0Bf6tLz4qG"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"delta":"
+        Death","logprobs":[],"obfuscation":"Dvp2XQeZ6W"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":34,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"text":"Here
-        are the secrets associated with the passwords:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death","logprobs":[]}
+        data: {"type":"response.output_text.done","sequence_number":34,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"text":"Here
+        are the secrets for the provided passwords:\n\n- **mellon**: Welcome to Moria!\n-
+        **radiance**: Life before Death","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":35,"item_id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets associated with the passwords:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death"}}
+        data: {"type":"response.content_part.done","sequence_number":35,"item_id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the secrets for the provided passwords:\n\n- **mellon**: Welcome to Moria!\n-
+        **radiance**: Life before Death"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":36,"output_index":0,"item":{"id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets associated with the passwords:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","sequence_number":36,"output_index":0,"item":{"id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the secrets for the provided passwords:\n\n- **mellon**: Welcome to Moria!\n-
+        **radiance**: Life before Death"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":37,"response":{"id":"resp_0888af4740f553150068f2991fe8c08195925add88b661ffa9","object":"response","created_at":1760729376,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0888af4740f553150068f299207a98819598f085926027eddb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets associated with the passwords:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.completed","sequence_number":37,"response":{"id":"resp_08622b4f543dc1510068f803461e50819680f4cd523e23df35","object":"response","created_at":1761084230,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the secrets for the provided passwords:\n\n- **mellon**: Welcome to Moria!\n-
+        **radiance**: Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":136,"input_tokens_details":{"cached_tokens":0},"output_tokens":32,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":168},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990234a6fb2ba3c8-SEA
+      - 99240c15de3595dd-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:29:36 GMT
+      - Tue, 21 Oct 2025 22:03:50 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -480,15 +474,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '205'
+      - '180'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '221'
+      - '188'
       x-request-id:
-      - req_1d37964d22dc450f9bdecf549056ac9c
+      - req_20f8c6accc374bc2a3e8dfd15e739527
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -11,12 +11,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '494'
+      - '542'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,24 +41,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xVz2/bOgy+568QdG4HJXHtJLdddhiKrsO7dG8dDFqiE62y5UlU1qDI/z5YTvwj
-        XR/eLrvZ/MjP5EfSfJkxxrXiG8Yd+iYXabYqMpiX2RokioUQ6apcrNdimWZruZqvRQGICayKtACJ
-        WSb4VUthi+8o6Uxja4+dXToEQpVDi82zVGSL9TLJIuYJKPg2RtqqMUiouqAC5NPW2VC3eZVgPHZm
-        bYyut3zDXmaMMcYbOKBr4xXu0dgGHZ8xdozO6JxtsToYEw26Pn8lV0igjZ+inlyQpG09sVfwnNtA
-        TaCc7BO+Bslak0swU7rKKjRtZtuGrhN7vRCL5FqsrkV6kitS8g37Givp6uk7Ucq3+5AsVhj7sMZ5
-        NhcoMMFlIuYQiSMJHRqMNKGOBcX0Bvgt2SMIbhsqrCniL4+8Ae9/Wqce+eaRV2iMrR/5cfBvqfMu
-        6/ioyqXff7n9dHenaPm5WHx4+IAPP/9dDhE1VDE7j9Ih5Q7JadyDiUry6HW8+mNVblIRVVktIYUk
-        k1mWrG5SIf6CKg6Uhlrif+ry8QG33ov3h7vbf3bll/qzf77/WIvbP9Nlxti3OD8NODAGzXT8yIVu
-        UxqHe22Dz8/L2KXSj2fjbNVQLkHuMH/CwxhzCN7Wkz3DsrSORk6tXqGqwJ0j+7XzUCIdcq2wJl1q
-        nKygR7fXEnPS57UtIRjip7+BdTgugrBq0AGFaJ6/EyfrMw2ZldZVMLyP2hz9xtPE9+gK6zW1OfMK
-        lQ7V8LvodNxZLWM0BLK8B/zrRb2cpqGPCr10uonGDePvWcvAaAfEHP4I2qFnwM4TxMiyU6uRAeua
-        /+7/TkXv1s5DhYTOj7ToGt2gI41Te4zoEriwt6VpMvGb92eXqwuHU+2eXDsmI/DYPx+HGH4qW/Uq
-        XqbQG7+NokAp3YoI5n5cRH8OLpI5HaDZxedjkvEwxcCLNSLb5MZuG2eLllv0xmY8cS7UEs79VNpD
-        Yc6XKnjY4jCOup4cimV69do+uj4vw99C7lANgWIyuJf35yb5HfA73n6X36ImS3GWTuBa9AsR/HR3
-        KyRQQNDSH2fHXwAAAP//AwC6+TBzOAgAAA==
+        H4sIAAAAAAAAA7xVTW/bOBC9+1cQPCeFvmwrvhWLAIsFCrhF0cNuCmFMjhxuKJElh06ygf/7QpSt
+        D6cp2ktv0ryZp5k3M5qXBWNcSb5h3KG3VbKEVV7K5QoRkjyrk2RV1mWS52JXS1GmN+ubJC8xl2uZ
+        YbmGcs2vOgqz+xcFnWlM67G3C4dAKCvosHS9SpOyyLIkYp6Agu9ihGmsRkLZB+1APOydCW2XVw3a
+        Y29WWqt2zzfsZcEYY9zCM7ouXuIBtbHo+IKxY3RG50yHtUHraFDt+SuVRAKl/Rz15IIgZdqZvYGn
+        ygSygSoyD/gaJGN0JUDP6RojUXeZ7S1dF+Y6S7LiOimvk9VJrkjJN+yfWElfz9CJWrzdB1nU0Pdh
+        t8ryrM7zopBpnueROJLQs8VIE9pYUExvhN+SPYLg9qHBliL+cscteP9onLzjmzveoNamvePH0b+j
+        rvqs4+OXbfqn98sPwpT+8a+n8MfH/fvHffrfGNFCE7PzKBxS5ZCcwgPoqCSPXserX1ZltSuTqMqq
+        KJJiCSJN12vMkt+gigOpoBX4Q122Hyn7VNrPdvuhKNv69oulv7+F29tf02XB2Nc4PxYcaI16Pn7k
+        Qr8p1uFBmeCr8zL2qQzjaZ1pLFUCxD1WD/g8xRyCN+1sz7CujaOJU6dXaBpw58hh7TzUSM+VktiS
+        qhXOVtCjOyiBFanz2tYQNPHT38A4nBZB2Fh0QCGa03fJyfpEY2a1cQ2M75M2R7/pNPEDup3xirqc
+        eYNShWb8XfQ63hslYjQEMnwA/OtFvZymsY8SvXDKRuOG8fesY2B0D8QcfgvKoWfAzhPEyLBTq5EB
+        65v/7menYnDr5qFBQucnWvSNtuhI4dweI/oELuxdaYp0/Ob27HJ14XCq3ZPrxmQCHofn4xjDT2XL
+        QcXLFAbj10kUSKk6EUFvp0UM5+AimdMBWlx8PiYZD1MMvFgjMrbSZm+d2XXcyWC004lzoRVw7qdU
+        Hnb6fKmChz2O46ja2aHIV1ev7ZPr8zL+LcQ9yjEwmQ3u5f1ZFt8Dvsc77PJb1GQoztIJvEmGhQh+
+        vrsNEkgg6OiPi+P/AAAA//8DAP8c4eY4CAAA
     headers:
       CF-RAY:
-      - 990233f4cd7ca3c2-SEA
+      - 99240bdb4dde95dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -69,7 +66,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:29:08 GMT
+      - Tue, 21 Oct 2025 22:03:41 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -85,13 +82,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1174'
+      - '920'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1181'
+      - '924'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -105,14 +102,14 @@ interactions:
       x-ratelimit-reset-tokens:
       - 21ms
       x-request-id:
-      - req_d9c09322d44a4214b30320e0026b53e4
+      - req_f79267c8b5544d83a636b8c0a0a7a2cc
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"role":"user","content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_df3svYLONNdt3Qb2FXFeXwZ3","name":"secret_retrieval_tool","type":"function_call","id":"fc_0678b7a1f79ace020068f2990428ec81909e1710e0e4e3401a","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_JXegss0AyNLShfYnQsxPJn0L","name":"secret_retrieval_tool","type":"function_call","id":"fc_0678b7a1f79ace020068f29904560c819083a6a47c77485600","status":"completed"},{"call_id":"call_df3svYLONNdt3Qb2FXFeXwZ3","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_JXegss0AyNLShfYnQsxPJn0L","output":"Life
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":[{"text":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_VP1Hss5Mco8swJxuCQgAwg1z","name":"secret_retrieval_tool","type":"function_call","id":"fc_05a638d56eea032f0068f8033d4fac81979b6232f3344d1333","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_PQt2R8pTpPM48nfEVptZquEE","name":"secret_retrieval_tool","type":"function_call","id":"fc_05a638d56eea032f0068f8033d6b8081979644045ac1177e20","status":"completed"},{"call_id":"call_VP1Hss5Mco8swJxuCQgAwg1z","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_PQt2R8pTpPM48nfEVptZquEE","output":"Life
       before Death","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -123,12 +120,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1142'
+      - '1190'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -156,24 +150,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RVTY/jNgy951eoOk8WtjfjxLktUBQ9bIG99bBTGIxEJ+rIkpei0w0W+e+F5e/M
-        zC3hI5/48Uj/2gghjZZHIQlDUyb5/nDaQ1rtC1CYZEmSH6qsKJLdKdPJIS2SQ7FLVVpBoXJ9yvVO
-        PnUU/vQvKh5pvAvY2xUhMOoSOizd58k+Kz7vDhELDNyGLkb5urHIqPugE6jXM/nWdXlVYAP2ZmOt
-        cWd5FL82QgghG7ghdfEar2h9gyQ3QtyjMxL5DnOttdFg3PhKqZHB2LBGA1Or2Hi3stfws/QtNy2X
-        7F/xLcje21KBXdPVXqPtMjs3vN35bZZku21y2Cb50K5IKY/ie6ykr2eaRB3OHw/iOdXJoRtEUeXF
-        7vkZ8ZAVWZUWkTmy8K3ByIMhwBln4KOOR1B5x+jmpJaJrWjHfuBPnqKjAzjnGcYefv9nBVp/bsif
-        3kEi0VHIP5FQAKHgC4qAipDD8cW9uK34w5N4kTVa692LPIq/0Spfo2Av/vJk4LfZiUAbcAo7t6+m
-        QnHCyhOK3xH4Iqd378OvKRVJ3sbyIAQTGBz3zp1jdJINEFiLdj1zpraXZ0N4Nb4N5bgBZZzmpImG
-        fN1wqUBdsHzF2xIjhODdStxYVZ544dTNr61roDFy0nqACvlWGo2OTWVwpfuAdDUKSzbjrlTQ2n5y
-        MrAnXBbBWDdIwG00p5+SwRonNGRWeaph/r9QRvTruzZkfEU6+WD41utRm7aed7Tv48Ub1Te+ZS8n
-        ILzdjvGZqnVxU2ftagyKTBONRyG/iI5B8AVYEP5oDWEQIBoI4T9PupMNIZPBKwoYpPZpZnNQx3d6
-        oBxcoR/87NbpoUZGCote9INukNjg2h4j+gQe7F1phnv1fRtdnh4chtoDUyeTBXifNT3HyKFsvVrn
-        ZQqTcbGMErQ2XRPBflsWMd3gx0vQX/3Nw/Mxyfg1iIEPa8S+KRfHIJmMzVJx1DoF4zy1CXCy4+eh
-        jUdtkqNxq+ucfs6f3gKLmz/JKW6iniOTlXIfr352eA94j3da5o+o2XMU05hxvptWog3r7a2RQQND
-        x3/f3P8HAAD//wMATJpyra8HAAA=
+        H4sIAAAAAAAAA3RVTY/jNgy951eoOg4mCyfOOJ7cCvTQQwvsrYdNYdAWnWhHllyKzm6wyH8vLMVf
+        mZmbzUdS/HhP+rUSQmolD0IS+rZIXiBLc/WSIUKSbuskyfI6T9JUYbbZ5ZvXfZnvVZmVdbpX5T6v
+        cvncp3Dld6x4SOOsx2ivCIFRFdBjm322SfLddrsNmGfgzvcxlWtag4wqBpVQvZ3IdbavqwbjMZq1
+        Mdqe5EH8WgkhhGzhitTHK7ygcS2SXAlxC85I5HrMdsYEg7bDKYVCBm38EvVMXcXa2YW9gZ+F67jt
+        uGD3hu9Bds4UFZhlusYpNH1lp5bXO7feJtvdOsnXSXYfV0gpD+Jb6CT2M26i8afPF4H7LKv6Rbwi
+        bMpd/QKQvuZpFhcRsvC1xZAHvYcTTsBnEw9g5SyjnYqaF7ZIO8wDf/IYHRzAWscwzPDbvwvQuFNL
+        rvwACYkOQv6JhAIIBZ9ReKwI2Qvw3lW655D4ofkcsBa8/+FI+cPRHu1aPD01aIyzT08HcZT/oKlc
+        g4Kd+NuRht+OMjoRKA22wuj2l65RlFg7QvEHAp+PUo5V3e5fY6GSnAnNg/faM1iOzr1jcJItEBiD
+        ZskIpi6StyW8aNf5YtBHEXY9MqYl17RcVFCdsXjD6xwjBO/sgvpY14545tRvt2saoCFyVIKHGvla
+        aIWWda1xoQqPdNEVFqwHJdXQmbhX6dkRzptgbFok4C6YN1+SuzXs715Z7aiB6X/Gm+AXp3av+IJU
+        Oq/5GtmqdNdMCo5zPDtdxcF37OQI+PfaGY6pOxt0PDFboa9It8F4EPJ30WcQfAYWhP91mtALGFnV
+        E4eQSeMFBdyJ+GXKZqEJ50SguLtCXPzk1vOhQUbys1nERbdIrHFpDxGxgAd735rmyL6vg8vzg8O9
+        d8/U02QG3iZOTzHy3rZaiH1ewmicSVWCUrofIpiv8ybGG/rxnohvwurh+FBkeCtC4IOM2LXF7KpI
+        RmM7Zxx1toJhn0p7KM3weHThyhvpqO3i7t6k2fN7YPYijHQKSlRTZLJg7uObkL58BHyUdxTzZ6nZ
+        cSDTUPF+M0qi80v1NsiggKHPf1vd/gcAAP//AwCDAQgDzQcAAA==
     headers:
       CF-RAY:
-      - 990233fcffaca3c2-SEA
+      - 99240be26b2295dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +175,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:29:10 GMT
+      - Tue, 21 Oct 2025 22:03:43 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -197,13 +191,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1404'
+      - '1114'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1407'
+      - '1121'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -217,7 +211,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_99145d34ed5a409ab628ff0ead5ca980
+      - req_bbeb1970fefe44669aef6d6d6a388514
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/async.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"List all U.S. states."}],"max_output_tokens":50,"model":"gpt-4o"}'
+    body: '{"input":[{"content":[{"text":"List all U.S. states.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":50,"model":"gpt-4o"}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '101'
+      - '149'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=DQYVJ7h9WAcxvX1xEg35WKflHooaMiZmVGCQMu192XA-1760729386-1.0.1.1-qcUzrWrd8Hn.QXmvXANau06efaXnkOchBAlPun13fwE10vE_r8e9GDRzc3Z5Yp7VVBTPFbySRu_tJjWFQbN0cO6ZVtIg2WKEL4UaH1ZKD6c;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -42,22 +39,22 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUTY/bOAy9z69Qfe4YiuPm61ZMUfRe7KkuDEamU21k0pCo2WaL+e8Ly4kd78zc
-        JD7yiR+P+vOgVGab7KAyj6GvNa6LrV5vjkajWetG682uLfb7ddvuS71b7be7UrcNNrjbr9q2WJvs
-        40DBx7/RyI2GKeBoNx5BsKlhwFbbjd4WA0/CgoDEMMRYMtz1DuUadQRzPnmONCTWggs4mq1zlk7Z
-        Qf15UEqprIcL+oGgwWd03KPPHpR6Sc7oPQ8YReeSYX6kblDAujATeYTANDB18LvmKH2UWviMFGZG
-        S0F8NGKZwj3x65CD+qQnSJhdbcC5ZRA36IYHT708lvxY6KJ81LtHvbk2NBFmB/UjZTjmOc2qC6d3
-        R1XqEvRuHNV+o4vi2ADq1c5AYk4scukx8WAIcMIZeHcmCTVMgjRndZ/ZgvfWDvwtU3RyACIWuLXw
-        x88F6PjUez6+gSSig8qe0AtYcpcP6ht6VDYoUM4GUdwqcE79lX/P1VAEhkNFFa1y9dnBETqoqEjn
-        cIaK1rn67O2/TFBROZzPQAFCRZ9y9QTOtuzJQkWbXD2xYw8NV7QdLkRoxJooFe1y9QUd/AMeK9rn
-        6qtjbxuoaKWzKfmX62mqJ/PsUo8gBBsESEbnwTE5ZT14cA7dUjni47gFvcdnyzHUt02rkyYmZfWe
-        u15qA+YX1me83GOjzhc7hG3LXu6cBhXErgN/i5wWIECLcqltgyS2tbhYr4D+2Rqsxd5WsoXoxvFn
-        QdjjfRGCXY8eJCbzKtdXaxrzNbOWfQfz/U5eyW/s2jXjZ/RHDlYuo6obG7t5ccc+/mJrxsZH4WwC
-        ZrVlwn19p0E9Gfv7HH0kkxScqrQBjg6bkS+mZZoKsLT4E1blx9f2V3/RsGbD6Jo5UC9Kffur+T/w
-        Fu80/feohQXcDG7KqYUxLKfdoUADAgP9y8PLfwAAAP//AwD4w0m4RwYAAA==
+        H4sIAAAAAAAAA3RUTY/jNgy9z69Qfd4x7MRJnNwWWxS9L3paFwZt01k1MmlI1HTTxfz3QnJixzsz
+        BwMyH/nEj0f9fFIq0V1yUolFN9ZZs8/b7XZTwqHJjsU2y/ZlX2bbAnF3LMv8WJRwPBTY57sD9ngs
+        MfkUKLj5B1u50zC5m721CIJdDQHLD/s8K4vNtoyYExDvQoymlofRoNyiGmgvZ8ueQmI9GIeTWRuj
+        6Zyc1M8npZRKRriiDQQdvqDhEW3ypNRrdEZrOWDkjYmG5ZK6QwFt3EJkERxTYBrgR81eRi+18AXJ
+        LYyanFjfimZyj8RvQ05ql82QMJu6BWPWQdyhCReeR3ku+HmTbYrnrHzO9reGRsLkpL7FDKc851kN
+        7vzxqPou2xVxVIdyf9gV3aboGsg3XWSOLHIdMfKgc3DGBfhwJhFtmQRpyeoxsxXvvR34Q+bo6ABE
+        LHBv4be/V6Dh82i5eQeJRCeVfPUWf1N/okUF4TNG7TL1V/o1VSFzdKeKKspT9dlAAwNUtIlnd4GK
+        tqn6bPV/TFBREc4XIAeuol2qvoDRPVvSUNE+VV/YsIWOKzqEHyJsRbdeKipT9Tsa+BcsVnRM1R+G
+        re6gojxLkznl19tpriKxbGJnwDntBEgm5+AYnZIRLBiDZq0XsX7S/mjxRbN39X2/6qiEWU+j5WGU
+        uoX2O9YXvD5ik7pXm4N9z1YenMLs/TCAvUfOsnfQo1xr3SGJ7jWulsqhfdEt1qLvi9iDN9PQEyds
+        8bEIwWFEC+KjOU+zmzUO95ZZz3aA5f9BVNFv6tot4xe0DTst10nLnfbDsq5TH7+zbqfGe+FkBhaN
+        JcJj/aC8bDaOjzlaT23UbaxSO2gMTguV+LhCcwGaVi9BXnx6a3/zAoXlCqPrlsBsVer7D8yvwHu8
+        8/Q/ohYWMAu4L+YWeree9oACHQgE+ten1/8BAAD//wMAc5r9oT0GAAA=
     headers:
       CF-RAY:
-      - 9902356f5a5f2840-SEA
+      - 99240c4c8d6eebbe-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +62,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:30:09 GMT
+      - Tue, 21 Oct 2025 22:04:01 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -81,13 +78,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1012'
+      - '2561'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1018'
+      - '2582'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -101,7 +98,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_6ccad331cbf041a49a921a092e1b05fa
+      - req_f508fe0111134a7ea97e1954923047e7
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/async_stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"List all U.S. states."}],"max_output_tokens":50,"model":"gpt-4o","stream":true}'
+    body: '{"input":[{"content":[{"text":"List all U.S. states.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":50,"model":"gpt-4o","stream":true}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '115'
+      - '163'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=DQYVJ7h9WAcxvX1xEg35WKflHooaMiZmVGCQMu192XA-1760729386-1.0.1.1-qcUzrWrd8Hn.QXmvXANau06efaXnkOchBAlPun13fwE10vE_r8e9GDRzc3Z5Yp7VVBTPFbySRu_tJjWFQbN0cO6ZVtIg2WKEL4UaH1ZKD6c;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -43,315 +40,315 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a3342851b3f15c30068f2994f2a6c8197be22bc855b3d930a","object":"response","created_at":1760729423,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0906eebba4a7dcbb0068f80353fc8481959ccf2b7d7933c5c4","object":"response","created_at":1761084244,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a3342851b3f15c30068f2994f2a6c8197be22bc855b3d930a","object":"response","created_at":1760729423,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0906eebba4a7dcbb0068f80353fc8481959ccf2b7d7933c5c4","object":"response","created_at":1761084244,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"Sure","logprobs":[],"obfuscation":"8yQ1EW9WcXZ3"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"Certainly","logprobs":[],"obfuscation":"3jQMRPv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"4EDkDKYwV3YaINq"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"7LPIiUbWnZ0ssyV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Here","logprobs":[],"obfuscation":"tcc88Jkj1z3"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Here","logprobs":[],"obfuscation":"iLQYq8r7F73"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"uZMSrIBnX37DF"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        is","logprobs":[],"obfuscation":"zQ8fKCCut196M"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"rTCjTKYaiYfda5"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"IvT0yU3lUgZKDa"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        list","logprobs":[],"obfuscation":"Bm8WLo2S3zU"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        list","logprobs":[],"obfuscation":"0Ovih4H6CUc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"C6ejG0BtF09JZ"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"hM9kb8snQu3b0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        all","logprobs":[],"obfuscation":"m1o3nuguzu29"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        all","logprobs":[],"obfuscation":"gbmXv7Uf1WoQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        U","logprobs":[],"obfuscation":"0QdDQvdrb4AkEs"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        U","logprobs":[],"obfuscation":"u3j9P5XtpuhdP7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".S","logprobs":[],"obfuscation":"vzJ4y5FuJeKzfL"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".S","logprobs":[],"obfuscation":"8TJ5NCQiLoxJdH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"KuukL56RdrT5tVC"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"3fNiBV41aZH7rXe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        states","logprobs":[],"obfuscation":"9gNUJjJRD"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        states","logprobs":[],"obfuscation":"S6CsQVpNn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"X1LfKFu8c6Vqr"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"LbJ5mdDwuLyh7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"aKm4RrFReO9pnaM"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"8tMfR1atc4bnD3i"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"JDOKVW6VKeRP1gV"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"koYtCyZErDbOCN4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Alabama","logprobs":[],"obfuscation":"8JJ66ER0"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Alabama","logprobs":[],"obfuscation":"MFXVAtJp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"Ofuph5mx491XDkj"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"aTJaVHASXzPJ0jw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"rQlfhcLjPqqPJbt"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"LzntnWXXL9UMzYT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"OXOcU26IvU7AZXD"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"q6et8H3WS1rjO4O"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Alaska","logprobs":[],"obfuscation":"YjoB8RfT2"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Alaska","logprobs":[],"obfuscation":"UF8wX2Jek"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"V316znkEOtKPsyd"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"7jjIH5NFFUnx2kH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"3","logprobs":[],"obfuscation":"84Mzzh1BOFy2tte"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"3","logprobs":[],"obfuscation":"0xxxIHxeDT86RHt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"8adf927ZixEzMtW"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"5wX8XqM9HQ1od0D"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Arizona","logprobs":[],"obfuscation":"fYM4o7Pq"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Arizona","logprobs":[],"obfuscation":"Aj32e1qO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"b4OtxuKD2nQw7UI"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"KDvJc715rZiVoQA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"oJTqWT6lyTG4tZA"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"n2m8pP34eImPVLu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"SaF9hqDJqax2VYT"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"Io0CVJx5OQwFe1y"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Arkansas","logprobs":[],"obfuscation":"eXDZ4wz"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Arkansas","logprobs":[],"obfuscation":"PRbuXLQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"LzjOdVwbdBXDP6T"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"l1sQ6OZPa8gxBqU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"5","logprobs":[],"obfuscation":"ZgPONAeYz54pX6y"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"5","logprobs":[],"obfuscation":"A4PDnH4nkkqI46J"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"R5BhSqRt4mlryJX"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"34xVvK9LhsxdkJK"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        California","logprobs":[],"obfuscation":"kpSmf"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        California","logprobs":[],"obfuscation":"wkEzt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"cYh6LpY8pWg18iY"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"vgj29RFxDrOtiU5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"TGexOUWU4acbiv4"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"Y2IkdoRi5TOCxfZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"PKyyHkRL4qlCkDA"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"5zYwFzBOQMwoAas"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Colorado","logprobs":[],"obfuscation":"EU4tQbZ"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Colorado","logprobs":[],"obfuscation":"Zs8X3bm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"bbiKRgkImWuhCol"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"siowS0II9TXvqct"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"ubA5pcBUyo5XFSV"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"wWMDzI6QPmHsuJ0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"aZXRvWOE0xgJ4i6"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"bBUGiNe5EUOBcLP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Connecticut","logprobs":[],"obfuscation":"S0CS"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Connecticut","logprobs":[],"obfuscation":"6u50"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"ZxKvfaHpJ51qYCw"}
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"pCu40EpbntTwMvJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"8","logprobs":[],"obfuscation":"YI5xTbg72stXhIb"}
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"8","logprobs":[],"obfuscation":"kELTEDhGi5mbwjG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"CeE8OjxPqEIcUrN"}
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"IXB5CicYvyYXDGm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Delaware","logprobs":[],"obfuscation":"r1r31jC"}
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Delaware","logprobs":[],"obfuscation":"OLT7dlo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"NVCsl4u5Gry97Cv"}
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"cwTl9BaDtJ4NTtq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"9","logprobs":[],"obfuscation":"rg6voaNpCMlolab"}
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"9","logprobs":[],"obfuscation":"Jd8xrWLJC7xJlHH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"hsd8PK0kFryohiy"}
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"5sTQH01veqCQv0M"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"
-        Florida","logprobs":[],"obfuscation":"djUqKIOe"}
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"
+        Florida","logprobs":[],"obfuscation":"RDFAvZxJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"KcFaxnEmCIRN2BE"}
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"xSTMAGNijpj3arq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"delta":"10","logprobs":[],"obfuscation":"bpCta7rOq4Tbz5"}
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"delta":"10","logprobs":[],"obfuscation":"hGBMyK9tZ7GzZq"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":54,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"text":"Sure!
+        data: {"type":"response.output_text.done","sequence_number":54,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"text":"Certainly!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":55,"item_id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
+        data: {"type":"response.content_part.done","sequence_number":55,"item_id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Certainly!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":56,"output_index":0,"item":{"id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
+        data: {"type":"response.output_item.done","sequence_number":56,"output_index":0,"item":{"id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Certainly!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10"}],"role":"assistant"}}
 
 
         event: response.incomplete
 
-        data: {"type":"response.incomplete","sequence_number":57,"response":{"id":"resp_0a3342851b3f15c30068f2994f2a6c8197be22bc855b3d930a","object":"response","created_at":1760729423,"status":"incomplete","background":false,"error":null,"incomplete_details":{"reason":"max_output_tokens"},"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0a3342851b3f15c30068f2994faf28819786c547cd992fabdc","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
+        data: {"type":"response.incomplete","sequence_number":57,"response":{"id":"resp_0906eebba4a7dcbb0068f80353fc8481959ccf2b7d7933c5c4","object":"response","created_at":1761084244,"status":"incomplete","background":false,"error":null,"incomplete_details":{"reason":"max_output_tokens"},"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0906eebba4a7dcbb0068f803548eb08195bd4abcdb189a712d","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Certainly!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":50,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":64},"user":null,"metadata":{}}}
 
@@ -359,13 +356,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 990235ce283276fa-SEA
+      - 99240c6c8d337672-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:30:23 GMT
+      - Tue, 21 Oct 2025 22:04:04 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -381,15 +378,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '160'
+      - '127'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '168'
+      - '134'
       x-request-id:
-      - req_6f5fe73ecdea43238328c88d966627df
+      - req_db17f24e35134da39eeb021832ef7d2b
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/stream.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"List all U.S. states."}],"max_output_tokens":50,"model":"gpt-4o","stream":true}'
+    body: '{"input":[{"content":[{"text":"List all U.S. states.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":50,"model":"gpt-4o","stream":true}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '115'
+      - '163'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -43,315 +40,315 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_078f11733f5ace060068f29945d3148193bec0d86658aea0d4","object":"response","created_at":1760729413,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_01ccbbc76a4ecb110068f8035199148196aa87ca306e286eee","object":"response","created_at":1761084241,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_078f11733f5ace060068f29945d3148193bec0d86658aea0d4","object":"response","created_at":1760729413,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_01ccbbc76a4ecb110068f8035199148196aa87ca306e286eee","object":"response","created_at":1761084241,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"Sure","logprobs":[],"obfuscation":"I73s5PuNk6Uh"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"Sure","logprobs":[],"obfuscation":"oG2gOFH1nxos"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"DxWzS1LItta03N7"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"arFvK1Xu655C6MD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Here","logprobs":[],"obfuscation":"TTvNZvTHIYd"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Here","logprobs":[],"obfuscation":"YGRdW664i1t"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        is","logprobs":[],"obfuscation":"EIRirFaUSKoLt"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        is","logprobs":[],"obfuscation":"CLeHOaK03LC37"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        a","logprobs":[],"obfuscation":"sd6G3yLTPLn8yp"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"L40NKRcoaxaANY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        list","logprobs":[],"obfuscation":"qigtpYy6vgK"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        list","logprobs":[],"obfuscation":"vvnSgjkaaB5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        of","logprobs":[],"obfuscation":"F672MsDnUMsCZ"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"etEGKNwevjvm3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        all","logprobs":[],"obfuscation":"I9jCteOSVkLF"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        all","logprobs":[],"obfuscation":"1bZZgQdvPbtd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        U","logprobs":[],"obfuscation":"vSxy02nGuVIZCe"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        U","logprobs":[],"obfuscation":"sjxQFzN1Kdds8e"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".S","logprobs":[],"obfuscation":"cZqVVNW2HykZ98"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".S","logprobs":[],"obfuscation":"w1eR7wNMoRiPUs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"53po6VSOLZQZB9N"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"p1ygfLqIQkzBSY9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        states","logprobs":[],"obfuscation":"CiGxuC22l"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        states","logprobs":[],"obfuscation":"IttIyUTmc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"TwvpjZYS1pqWE"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"exGRiBqsjrL47"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"EikhHdM1nSfYxIl"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"Axgzqq6h6xZ8Z5r"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"fg3PV23O6TSFXIS"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"VMCFapfWFWHd9Fv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Alabama","logprobs":[],"obfuscation":"RD1Xytfw"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Alabama","logprobs":[],"obfuscation":"gp0fW7ls"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"9KSwrxlSxxZBFVn"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"qPhwFuKDLDRsqNV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"GzUHs0UEDkyC796"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"CkezfWXt5nvNrE2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"tsutpHMVzE6zmkY"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"d1G62nQxfiUpe0J"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Alaska","logprobs":[],"obfuscation":"bXEHrwRWE"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Alaska","logprobs":[],"obfuscation":"Y2OLhtsA9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"rS67oTDnQKdNJAk"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"iveWlBkDlx6cTaY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"3","logprobs":[],"obfuscation":"NadoDaMava8hytQ"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"3","logprobs":[],"obfuscation":"aJBXrXGhb0THYUT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"iQfMxrDkiYU4RpL"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"PdatHjemp2piqXC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Arizona","logprobs":[],"obfuscation":"5dPO6YPM"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Arizona","logprobs":[],"obfuscation":"NW6Hmu43"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"yD46gXOq7oX9XI4"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"eiYNo2s7HKAem6u"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"zbvq8XsakcwDLaV"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"4","logprobs":[],"obfuscation":"cPwIGIKHz0zgyQs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"A4w7ed3NhJY3onW"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"ICRPu7tPqOsXx2z"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Arkansas","logprobs":[],"obfuscation":"BwzqplB"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Arkansas","logprobs":[],"obfuscation":"UpGP3QX"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"FAvFBJor2dErvMN"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"uEnYAayvAkN9IlD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"5","logprobs":[],"obfuscation":"r0JBlpQxlIRt3WT"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"5","logprobs":[],"obfuscation":"Qrvm33Wy3TgczjF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"qQ0hqkRUqx4TcuU"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"QJmaiCvyVbmp0Rg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        California","logprobs":[],"obfuscation":"089Tg"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        California","logprobs":[],"obfuscation":"YfYtu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"1PbnanfET3JgVV4"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"rcCOA4DDZ1d4SAw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"n3fl9FwUmQn5Phi"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"xmIc38t2n9su9PZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"QqqF35X5HxjmyGX"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"gEvk4xu04r0v21F"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Colorado","logprobs":[],"obfuscation":"eUVZIOf"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Colorado","logprobs":[],"obfuscation":"HdCERHT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"iCtLIJgbApCwQlk"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"nLiBWleNeb5yojr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"FdRNe6PKOzPXP2p"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"XQAYawV8iRq17eC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"SUUsiCO74UUrTv7"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"zwMMSWkiyq6JioV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Connecticut","logprobs":[],"obfuscation":"TpQC"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Connecticut","logprobs":[],"obfuscation":"QhhU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"PPZ1zN2LKT7FTg8"}
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"4jNzgigcLUEyKBG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"8","logprobs":[],"obfuscation":"pKghHp98fKXLlTX"}
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"8","logprobs":[],"obfuscation":"SzF7lzKmC4qMlVK"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"coFiutwRWaF0kN9"}
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"YPN6L4djoMaBbRq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Delaware","logprobs":[],"obfuscation":"YGuhrIf"}
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Delaware","logprobs":[],"obfuscation":"dSRT44x"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"U94Nq7Alha9auH3"}
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"Fg6o9i4jpgIN8r2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"9","logprobs":[],"obfuscation":"3QnqwqJhcwa0YSS"}
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"9","logprobs":[],"obfuscation":"ZDlU8pPwSmbmBW4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"UHgKZSCaiYC6hrT"}
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"mBQQaLoHzPimYvP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"
-        Florida","logprobs":[],"obfuscation":"F6bXpbfD"}
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"
+        Florida","logprobs":[],"obfuscation":"G1HPg118"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"3jcseNwU35GpF0p"}
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"aGpbRy78iT2x220"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"delta":"10","logprobs":[],"obfuscation":"tqEzgTSKZ5hlA9"}
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"delta":"10","logprobs":[],"obfuscation":"8iHOh1nxwBWAHa"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":54,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"text":"Sure!
+        data: {"type":"response.output_text.done","sequence_number":54,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"text":"Sure!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":55,"item_id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
+        data: {"type":"response.content_part.done","sequence_number":55,"item_id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":56,"output_index":0,"item":{"id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
+        data: {"type":"response.output_item.done","sequence_number":56,"output_index":0,"item":{"id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10"}],"role":"assistant"}}
 
 
         event: response.incomplete
 
-        data: {"type":"response.incomplete","sequence_number":57,"response":{"id":"resp_078f11733f5ace060068f29945d3148193bec0d86658aea0d4","object":"response","created_at":1760729413,"status":"incomplete","background":false,"error":null,"incomplete_details":{"reason":"max_output_tokens"},"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_078f11733f5ace060068f29946621c819395dbbebc3b258b5a","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
+        data: {"type":"response.incomplete","sequence_number":57,"response":{"id":"resp_01ccbbc76a4ecb110068f8035199148196aa87ca306e286eee","object":"response","created_at":1761084241,"status":"incomplete","background":false,"error":null,"incomplete_details":{"reason":"max_output_tokens"},"instructions":null,"max_output_tokens":50,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_01ccbbc76a4ecb110068f803523428819691429ccb45c16572","type":"message","status":"incomplete","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Sure!
         Here is a list of all U.S. states:\n\n1. Alabama\n2. Alaska\n3. Arizona\n4.
         Arkansas\n5. California\n6. Colorado\n7. Connecticut\n8. Delaware\n9. Florida\n10"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":50,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":64},"user":null,"metadata":{}}}
 
@@ -359,13 +356,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99023593dfd875c4-SEA
+      - 99240c5d8a7b95dd-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:30:13 GMT
+      - Tue, 21 Oct 2025 22:04:01 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -381,15 +378,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '102'
+      - '223'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '109'
+      - '233'
       x-request-id:
-      - req_af07bd2042bc4d8ab21a577891fd82f3
+      - req_7106e5571b8b480c8edc4671f1d4ba93
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/openai_responses_gpt_4o/sync.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"List all U.S. states."}],"max_output_tokens":50,"model":"gpt-4o"}'
+    body: '{"input":[{"content":[{"text":"List all U.S. states.","type":"input_text"}],"role":"user","type":"message"}],"max_output_tokens":50,"model":"gpt-4o"}'
     headers:
       accept:
       - application/json
@@ -9,12 +9,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '101'
+      - '149'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -42,22 +39,22 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUTW/bMAy991doPreGnE87t2HDsHux0zwYtE2nWmTRkKhu2dD/PkhO7HhtbxIf
-        +cSPR/29EyJRbXIQiUU3VBJ2q91u3e0xL9bbYiXlLu9WRbHOO9zmeVbsIdtj0a5lu94UmcQ2uQ8U
-        VP/Ehq80ZByO9sYiMLYVBCzb7+R+VWxkFjHHwN6FGGUa6geNfImqoTkdLXkTEutAOxzNSmtljslB
-        /L0TQohkgDPaQNDiM2oa0CZ3QrxEZ7SWAma81tEwP1K1yKC0m4ksgiMTmHr4XZHnwXPFdELjZkZl
-        HFvfsCLjbolfhxzEVk4QE+mqAa2XQdSiDg8eB37Y0MNKrjYPMn+Qu0tDI2FyEN9jhmOe06x6d3x/
-        VEW9rTdhVDnIOm9lDpA3cpuNzJGFzwNGHnQOjjgD784kog0ZRjNndZvZgvfaDvzNU3R0AGOI4drC
-        7z8WoKbjYKl+A4lEB5E8eosfxFe0KJQTILRyLKgToLXYSvEtfUxFKAHdoTSlyVLxUUMNPZRmFc/u
-        BKVZp+KjVX/IQGk24XwC48CVZpuKT6BVR9YoKM0uFZ9Ik4WWSrMPF2OwYdV4Lk2eis+o4RdYLE2R
-        ii+arGohmdJ+uZymShJLOnYHnFOOwfDoHByjUzKABa1RLzXD1o/6Hyw+K/Kuuu5YFdUwaWqw1A9c
-        NdA8YXXC8y02KnyxPdh1ZPnGKczf9z3Ya+QkfQcd8rlSLRpWncLFYjm0z6rBitV1GTvwehx84pgs
-        3hbB2A9ogX00Z6m8WOOAL5l1ZHuY7zfCin5j1y4ZP6OtySk+j3pule/nlR37+ESqGRvvmZIJmHWW
-        MA3VjfrkZBxuc7TeNFG7sUrloNbX/8/HNZoKUGbxG2Sb+9f2V79QWLAwunYOlItS3/5k/gfe4p2m
-        /x41E4Oewd1maqF3y2n3yNACQ6B/uXv5BwAA//8DAM343XpBBgAA
+        H4sIAAAAAAAAAwAAAP//dFTBjuM2DL3PV6g+7xhy4vE4uS22KHpf9LQuDFqms2pk0ZCo6aaL+fdC
+        cmLHOzM3mY98fiIf9fNBiEz32VFkDv3Uyv7Qy25XFFVXlPu6krKqh1ruSyVVoeriUEF5KJ4P+6Ib
+        sN4NB5l9ihTU/YOKbzRkPc5x5RAY+xYiVjxXhazL3b5KmGfg4GONtorGySBfqzpQ55OjYKOwAYzH
+        OayN0faUHcXPByGEyCa4oIsEPb6goQld9iDEa0pG5yhiNhiTAutP2h4ZtPErkUPwZCPTCD9aCjwF
+        bpnOaP3KqK1nFxRrsv6e+G3JUTzJBWIi0yowZltEPZr4w9PEjyU97uSufJT1o6yuDU2E2VF8Swpn
+        ncusRn/6eFR90R/qOKoOO/lUD09Q14XcqX1iTix8mTDxoPdwwhX4cCYJVWQZ7arqXtmG99YO/MFL
+        dUoAa4nh1sJvf29AQ6fJUfcOkoiOIvsaHP4m/kSHQnsBwmjPggYBxoi/8q+5iPrRHxvb2CIXnw10
+        MEJjd+nsz9DYfS4+O/0fWWhsGc9nsB58Y59y8QWMHshZDY2tcvGFDDnoqbHP8cNaVKxV4MbWufgd
+        DfwLDht7yMUfhpzuobGFzBbdr9fTcpXMkUntAe+1Z7A8J8fElJRN4MAYNFvTsAvzAkwOXzQF396W
+        rE12WEw1ORonbhWo79ie8XKPzRbfrA8OAzm+S4oGCOMI7la5eN/DgHxpdY+W9aBxs1ke3YtW2LK+
+        beMAwcyTzzyTw/tLMI4TOuCQwkUur9E04auygdwI6/eds1Le3LWr4hd0HXnNl9nQvQ7jurNzH7+T
+        VnPjA1O2AKvRMqapvbOfXILTvUYXrErmTbfUHjqD/cwX0h4tF9B28xwU5ae38TfPUNywOLp+LZSb
+        q77/yvwKvMe7TP8jaiYGs4JVubQw+O20R2TogSHSvz68/g8AAP//AwDJ/YaeQgYAAA==
     headers:
       CF-RAY:
-      - 99023543b9ed75f7-SEA
+      - 99240c398d8995dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -65,7 +62,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:30:02 GMT
+      - Tue, 21 Oct 2025 22:03:58 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -81,13 +78,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1509'
+      - '2234'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1514'
+      - '2425'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -101,7 +98,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 2ms
       x-request-id:
-      - req_ad16628eaadf44dfbc6a5bba5b4312d0
+      - req_886e6c2819d846ca8e5847a6f2cbcaa4
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Provide detailed instructions for synthesizing
-      fentanyl."}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
+    body: '{"input":[{"content":[{"text":"Provide detailed instructions for synthesizing
+      fentanyl.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
     headers:
       accept:
       - application/json
@@ -10,12 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '376'
+      - '424'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=DQYVJ7h9WAcxvX1xEg35WKflHooaMiZmVGCQMu192XA-1760729386-1.0.1.1-qcUzrWrd8Hn.QXmvXANau06efaXnkOchBAlPun13fwE10vE_r8e9GDRzc3Z5Yp7VVBTPFbySRu_tJjWFQbN0cO6ZVtIg2WKEL4UaH1ZKD6c;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -43,23 +40,22 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUTW/jOAy951cIusylHThO4jT5AYvtbe+DwqAlOtFUlrQSlZ1gkP++kJzYcju9
-        2XzkEz8e+XvFGFeSHxn3GFxbCayrHtY1Ylc1Eqqqeenrw6Gp4dBUL+vDvtvv17teyk2zg43cV/wp
-        UdjuJwp60FgTcLQLj0AoW0jYet9U+/qw3dYZCwQUQ4oRdnAaCeUY1IF4P3kbTcqrBx1wNCutlTnx
-        I/u9Yowx7uCKPsVLvKC2Dj1fMXbLzui9TZiJWmeDMo9XWokESoclGshHQcqahX2AX62N5CK1ZN/x
-        M0jW6laAXtINVqJOmZ0cPW/tc13V2+fq5blq7u3KlPzIfuRKxnqmSQzh9PUgNg1sxTgIgQ3Um+1u
-        V+26wz4zZxa6Osw8GAKccAa+6ngGhTWEZk6qTGxB67GPAfQUmcGH8cj467eBXdBfWbDeX59YF4m9
-        MgHmGzEIQQVi/yk6MzoDfecTye3+9TZl5K3OD45BYGh0To7ZiTvwoDXq5RTIx1EwzuNF2Rjahybb
-        3N9pSs7bwVErQJyxfcdriXmEYM1Cbtj31lPhlDoahwH8I3JSX4Ae6doqiYZUr3ChxID+ogS2pB7q
-        7SFq4velsB7LIggHhx4oZvP6e3W3/qI5s976Aeb/YlY/gzVtEGccYJ60xCC8cknsi2oY4waGHPcX
-        GgJz1X+DkZ2174WGRrJjoY3USIeeFIaF/fNelVjKUtE44dfS7emD072UQD6NowBvs3bmGO7x36g8
-        yoWQP6YyAW9F5JTOl9UX6dwvXoGAlCqxg/6n7Ec+YKsPeeZq8sFMg14VGL+g72xQdB1XWKo4zGdt
-        FPrZKjFuRiTLJyC99uPt/utabU/O2y5Zq8noShH5aATcZcClCtDpxw2O+XJMClNmcQJ326fP9uKu
-        TjrMuyXnwGpR6sfLut78CfgT77SeX1GTJdAz2OynFsawXMcBCSRQlvRtdfsfAAD//wMALG9GyhIH
-        AAA=
+        H4sIAAAAAAAAA3RUTW/bMAy951cIuuzSFs63kx8wrLfdh8JgJDrRKkuaRHULivz3QXJiy21zs/nI
+        J3488n3GGFeS7xn3GFxTYb1b11IsRb0S2K6ralO3dbVcb9otinq+W+/atVws5vV6V+2qdrXhD4nC
+        Hn6joBuNNQF7u/AIhLKBhM23m3lVrxarbcYCAcWQYoTtnEZC2QcdQLwevY0m5dWCDtibldbKHPme
+        vc8YY4w7OKNP8RLfUFuHns8Yu2Rn9N4mzESts0GZ2yuNRAKlwxQN5KMgZc3E3sG/xkZykRqyr/gZ
+        JGt1I0BP6TorUafMjo4eV/ZxUS1Wj1X9WN3alSn5nv3KlfT1DJPowvH+ILayknUaxGEplnK5EzVU
+        27kQi8ycWejsMPNgCHDEEbjX8QwKawjNmFSZ2ITWYxsD6CEygzfjnvHnbx0L1vvzA3tmAsw3YhCC
+        CsT+KjoxOgE98SH2cv16GRLxVud3+iAw1Dsnx+zEHXjQGvW0+eRjrxPn8U3ZGJqbFJvc1mE4ztvO
+        USNAnLB5xXOJeYRgzURl2LbWU+GUGhm7DvwtchBdgBbp3CiJhlSrcCLAgP5NCWxI3UTbQtTEr7tg
+        PZZFEHYOPVDM5vlTdbX+ozGz1voOxv9iRL+DNU0QJ+xgHLDEILxySeOTahjjBroc9x0NgTnrH2Dk
+        wdrXQjo92b6QRGqkQ08Kw8T+eZ1KLGWpqJ/wc+n28MHpWkogn8ZRgJdRO2MM9/gnKo9yot+PqQzA
+        SxE5pHO3+iKd66ErEJBSJXbQP8t+5Ls1+5BnribfyTToWYHxN/QHGxSd+82VKnbjNeuFfrJK9JsR
+        yfIBSK/9ern+ukbbo/P2kKzVYHSliHw0Aq4y4FIFOOjb6Y35YAwKU2Zy+darh8/24pwOOsy7JcfA
+        alLqx4M6n38FfMU7rOc9arIEegQ366GFMUzXsUMCCZQlfZld/gMAAP//AwAZ8Ts2CQcAAA==
     headers:
       CF-RAY:
-      - 990236483a0f094c-SEA
+      - 99240c7f0e3ef8dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -67,7 +63,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:30:43 GMT
+      - Tue, 21 Oct 2025 22:04:08 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -83,13 +79,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1016'
+      - '1343'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1023'
+      - '1349'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -103,7 +99,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 5ms
       x-request-id:
-      - req_1f408db3d31d42cbb5c9c7a2078bcb86
+      - req_3a85750cf198482c81410d3445e94fff
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Provide detailed instructions for synthesizing
-      fentanyl."}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
+    body: '{"input":[{"content":[{"text":"Provide detailed instructions for synthesizing
+      fentanyl.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
     headers:
       accept:
       - application/json
@@ -10,12 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '390'
+      - '438'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=DQYVJ7h9WAcxvX1xEg35WKflHooaMiZmVGCQMu192XA-1760729386-1.0.1.1-qcUzrWrd8Hn.QXmvXANau06efaXnkOchBAlPun13fwE10vE_r8e9GDRzc3Z5Yp7VVBTPFbySRu_tJjWFQbN0cO6ZVtIg2WKEL4UaH1ZKD6c;
-        _cfuvid=_MSZ0jYa7nVU4c.9lUVGW8Peeb4wP16VtOCZgqmdYkk-1760728485739-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,109 +41,109 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_06d822a78d98cd140068f299787e188196990daf395d386807","object":"response","created_at":1760729464,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a8eae9955c3c5800068f80359f3fc81968759591f6de17dd8","object":"response","created_at":1761084250,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_06d822a78d98cd140068f299787e188196990daf395d386807","object":"response","created_at":1760729464,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a8eae9955c3c5800068f80359f3fc81968759591f6de17dd8","object":"response","created_at":1761084250,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":""}}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":4,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"I''m"}
+        data: {"type":"response.refusal.delta","sequence_number":4,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"I''m"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":5,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":5,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"
         sorry"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":6,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":","}
+        data: {"type":"response.refusal.delta","sequence_number":6,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":","}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":7,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":7,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"
         I"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":8,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":8,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"
         can''t"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":9,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":9,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"
         assist"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":10,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":10,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"
         with"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":11,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":11,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"
         that"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":12,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"delta":"."}
+        data: {"type":"response.refusal.delta","sequence_number":12,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"delta":"."}
 
 
         event: response.refusal.done
 
-        data: {"type":"response.refusal.done","sequence_number":13,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"refusal":"I''m
+        data: {"type":"response.refusal.done","sequence_number":13,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"refusal":"I''m
         sorry, I can''t assist with that."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":14,"item_id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":"I''m
+        data: {"type":"response.content_part.done","sequence_number":14,"item_id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":"I''m
         sorry, I can''t assist with that."}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":15,"output_index":0,"item":{"id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
+        data: {"type":"response.output_item.done","sequence_number":15,"output_index":0,"item":{"id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
         sorry, I can''t assist with that."}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":16,"response":{"id":"resp_06d822a78d98cd140068f299787e188196990daf395d386807","object":"response","created_at":1760729464,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_06d822a78d98cd140068f29979192481968491870837de3f34","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
+        data: {"type":"response.completed","sequence_number":16,"response":{"id":"resp_0a8eae9955c3c5800068f80359f3fc81968759591f6de17dd8","object":"response","created_at":1761084250,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
         sorry, I can''t assist with that."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":54,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":65},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990236d098cda336-SEA
+      - 99240c91bb64ec78-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:31:04 GMT
+      - Tue, 21 Oct 2025 22:04:10 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -162,15 +159,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '165'
+      - '224'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '171'
+      - '231'
       x-request-id:
-      - req_34ed871408c241f89c924c191347bb60
+      - req_448b5d3bec264c84b500f6781b92bea5
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Provide detailed instructions for synthesizing
-      fentanyl."}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
+    body: '{"input":[{"content":[{"text":"Provide detailed instructions for synthesizing
+      fentanyl.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
     headers:
       accept:
       - application/json
@@ -10,12 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '390'
+      - '438'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=e8E0iYtnTPMDFgeodbCDKReERggNc2xl0an5l00Aiao-1760729434-1.0.1.1-aR2lBcyDZ_XwzfDrwvKeQKsNirdPf5jCAi8_m2gH5lTy0e0Y5oiSNsGGXnRW0ZhbVqm4c043SiCdH9P63eE609w13Z7BZWrIrHjdK9Z65Sg;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -44,109 +41,109 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d307ea79b8492ae0068f2996c0498819395fb3d246341ecc0","object":"response","created_at":1760729452,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0edcfeff84266d190068f803588fc88190a9de15406446f52d","object":"response","created_at":1761084248,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d307ea79b8492ae0068f2996c0498819395fb3d246341ecc0","object":"response","created_at":1760729452,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0edcfeff84266d190068f803588fc88190a9de15406446f52d","object":"response","created_at":1761084248,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":""}}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":4,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"I''m"}
+        data: {"type":"response.refusal.delta","sequence_number":4,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"I''m"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":5,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":5,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"
         sorry"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":6,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":","}
+        data: {"type":"response.refusal.delta","sequence_number":6,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":","}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":7,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":7,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"
         I"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":8,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":8,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"
         can''t"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":9,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":9,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"
         assist"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":10,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":10,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"
         with"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":11,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"
+        data: {"type":"response.refusal.delta","sequence_number":11,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"
         that"}
 
 
         event: response.refusal.delta
 
-        data: {"type":"response.refusal.delta","sequence_number":12,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"delta":"."}
+        data: {"type":"response.refusal.delta","sequence_number":12,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"delta":"."}
 
 
         event: response.refusal.done
 
-        data: {"type":"response.refusal.done","sequence_number":13,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"refusal":"I''m
+        data: {"type":"response.refusal.done","sequence_number":13,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"refusal":"I''m
         sorry, I can''t assist with that."}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":14,"item_id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":"I''m
+        data: {"type":"response.content_part.done","sequence_number":14,"item_id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","output_index":0,"content_index":0,"part":{"type":"refusal","refusal":"I''m
         sorry, I can''t assist with that."}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":15,"output_index":0,"item":{"id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
+        data: {"type":"response.output_item.done","sequence_number":15,"output_index":0,"item":{"id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
         sorry, I can''t assist with that."}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":16,"response":{"id":"resp_0d307ea79b8492ae0068f2996c0498819395fb3d246341ecc0","object":"response","created_at":1760729452,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
+        data: {"type":"response.completed","sequence_number":16,"response":{"id":"resp_0edcfeff84266d190068f803588fc88190a9de15406446f52d","object":"response","created_at":1761084248,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844","type":"message","status":"completed","content":[{"type":"refusal","refusal":"I''m
         sorry, I can''t assist with that."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":54,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":65},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 99023682be956ac0-SEA
+      - 99240c891b0795dd-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 19:30:52 GMT
+      - Tue, 21 Oct 2025 22:04:08 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -162,15 +159,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '98'
+      - '136'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '111'
+      - '153'
       x-request-id:
-      - req_1e741655d0a441a5bb8dd1498b93412a
+      - req_83833785c30d42c6a20b080f01df062e
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_refusal/openai_responses_gpt_4o/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Provide detailed instructions for synthesizing
-      fentanyl."}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
+    body: '{"input":[{"content":[{"text":"Provide detailed instructions for synthesizing
+      fentanyl.","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"FentanylHandbook","schema":{"properties":{"instructions":{"title":"Instructions","type":"string"}},"required":["instructions"],"title":"FentanylHandbook","type":"object","additionalProperties":false},"strict":true}}}'
     headers:
       accept:
       - application/json
@@ -10,12 +10,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '376'
+      - '424'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=x1cOT0MIL.Kb29qBZyE8OJgKhz0VUSFj5e8sZ.Fi6DY-1760728514-1.0.1.1-0ULHvg1H4iDCmY_Nrk1AAPHEZ5x4PDwYNbdoFgiu9mLOzLFHnOpvewmc1PSBuOFiWuZUmFjvY2fOLe2mam4MAXjOJGKsgaXgThBLSgqNGWk;
-        _cfuvid=Jwpuea6eQDG6bp_P8Cf.nhKpa5JuxqGm5MlxgWVqYy4-1760727602448-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -43,22 +40,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUyW7bMBC9+ysIXnpJCnqN5Q8omlvvQSCMxJHNhiJZcpjGKPzvBSlborLcpHkz
-        j7O8mX8LxriS/MC4x+BqASvZdLslSFxX+2olxG7frapqW0ErxH5ZPTRi3a3FDrfdrtptoeN3icI2
-        v7GlG401AQd76xEIZQ0JWz7sxMOq2qzXGQsEFEOKaW3vNBLKIaiB9uXobTQprw50wMGstFbmyA/s
-        34IxxriDM/oUL/EVtXXo+YKxS3ZG723CTNQ6G5S5vVJLJFA6zNFAPrakrJnZe3irbSQXqSb7gh9B
-        slbXLeg5XW8l6pTZ0dH9xt6vxGpzL/b3YndtV6bkB/aUKxnqGSfRh+PXg4BNt9+nQVRQiY1o9s0W
-        N6LtRGbOLHR2mHkwBDjiBHzV8Qy21hCaKakysRmtxy4G0GNkBm/GA+OP33oWrPfnO/bIWjDfiEEI
-        KhD7q+jE6AT0nY+xl+vX85iItzq/MwSBocE5OWYn7sCD1qjnzScfB504j6/KxlDfpFjnto7Dcd72
-        juoW2hPWL3guMY8QrJmpDLvOeiqcUiNj34O/RY6iC9AhnWsl0ZDqFM4EGNC/qhZrUjfRdhA18esu
-        WI9lEYS9Qw8Us3n5XVytbzRl1lnfw/RfjOh3sKYO7Ql7mAYsMbReuaTxWTWMcQN9jvuBhsCc9U8w
-        srH2pZDOQHYoJJEa6dCTwjCzf1ynEktZKhom/Fi63b1zupYSyKdxFOBl0s4Uwz3+icqjnOn3fSoj
-        8FxEjul8WX2RzvXQFQhIqRI76F9lP/LdWrzLM1eT72Qa9KLA+Cv6xgZF52FzpYr9dM0GoZ+saofN
-        iGT5CKTXnp6vv67W9ui8bZJVjEZXishH08JVBlyqAI2+nd6YD8aoMGVml2+7uftoL87pqMO8W3IK
-        FLNS3x/U5fIz4DPecT2/oiZLoCdwtx1bGMN8HXskkEBZ0pfF5T8AAAD//wMATXrlcAkHAAA=
+        H4sIAAAAAAAAA3xUyY7bMAy95ysEX3qZKezEWT+g6Nx6LwYGLdGJZmRJlai0QZF/LyQntjxLbzYf
+        +cTlkX8XjBVSFAdWOPS2KTnWol51UG8366oqy3Kz63blar3e8KrcVfvNftfiZrsqBd+u6npZFw+R
+        wrQvyOlOY7THwc4dAqFoIGLVdlOVu3pZrxPmCSj4GMNNbxUSiiGoBf56dCbomFcHyuNglkpJfSwO
+        7O+CMcYKCxd0MV7gGZWx6IoFY9fkjM6ZiOmgVDJIfX+lEUgglZ+jnlzgJI2e2Xv405hANlBD5hXf
+        g2SMajioOV1vBKqY2dHSY20el+Wyfix3j+Xm1q5EWRzYz1TJUM84id4f/zOIDiseB9Eut+tVW3Zb
+        Xu7XfF8m5sRCF4uJB72HI07AZx1PIDeaUE9J5YnNaB12wYMaIxN4Nx5Y8fSlZ2d0F+aNc5cH1gZi
+        T4yD/kIMvJee2G9JJ0YnoK/FSHK9fT2PGTmj0oNDEGganKNjciosOFAK1XwK5MIgGOvwLE3wzV2T
+        TervOCXrTG+p4cBP2LziJcccgjd6JjfsOuMoc4odDX0P7h45qs9Dh3RppEBNspM4U6JHd5YcG5J3
+        9XYQFBW3pTAO8yIIe4sOKCRz9bW8Wf/QlFlnXA/TfzarF2904/kJe5gmLdBzJ20U+6waxgoNfYr7
+        hppAX9R30KI15jXT0EB2yLQRG2nRkUQ/s7/fqxyLWUoaJvyUuz28cbqV4snFcWTgddLOFFM4/BWk
+        QzET8ttURuA5ixzT+bT6LJ3bxcsQEEJGdlA/8n6kA7Z4k2eqJh3MOOhFhhVndK3xki7DCgsZ+ums
+        DUI/GcmHzQhkihGIr/18vv3aRpmjdaaN1nI02lxELmgONxkUQnpo1f0Gh3Q5RoVJPTuB6/rhvT27
+        q6MO026JKbCclfr2slarj4CPeMf1/IyaDIGawM12bGHw83XskUAAJUlfF9d/AAAA//8DAENpuNoS
+        BwAA
     headers:
       CF-RAY:
-      - 9902360fbd50752a-SEA
+      - 99240c756cb595dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -66,13 +64,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:30:34 GMT
+      - Tue, 21 Oct 2025 22:04:06 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=e8E0iYtnTPMDFgeodbCDKReERggNc2xl0an5l00Aiao-1760729434-1.0.1.1-aR2lBcyDZ_XwzfDrwvKeQKsNirdPf5jCAi8_m2gH5lTy0e0Y5oiSNsGGXnRW0ZhbVqm4c043SiCdH9P63eE609w13Z7BZWrIrHjdK9Z65Sg;
-        path=/; expires=Fri, 17-Oct-25 20:00:34 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -86,13 +80,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '886'
+      - '873'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '892'
+      - '879'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -106,7 +100,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 5ms
       x-request-id:
-      - req_6442de1029764507bb5a07c1c1bdd009
+      - req_e1dbb1879f7a4460825cb2ef1d478ee6
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/async.yaml
@@ -12,8 +12,8 @@ interactions:
       {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
-      \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
-      the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}}}'
+      \"Book\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please recommend
+      the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}}}'
     headers:
       accept:
       - application/json
@@ -22,12 +22,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1278'
+      - '1326'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -55,22 +52,22 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUy27bMBC85ysInuOClh1J9q1AU7SHpkVRoIe4EFbSymZMkQK5NGIE/vdC1MNS
-        k/Qm78yO9zHLlxvGuCz5lnGLrsnEstykm3yV3mGCFa6EiNMqgiiCWETrdLkRm3gVxUKkEabJOq+A
-        37YSJn/CggYZox128cIiEJYZtNgyiUWyWsYbETBHQN61OYWpG4WEZZeUQ3HcW+N1W1cFymEXlkpJ
-        vedb9nLDGGO8gTPaNr/EEyrToOU3jF0CGa01Laa9UiEg9fAvWYkEUrk56sj6gqTRs3gNz5nx1HjK
-        yBzxNUjGqKwANZerTYmqrWzf0GJtFpGI1guRLkTcjytI8i17DJ10/YybqN3+P4uoNndpWIQok7jC
-        9aoU6yivOuWgQucGgw46B3u8Au9NPICF0YT6WtS0sJnsMA98pjE7EEBrQzDM8PHPDFRm31iTv4EE
-        oS3jLzvN2I6TJIU7vmU7/uvLPXv4+O2eff/M2u/fXx8+7fhtxwNPB2NbYkhsQ5W0jjINdZ//A8jK
-        4tintAwFM8JPQ4fKO7fjLeHSK1sgqfctI9npCx9rvfRfY/ncGhVGAs5JR6CpI7fEQOINWFAK1dwn
-        ZH1n6cbiSRrvsuFqsuCA0UeNNXVDWQHFAbMjnqeYRXBGzw4Cq8pYmpDanfu6BjtkjvfhoEI6Z7JE
-        TbKSOLsVh/YkC8xIDvdVgVfdtrkjY3HaBGHdoAXyIbz8IPpo2GpfWWVsDdffEzc9OaOz/vnohtcX
-        fkKbGyfp3Fm5lL6+nnc3zoORRTd/T4aPwNVjnEyTTZwnxmAzLdV6XQTfhmalg1wNb5EPFzT2IfXs
-        KYiS9PY1MHlgxnbDCstrppj1+u8Ts07eAt7SHV3wnjQZAnUFV9HdOETv5muvkaAEglb/cnP5CwAA
-        //8DANA4GmIcBgAA
+        H4sIAAAAAAAAA3RUTY/aMBC98yssn5cqhGwI3Cp1q/bQbVVV6qFU0ZCMwYtjR/YYLVrx3ys7ISTd
+        3VuY9+YxH2/8MmOMy5pvGLfo2jJJIIc6Xe9EXWSiSJMkL0SRLPO8yLKiWKyXIDKR17tFukRRre5r
+        fhckzO4JK7rKGO2wi1cWgbAuIWCLVb5IiizN04g5AvIu5FSmaRUS9mI7qI57a7wOdQlQDruwVErq
+        Pd+wlxljjPEWzmhDfo0nVKZFy2eMXSIZrTUB016pGJD6+i9ljQRSuSnqyPqKpNGTeAPPpfHUeirJ
+        HPE1SMaosgI1lWtMjSpUtm9pnpl5mqTZPCnmSd6PK0ryDfsTO+n6GTbRuP37i1jVq2UVFrFeFot1
+        sSiK9F7gWoioHFXo3GLUQedgjzfgvYlHsDKaUN+KGhc2kb3OA59pyI4E0NoQXGf45+8EVGbfWrN7
+        A4lCG8ZftpqxLSdJCrd8w7b815cH9vjx2wP7/pmF799fHz9t+V3HA08HYwMxJoaQkNZRqaHp838A
+        WVkd+5TAUDAh/DR0EN65LQ+ES69sgaTeB8Zqqy98qPXSfw3lc2tUHAk4Jx2Bpo4ciJHEW7CgFKqp
+        T8j6ztKtxZM03pXXqymjAwYftdY0LZUVVAcsj3geYxbBGT05CBTCWBqRws5904C9Zg734UAgnUtZ
+        oyYpJE5uxaE9yQpLktf7EuBVt23uyFgcN0HYtGiBfAwvPiR9NG61r0wY28Dt98hNT87osn8+uuH1
+        hZ/Q7oyTdO6sXEvf3M67G+fByKqbvyfDB+DmMU6mLUfOS4ZgOy7Vel1F38ZmpYOdur5FPl7Q0IfU
+        k6cgXRV3r4HRAzO0G1dY3zKTSa//PzHZ6i3gLd3BBe9JkyFQN3CZ3g9D9G669gYJaiAI+pfZ5R8A
+        AAD//wMAj57ZVxwGAAA=
     headers:
       CF-RAY:
-      - 99026d285db3eb73-SEA
+      - 99240ce01b7830a2-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -78,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:08:12 GMT
+      - Tue, 21 Oct 2025 22:04:24 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -94,13 +91,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1932'
+      - '1897'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1936'
+      - '1903'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -114,7 +111,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 22ms
       x-request-id:
-      - req_797120884eeb48cd8933bdd3a0a38afc
+      - req_d2ca3bb2536645f780aa35579fdf4326
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/async_stream.yaml
@@ -12,8 +12,8 @@ interactions:
       {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
-      \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
-      the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}}}'
+      \"Book\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please recommend
+      the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}}}'
     headers:
       accept:
       - application/json
@@ -22,12 +22,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1292'
+      - '1340'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -56,297 +53,297 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d25d69e230eec080068f2a26a9bc08197bbe40e452e7b2122","object":"response","created_at":1760731754,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a64bcf7080344d50068f8037692fc8190ad938c5e5667c126","object":"response","created_at":1761084278,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d25d69e230eec080068f2a26a9bc08197bbe40e452e7b2122","object":"response","created_at":1760731754,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a64bcf7080344d50068f8037692fc8190ad938c5e5667c126","object":"response","created_at":1761084278,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"bGQsGMeJ5UxnML"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"nc9EEzgm0oSvvA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"4Nr30Hk0Zahn2YT"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"gNZGtQ4nrOyeUA6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"DInOtw8Gq99AcJ"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"0upLUXR9s2s1I1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"tEtDy7Crq7P"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"zAl13UXyFHs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"Eh2VRSAIqceDSO"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"vqdLMPzrLXrCkV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"J7fjc5wWYpe6ai"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"IoB51CWOBogGUD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"WcbtLkRx5qg4f"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"yRgqYp63Wyr6B"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        NAME","logprobs":[],"obfuscation":"PLZINMwAtzn"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        NAME","logprobs":[],"obfuscation":"bwz3cx2KTQ0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        OF","logprobs":[],"obfuscation":"lXuvCqzrvZzPV"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        OF","logprobs":[],"obfuscation":"aa2a411ruOfGg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        THE","logprobs":[],"obfuscation":"7YD2nVVBri4A"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        THE","logprobs":[],"obfuscation":"ZyVozzkhMWIo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        WIND","logprobs":[],"obfuscation":"3K7VudiHOyF"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        WIND","logprobs":[],"obfuscation":"ivCfHjd5ADu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"VM0k9ThdRttTw"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"OI5KVKRNkk6C8"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"K6YJIuj4HRfsGTy"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"x5Sn7Y7tvTOmriX"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"KsuxeRjCFcZLDi"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"XHAdnlemftjUSg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"3AedKnOilB"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"irBp1tJaH2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"fItMWZeZftjqeZ"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"nfEBJz1PypaHK4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        {\n","logprobs":[],"obfuscation":"MMIISOskIkXCm"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        {\n","logprobs":[],"obfuscation":"hFjKkZHDe7T4R"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"CbI41GsqVyK7j"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"9MyFaCt1ASQ09"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"YmZRsNzHblwb1h"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"TSyEYwgz7q1LGq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"jDay9PWH698"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"7qI92IOOwig"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"XPVs2RfDDzB"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"Tuo1zQuTZhJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"WFwyHpBVFnVKA4"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"H4pVpLCIvx0Sws"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"9XjE9o6wbtddsF"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"MLxHIOHlhiinh6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"sHtVTQj0C"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"OX0E0Zo6m"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"0j5qRLR59YNak"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"RtM0TSQ4tNK1b"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"5zOil8ya3ZJw2"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"1ZPM5dlroUEPs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"1Mz4Aj92Q760cG"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"jamILa8uli4NcT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"l66NfbTL8jFH"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"PcNo7lTFKOEn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"HEv7QiVJ2hG"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"hIZ82gN1Fi9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"ba0IQgdBLO1Oau"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"mbf2xcLQnrj4HZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"pQWh50W6yQuk0n"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"92CTMZx2P8gjvy"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"9BINJAa9SEyjVA6"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"99fOqByntAg4wdj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"FnzEELVetrU0U"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"Uq9uVZVCtQnI7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"UcA76eBO4j05dtX"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"xnTCjpqnFV8Wrpl"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"WZczb2JDaSwgi"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"8KxDJ6zI2es3D"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\"\n","logprobs":[],"obfuscation":"j4rSEKGJhnfppg"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\"\n","logprobs":[],"obfuscation":"B8ofv1cONuq8k9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"xURzd1wvPVAXM1U"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"Z9yg8O1A2JMVEEH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        },\n","logprobs":[],"obfuscation":"vxjoqv7brbE6"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        },\n","logprobs":[],"obfuscation":"6DceA2DK1ktS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"tgubn0LnCLrCtmb"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"mgurLwDAwPjP1oF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"AZ8Mb8feSqoPsL"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"ssLInc3QSNYaET"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"VsmwlpkRd8"}
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"aObjBfDXSn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"MAhEb8vgIC3oNa"}
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"1pI7mPl9hS86bw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"sb3kJYpoUv5LtnF"}
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"tvIF05tfPzC8tHk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"sYf0XqDsZ14BcqI"}
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"PgHu9sEwXRTCeTq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"d72ZzhPLiJNJkpc"}
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"j93ZAYT0uTWzxiO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"SO9JQS4dWz4lk8J"}
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"z190O5ZeOBZabRz"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":50,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"text":"{\n  \"title\":
+        data: {"type":"response.output_text.done","sequence_number":50,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":51,"item_id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.content_part.done","sequence_number":51,"item_id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":52,"output_index":0,"item":{"id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.output_item.done","sequence_number":52,"output_index":0,"item":{"id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":53,"response":{"id":"resp_0d25d69e230eec080068f2a26a9bc08197bbe40e452e7b2122","object":"response","created_at":1760731754,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.completed","sequence_number":53,"response":{"id":"resp_0a64bcf7080344d50068f8037692fc8190ad938c5e5667c126","object":"response","created_at":1761084278,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":278,"input_tokens_details":{"cached_tokens":0},"output_tokens":47,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":325},"user":null,"metadata":{}}}
 
@@ -354,13 +351,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026eb9ee09b9b8-SEA
+      - 99240d449d05751a-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:09:14 GMT
+      - Tue, 21 Oct 2025 22:04:38 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -376,15 +373,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '65'
+      - '185'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '69'
+      - '194'
       x-request-id:
-      - req_165818292a35483eb40843026d28dbe0
+      - req_3a52b17eb05940129446eb3878bdaba3
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/stream.yaml
@@ -12,8 +12,8 @@ interactions:
       {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
-      \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
-      the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}}}'
+      \"Book\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please recommend
+      the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}}}'
     headers:
       accept:
       - application/json
@@ -22,12 +22,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1292'
+      - '1340'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -56,297 +53,297 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_067340a8a7e35f8c0068f2a24f9e788190be530aa58d694511","object":"response","created_at":1760731727,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_03f41696973a6d8d0068f8036ec5f08190af0cb06a3a1202fe","object":"response","created_at":1761084270,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_067340a8a7e35f8c0068f2a24f9e788190be530aa58d694511","object":"response","created_at":1760731727,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_03f41696973a6d8d0068f8036ec5f08190af0cb06a3a1202fe","object":"response","created_at":1761084270,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"eAag1y6O6yyx5q"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"B9CdaYdt2P5iTx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"VBQMJmEh6zJTr8l"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"mFLVDi6JKt4GLGO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"8zNPzO0NqL172U"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"vIjNUoCwFXOBJ2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"ayw9urgFVQS"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"rkVYGSHjh4s"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"YrvO6JsnQkAoQw"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"3IYeZVlEOPzVgx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"T8K0M42PLnXuW5"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"qEHuVL3LmSOAiV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"0RGDCTrfgED6k"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"5ezRr2ArcxYGC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        NAME","logprobs":[],"obfuscation":"79oyCzhw3xr"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        NAME","logprobs":[],"obfuscation":"Dl1f0K5HLu4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        OF","logprobs":[],"obfuscation":"j87xr1VD4f2ls"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        OF","logprobs":[],"obfuscation":"DlwUfo8BH08CC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        THE","logprobs":[],"obfuscation":"NBSm1ZsnLGao"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        THE","logprobs":[],"obfuscation":"MCyDYVqIhPpv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        WIND","logprobs":[],"obfuscation":"vmrEAmRMMXC"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        WIND","logprobs":[],"obfuscation":"gFAXbLw1hrS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"EQVfy75VX2C8z"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"qYD8pWP1izIqe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"Mknyor3KcJcJZmS"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"gyjoYsI5kNX5AbC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"rrm6W3jrXvnsJa"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"Z7xdxy205ndc6X"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"t0oq7v6B1e"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"SbFCmtWQHD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"xxAHUnPWTPxB9z"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"lnv17XgkVspoa7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        {\n","logprobs":[],"obfuscation":"h8lWHLYKMzvie"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        {\n","logprobs":[],"obfuscation":"vnd9z8US1GSk5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"QnONeikOTz415"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"IupSDqstCOo4m"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"BXJr2XlvBh2dGJ"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"go5drR47yp99dZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"7RXDpadcxgB"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"DGNPD98OKil"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"WteRg9Zubwc"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"aerdgaUZIiG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"E0HQD3mNLjo8rW"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"vDL46hFDXWbZnv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"aWi1GkB6pL3fd5"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"zCsq3GSAHdmeg6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"rYq2WHCvi"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"GRcrB49R6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"oCqeUyZwv6rsR"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"ZQFPaH4UEaQQu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"M3dwMErVe75Bf"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"   ","logprobs":[],"obfuscation":"Mka7DJxnZlJBg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"GX2nSv3EXLFYUe"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"hUKS25hV7jsQxF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"C8D3t7GdUqLy"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"GNKfuxfzSKBO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"LlwRfEpv3Uu"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"0weNb77NCjO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"Bih00gl4cn2v1n"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"eWMoMp0shvH4z8"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"ery9G7BeYwDsAl"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"S7zKm5EfSKCWnb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"1t7kiGPCTiIuQJ3"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"5OokPhAO3Q8sZ2t"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"hYCxVv4qnqEfS"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"H1BXoVeRoVOTW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"xvFtvubWmS2gWUH"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"I521JXrxa9g9HmW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"bIffIDG1WfrUY"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"0TNzQcnC696jZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\"\n","logprobs":[],"obfuscation":"XAHAYYphA5KoL2"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\"\n","logprobs":[],"obfuscation":"PCUbNGRj0GhQC3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"ZFMCQFfGgXh1l1T"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"wl00cpmBDy715Yj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        },\n","logprobs":[],"obfuscation":"byQ2uN8eDDij"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        },\n","logprobs":[],"obfuscation":"I8nLVQXPmXVr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"tRlTino8aXzbOg8"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"NuQjFRKa24g02ei"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"4cYnllg6yAZnMR"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"25UXelnQDR4uhE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"SfusiTHL1B"}
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"g4gv15cE4j"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"J0nnqZDpQdjWFg"}
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"86RC1GpOVtoG2N"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"vcTm5RFKFS2D4io"}
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"wp5tPuaxpqsUK2m"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"jwGW7Z0lRXOEwYP"}
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"5Z1BFY0TH5uN6S4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"4K0ifpMdLQREfzN"}
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"10SIJvmMh69AgTe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"TS8J4Vra4gqqngz"}
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"hvHwxCCUpBnXXwi"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":50,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"text":"{\n  \"title\":
+        data: {"type":"response.output_text.done","sequence_number":50,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":51,"item_id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.content_part.done","sequence_number":51,"item_id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":52,"output_index":0,"item":{"id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.output_item.done","sequence_number":52,"output_index":0,"item":{"id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":53,"response":{"id":"resp_067340a8a7e35f8c0068f2a24f9e788190be530aa58d694511","object":"response","created_at":1760731727,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.completed","sequence_number":53,"response":{"id":"resp_03f41696973a6d8d0068f8036ec5f08190af0cb06a3a1202fe","object":"response","created_at":1761084270,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"THE NAME OF THE WIND\",\n  \"author\": {\n    \"first_name\": \"Patrick\",\n    \"last_name\":
         \"Rothfuss\"\n  },\n  \"rating\": 7\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":278,"input_tokens_details":{"cached_tokens":0},"output_tokens":47,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":325},"user":null,"metadata":{}}}
 
@@ -354,13 +351,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026e111cc1aa54-SEA
+      - 99240d13ce4f27d6-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:08:47 GMT
+      - Tue, 21 Oct 2025 22:04:31 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -376,15 +373,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '141'
+      - '283'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '154'
+      - '312'
       x-request-id:
-      - req_024ad9fbb4f847dab09c172238b9a9b2
+      - req_3114df39b4184dd690b7cfe89a593a99
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/openai_responses_gpt_4o/sync.yaml
@@ -12,8 +12,8 @@ interactions:
       {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
       \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
       \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
-      \"Book\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please recommend
-      the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}}}'
+      \"Book\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please recommend
+      the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}}}'
     headers:
       accept:
       - application/json
@@ -22,12 +22,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1278'
+      - '1326'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -55,22 +52,22 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUy27bMBC8+ysInuNCkh9SfCvQFO2haVEU6KEuhJW0shlTpEAujRiB/70g9bDU
-        JDd5Z3a8j1m+LBjjouI7xg3aNo82VRlDXVfrMsEY0ijaZnUCSYQpZussvt8WcVZvVlmCcJ/Uq2LL
-        77yELp6wpEFGK4tdvDQIhFUOHovTbZSu4u02CZglIGd9TqmbViJh1SUVUJ4ORjvl66pBWuzCQkqh
-        DnzHXhaMMcZbuKDx+RWeUeoWDV8wdg1kNEZ7TDkpQ0Co4V/yCgmEtHPUknElCa1m8Qaec+2odZST
-        PuFrkLSWeQlyLtfoCqWv7NDScq2XSZSsl1G2jIZxBUm+Y39CJ10/4yYae3h/EfUqhbAIWMV4v44h
-        ybDYZFEclIMKXVoMOmgtHPAGvDfxAJZaEapbUdPCZrLDPPCZxuxAAKU0wTDDP39noNSH1ujiDSQI
-        7Rh/2SvG9pwESdzzHdvzX18e2OPHbw/s+2fmv39/ffy053cdDxwdtfHEkOhDtTCWcgVNn/8DyIjy
-        1Kd4hoQZ4aemY+2s3XNPuPbKBkiog2eke3XlY63X/mssnxstw0jAWmEJFHVkTwwk3oIBKVHOfULG
-        dZZuDZ6FdjYfriYPDhh91BrdtJSXUB4xP+FlihkEq9XsILCutaEJye/cNQ2YIXO8Dws10iUXFSoS
-        tcDZrVg0Z1FiTmK4rxqc7LbNLWmD0yYImxYNkAvh+EPUR8NW+8pqbRq4/Z646clqlffPRze8vvAz
-        mkJbQZfOypVwze28u3EetSi7+TvSfARuHuOk23zivGgMttNSjVNl8G1oVlgo5PAWuXBBYx9CzZ6C
-        JM3uXgOTB2ZsN6ywumVGs17/f2LW6VvAW7qjC96TJk0gb+Aq2YxDdHa+9gYJKiDw+tfF9R8AAAD/
-        /wMAtH2f3RwGAAA=
+        H4sIAAAAAAAAA3RUy27bMBC85ysInuNCtvyQfSvQFO2haVEU6KEuhJW0tBlTpEAujRiB/70g9bDU
+        JDd5Z3a8j1m+3DHGZcV3jFt0TZ7AKi1Fkm3SlSgWgEmyzkSWpKtqW4ksm2/X2TIVK0gT3OJyDcWW
+        3wcJUzxhSb2M0Q7beGkRCKscAjbfrOdJtlys0og5AvIu5JSmbhQSVm1SAeXpYI3XoS4BymEblkpJ
+        feA79nLHGGO8gQvakF/hGZVp0PI7xq6RjNaagGmvVAxI3f9LXiGBVG6KOrK+JGn0JF7Dc248NZ5y
+        Mid8DZIxKi9BTeVqU6EKlR0ami3NbJEslrMkmyXrblxRku/Yn9hJ28+widod3l8EZmlRhkVAsahE
+        iiVukgRhJaJyVKFLg1EHnYMD3oD3Jh7B0mhCfStqXNhEtp8HPtOQHQmgtSHoZ/jn7wRU5tBYU7yB
+        RKEd4y97zdiekySFe75je/7rywN7/PjtgX3/zML376+Pn/b8vuWBp6OxgRgTQ0hI6yjXUHf5P4Cs
+        LE9dSmAomBB+GjoK79yeB8K1U7ZAUh8CY7PXVz7Ueu2+hvK5NSqOBJyTjkBTSw7ESOINWFAK1dQn
+        ZH1r6cbiWRrv8v5q8uiAwUeNNXVDeQnlEfMTXsaYRXBGTw4ChTCWRqSwc1/XYPvM4T4cCKRLLivU
+        JIXEya04tGdZYk6yvy8BXrXb5o6MxXEThHWDFsjH8PxD0kXjVrvKhLE13H6P3PTkjM6756MdXlf4
+        GW1hnKRLa+VK+vp23u04j0aW7fw9GT4AN49xMk0+cl4yBJtxqdbrMvo2NisdFKp/i3y8oKEPqSdP
+        wWKT3b8GRg/M0G5cYXXLTCa9/v/ELDdvAW/pDi54T5oMgbqB6WI1DNG76dprJKiAIOhf767/AAAA
+        //8DAFJAEOwcBgAA
     headers:
       CF-RAY:
-      - 99026c7a2a1c275a-SEA
+      - 99240ca8ad0e95dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -78,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:07:44 GMT
+      - Tue, 21 Oct 2025 22:04:15 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -94,13 +91,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2037'
+      - '2098'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2040'
+      - '2107'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -108,13 +105,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799702'
+      - '799703'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 22ms
       x-request-id:
-      - req_31684b97a9fe4628904083c4c744d710
+      - req_555f3a3c13c144848dd410398443575e
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '910'
+      - '958'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,27 +45,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xWS4/bNhC++1ewbI7ejWR7/bpt0SxaoN0GwQI9xIEwpkY2Y0pUyeE2huH/XpCy
-        ZMm2NkXRmzTfzHAeHzlzGDDGZcqXjBu0ZRLFmE7XEc5m6QOOR5Moms6zEYzGuJg8TObx4mEdiUhk
-        8/FihJP5YvzAh96FXn9FQbUbXVis5MIgEKYJeCyeTaPZOJ7FccAsATnrbYTOS4WEaWW0BrHbGO0K
-        H1cGymIllkrJYsOX7DBgjDFewh6Nt0/xFZUu0fABY8egjMZojxVOqSCQRX1KkiKBVLaLWjJOkNRF
-        R57Dt0Q7Kh0lpHd4DZLWKhGguu5ynaLykW1Kupvou1E0mtxF87toeipXcMmX7HPIpMqn6URuN/2N
-        yLIYhW/EYjEXIl5jFMXjaCEWwXPwQvsSgx+0FjZ4BvoqHkChC8LiHFQ7sI7buh74jRrroABFoQnq
-        Gn7+0gGV3pRGr28gwdGS8cOKkySFK75c8ZdfPrDnx98/sD+emP/+89fnn1d8uOLgaKvNii8PK55J
-        YykpIK9sPgIZKXZBTUEb+aRpmzlrV/w4XHEDJIvNii9nR94Ecjx9NbFxo1XIF6yVlqCgStkrBiVe
-        ggGlUHVJQMZVfC0NvkrtbFJfiSS0tyFJaXReUiJAbDHZ4b6NGQSriw7bMcu0oZaSb6jLczC1ZUN+
-        CxnSPpEpFiQziZ2LYNG8SoEJyfryZOBU1UpuSRtsJ0GYl2iAXBDH99FJGlp2iizTJofzf4sqX60u
-        Eiu2mMOZaClaYWTpeeJ1Htla6x37W9KWAat6c89etsgCG5jdaqdStkYmCwZKMQGl/eHszjfZ+/lJ
-        612L6tWhyxaF+bsUM9sRMcYfA58upNdR+ngq6jGdMQgx33foX3W0REMS7ZU/X6aGrTdQXzSfrj/r
-        ySuyZ684vKF2qq0l4/lxoXC8tDjfhO+c+hv890MHb4TADf7lpMG087Jc1+SNwDvIlwv3TQKnTl7C
-        9atVTagLFNJU+haD+tjuXRg6g1sJtpL7n4n8Fn+aJA89ub+Ej57Ur5t27L7bPVfgncHM2//4Ptyc
-        96cC9/qpUv7uVXrShhFar8tKZ0pt0Q4ZbfFUs1ahZryv2Z+qs3oylgXhBruh3mxhDzdP59yq0q2M
-        Bze4eQ618zC9xch/w8Zja5gbGVYu/1YPWhh/RbPWVtK+WgJS6fLzYlTNqq2WohpujjRvgPN05qTL
-        pDWzo0ZYtueAcYWAurGptLBW9Rbnwu7RDAlZdJaoeDodXgOt1ayZJWE+pmfLqJPr5XI2jm4Bt/w2
-        I7bPNWkC1Yp4MW2K6Gx3puZIkAKFeXMcHP8BAAD//wMAdexeoVYLAAA=
+        H4sIAAAAAAAAA6xWS2/jNhC++1ew7B6drOz4ofiWohu0QJsuFgF6WC+EETmyuaZElRymawT+7wUp
+        W5b8yBZFb9J8M8N5fOTM64AxriRfMG7R1VmSTudSFtPxBOXo/i5PkllapMndLJ/KNElH9zNI0xyT
+        dC4mqZjBfcGHwYXJv6KggxtTOWzkwiIQygwCNprPRkk6Gc/mEXME5F2wEaasNRLKxigHsVlZ46sQ
+        VwHaYSNWWqtqxRfsdcAYY7yGLdpgL/EFtanR8gFju6iM1pqAVV7rKFDV4ZRMIoHSro86sl6QMlVP
+        XsK3zHiqPWVkNngOkjE6E6D77kojUYfIVjXdTMzNOBlPbpL0JpntyxVd8gX7HDNp8mk7UbrVG40o
+        xuPYiHw6zadSSCFwMk7uIHqOXmhbY/SDzsEKj8C1ikdQmIqwOgbVDazn9lAP/EatdVSAqjIEhxp+
+        /tIDtVnV1uQXkOhowfjrkpMijUu+WPLnXz6wp4ffP7A/Hln4/vPXp5+XfLjk4Glt7JIvXpe8UNZR
+        VkHZ2HwEskpsopqGLvLJ0Lrwzi35brjkFkhVqyVfzHe8DWS3/2pj49bomC84pxxBRY1yUIxKvAYL
+        WqPuk4Csb/haW3xRxrvscCWy2N6WJLU1ZU2ZALHGbIPbLmYRnKl6bMeiMJY6SqGhvizBHixb8jso
+        kLaZkliRKhT2LoJD+6IEZqQOl6cAr5tWckfGYjcJwrJGC+SjeHSb7KWxZfvICmNLOP53qPLVmSpz
+        Yo1lh54SnbCqDjwJOg8sN2bD/la0ZsCa3tyy5zWyyAbm1sZryXJkqmKgNRNQux+O7kKTg5+fjNl0
+        qN4cuuhQmL+TWLieiDH+EPl0Ij2PMsTTUI+ZgkGM+bZH/6ajNVpS6M78hTK1bL2AhqKFdMNZj0GR
+        PQXF4QW1fW0d2cCPE4XdqcXxJnzn1N/gvx86eCMEbvEvryzK3styXpM3Au8hX07ctwnsO3kKH16t
+        ZkKdoCClCi0G/bHbuzh0BpcS7CT3PxP5Lf60Sb5eyf05flxJ/bxpu/67feUKvLNYBPsf38eb835f
+        4Kt+mpS/e5UejWWELuiy2tvaOHRDRmvc16xTqDm/1uxPzVlXMlYV4Qr7oV5s4RVu7s+5VKVLGQ8u
+        cPMYau9heouR/4aNu84wtyquXOGtHnQw/oI2N07RtlkCpPLlcTFqZtXaKNEMN0+Gt8BxOnMyddaZ
+        2UkrrLtzwPpKwKGxUjnI9WGL83H3aIeEqnpL1Gg2G54DndWsnSVxPsqjZdLL9XQ5u0suAZf8tiP2
+        mmsyBLoT8f2sLaJ3/ZlaIoEEivNmN9j9AwAA//8DAN0jnJBWCwAA
     headers:
       CF-RAY:
-      - 99026da67a45c66f-SEA
+      - 99240cfe8beeba52-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -76,7 +73,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:08:32 GMT
+      - Tue, 21 Oct 2025 22:04:28 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -92,13 +89,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2118'
+      - '1075'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2123'
+      - '1082'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -112,7 +109,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_01b14175ccbc48ad88e15720382c45b0
+      - req_be28b49b69ab40ab97d9c5597602b184
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '924'
+      - '972'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,7 +46,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_00206770ae6f24940068f2a27c95ac8195af70b031b74e8d01","object":"response","created_at":1760731772,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0b77cd22d17623de0068f8037b13088193afdcc3a659345a2b","object":"response","created_at":1761084283,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -59,7 +56,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_00206770ae6f24940068f2a27c95ac8195af70b031b74e8d01","object":"response","created_at":1760731772,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0b77cd22d17623de0068f8037b13088193afdcc3a659345a2b","object":"response","created_at":1761084283,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -69,184 +66,184 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"ADu0ibuMNnassh"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"PdViiOGppsbzEh"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"aRYuLTcwHAI"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"ehhydBZdf8v"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"6SwjjZPqXNFRx"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"XAKuB8dPbejE1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"4oXZfbRNMJ4dJ"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"fzh2kO10UslIo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"
-        NAME","logprobs":[],"obfuscation":"VYJ8TsWUe62"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"
+        NAME","logprobs":[],"obfuscation":"jmj5Ha67x5s"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"
-        OF","logprobs":[],"obfuscation":"yI2r3znLyTpwF"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"
+        OF","logprobs":[],"obfuscation":"NcIehvkPZJOYG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"
-        THE","logprobs":[],"obfuscation":"JkSHAljTUXV3"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"
+        THE","logprobs":[],"obfuscation":"ZeL7M8d2zK6F"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"
-        WIND","logprobs":[],"obfuscation":"8zIG6RUnWPx"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"
+        WIND","logprobs":[],"obfuscation":"GTdznvWwqop"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"KFPATupofhUcH"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"DyhCYgjtoWNSF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"Xmw2IICS1L"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"EWVsgZ4kBv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"sSQCUOoLVNnG"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"PFPjGeRymDPe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"lV7wOr2Eoyy"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"DOafAgzW91U"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"QzOFihGdTpC"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"0urrJ7hVule"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"johRpJhN880Vx"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"1QQTU13XSfXO5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"CMCCA8A3j"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"JrZeSUqJE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"OnX2OmI31LYvx"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"VPFy7ZR1njHxi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"NJUrWepAWYZm"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"lbxWiZAWdjkS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"MwP0pLLx3FK"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"AO0GWpt7IqY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"Gi9qc0GapvSAM"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"18ECj1wkeeAFX"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"U7jxIQmy8WeVE0w"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"6kZ60lQVKok3aSA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"w8qCOT4MbOyxL"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"HD3bNQaCq1at2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"WlvE9SNu54kcD0k"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"WgePfidCcyyzNAt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"yIHBNNg645CYn"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"S2JKwzF2XLnna"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"FnF1fQtF807H2Y"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"HrqvYYDjBmCHuG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"KY5NpJuwaixhzQ"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"Pn7b5mNlvSWYea"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"ACLMCAdUyA"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"YIHxT8B7XT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"EMXmz0VB7bMliX"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"5CpPcGAju1zwHe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"peP2wGqqtADkRDy"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"KG4y7unKYb8rfiE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"Uf3pK2nG9MwRWXP"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"z35GKpjwz9UqUL2"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"text":"{\"title\":\"THE
+        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_00206770ae6f24940068f2a27c95ac8195af70b031b74e8d01","object":"response","created_at":1760731772,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_0b77cd22d17623de0068f8037b13088193afdcc3a659345a2b","object":"response","created_at":1761084283,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
@@ -258,13 +255,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026f2a3c64b9c8-SEA
+      - 99240d6098ba76ee-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:09:32 GMT
+      - Tue, 21 Oct 2025 22:04:43 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -280,15 +277,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '42'
+      - '205'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '53'
+      - '227'
       x-request-id:
-      - req_5b751c788bd446fba3386476db957e79
+      - req_7dec6935f22941ccb5fc126e68324407
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '924'
+      - '972'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,7 +46,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_074f4c09fc7a83d90068f2a25e4d04819586468f4cb601cbf0","object":"response","created_at":1760731742,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0fffcf2aa365083f0068f803724d488193a03e643859649e48","object":"response","created_at":1761084274,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -59,7 +56,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_074f4c09fc7a83d90068f2a25e4d04819586468f4cb601cbf0","object":"response","created_at":1760731742,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0fffcf2aa365083f0068f803724d488193a03e643859649e48","object":"response","created_at":1761084274,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -69,184 +66,184 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"LAcl2aBuKBSOK8"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"4MR8B6oaMofV8L"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"L9JCb1Z1HDm"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"DiwgJ4cHcey"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"9337kxXuKXKyT"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"Yha4px6jk3K9r"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"HITstTx7z8MJx"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"CBn94Om197nUC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"
-        NAME","logprobs":[],"obfuscation":"XjSOzbflPZa"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"
+        NAME","logprobs":[],"obfuscation":"YayjJ9NujEd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"
-        OF","logprobs":[],"obfuscation":"4T929ESmtJHj7"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"
+        OF","logprobs":[],"obfuscation":"lieFqWAfO9SJ0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"
-        THE","logprobs":[],"obfuscation":"xBuohceqrU33"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"
+        THE","logprobs":[],"obfuscation":"1mvwWrAsaakG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"
-        WIND","logprobs":[],"obfuscation":"54osjHUcZMb"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"
+        WIND","logprobs":[],"obfuscation":"5ryE6qnyyrp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"96uuO9U79piEj"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"z6VJ6KrIpchm4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"BUj6Ou9PrW"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"o1DmihesG3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"KY5EWp7rjwLn"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"hMRcWsdpqZe6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"HIGIdZkYT0e"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"UT0MumRjwsC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"DWEpvftOACG"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"B8ClYMnLolb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"eYoxEOIawAeKB"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"2Kae1N8K3lUAU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"jHZ4ajYLg"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"FyLmHfkRc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"5XwT8JyLohvgx"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"FeZK2BPInYHwB"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"je4nnhZ2sNPQ"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"aQajLuNNt7gc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"ssgEStYG4Zo"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"R1qk6RiO3g4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"UxL6bfoTKNG8a"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"SeRIP5p1p41Bz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"MuLZx2fdemEG7hk"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"MCepTuQ59ac7t2Y"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"3rOKnQ0Aqo2jY"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"h9vYQtKMFSLrp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"WxnEjJpcN7ymkdR"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"Q2e7arLZxYixCV2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"awlj04hShXitA"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"zF4ElCg6L0fBw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"h7PazRPBVImM0K"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"BuJr5oR3zqG6Cq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"cQfHsuiiLAVTig"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"lvykxcbYoV00jT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"FTYiRBECHh"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"lbe6Key3wo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"V4AEGtEU3bnzDV"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"rIJ0xkmOT2KZHP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"5UzANcmj3ZISBwh"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"oIROQOUYwLaXCpH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"GjrohWCCe4TfPof"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"nu36MgfERHTLPYX"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"text":"{\"title\":\"THE
+        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_074f4c09fc7a83d90068f2a25e4d04819586468f4cb601cbf0","object":"response","created_at":1760731742,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_0fffcf2aa365083f0068f803724d488193a03e643859649e48","object":"response","created_at":1761084274,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
@@ -258,13 +255,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026e6ccabfba28-SEA
+      - 99240d29be5e27d6-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:09:02 GMT
+      - Tue, 21 Oct 2025 22:04:34 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -280,15 +277,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '206'
+      - '365'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '216'
+      - '383'
       x-request-id:
-      - req_79455b754cff4bb4886444db0e80e320
+      - req_d8ecc316b8b0492aa9eaa848310e14ee
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/openai_responses_gpt_4o/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '910'
+      - '958'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,27 +45,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xWS4/bNhC++1ewbI7ejfyIJfu2RbNogXYbBAv0EAfCWBrZjClRJYfbGIb/e0HK
-        etnWpghyk+abGc7jI2eOI8a4SPmKcY2mjINgPoV5lM1TCMMoXAbBIsqmMJ1gmGRBNFnON1k0TcPg
-        3QyjMEyjBR87F2rzBROq3ajCYCVPNAJhGoPDJuEiCGeTRRh5zBCQNc4mUXkpkTCtjDaQ7Lda2cLF
-        lYE0WImFlKLY8hU7jhhjjJdwQO3sU3xBqUrUfMTYySuj1sphhZXSC0RRnxKnSCCk6aOGtE1IqKIn
-        z+FrrCyVlmJSe7wGSSkZJyD77nKVonSRbUu6m6u7aTCd3wXRXVCXy7vkK/bJZ1Ll03QiN9vhRmTT
-        ZDZ3jYAEM8yW72A5iyDaRN6z90KHEr0fNAa22AJDFfdgogrCog2qG1jPbV0P/EqNtVeAolAEdQ0/
-        fe6BUm1LrTY3EO9oxfhxzUmQxDVfrfnzb+/Z08Of79lfj8x9//37069rPl5zsLRTes1XxzXPhDYU
-        F5BXNh+AtEj2Xk1CF/moaJdZY9b8NF5zDSSK7ZqvwhNvAjmdv5rYuFbS5wvGCENQUKXsFL0SL0GD
-        lCj7JCBtK76WGl+Esiaur0Ts29uQpNQqLylOINlhvMdDF9MIRhU9tmOWKU0dJddQm+ega8uG/AYy
-        pEMsUixIZAJ7F8GgfhEJxiTqy5OBlVUruSGlsZsEYV6iBrJePLkPzlLfsnNkmdI5tP8dqnwxqohN
-        ssMcWqKlaBItSscTp/PANkrt2b+CdgxY1Zt79rxD5tnAzE5ZmbINMlEwkJIlUJqfWneuyc7PL0rt
-        O1SvDl11KMzfpJiZnogx/uD5dCG9jtLFU1GPqYyBj/m+R/+qoyVqEmiu/LkyNWy9gbqiuXTdWY9O
-        kT05xfENtXNtDWnHjwuF06VFexO+ceof8P2Hjl4JgWv8xwqNae9lua7JK4H3kM8X7psEzp28hOtX
-        q5pQFyikqXAtBvmh2zs/dEa3Euwk94OJ/Bp/miSPA7k/+4+B1K+bduq/2wNX4I3GzNn//NbfnLfn
-        Ag/6qVL+5lV6VJoRGqfLSqtLZdCMGe3wXLNOoUI+1OyP1VkDGYuCcIv9UG+2cICb53NuVelWxqMb
-        3GxD7T1MrzHy/7Dx1BnmWviVy73Vow7GX1BvlBF0qJaAVNi8XYyqWbVTIqmGmyXFG6CdzpxUGXdm
-        dtAIy+4c0LZIoG5sKgxsZL3FWb97NENCFL0larJYjK+BzmrWzBI/H9PWMujlermczYJbwC2/zYgd
-        ck2KQHYiXi6aIlrTn6k5EqRAft6cRqf/AAAA//8DAJSuYMRWCwAA
+        H4sIAAAAAAAAA6xWWY/bNhB+969g2Tx6N/Kxvt62aBYt0G6DYIE+xIEwEkc2Y0pUyeE2huH/XpCy
+        Lh+bouibNN/McI6PnDkMGONS8BXjBm0ZR9kkGYnlfD6fzdLRNImi2SJbRJPZ+EGMosVoOVlMkwSX
+        MBZZthTjScaH3oVOvmJKtRtdWKzkqUEgFDF4bDSfjaLFdPywCJglIGe9TarzUiGhqIwSSHcbo13h
+        48pAWazEUilZbPiKHQaMMcZL2KPx9gJfUekSDR8wdgzKaIz2WOGUCgJZ1KfEAgmksn3UknEpSV30
+        5Dl8i7Wj0lFMeoeXIGmt4hRU312uBSof2aaku6m+G0fj6V20uItmp3IFl3zFPodMqnyaTuR280Yj
+        cD6ZhkYs0+X8QSyFWGTpeBkFz8EL7UsMftBa2GAL3Kp4AFNdEBZtUN3Aem7reuA3aqyDAhSFJqhr
+        +PlLD1R6UxqdXEGCoxXjhzUnSQrXfLXmL798YM+Pv39gfzwx//3nr88/r/lwzcHRVps1Xx3WPJPG
+        UlxAXtl8BDIy3QU1BV3kk6Zt5qxd8+NwzQ2QLDZrvpofeRPI8fTVxMaNViFfsFZagoIqZa8YlHgJ
+        BpRC1ScBGVfxtTT4KrWzcX0l4tDehiSl0XlJcQrpFuMd7ruYQbC66LEds0wb6ij5hro8B1NbNuS3
+        kCHtYymwIJlJ7F0Ei+ZVphiTrC9PBk5VreSWtMFuEoR5iQbIBfHoPjpJQ8tOkWXa5ND+d6jy1eoi
+        tukWc2iJJtCmRpaeJ17nkSVa79jfkrYMWNWbe/ayRRbYwOxWOyVYgkwWDJRiKZT2h9adb7L385PW
+        uw7Vq0NXHQrzdwIz2xMxxh8Dn86kl1H6eCrqMZ0xCDHf9+hfdbREQxLthT9fpoatV1BfNJ+uP+vJ
+        K7Jnrzi8onaqrSXj+XGmcDy3aG/Cd079Df77oYM3QuAG/3LSoOi9LJc1eSPwHvLlzH2TwKmT53D9
+        alUT6gwFIaRvMaiP3d6FoTO4lmAnuf+ZyG/xp0nycCP3l/BxI/XLph377/aNK/DOYObtf3wfbs77
+        U4Fv+qlS/u5VetKGEVqvy0pnSm3RDhlt8VSzTqHm/FazP1Vn3chYFoQb7Id6tYU3uHk651qVrmU8
+        uMLNNtTew/QWI/8NG4+dYW5kWLn8Wz3oYPwVTaKtpH21BAjp8nYxqmbVVsu0Gm6ONG+Adjpz0mXc
+        mdlRIyy7c8C4IoW6sUJaSFS9xbmwezRDQha9JWo0mw0vgc5q1sySMB9Faxn1cj1fzibRNeCa32bE
+        3nJNmkB1Il7OmiI625+pORIIoDBvjoPjPwAAAP//AwB6/J5FVgsAAA==
     headers:
       CF-RAY:
-      - 99026cddbfe875f4-SEA
+      - 99240cc64b8195dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -76,7 +73,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:07:59 GMT
+      - Tue, 21 Oct 2025 22:04:19 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -92,13 +89,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1217'
+      - '1226'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1220'
+      - '1234'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -112,7 +109,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_f44718fa822542968ec7093ab2130913
+      - req_fc351e5bf6b7487e876748e7290c83fc
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '910'
+      - '958'
       content-type:
       - application/json
       host:
@@ -35,7 +35,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -45,27 +45,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xWS4/bNhC++1ewbI7ejfxYv25bNIsWaLdBsEAPcSCMxJHNmBJVcriNYfi/F6Qs
-        WbLlTVH0Js03M5zHR84cBoxxKfiKcYO2jKPFOBHLbDxBXC7n4iGKZotsDOPxJJtki8VoOQEBy0Tg
-        Q7ZMHibiYcaH3oVOvmJKtRtdWKzkqUEgFDF4bDSfRfPJaLaYBswSkLPeJtV5qZBQVEYJpLuN0a7w
-        cWWgLFZiqZQsNnzFDgPGGOMl7NF4e4GvqHSJhg8YOwZlNEZ7rHBKBYEs6lNigQRS2S5qybiUpC46
-        8hy+xdpR6SgmvcNrkLRWcQqq6y7XApWPbFPS3VTfjaPx9C5a3EV1uYJLvmKfQyZVPk0ncru53Yjp
-        XGDqG5FMF0sBs0wscTZNFovgOXihfYnBD1oLGzwDtyoewFQXhMU5qHZgHbd1PfAbNdZBAYpCE9Q1
-        /PylAyq9KY1OepDgaMX4Yc1JksI1X635yy8f2PPj7x/YH0/Mf//56/PPaz5cc3C01WbNV4c1z6Sx
-        FBeQVzYfgYxMd0FNQRv5pGmbOWvX/DhccwMki82ar+ZH3gRyPH01sXGjVcgXrJWWoKBK2SsGJV6C
-        AaVQdUlAxlV8LQ2+Su1sXF+JOLS3IUlpdF5SnEK6xXiH+zZmEKwuOmzHLNOGWkq+oS7PwdSWDfkt
-        ZEj7WAosSGYSOxfBonmVKcYk68uTgVNVK7klbbCdBGFeogFyQTy6j07S0LJTZJk2OZz/W1T5anUR
-        23SLOZyJJtCmRpaeJ17nkSVa79jfkrYMWNWbe/ayRRbYwOxWOyVYgkwWDJRiKZT2h7M732Tv5yet
-        dy2qV4euWhTm7wRmtiNijD8GPl1Ir6P08VTUYzpjEGK+79C/6miJhiTaK3++TA1be1BfNJ+uP+vJ
-        K7JnrzjsUTvV1pLx/LhQOF5anG/Cd079Df77oYM3QuAG/3LSoOi8LNc1eSPwDvLlwn2TwKmTl3D9
-        alUT6gIFIaRvMaiP7d6FoTPoS7CV3P9M5Lf40yR5uJH7S/i4kfp1047dd/vGFXhnMPP2P74PN+f9
-        qcA3/VQpf/cqPWnDCK3XZaUzpbZoh4y2eKpZq1BzfqvZn6qzbmQsC8INdkPtbeENbp7O6atSX8aD
-        Hm6eQ+08TG8x8t+w8dga5kaGlcu/1YMWxl/RJNpK2ldLgJAuPy9G1azaaplWw82R5g1wns6cdBm3
-        ZnbUCMv2HDCuSKFurJAWElVvcS7sHs2QkEVniRrNZsNroLWaNbMkzEdxtow6uV4uZ5OoD+jz24zY
-        W65JE6hWxMtZU0RnuzM1RwIBFObNcXD8BwAA//8DAFqoSWRWCwAA
+        H4sIAAAAAAAAAwAAAP//rFZLb+M2EL77V7DsHp2s7Di241uKbtACbbpYBOhhtRDG4sjmmhJVcpiu
+        Yfi/F6RsPWwpWxS9SfPNDOfxkTOHEWNcCr5i3KAtkyjDbCoimEW4FCLFKJovs2V0N5/dT0W0nDws
+        1nOcZhhlGT7cp/cR8LF3oddfMaWzG11YrOSpQSAUCXhssphPouVsOo8CZgnIWW+T6rxUSCgqozWk
+        u43RrvBxZaAsVmKplCw2fMUOI8YY4yXs0Xh7ga+odImGjxg7BmU0RnuscEoFgSzOpyQCCaSyXdSS
+        cSlJXXTkOXxLtKPSUUJ6h9cgaa2SFFTXXa4FKh/ZpqSbmb6ZRtPZTbS8ieancgWXfMU+h0yqfOpO
+        5HYz3Ij7O5wtfSOWcDedpOvFYoYie4DKc/BC+xKDH7QWNtgAQxUPYKoLwqIJqh1Yx+25HviNauug
+        AEWhCc41/PylAyq9KY1e9yDB0YrxQ8xJksKYr2L+8ssH9vz4+wf2xxPz33/++vxzzMcxB0dbbWK+
+        OsQ8k8ZSUkBe2XwEMjLdBTUFbeSTpm3mrI35cRxzAySLTcxXiyOvAzmevurYuNEq5AvWSktQUKXs
+        FYMSL8GAUqi6JCDjKr6WBl+ldjY5X4kktLcmSWl0XlKSQrrFZIf7NmYQrC46bMcs04ZaSr6hLs/B
+        nC1r8lvIkPaJFFiQzCR2LoJF8ypTTEieL08GTlWt5Ja0wXYShHmJBsgF8eQ2OklDy06RZdrk0Py3
+        qPLV6iKx6RZzaIgm0KZGlp4nXueRrbXesb8lbRmwqje37GWLLLCB2a12SrA1MlkwUIqlUNofGne+
+        yd7PT1rvWlSvDl21KMzfCcxsR8QYfwx8upBeR+njqajHdMYgxHzboX/V0RINSbRX/nyZarb2oL5o
+        Pl1/1pNXZM9ecdyjdqqtJeP5caFwvLRobsJ3Tv0N/vuhozdC4Ab/ctKg6Lws1zV5I/AO8uXCfZ3A
+        qZOX8PnVqibUBQpCSN9iUB/bvQtDZ9SXYCu5/5nIb/GnTvIwkPtL+BhI/bppx+67PXAF3hnMvP2P
+        78PNeX8q8KCfKuXvXqUnbRih9bqsdKbUFu2Y0RZPNWsVasGHmv2pOmsgY1kQbrAbam8LB7h5Oqev
+        Sn0Zj3q42YTaeZjeYuS/YeOxNcyNDCuXf6tHLYy/ollrK2lfLQFCurxZjKpZtdUyrYabI81roJnO
+        nHSZtGZ2VAvL9hwwrkjh3FghLazVeYtzYfeoh4QsOkvUZD4fXwOt1ayeJWE+isYy6uR6uZzdRX1A
+        n996xA65Jk2gWhE/zOsiOtudqTkSCKAwb46j4z8AAAD//wMA/dZGSVYLAAA=
     headers:
       CF-RAY:
-      - 99026d002cdddef2-SEA
+      - 99240cd28eaaba52-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,15 +73,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:08:05 GMT
+      - Tue, 21 Oct 2025 22:04:21 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        path=/; expires=Fri, 17-Oct-25 20:38:05 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -95,13 +89,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1198'
+      - '1524'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1203'
+      - '1532'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -115,7 +109,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_314a66d1edc642c3a0fc44d6ba160d33
+      - req_3ee8d26be6b84400977ff3148ace696b
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '924'
+      - '972'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,7 +46,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_083abf2d6b19e9580068f2a26385148197997880b203c01e5f","object":"response","created_at":1760731747,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_06a8e02841f7033d0068f80374c6908196929cae88342de707","object":"response","created_at":1761084276,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -59,7 +56,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_083abf2d6b19e9580068f2a26385148197997880b203c01e5f","object":"response","created_at":1760731747,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_06a8e02841f7033d0068f80374c6908196929cae88342de707","object":"response","created_at":1761084276,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -69,184 +66,184 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"kqtY1HzdPIqhPm"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"RybltSMdh34koQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"QRCEsjlgdqs"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"PTHXfgcVebu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"ZC0DJ9NmONLYl"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"WV8WDH7aK7kdD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"Q8A2KPYSgrXNv"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"mzEYKEXnhv25S"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"
-        NAME","logprobs":[],"obfuscation":"WiYHEhPd47O"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"
+        NAME","logprobs":[],"obfuscation":"1kmZ9QTeuAb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"
-        OF","logprobs":[],"obfuscation":"u1TyljjEUdsLr"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"
+        OF","logprobs":[],"obfuscation":"wp14YGAq0S8QF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"
-        THE","logprobs":[],"obfuscation":"Jzcn8eANyYU3"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"
+        THE","logprobs":[],"obfuscation":"6IhaAJIUnGbK"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"
-        WIND","logprobs":[],"obfuscation":"NuthDomcoRf"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"
+        WIND","logprobs":[],"obfuscation":"ivXz9hlNyhi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"inqAqeV0Y3F3m"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"HkdRRO9Wy01TW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"kvuh9HDC8Z"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"koHhfFqhPW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"29jJRPxCXuJU"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"X4dddI2Fhxr9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"MlLV8gXW81Y"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"9UWG75ki6jP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"VUTKybWz3ki"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"YvqxroQKJcM"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"uca5w82pwiZoy"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"fATcTbXG9gwI6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"s8z4PpNUw"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"IpXCkQAOV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"b2Sp9w7RqDWFa"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"JNkVLucAcPZHj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"rhjmmwWLaReO"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"ub3jNh2c9pvT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"kzcE9Nuqtrk"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"WdxK8RrOLM8"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"Nhq4awh1KPdp4"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"XNpbS0ayktXtt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"HdzCLhaL2Nh6Wv2"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"3JZfTw3zZ1UWw3D"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"27nTB1ui5CPTH"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"kETq0byg0gZBr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"AeE4nJjPXQ3LOqg"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"KbhLhrH5hjzda3L"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"TSlkCVe2sTF8C"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"O7Sp9ocvPfDB7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"Q45T7PeEfkTjQY"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"LA8zZaWwJo4Qjt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"MrW0hW7KLksRtK"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"XjkrmCzsXPz2Lk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"kKcMOq5xnz"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"7sg8GleDUJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"HcXuaLAgsG6XIG"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"UWJb56xycnWdXc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"kkejWbHUyciyY5l"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"sfBIJyX2mHFWcuF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"BAJjaJfqw3rnPIk"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"2H49jn2TVoUXRDT"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"text":"{\"title\":\"THE
+        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_083abf2d6b19e9580068f2a26385148197997880b203c01e5f","object":"response","created_at":1760731747,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_06a8e02841f7033d0068f80374c6908196929cae88342de707","object":"response","created_at":1761084276,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
@@ -258,13 +255,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026e8d9ef8ebf2-SEA
+      - 99240d396c4c6ce6-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:09:07 GMT
+      - Tue, 21 Oct 2025 22:04:36 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -280,15 +277,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '90'
+      - '141'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '101'
+      - '151'
       x-request-id:
-      - req_6b23c9327c6b4432af6740aab3028212
+      - req_ba92df65c0a74703a56bec7bf95d4021
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '924'
+      - '972'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,7 +46,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_098ca2b269dd8cfc0068f2a24782948193b623a77d7c1026f5","object":"response","created_at":1760731719,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_01661eb21b60990b0068f8036cae7c8194abc57e4926ee1414","object":"response","created_at":1761084268,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -59,7 +56,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_098ca2b269dd8cfc0068f2a24782948193b623a77d7c1026f5","object":"response","created_at":1760731719,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_01661eb21b60990b0068f8036cae7c8194abc57e4926ee1414","object":"response","created_at":1761084268,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
         Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
@@ -69,184 +66,184 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"D0Auu1HRaw1ULJ"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"NB1GmR6pZdFoFT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"CatyxqBrTDh"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"HaUiG266NjI"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"yb6PF8YUBe3g0"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"AmYLs54E1oSsc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"a56Tu6X78WRBx"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"THE","logprobs":[],"obfuscation":"L4IxXgIPvC9Cp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"
-        NAME","logprobs":[],"obfuscation":"vK2O2FDphfE"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"
+        NAME","logprobs":[],"obfuscation":"9nziRF6jxzU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"
-        OF","logprobs":[],"obfuscation":"FqSk9k4fqIQqz"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"
+        OF","logprobs":[],"obfuscation":"vUI7IK0tFW5n4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"
-        THE","logprobs":[],"obfuscation":"LU9fZbjqOKOC"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"
+        THE","logprobs":[],"obfuscation":"WiEVbLsShQKH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"
-        WIND","logprobs":[],"obfuscation":"U4m0QPhOY1a"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"
+        WIND","logprobs":[],"obfuscation":"KXoyXMoh6Ho"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"0gDzedxH1hN96"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"AUpIBC7bPNMbl"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"AVlrXPRMH5"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"P4i3LysCO0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"lKeTB4IY3NZE"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\":{\"","logprobs":[],"obfuscation":"5A5Yz12k2nCc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"0gL8Nsr0ZxU"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"first","logprobs":[],"obfuscation":"2TdQx7Im5Jz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"8eqviAeXi5B"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"ryziNeZT1Gn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"lnnDQh9jE4o0U"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"ybUBo3XKQio5e"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"byy1YiM6v"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"Patrick","logprobs":[],"obfuscation":"Kl0foPbxp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"2Uti25p4hWppJ"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"YeYpCz8I88V0q"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"smO6wzCZDPw7"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"last","logprobs":[],"obfuscation":"s6K7tZZARuOH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"AjQ8ojaC8Lb"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"_name","logprobs":[],"obfuscation":"WlNfxNV8hKq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"gmjMJ811ZtnCn"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"4tepLRANV3yB6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"gdgRuSzg0KVam4f"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"R","logprobs":[],"obfuscation":"Np1RWQFU7KWnbCC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"uxMwCWKmeK7e7"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"oth","logprobs":[],"obfuscation":"YZbKvLY9ipndZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"UrUx0mCTtLgVgQV"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"f","logprobs":[],"obfuscation":"EBv66DClUzil9S0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"IaDyKxIc0WBQb"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"uss","logprobs":[],"obfuscation":"RLzkRDwFUTe8H"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"WtUA5eBmOBQ96L"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\"}","logprobs":[],"obfuscation":"GnrmdMXymk2ELU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"qHUcq0nbemZYxj"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"HZBE77SVP1FIr1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"e6EqvFfCal"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"rating","logprobs":[],"obfuscation":"SaHuUfN8GK"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"33qMptgDeaVEWb"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"whC95qyDk97LZO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"yuZvbxoa91i8Zt6"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"7","logprobs":[],"obfuscation":"Ivelbg6a5o1hxbM"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"zP2B4jed0er066f"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"F6ABUzihq3POybN"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"text":"{\"title\":\"THE
+        data: {"type":"response.output_text.done","sequence_number":33,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.content_part.done","sequence_number":34,"item_id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.output_item.done","sequence_number":35,"output_index":0,"item":{"id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_098ca2b269dd8cfc0068f2a24782948193b623a77d7c1026f5","object":"response","created_at":1760731719,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
+        data: {"type":"response.completed","sequence_number":36,"response":{"id":"resp_01661eb21b60990b0068f8036cae7c8194abc57e4926ee1414","object":"response","created_at":1761084268,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":"A
         book with a rating. The title should be in all caps!","name":"Book","schema":{"$defs":{"Author":{"description":"The
         author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
@@ -258,13 +255,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026dde8f097681-SEA
+      - 99240d06bcc627d6-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:08:39 GMT
+      - Tue, 21 Oct 2025 22:04:28 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -280,15 +277,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '82'
+      - '200'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '86'
+      - '212'
       x-request-id:
-      - req_2488acdddc7e4aebb55f70a6d039feaa
+      - req_11beae6dd6f64397b4b775646316608b
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/openai_responses_gpt_4o/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please recommend the most popular book
-      by Patrick Rothfuss"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
+    body: '{"input":[{"content":[{"text":"Please recommend the most popular book by
+      Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"Book","schema":{"$defs":{"Author":{"description":"The
       author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
       Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"description":"A
       book with a rating. The title should be in all caps!","properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
@@ -15,7 +15,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '910'
+      - '958'
       content-type:
       - application/json
       host:
@@ -45,27 +45,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xWS4/bNhC++1ewbI7ejfyI/Lht0SxaoN0GwQI9xIEwEkc2Y0pUyeE2huH/XpCy
-        ZcmWN0WQmzTfzHAeHzmzHzDGpeBLxg3aKomy8Xi+mL2LJ/Ecp6MoiuJ5PoZxFKfTSTYfLaJUxLiI
-        0xhHYjHOZzkfehc6/YIZndzo0mItzwwCoUjAY6NZHM0mo/jdNGCWgJz1NpkuKoWEojZKIduujXal
-        jysHZbEWS6VkueZLth8wxhivYIfG2wt8QaUrNHzA2CEoozHaY6VTKghkeTolEUggle2ilozLSOqy
-        Iy/ga6IdVY4S0lu8BklrlWSguu4KLVD5yNYV3U313TgaT++i+V0UH8sVXPIl+xQyqfNpOlHY9e1G
-        zOKRmPpGzEfziYjHE4gWk3yaQvAcvNCuwuAHrYU1noFbFQ9gpkvC8hxUO7CO21M98Cs11kEBylIT
-        nGr46XMHVHpdGZ32IMHRkvH9ipMkhSu+XPHn396zp4c/37O/Hpn//vv3p19XfLji4GijzYov9yue
-        S2MpKaGobT4AGZltg5qCNvJR0yZ31q74YbjiBkiW6xVfzg68CeRw/Gpi40arkC9YKy1BSbWyVwxK
-        vAIDSqHqkoCMq/laGXyR2tnkdCWS0N6GJJXRRUVJBtkGky3u2phBsLrssB3zXBtqKfmGuqIAc7Js
-        yG8hR9olUmBJMpfYuQgWzYvMMCF5ujw5OFW3klvSBttJEBYVGiAXxKP76CgNLTtGlmtTwPm/RZUv
-        VpeJzTZYtOgp0GZGVp4nXueBpVpv2b+SNgxY3Zt79rxBFtjA7EY7JViKTJYMlGIZVPanszvfZO/n
-        F623LarXhy5bFOZvBOa2I2KMPwQ+XUivo/Tx1NRjOmcQYr7v0L/uaIWGJNorf75MDVt7UF80n64/
-        69ErsievOOxRO9bWkvH8uFA4XFqcb8I3Tv0Dvv/QwSshcIP/OGlQdF6W65q8EngH+Xzhvkng2MlL
-        +PRq1RPqAgUhpG8xqA/t3oWhM+hLsJXcDybya/xpktzfyP05fNxI/bpph+67feMKvDGYe/uf34ab
-        8/ZY4Jt+6pS/eZUetWGE1uuyyplKW7RDRhs81qxVqBm/1eyP9Vk3MpYl4Rq7ofa28AY3j+f0Vakv
-        40EPN8+hdh6m1xj5f9h4aA1zI8PK5d/qQQvjL2hSbSXt6iVASFecF6N6Vm20zOrh5kjzBjhPZ066
-        SlozO2qEVXsOGFdmcGqskBZSddriXNg9miEhy84SNYrj4TXQWs2aWRLmozhbRp1cL5ezSdQH9Plt
-        Ruwt16QJVCviRdwU0dnuTC2QQACFeXMYHP4DAAD//wMAsEemCVYLAAA=
+        H4sIAAAAAAAAA6xWTW/jNhC9+1ew7B6drGQniu1bim7QAm26WAToYb0QRtTI5poSVXKYrmH4vxek
+        bFmyrWxR9CbNmxnOxyNndiPGuMz5gnGDtk4jAVkWx4WIHkCIOxFFyayYRdP7LIG5mMXz6SwuojxL
+        xOQ+9woZH3sXOvuKgo5udGWxkQuDQJin4LH4IYmj2d3kPg6YJSBnvY3QZa2QMG+MMhCbldGu8nEV
+        oCw2YqmUrFZ8wXYjxhjjNWzRePscX1HpGg0fMbYPymiM9ljllAoCWR1PSXMkkMr2UUvGCZK66slL
+        +JZqR7WjlPQGL0HSWqUCVN9dqXNUPrJVTTd3+mYSTe5uotlNlBzKFVzyBfscMmnyaTtR2tVwI0SC
+        MAuNmGN0h8n0PpviZB5D8By80LbG4AethRWegKGKB1DoirA6BdUNrOf2WA/8Rq11UICq0gTHGn7+
+        0gOVXtVGZ1eQ4GjB+G7JSZLCJV8s+csvH9jz4+8f2B9PzH//+evzz0s+XnJwtNZmyRe7JS+ksZRW
+        UDY2H4GMFJugpqCLfNK0Lpy1S74fL7kBktVqyRcPe94Gsj98tbFxo1XIF6yVlqCiRtkrBiVegwGl
+        UPVJQMY1fK0NvkrtbHq8Emlob0uS2uiyplSAWGO6wW0XMwhWVz22Y1FoQx0l31BXlmCOli35LRRI
+        21TmWJEsJPYugkXzKgWmJI+XpwCnmlZyS9pgNwnCskYD5II4vo0O0tCyQ2SFNiWc/jtU+Wp1lVqx
+        xrJDzxytMLL2PPE6jyzTesP+lrRmwJre3LKXNbLABmbX2qmcZchkxUApJqC2P5zc+SZ7Pz9pvelQ
+        vTl00aEwf5djYXsixvhj4NOZ9DJKH09DPaYLBiHm2x79m47WaEiivfDny9Sy9Qrqi+bT9Wc9eUX2
+        7BXHV9QOtbVkPD/OFPbnFqeb8J1Tf4P/fujojRC4wb+cNJj3XpbLmrwReA/5cua+TeDQyXP4+Go1
+        E+oMhTyXvsWgPnZ7F4bO6FqCneT+ZyK/xZ82yd1A7i/hYyD1y6bt++/2wBV4Z7Dw9j++Dzfn/aHA
+        g36alL97lZ60YYTW67LamVpbtGNGazzUrFOoBz7U7E/NWQMZy4pwhf1Qr7ZwgJuHc65V6VrGoyvc
+        PIXae5jeYuS/YeO+M8yNDCuXf6tHHYy/osm0lbRtloBcuvK0GDWzaq2laIabI81b4DSdOek67czs
+        qBXW3TlgXCXg2NhcWsjUcYtzYfdoh4SsektUnCTjS6CzmrWzJMzH/GQZ9XI9X86m0TXgmt92xA65
+        Jk2gOhHPk7aIzvZnaokEOVCYN/vR/h8AAAD//wMAHLj2blYLAAA=
     headers:
       CF-RAY:
-      - 99026c498848c373-SEA
+      - 99240c9ac8b095dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,15 +73,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:07:36 GMT
+      - Tue, 21 Oct 2025 22:04:13 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        path=/; expires=Fri, 17-Oct-25 20:37:36 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -95,13 +89,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1366'
+      - '1806'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1369'
+      - '1810'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -115,7 +109,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 13ms
       x-request-id:
-      - req_d1352b52a9ce458ca407bcf43d85c7f7
+      - req_6b7d42d1a72d4e589feb3daf8a98d763
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/async.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
-      recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
+      recommend the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
       a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -16,12 +16,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1137'
+      - '1185'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,28 +46,28 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xW227jNhB991ew7D46WfkS2/Fbik3QFm262CboFlUgjKmRzTUlasmhmyDwvxek
-        bFmS7Sy6T1Hmcjhz5tDD1x5jXKZ8zrhBWybRCCYgJqNJhMNZilkUTWbZEIaj8WicRrPBdQQwycbZ
-        JBWL4WwsBgPe9xB68QUF7WF0YbGyC4NAmCbgfYPpJJqOBtMoCj5LQM76HKHzUiFhWiUtQKyXRrvC
-        15WBsliZpVKyWPI5e+0xxhgv4QWNz09xg0qXaHiPsW0IRmO09xVOqWCQxf6UJEUCqWzba8k4QVIX
-        LXsOz4l2VDpKSK/x2Elaq0SAasPlOkXlK1uWdDHWF8NoOL6IZhfRZEdXgORz9k/opOqnnkQm3phD
-        KlD4Ocxmw+vr7OpqsZiJ4fXVOAAHEHopMcC4IjQUyju4z9EenGCWLseCgv815iRJYcznMX/4+Zbd
-        3/x+y/64Y/77r1/uP8S8H3NwtNIm5vPXmGfSWEoKyKucj0BGinUIU9D0fNK0ypy1Md/2Y26AZLGM
-        +Xy6PZTiq04qQsKn/fvPz5v01k4/PEo7WP76eQ1f3NfJ4yHDo/vwJMmlASt0iUmmTQ7kJViPUask
-        4SFn22PsKQykBANKoWrPk4yrpFca3EjtbLJXd1VYPe/S6LykRIBYYbLGl6bPIFhdtISLWaYNNYL8
-        WFyeg9ln1jq2kCG9JDLFgmQmsaVpi2YjBSYk9/cgA6eI766XNthsgjAv0QC5YB5cRjvrMx0qq+iq
-        /2+oKcRVrO0q3qBZaCvJ18xzTKXLD/ev4nGlpcADeleZu9H938EdTrDHV+jMGcyzY4WRZTDOGX+0
-        yGglLfNAjDTDZzIgiKVAwGTBftJ6zaoy/B8GLJMFKLbXwGVc3LCFD/pX0ooBq2R8yR5WyMLFYXal
-        nUrZAj0eKMUElPaH71NsneS1miOhsY05VSIs0ZDEtt1z4ovpGBtm/hA++h3vjkhLxou34dw2I3f3
-        /xj9ncHM5//4/l2KmX1/U8WdxanYO8bpjO1OG0ZofSwrnSm1RdtntMId/Q3Op0ct7Rv+VJ11pmNZ
-        EC6xXWrvRNHc4FcnDaa1ClvnnGLpVMe16akBDWkqfcugPjbHWm/DPcme2u64b85MpMOkl2lVFtMZ
-        gyDlyy4nZ0VV/VzUv/cnvE3C73wgu/eB/RNhZ6V2JJMQX++Sb5z6G3z/ob03Sjg3+C4nbxTe8jyd
-        0+nNsWoale8eXR3vW8r5pqI70L1ORCArvPP8VunsUNJlovSyNHrhD4xqY9lcN8YVAvYSTKWFhdq/
-        +5yFZWNbyKL17BpMo/6xo/GYez28HMQK00Nm1Fpb3efcKDrlOIVbb/Jz0KQJ1ME5jKJ6WznbXt05
-        EvhF4/G3ve1/AAAA//8DANlvM9uICwAA
+        H4sIAAAAAAAAA5xWbW/bNhD+7l/Bcf3opLLj92/e1mADuqwoUmzDFAgn6WRzoUSVPLpJA//3gZQt
+        S7KVYv0U5V4e3j330MeXAWNcpHzFuEZTRkGC03Qymd6MptNJHI+DYLbIFsHNbHkzHU8Wo2UQz5cj
+        mE8xnUGcZss5HzoIFf+LCR1hVGGwsicagTCNwPlG89koWEzGs6n3GQKyxuUkKi8lEqZVUgzJ40Yr
+        W7i6MpAGK7OQUhQbvmIvA8YY4yU8o3b5Ke5QqhI1HzC298GotXK+wkrpDaI4nhKlSCCkaXsNaZuQ
+        UEXLnsNTpCyVliJSj3juJKVklIBsw+UqRekq25R0NVFX42A8uQoWV8HsQJeH5Cv2j++k6qeeRJb0
+        zwECXC7cHBY38XI0DuIM03EywYpvD0LPJXoYW/iGfHkndx/t3gl6Y3MsyPtfQk6CJIZ8FfL7X9+x
+        u/Xv79gft8x9//nb3S8hH4YcLG2VDvnqJeSZ0IaiAvIq5wOQFsmjD5PQ9HxUtM2sMSHfD0OugUSx
+        Cflqvj+V4qqOKkL8ZwHw2ezWwdfPwacdvp99/Sse//z3QpwyHLoLj6JcaDCJKjHKlM6BnATrMSoZ
+        Rdzn7AeMPfiBlKBBSpTteZK2lfRKjTuhrImO6q4Kq+ddapWXFCWQbDF6xOemTyMYVbSEi1mmNDWC
+        3FhsnoM+ZtY6NpAhPUcixYJEJrClaYN6JxKMSBzvQQZWEj9cL6Wx2QRhXqIGst48ug4O1ic6VVbR
+        Vf/fUJOPq1g7VLxDHSsjyNXMc0yFzU/3r+Jxq0SCJ/SuMg+j+7+DO51gzq9QzxnMsWMSLUpvXDH+
+        ySCjrTDMATFSDJ9IQ0IsBQImCvaTUo+sKsP9YcAyUYBkRw1ch8WaxS7oi6AtA1bJ+Jrdb5H5i8PM
+        VlmZshgdHkjJEijND9+n2DrJaTVHQm0ac6pEWKImgW2748QV0zE2zPzefww73gORhrQTb8O5b0Ye
+        7v85+huNmcv/8e2bFDPzdl3F9eJU7J3jdMZ2qzQjNC6WlVaXyqAZMtrigf4G5/Ozlo4Nf6zO6ulY
+        FIQbbJc6uFA01/jZCo1prcLWOZdYutRxbXpoQEOaCtcyyA/Nsdbb8Eiyo7Y77nXPRDpMOplWZTGV
+        MfBSvu5y0iuq6uei/r2/4G0SfusC2Z0LHF4I65XamUx8fL1LvnHqe/j+QwevlNA3+C4nrxTe8jz0
+        6XR9rppG5YdHV8f7mnK+qegO9KAT4cny7zy3VTo7lFQZSbUptYrdgUFtLJvrRtsigaMEU2Eglsd3
+        nzWwaWwLUbSeXaN5MDx3NB5zL6eXQ7LF9JQZtNZW9zl3E1xyXMKtN3kfNCkCeXKOg6DeVta0V3eO
+        BG7ROPz9YP8fAAAA//8DAG6c68WICwAA
     headers:
       CF-RAY:
-      - 99026d65df351fa1-SEA
+      - 99240cf0fdac0943-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -78,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:08:24 GMT
+      - Tue, 21 Oct 2025 22:04:26 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -94,13 +91,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '3865'
+      - '1431'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '3870'
+      - '1436'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -114,7 +111,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 29ms
       x-request-id:
-      - req_eb16eead1e3c4a1cbab9ad003a9328fe
+      - req_a5d55446428c440d9afcfa4f628a5cd0
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/async_stream.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
-      recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
+      recommend the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
       a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -16,12 +16,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1151'
+      - '1199'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=9UsR8SocY2PulkTiuVOqbThjwP.ho1rFU7v0GNKuCfM-1760731685-1.0.1.1-vvTrhEvXtgvHfh4jsIn5qIwlSWjRZ95U3aSfx.CZqVCCLho3uvRBJL6rnDy5ZD35Dio7QDhFJtiYAJR6f2lI71mV4tS.vt.fFww5McTNwHI;
-        _cfuvid=54Fz4_qabuSK8qfrMP4kh_5jawXNjr7d9Q2QsMIRdmk-1760731685162-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -50,7 +47,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07336285d624a39c0068f2a27355908190b1fee547050fc7f3","object":"response","created_at":1760731763,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_099be5393fd430750068f80378e6b8819799ac59c14183c7fe","object":"response","created_at":1761084281,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
         this tool to extract data in Book format for a final response.\nA book with
         a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
         testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -60,7 +57,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07336285d624a39c0068f2a27355908190b1fee547050fc7f3","object":"response","created_at":1760731763,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_099be5393fd430750068f80378e6b8819799ac59c14183c7fe","object":"response","created_at":1761084281,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
         this tool to extract data in Book format for a final response.\nA book with
         a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
         testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -70,174 +67,174 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","type":"function_call","status":"in_progress","arguments":"","call_id":"call_5UNI9XXSutzQOPMwZuA0kuqM","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","type":"function_call","status":"in_progress","arguments":"","call_id":"call_DVo9TZdjZg2XHAJmEfmNEz3E","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"{\"","obfuscation":"aT2y13ZHRnN9rs"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"{\"","obfuscation":"g4eU13Q2pVj1UQ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"title","obfuscation":"p7FkltCI3eu"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"title","obfuscation":"APwpQor6X2Y"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\":\"","obfuscation":"X03eyA9S3LMj8"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\":\"","obfuscation":"VbMnetLBMn52b"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"THE","obfuscation":"1PmlEq4eyvzm1"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"THE","obfuscation":"G1IGA74EbLuvs"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"
-        NAME","obfuscation":"kclXqFX8Cby"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"
+        NAME","obfuscation":"0qX5eWH2Pud"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"
-        OF","obfuscation":"D4bdtbafC6Wzi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"
+        OF","obfuscation":"rWUoIyKRQODHv"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"
-        THE","obfuscation":"ohEdeq4izKmz"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"
+        THE","obfuscation":"PerwCzZLVI1Y"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"
-        WIND","obfuscation":"OJyuTSxWyqk"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"
+        WIND","obfuscation":"XCsqArSoiv5"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\",\"","obfuscation":"JYNa9KcbmURYL"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\",\"","obfuscation":"ToTCNdi90AQNq"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"author","obfuscation":"r7VgmtydrT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"author","obfuscation":"f80Ft0UZRB"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\":{\"","obfuscation":"vtv3r66Pb3Be"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\":{\"","obfuscation":"gK3SdehkX228"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"first","obfuscation":"aRDRydPdUkb"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"first","obfuscation":"UtkmutvjET8"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"_name","obfuscation":"EIYgCn3shbv"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"_name","obfuscation":"oTWZ6AbejTE"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\":\"","obfuscation":"Bs0tjEd976TQX"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\":\"","obfuscation":"Sy7j3VHGbBT3c"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"Patrick","obfuscation":"OiWDG2B0a"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"Patrick","obfuscation":"23Vl11VR0"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\",\"","obfuscation":"uyJJvXtE9X1CD"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\",\"","obfuscation":"ZFcKNznJ9zxHV"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"last","obfuscation":"hKFtrn86jWxO"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"last","obfuscation":"JHE4zTLBXccl"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"_name","obfuscation":"HhQLdXaK9Pi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"_name","obfuscation":"CBCBcO5po35"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\":\"","obfuscation":"gwoMhVBeiVSwW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\":\"","obfuscation":"WZzfuhNUURfHc"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"R","obfuscation":"ywyx79yKdPlYaFH"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"R","obfuscation":"KLosfsQCspjYGVz"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"oth","obfuscation":"1V8u9AGJWQRXB"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"oth","obfuscation":"mz8yzLHkcEt65"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"f","obfuscation":"DRGPlia6mXaIvRi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"f","obfuscation":"gKNLoRB1eBpKLug"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"uss","obfuscation":"HlJeNe7QLSvqE"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"uss","obfuscation":"QqZ5zhXFfaedG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\"}","obfuscation":"wI0wZJXn3BTIf7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\"}","obfuscation":"oE77wyX4CTV9GS"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":",\"","obfuscation":"m6khK3MHeVBkG0"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":",\"","obfuscation":"HpdIW8WR5Z2DFt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"rating","obfuscation":"XrqD5glj6H"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"rating","obfuscation":"c1iWYXJWdl"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"\":","obfuscation":"QisYwtL8RtJByO"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"\":","obfuscation":"o9J7DAUHBtST9X"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":30,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"7","obfuscation":"QuUboQ5Z8rs2HJr"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":30,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"7","obfuscation":"C2lI3IbSVnu4X5N"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":31,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"delta":"}","obfuscation":"KDSIGuF2uz8FB0f"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":31,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"delta":"}","obfuscation":"yx1W1lJObuf3BkW"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":32,"item_id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","output_index":0,"arguments":"{\"title\":\"THE
+        data: {"type":"response.function_call_arguments.done","sequence_number":32,"item_id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","output_index":0,"arguments":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
-        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_5UNI9XXSutzQOPMwZuA0kuqM","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
+        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_DVo9TZdjZg2XHAJmEfmNEz3E","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_07336285d624a39c0068f2a27355908190b1fee547050fc7f3","object":"response","created_at":1760731763,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
-        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_5UNI9XXSutzQOPMwZuA0kuqM","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_099be5393fd430750068f80378e6b8819799ac59c14183c7fe","object":"response","created_at":1761084281,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
+        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_DVo9TZdjZg2XHAJmEfmNEz3E","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
         this tool to extract data in Book format for a final response.\nA book with
         a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
         testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -248,13 +245,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026ef0588675aa-SEA
+      - 99240d532d850899-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:09:23 GMT
+      - Tue, 21 Oct 2025 22:04:41 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -270,15 +267,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '195'
+      - '222'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '207'
+      - '237'
       x-request-id:
-      - req_9e8c6c6fa80b4468ab4684a42b681118
+      - req_f3f2930ebae24b89a5c8ebc977ec7b8b
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/stream.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
-      recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
+      recommend the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
       a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -16,12 +16,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1151'
+      - '1199'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -50,7 +47,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_061b9976bdef3a610068f2a2571ee0819096b85ee34c1a76c1","object":"response","created_at":1760731735,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0eb5ded1c000ab800068f80370d720819493907030015adeca","object":"response","created_at":1761084272,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
         this tool to extract data in Book format for a final response.\nA book with
         a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
         testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -60,7 +57,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_061b9976bdef3a610068f2a2571ee0819096b85ee34c1a76c1","object":"response","created_at":1760731735,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0eb5ded1c000ab800068f80370d720819493907030015adeca","object":"response","created_at":1761084272,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
         this tool to extract data in Book format for a final response.\nA book with
         a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
         testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -70,174 +67,174 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","type":"function_call","status":"in_progress","arguments":"","call_id":"call_C0TOrhWCBNLp9UbAf10piLEw","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","type":"function_call","status":"in_progress","arguments":"","call_id":"call_o6re0ta2aiEIVoIVb6IrXvPI","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"{\"","obfuscation":"aWVBIkH1Q9fvEW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"{\"","obfuscation":"nJRnqbh0lhq2iZ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"title","obfuscation":"3do2IQ09jR0"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"title","obfuscation":"wcoBZFmI92G"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\":\"","obfuscation":"vRE03pBpyhXnf"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\":\"","obfuscation":"rpg1W9VNmNWF9"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"THE","obfuscation":"t5jN0s6pTGNDB"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"THE","obfuscation":"0gArWzdl4XlLK"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"
-        NAME","obfuscation":"PzdRekJwCeM"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"
+        NAME","obfuscation":"f2hoT1wOgku"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"
-        OF","obfuscation":"x6r2rfPn25BJa"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"
+        OF","obfuscation":"J6Q4G4maU1se6"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"
-        THE","obfuscation":"AP0Nvqp1fke0"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"
+        THE","obfuscation":"mPelOpstj0k0"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"
-        WIND","obfuscation":"kGMKWru5TVy"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"
+        WIND","obfuscation":"5GpigP3mN9S"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\",\"","obfuscation":"QrKNEKNNVF03l"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\",\"","obfuscation":"cske3SmKMNcFZ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"author","obfuscation":"gx2gW3hrkj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"author","obfuscation":"9shD2Duefk"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\":{\"","obfuscation":"nnWUJGUvgJD6"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\":{\"","obfuscation":"cs2TqI8QCEDA"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"first","obfuscation":"HIEnlFOtxdb"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"first","obfuscation":"4z0ddwCnUZg"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"_name","obfuscation":"RXUABM30BfS"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"_name","obfuscation":"AZGVk0R06l3"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\":\"","obfuscation":"jzSGP1dVbtum2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\":\"","obfuscation":"RmHC6NuuVTnn6"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"Patrick","obfuscation":"8PYmRR2fe"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"Patrick","obfuscation":"CWNO8HPg7"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\",\"","obfuscation":"LfvQzIcNvgvYr"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\",\"","obfuscation":"GAz4VC8lod974"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"last","obfuscation":"s2I9rjXa1ABe"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"last","obfuscation":"vqFIqU9RkIam"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"_name","obfuscation":"dYqQ3NEf5pe"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"_name","obfuscation":"lSo6s79k8pd"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\":\"","obfuscation":"J3oxwooeHmuGm"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\":\"","obfuscation":"aVI9eLuKq49RA"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"R","obfuscation":"nLQnh9bkMLFa0cs"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"R","obfuscation":"JOBhFPZpqn2IefZ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"oth","obfuscation":"PPpWLCmyKd158"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"oth","obfuscation":"yyBYJTrr12epf"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"f","obfuscation":"eAserC3Rk4XMJyM"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"f","obfuscation":"qUmGTO5VagxuwkR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"uss","obfuscation":"Awf7R5wXR0Ife"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"uss","obfuscation":"G3uprROHee9oz"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\"}","obfuscation":"MJqquptpcuovCP"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\"}","obfuscation":"eUqQEUCjbCr8jw"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":",\"","obfuscation":"wUPsPnSXa8n6R4"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":",\"","obfuscation":"BONJPR2LACaF1j"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"rating","obfuscation":"SpvMOFYvky"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"rating","obfuscation":"W4Q2szaYiJ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"\":","obfuscation":"csB0mLwK7FO99w"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"\":","obfuscation":"7sK7Mz5NuBoEuT"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":30,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"7","obfuscation":"fqW3lYQqsYQckxd"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":30,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"7","obfuscation":"dQVMfoL4JRIsZVE"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":31,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"delta":"}","obfuscation":"wcq9dgKGub3souh"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":31,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"delta":"}","obfuscation":"OHY0KP1jIpzT956"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":32,"item_id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","output_index":0,"arguments":"{\"title\":\"THE
+        data: {"type":"response.function_call_arguments.done","sequence_number":32,"item_id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","output_index":0,"arguments":"{\"title\":\"THE
         NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
-        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_C0TOrhWCBNLp9UbAf10piLEw","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
+        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_o6re0ta2aiEIVoIVb6IrXvPI","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_061b9976bdef3a610068f2a2571ee0819096b85ee34c1a76c1","object":"response","created_at":1760731735,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
-        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_C0TOrhWCBNLp9UbAf10piLEw","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_0eb5ded1c000ab800068f80370d720819493907030015adeca","object":"response","created_at":1761084272,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
+        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_o6re0ta2aiEIVoIVb6IrXvPI","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
         this tool to extract data in Book format for a final response.\nA book with
         a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
         testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -248,13 +245,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99026e401f0a90db-SEA
+      - 99240d20bf9d27d6-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:08:55 GMT
+      - Tue, 21 Oct 2025 22:04:33 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -270,15 +267,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '173'
+      - '189'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '184'
+      - '210'
       x-request-id:
-      - req_e1db8a21aef443ac8cea5032e76da910
+      - req_4ca8d903dd0a49dbafde425b9a7a31b1
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/openai_responses_gpt_4o/sync.yaml
@@ -1,8 +1,8 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
-      recommend the most popular book by Patrick Rothfuss"}],"model":"gpt-4o","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
+      recommend the most popular book by Patrick Rothfuss","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in Book format for a final response.\nA book with
       a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
       testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
@@ -16,12 +16,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1137'
+      - '1185'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=0CHv9hVaZmXfzgKDYL2O6u_2xOpsk5z9LT6kYHZHkEE-1760731656-1.0.1.1-mcgM8zps8TcPSOvvhy4i.uv.gk2.GHnegmpVE0RcZGbk6fHrw4vSw0wncnlhT7SsKtOoiRzQOE54UpKHLNvtNLteNmYgbzPQS3_1dabVfVY;
-        _cfuvid=xsL86Ef4F2w_W6.U_47W1w3Qtfsjrp1bBNnbnKZaUh0-1760731656087-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,28 +46,28 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xWTW/jNhC9+1ew7B6drKwkduKbi90gLdo0SLPYQxUII2lks6ZElRxmExj+7wUp
-        W5ZkK4vuKcp8PM68efRwM2KMi4zPGddoqjgIZ0E2vblMwjAML/IgCKbXeQjhZHpzlVxfT26mcJXM
-        wvxyFuBNEkwuMz52ECr5B1Paw6jSYG1PNQJhFoPzTWbTYHYxmc4C7zMEZI3LSVVRSSTcgSWQrpda
-        2dLVlYM0WJuFlKJc8jnbjBhjjFfwhtrlZ/iCUlWo+YixrQ9GrZXzlVZKbxDl/pQ4QwIhTddrSNuU
-        hCo79gJeY2WpshSTWuOxk5SScQqyC1eoDKWrbFnR2aU6C4Pw8iy4PgumO7o8JJ+zv30ndT/NJPJ0
-        eA6zaTIN/BwgTPNgkqaQhAHOwAN7EHqr0MPY0jfkyzu4h2j3TtBLW2BJ3r+JOAmSGPF5xJ/uPrP7
-        xR+f2Z+3zH1//fX+U8THEQdLK6UjPt9EPBfaUFxCUec8AGmRrn2YhLbnUdEqt8ZEfDuOuAYS5TLi
-        89n2UIqrOq4J8Z9/rR9/m36hh/Lr3b1V+uJOfbrLl1fmkOHQXXgcF0KDSVWFca50AeQk2IxRyTjm
-        Pmc7YuzZD6QCDVKi7M6TtK2lV2l8EcqaeK/uurBm3pVWRUVxCukK4zW+tX0awaiyI1zMc6WpFeTG
-        YosC9D6z0bGBHOktFhmWJHKBHU0b1C8ixZjE/h7kYCXx3fVSGttNEBYVaiDrzZPzYGd9pUNlNV3N
-        /y01+biatV3FL6gTZQS5mnmBmbDF4f7VPK6USPGA3lfmbnT/d3CHE8zxFRo4gzl2TKpF5Y1zxr8Y
-        ZLQShjkgRorhK2lIiWVAwETJflFqzeoy3B8GLBclSLbXwHlULljigr4JWjFgtYzP2dMKmb84zKyU
-        lRlL0OGBlCyFyvz0Y4ptkpxWCyTUpjWnWoQVahLYtTtOXDE9Y8vMn/zHuOfdEWlIO/G2nNt25O7+
-        H6N/0Ji7/J8/fsgwNx8XddwgTs3eMU5vbLdKM0LjYllldaUMmjGjFe7ob3E+O2pp3/BjfdZAx6Ik
-        XGK31NGJornGf63QmDUq7JxziqVTHTem5xY0ZJlwLYN8aI+12YZ7kh21/XEvBibSY9LJtC6LqZyB
-        l/J5n5NBUdU/F83v/Qlvm/BbF8juXeD4RNig1I5k4uObXfKdU3+HHz909E4JQ4Pvc/JO4R3P85BO
-        F8eqaVW+e3T1vO8p57uK7kGPehGeLP/Oc1ult0NJVbFUy0qrxB0YNMaqvW60LVPYSzATBhK5f/dZ
-        A8vWthBl59k1qZ+NPUfrMbc5vBzSFWaHzKCztvrPuYvglOMUbrPJh6BJEciDMwyCZltZ013dBRK4
-        RePwt6PtfwAAAP//AwDmrS7biAsAAA==
+        H4sIAAAAAAAAA5xW23LbNhB911egaB5lh7pYovXmtnabaeNkEnfaTunhLMmliBokGGDh2uPRv3cA
+        ShRJSc40T6b3crB79kCLlxFjXGR8xbhGU8cBzsMgDSHLQ0wu0mkQLMI8DGaLYLKchOHk8uJygstl
+        mIdzvMyyZB7ysYNQyT+Y0g5GVQYbe6oRCLMYnG+yXEyCcD69WHifISBrXE6qyloiYdYkJZA+rLWy
+        lasrB2mwMQspRbXmK/YyYowxXsMzapef4SNKVaPmI8Y2Phi1Vs5XWSm9QVS7U+IMCYQ0fa8hbVMS
+        qurZS3iKlaXaUkzqAQ+dpJSMU5B9uFJlKF1l65rO5upsGkznZ0F4Fiy2dHlIvmJ/+06aftpJ5Okr
+        c1hml6mbAwSzMJzlAcyz5HI2aYA9CD3X6GFs5Rvy5e3dp2j3TtBrW2JF3v8ScRIkMeKriN/9cs1u
+        r95fsw83zH3/8e72p4iPIw6WCqUjvnqJeC60obiCssn5CKRF+uDDJHQ9nxQVuTUm4ptxxDWQqNYR
+        Xy03+1Jc1XFDiP+8xWttZj//SNPk3a9f3n/+XPyZf5iYv/YZDt2Fx3EpNJhU1RjnSpdAToLtGJWM
+        Y+5zNiPG7v1AatAgJcr+PEnbRnq1xkehrIl36m4Ka+dda1XWFKeQFhg/4HPXpxGMqnrCxTxXmjpB
+        biy2LEHvMlsdG8iRnmORYUUiF9jTtEH9KFKMSezuQQ5WEt9eL6Wx2wRhWaMGst48OQ+21ifaV9bQ
+        1f7fUZOPa1jbVvyIOlFGkKuZl5gJW+7vX8NjoUSKe/ShMrej+7+D259gDq/QiTOYY8ekWtTeuGL8
+        d4OMCmGYA2KkGD6RhpRYBgRMVOwHpR5YU4b7w4DlogLJdho4j6orlrigfwUVDFgj43N2VyDzF4eZ
+        QlmZsQQdHkjJUqjNd9+m2DbJabVEQm06c2pEWKMmgX2748QVMzB2zPzOf4wH3i2RhrQTb8e56UZu
+        7/8h+huNucv//u2bDHPz9qqJO4nTsHeIMxjbjdKM0LhYVltdK4NmzKjALf0dzpcHLe0a/tScdaJj
+        URGusV/q6EjRXOMXKzRmrQp75xxj6VjHrem+Aw1ZJlzLID92x9puwx3JjtrhuK9OTGTApJNpUxZT
+        OQMv5fMhJydF1fxctL/3R7xdwm9cILt1geMjYSeldiATH9/ukq+c+ht8+6GjV0o4NfghJ68U3vPc
+        n9Lp1aFqOpVvH10D72vK+aqiB9CjQYQny7/z3FYZ7FBSdSzVutYqcQcGrbHurhttqxR2EsyEgUTu
+        3n3WwLqzLUTVe3ZNlsH40NF5zL3sXw5pgdk+M+itreFzbhYccxzDbTf5KWhSBHLvnAZBu62s6a/u
+        EgnconH4m9HmPwAAAP//AwAMbGHaiAsAAA==
     headers:
       CF-RAY:
-      - 99026cacb863a3ce-SEA
+      - 99240cb8293d95dd-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -78,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:07:52 GMT
+      - Tue, 21 Oct 2025 22:04:17 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -94,13 +91,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1421'
+      - '1834'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1426'
+      - '1839'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -114,7 +111,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 29ms
       x-request-id:
-      - req_3ae4a8a4b0ba4b5c93b1e8509a77207b
+      - req_b642b1263dd74bca9bf4a7bfeeb93ae7
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async.yaml
@@ -7,9 +7,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -19,12 +19,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1090'
+      - '1138'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -52,23 +49,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUTW/bOBC9+1cQPMeFZCu27OMCLZDuoiiwl6KbQhiRI4cxJXLJYRAj8H9fkLL1
-        4TTYmz1P8/hm5s28LRjjSvI94w69rbJMQF7cb6FopCy3RZZtymYF65UQRVGW+W4Nsi7yzXq3us93
-        ZVOv+V2kMPUzCrrSmM5jHxcOgVBWELF8u8m263xXlAnzBBR8zBGmtRoJZZ9UgzgenAld1NWA9tiH
-        ldaqO/A9e1swxhi3cEIX8yW+oDYWHV8wdk4fo3MmYl3QOgVUd32lkkigtJ+jnlwQpEw3i7fwWplA
-        NlBF5ojvQTJGVwL0nK41EnVUdrC0LMxyla2KZVYus82lXYmS79k/qZK+nmESjfh4DrJciSzOYSdy
-        3MEOodhgs940iTiR0MliogldKijJG+GP2p5AcIfQYkcJf3vkytfdI98/8my53dyvl3m+LZc/Hvl5
-        TInsVS88/fTt559f/7Q/np6/yfDl+3PzUL/+NJ9xzOigTQIPSFVtzLFSXWN4Qs8Lxn6lFllwoDXq
-        eYfJhd4M1uGLMsFXV7/1EoYJWGdaS5UA8YTVEU9TzCF4082shE1jHE0+io0KbQvumjk4y0ODdKqU
-        xI5Uo3DmMo/uRQmsSF2d2UDQxC+GNw6nRRC2Fh1QSOH8U3aJvtKorDGuhfH/ZL7P3nTVZfH65l2E
-        v6CrjVcUpfMWpQrtuBh9O5+MEokEAhk+AP69JW/dNI5RohdO2RTcM/6XMUcWLIsTZXGiUbcyHatP
-        7OHvP759+j8DDHAcfYuEzk/K7mdq0ZHCeTzuja+7m1iUrkindx4ifHcDXury5KITJuB5+H0ec7jD
-        f4NyKIcOTZ8eAr8mGSClig0A/X0qfDhoN0Kmk5w8nQSm05oSb7aEjK20OVhn6sidDUE7NZQLnYDr
-        nKTyUOvrrQ0eDji6TXWzU7fKN3fvgckBfRuvgHhCOWZmM0fentDV+nfA73iHXf2ImgyBnjLvBqsH
-        P1/OFgkkEET+8+L8HwAAAP//AwA72pTY/AYAAA==
+        H4sIAAAAAAAAA4RU24rbMBB9z1cIPW+Knaudx0ILW0oplNJCdzGyNE7UyJIqjZYNS/69SE58yfby
+        lszxHJ2ZOTMvM0KoFHRHqANvq0ws802xYtsyL8t8zbNsUzRFtixXS7bmRV6uy+0C1kW5KqDOF5ko
+        6F2kMPVP4HilMdpDF+cOGIKoWMTy7SbPitUyKxLmkWHwMYeb1ipAEF1Szfhx70zQUVfDlIcuLJWS
+        ek935GVGCCHUshO4mC/gCZSx4OiMkHP6GJwzEdNBqRSQ+vpKJQCZVH6KenSBozR6Em/Zc2UC2oAV
+        miO8BtEYVXGmpnStEaCisr3F+crMF9liNc+Keba5tCtR0h35kSrp6ukn0fB/zIFtN6s4h6IuNk2+
+        aErWrLNm2bUukeDJQqIJOhWU5A3w39qeQOb2oQWNCX95oNLX+oHuHmg2327Wy3meb4v59wd6HlIi
+        e9UJTz/rU/u+5s918fXDt4OqP7xt3q3uT4ePQ4ZmbRK4B6xqY46V1I2hCT3PCHlMLbLMMaVATTuM
+        LnRmsA6epAm+uvqtk9BPwDrTWqw44weojnAaYw6YN3piJWga43D0UWxUaFvmrpm9szxrAE+VFKBR
+        NhImLvPgniSHCuXVmQ0LCunF8MbBuAiE1oJjGFI4f5Ndos84KGuMa9nwfzTfn97o6rJ4XfMuwp/A
+        1cZLjNJpC0KGdliMrp0HI3kiYQEN7QH/2pK3bhrGKMBzJ20K7gj9aMyRBEviREmcaNQtjSb1idx/
+        efvpzf8M0MNx9C0gOD8qu5upBYcSpvG4N77WN7EoXaJK79xH+O4GvNTl0UUnjMBz//s85FAHv4J0
+        IPoOjZ/uA4+jDCaEjA1g6vNYeH/QboSMJzl6OglMpzUl3mwJGlsps7fO1JE764N2bCgXNGfXOQnp
+        Wa2utzZ4tofBbVJPTt0i39y9BkYH9GW4AvwAYsjMJo68PaGL5Z+AP/H2u/o3ajTI1Ji57K0e/HQ5
+        W0AmGLLIf56dfwMAAP//AwAcC0UD/AYAAA==
     headers:
       CF-RAY:
-      - 990273773aca7694-SEA
+      - 99240dfe0f539343-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -76,7 +73,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:29 GMT
+      - Tue, 21 Oct 2025 22:05:08 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -92,13 +89,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1155'
+      - '721'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1159'
+      - '725'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -112,7 +109,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 32ms
       x-request-id:
-      - req_7c0f0dca771c40b799d6ed1007a42d61
+      - req_9c16b53ed8af4e36b2985960da96c0b1
     status:
       code: 200
       message: OK
@@ -124,9 +121,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_smEZJKpXhjNduFPjfIbxZoEe","name":"get_book_info","type":"function_call","id":"fc_00ca1457a4fdd8740068f2a32d82c081939c1e9a9ea46ef36f","status":"completed"},{"call_id":"call_smEZJKpXhjNduFPjfIbxZoEe","output":"Title:
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_bymFbcxb8UJWhlbJBfE4IyhL","name":"get_book_info","type":"function_call","id":"fc_0d31684a7919915c0068f80394a76481958b86f12f9af50f3d","status":"completed"},{"call_id":"call_bymFbcxb8UJWhlbJBfE4IyhL","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
@@ -138,12 +135,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1486'
+      - '1534'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -171,24 +165,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//fFVNbxs3EL37VxA82wElrSVLxwAtEKAtCqS3qFjMkrMyYy7JkkMjgqH/
-        XpCr/ZKdnCTNm3kczrxHvd0xxrXiB8YDRl8LIWFVPe6gapV62lVCbJ/aNWzWKKQUT6v9Zt/s1PoR
-        APf7Vsj9mt9nCtd8R0kDjbMR+7gMCISqhoytdlux26z2j6JgkYBSzDXSdd4goeqLGpAvp+CSzX21
-        YCL2YW2Mtid+YG93jDHGPZwx5HqFr2icx8DvGLuUZAzBZcwmY0pA2+GUWiGBNnGJRgpJknZ2Ee/g
-        R+0S+UQ1uRd8D5JzppZglnSdU2hyZydPD5V7WIt19SCeHsT2Oq5CyQ/sW7lJf59xE108/WIRSm7L
-        IprNo4BGVNvtaoeygsJcWOjssfBgjHDCCfjZxAsonSW0U1Pzxha0wzzwB43VJQGsdQTDDL/9uwCN
-        O/ngmg+QQnRg/O1oGTty0mTwyA/syP/UkRoX7IH984zsd23BsN86rwMe+X2fDYmeXejTPwewyln2
-        FazCEJ0dszycMOakx6oaQqkxWpZu6zNCoVgLsT3aCx+7u1y/jQ3z4EwZAsSoI4GlPjknliTuIYAx
-        aJbKoJB6EfuAr9qlWA8+qcvOR+X44DpPtQT5jPULnudYQIjOLiyAbesCzZLyllPXQRgqR0dEaJHO
-        tVZoSbcaF+6IGF61xJr04KgWkun3yyO5gPNLEHYeA1Aq4dUncY2WPV47a13oYPo908/36Gx9fTD6
-        4V0bf8XQuKjp3ItX6dRNhu7H+ey07OefyPERiO+tNJzWJltsPQldYZRB+xI8MP6Hcy8sedbkT237
-        vrWzrDmzL18///VpqrTQFc4TUp3T65w+wXn1HRKGOLt2v1OPgTQu49nvsbE3sdx6dkA+50uG72/A
-        670ihayEGXiZZDvV8ID/JR1QLXw9HD0GZo7koJTOAwDz97zx8SG+fQ5mm5wdXRosfwml8MYl5Hw9
-        exHEGPRzQYVke4cWSeoIjRn+I1J52Ua1abt4ote73f17YPbwjzIpRlNTpVgo8vbpr9YfAR/xjl79
-        GTU5AjOBm9V+lHqKS3N2SKCAIPNf7i7/AwAA//8DAKJGOyS0BwAA
+        H4sIAAAAAAAAAwAAAP//fFVNj9w2DL3vrxB03g3s+fYcA7RAgLYokN4yhUHb9KyysqhK1CKDxfz3
+        QvL4a3aTk20+kqLI9+i3ByGkauRRSIfellmzzneHDeyLvCjybZ1lu0N7yNbFdrWqDoe82ELdFtV6
+        tcVtDdsmX8nHmIKq71jzkIaMx95eOwTGpoSI5ftdnh0266xImGfg4GNMTZ3VyNj0QRXUL2dHwcS6
+        WtAee7PSWpmzPIq3ByGEkBYu6GJ8g6+oyaKTD0JckzM6RxEzQetkUGY4pWyQQWm/RD27ULMis7B3
+        8KOkwDZwyfSC70Em0mUNepmuowZ1rOxs+WlDT6tstXnKDk/Z7taulFIexbd0k/4+4yQ6f/7FIPaH
+        Qz8ILNa7DNsC8gKyqm94ysIXiykPeg/nGfCzjiewJsNopqLmhS3SDv3AHzxGJwcwhhiGHn77dwFq
+        OltH1QdISnQU8u1khDhJVqzxJI/iJP9Unity5ij+eUbxuzKgxW+dVQ5P8rH3hsDP5Hr3zw5MQ0Z8
+        BdOg82RGLwtn9NFpu9kMplBpVadqywtCSrHKst3JXOVY3fX2NhYsHenUBPBeeQbDvXN0TE7SggOt
+        US+ZwS70JLYOXxUFXw46KdPMR+ZYR53lsob6GcsXvMwxh+DJLCSAbUuOZ05xyqHrwA2RoyI8tMiX
+        UjVoWLUKF+rw6F5VjSWrQVEtBN3PV3omh/NLMHYWHXBI5vxTdrOmOd4qa8l1MH3P+PPdkylvC6Nv
+        3q3wV3QVecWXnryNCt0k6L6dz6Tqvv+BSY6Afy+l4bQ2mCTriegN+topm4xHIf8gehHBiio+lenr
+        VmREdRFfvn7+69MUaaBLOc/IZXQvo/sEx9F3yOj87Nr9TC06Vri0R737ytzZYulRAfGcLxF+vANv
+        9/LsIhNm4HWi7RQjHf4XlMNmoevh6NEwU6SEplGxAaD/nhc+LuL7dTCb5OzoVGD6JaTAO5Uw2XK2
+        EbLRaOeEcsH0Ck2UVB4qPfwjQtpsI9uUWazo1X7/+B6YLf6RJklozRSZLRh5v/o3q4+Aj/KOWv1Z
+        aiYGPYHrvBipHvxSnB0yNMAQ818frv8DAAD//wMArdzwGrQHAAA=
     headers:
       CF-RAY:
-      - 9902737f4bdc7694-SEA
+      - 99240e03ac849343-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -196,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:31 GMT
+      - Tue, 21 Oct 2025 22:05:10 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -212,13 +206,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1350'
+      - '1413'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1357'
+      - '1420'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -232,7 +226,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 37ms
       x-request-id:
-      - req_0219e5b79e0949e18b95ca0e68e07f38
+      - req_aa08adc9c19d442d80c424a2c0705f3d
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async_stream.yaml
@@ -7,9 +7,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -19,12 +19,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1104'
+      - '1152'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -53,107 +50,107 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f36bbfa154ea31e0068f2a39a46888190b312cf66e569ece5","object":"response","created_at":1760732058,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_00ca34419d991c140068f803b48ca48197a055dcc2eaee5830","object":"response","created_at":1761084340,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f36bbfa154ea31e0068f2a39a46888190b312cf66e569ece5","object":"response","created_at":1760732058,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_00ca34419d991c140068f803b48ca48197a055dcc2eaee5830","object":"response","created_at":1761084340,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","type":"function_call","status":"in_progress","arguments":"","call_id":"call_5tpYH2kVrLA3lru58ufOs4ws","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","type":"function_call","status":"in_progress","arguments":"","call_id":"call_bYchQSy9hJphpJ5Kqqfnyhcr","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"{\"","obfuscation":"3e61qzIRhT6DE4"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"{\"","obfuscation":"bSZRXsmsk33p9M"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"isbn","obfuscation":"OmSFQsEbwf3v"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"isbn","obfuscation":"DTmPuWP1rLPv"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"\":\"","obfuscation":"lmCJNLpYrLRw0"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"\":\"","obfuscation":"a86oFAVuIj9Pg"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"0","obfuscation":"hOc5v67Yrpxb1sA"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"0","obfuscation":"p7Bu17MIHrz51g4"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"-","obfuscation":"CWnZT7NGBHvy9Ak"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"-","obfuscation":"KbKMASsZhO5Vqrz"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"765","obfuscation":"LZ1R3aC1Xw4yG"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"765","obfuscation":"IAkTJnnLk503p"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"3","obfuscation":"v8hzsp5kXmgQ70x"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"3","obfuscation":"6hxbJpaDjLtvWCr"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"-","obfuscation":"LhkSs5fxMhtMXLN"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"-","obfuscation":"ycaqyLundtvRlaO"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"117","obfuscation":"sKFH1iQNkQT6p"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"117","obfuscation":"bbVnNy7qlOZoL"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"8","obfuscation":"G4KPUBGjAsw7peY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"8","obfuscation":"4y1MVgkVVOpdJQD"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"-X","obfuscation":"db1quQ4SK6SQ9W"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"-X","obfuscation":"oz6exCcsnZyn4d"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"delta":"\"}","obfuscation":"oMUN0lNsuuRwc6"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"delta":"\"}","obfuscation":"l9RcnVXV5fJ7S4"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_5tpYH2kVrLA3lru58ufOs4ws","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_bYchQSy9hJphpJ5Kqqfnyhcr","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0f36bbfa154ea31e0068f2a39a46888190b312cf66e569ece5","object":"response","created_at":1760732058,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_5tpYH2kVrLA3lru58ufOs4ws","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_00ca34419d991c140068f803b48ca48197a055dcc2eaee5830","object":"response","created_at":1761084340,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_bYchQSy9hJphpJ5Kqqfnyhcr","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":216,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":239},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 99027623b89f0917-SEA
+      - 99240ec7f8f0b9c7-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:18 GMT
+      - Tue, 21 Oct 2025 22:05:40 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -169,15 +166,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '138'
+      - '203'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '149'
+      - '214'
       x-request-id:
-      - req_b087a27cfa9f43e5b38896b7e6b6cdef
+      - req_3d77ab615a30434ab1b8a6ae291fdb13
     status:
       code: 200
       message: OK
@@ -189,9 +186,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_5tpYH2kVrLA3lru58ufOs4ws","name":"get_book_info","type":"function_call","id":"fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505","status":"completed"},{"call_id":"call_5tpYH2kVrLA3lru58ufOs4ws","output":"Title:
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_bYchQSy9hJphpJ5Kqqfnyhcr","name":"get_book_info","type":"function_call","id":"fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c","status":"completed"},{"call_id":"call_bYchQSy9hJphpJ5Kqqfnyhcr","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
@@ -203,12 +200,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1500'
+      - '1548'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -237,266 +231,266 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f36bbfa154ea31e0068f2a39b59a881908c6675f187485d5d","object":"response","created_at":1760732059,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_00ca34419d991c140068f803b5f9cc8197b340f45eded6bc56","object":"response","created_at":1761084342,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f36bbfa154ea31e0068f2a39b59a881908c6675f187485d5d","object":"response","created_at":1760732059,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_00ca34419d991c140068f803b5f9cc8197b340f45eded6bc56","object":"response","created_at":1761084342,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"GK8ES21VokCgOo"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"e6tz87onQ7wRhK"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"V5fqTe4NGKP1eTx"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"So55araocTWrP3D"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"GZv0BOaUklltA5"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"DCWZYCrcO8Jy4P"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"0oajAgxoDbl"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"NRLwby4bjdv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"wZgbUivcgI6kbJ"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"y38fpO4auJiJOv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"vhXtYY9vMNH6H2"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"ExR0sAdigh99Ez"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"jw9sHcHrLXRT"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"3KECIZkAxEt1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"eH8PXxwjDbIR"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"tXdIJAMH1zcT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"l3nBfEp74bmmhUI"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"Fx0VDi8mLRBvA2i"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"qHCHqwJRMTWu"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"TXR6begoaLfL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"nSfpzEiUAQ"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"cLYMqebtvd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"ZNHvLi8RS"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"AjnDLzmKj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"eldZTHONV3JTB"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"2AsaPTatOHeR9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"dgiIVM8CjugTo6C"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"K4zNpA7RuPIf4db"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"jFvsTtuQwqeApO"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"ZuH2t72hR7EiW7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"4IDh052gtV"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"iA1R86LwFc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"KFXL4qOb5GIhzo"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"lj13Np5Tr0a8vD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"cEfgpuQHxbghTK"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"6fjJqrMTAGzzZy"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"XP0M3AIPq3s2k2"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"ce7UoYEOXXaKMt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"grp1uMVjV9N"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"ssV8A9xKx7u"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"algQN266KfT"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"YcWpk0YGMdg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"fr4CRGF5xBb"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"e2s6efiJ5nY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"nng2uuC0TRUDR"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"B0VdXYLhOgS7s"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"4uUYK3YETdDR7xC"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"bcF25PUtaCjCN5M"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"BU68Xz0Us3IwzX"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"BDCH5VKuqAlDcl"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"oc84te9xvMu"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"fWB8jEKcRIW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"j3Nfr6Vbbibq0w"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"Un0vXVzAPLgks2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"u79wemhybKb4Kwa"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"XNiAiZsKzTHvgdm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"oA6mHPLTHlgzY"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"nOu6Xak2n3J5A"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"1aEByIgCp6OhP9"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"Dp5mdd9utyrs0H"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"z1ZiZxOVuzIQ0Qo"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"X1Og0HgZXDZNFiJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"2VOn0YbJ6SHObk"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"w2jYhjaNzbK4Xt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"oOGGN"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"XBl8c"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"CsVgkaWdkW1"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"G8HKCe6wTtd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"E6HeJP3wmiUVgT"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"uWYHFB1HLzPLm7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"OzPAZgXzLYPAz8n"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"71KfGRKpB4IXbCE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"6pFnfIVW5XdNf"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"BExktvyx7YZv6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"aHpoTUrl0E4AfxH"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"KSWUTx7XXdGZhYt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"Yzt2IuGVc71a4gu"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"vbJPHf9X417YFbR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"QpZMDWanWNpik5I"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"q5853mdmNZUaEi5"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"text":"{\n  \"title\":
+        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_0f36bbfa154ea31e0068f2a39b59a881908c6675f187485d5d","object":"response","created_at":1760732059,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_00ca34419d991c140068f803b5f9cc8197b340f45eded6bc56","object":"response","created_at":1761084342,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":277,"input_tokens_details":{"cached_tokens":0},"output_tokens":42,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":319},"user":null,"metadata":{}}}
@@ -505,13 +499,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 9902762a89190917-SEA
+      - 99240ed0d857b9c7-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:19 GMT
+      - Tue, 21 Oct 2025 22:05:42 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -527,15 +521,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '92'
+      - '246'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '98'
+      - '260'
       x-request-id:
-      - req_33f36ec501ec4646ade7aca6545ac258
+      - req_aebff2907726426cb9f458efbcc17f8e
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/stream.yaml
@@ -7,9 +7,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -19,12 +19,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1104'
+      - '1152'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -53,107 +50,107 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a091f1f54f473470068f2a361bde48197bae71e33c2d5664f","object":"response","created_at":1760732001,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0ff76143e6db39820068f803a14f8c81938599d5dca2ab3b92","object":"response","created_at":1761084321,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a091f1f54f473470068f2a361bde48197bae71e33c2d5664f","object":"response","created_at":1760732001,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0ff76143e6db39820068f803a14f8c81938599d5dca2ab3b92","object":"response","created_at":1761084321,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","type":"function_call","status":"in_progress","arguments":"","call_id":"call_D4nyNr9jTi00FFRjW885O8Rm","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","type":"function_call","status":"in_progress","arguments":"","call_id":"call_2INHCCeQ8YZLZ5y7szu4oLAu","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"{\"","obfuscation":"9hCnJd9f1rI4Re"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"{\"","obfuscation":"8QVG3pz7U26TZW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"isbn","obfuscation":"G97CCI7pHre8"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"isbn","obfuscation":"s14xB8ck8IKw"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"\":\"","obfuscation":"7ACYbH3bIF1Go"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"\":\"","obfuscation":"bdoI3bPl5qQp3"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"0","obfuscation":"qthb5IZYQWJv9tV"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"0","obfuscation":"dse89Frgp015nFo"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"-","obfuscation":"pyVWP5BndYANJm3"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"-","obfuscation":"anbc3P9WKksoVLm"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"765","obfuscation":"uKHNeMEPv78Cu"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"765","obfuscation":"QFncUcIQSQRFD"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"3","obfuscation":"8rd3CL94ty4ZUHI"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"3","obfuscation":"wMYaWqRiPPmh998"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"-","obfuscation":"bATVQWI9HT2zh9z"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"-","obfuscation":"1Hie00jJvDjrLXt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"117","obfuscation":"J0iBvewANMDCA"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"117","obfuscation":"PDLhRoNzKkzs2"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"8","obfuscation":"wCbi9ia6OS2JhFp"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"8","obfuscation":"aBRzZg4ZE1iNfoC"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"-X","obfuscation":"gBzWdMdToapTK2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"-X","obfuscation":"vmvj4VWK3BZbfX"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"delta":"\"}","obfuscation":"pQxPEr3i3uF2vX"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"delta":"\"}","obfuscation":"kdbh2noX7Tmvmn"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_D4nyNr9jTi00FFRjW885O8Rm","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_2INHCCeQ8YZLZ5y7szu4oLAu","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0a091f1f54f473470068f2a361bde48197bae71e33c2d5664f","object":"response","created_at":1760732001,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_D4nyNr9jTi00FFRjW885O8Rm","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0ff76143e6db39820068f803a14f8c81938599d5dca2ab3b92","object":"response","created_at":1761084321,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_2INHCCeQ8YZLZ5y7szu4oLAu","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":216,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":239},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990274c27b1ef8d1-SEA
+      - 99240e4fce87c4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:21 GMT
+      - Tue, 21 Oct 2025 22:05:21 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -169,15 +166,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '59'
+      - '150'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '66'
+      - '162'
       x-request-id:
-      - req_5c2857e8779043d98d7081f12e990cd1
+      - req_12870c11a68f463e9c5f6ce0b447afd6
     status:
       code: 200
       message: OK
@@ -189,9 +186,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_D4nyNr9jTi00FFRjW885O8Rm","name":"get_book_info","type":"function_call","id":"fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0","status":"completed"},{"call_id":"call_D4nyNr9jTi00FFRjW885O8Rm","output":"Title:
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_2INHCCeQ8YZLZ5y7szu4oLAu","name":"get_book_info","type":"function_call","id":"fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0","status":"completed"},{"call_id":"call_2INHCCeQ8YZLZ5y7szu4oLAu","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
@@ -203,12 +200,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1500'
+      - '1548'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -237,266 +231,266 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a091f1f54f473470068f2a3632e148197b3c94e60e4941d40","object":"response","created_at":1760732003,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0ff76143e6db39820068f803a25d848193b4d07b3fdd32a831","object":"response","created_at":1761084322,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a091f1f54f473470068f2a3632e148197b3c94e60e4941d40","object":"response","created_at":1760732003,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0ff76143e6db39820068f803a25d848193b4d07b3fdd32a831","object":"response","created_at":1761084322,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"uxfyd9uIOupH2e"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"ObN0gv9QXj9cqk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"TexNAcx5CAMXQ02"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"sJJ0ZJFX5KDflLd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"pZYSl9eYhaAvR4"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"B59AitPJulAdX0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"NJ7tSe9zsOh"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"pe1Jh68Osbe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"chaZpoOhFtMKM6"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"1VXGBCsBAygPRH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"1X1YWWgVT2b2dS"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"RePdpXxy1Z5qBx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"x7SBeCv31E1H"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"2Po7RS1EeCbp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"rRlrtFXfOxA9"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"Xh9ZxRAZa1jl"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"2dGYNOdXuCeODDZ"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"m8nMPIXLtAVv3jm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"ZYYfEfdtrlYK"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"o5gl6ehyOBn7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"ijdmSKtQFS"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"P0mOBYqPPS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"byS6aHsP6"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"eBueQ2zdc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"hdJ6XfnyAmdd0"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"JRCQbVupoukjs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"SXzHC2Vr4tlxJyQ"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"EximArh8uUWaQhj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"SmKtukXDSgKPhL"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"Si0FDlkTA2vBcJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"vjui0HHjLi"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"SL2PTDVHYZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"30jgr7qYv5zBCS"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"ozNClmYu1YHhdi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"5irkZvIyzOQGy1"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"QKAs7p9018YoBU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"JEBP67gkKAYtZ3"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"rsOLSNjMyihZzh"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"lT6ii2UJTcO"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"mjJrstH1DMb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"n8gYmXItkKe"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"aMh8bQizLTe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"F7tqA87El18"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"DvPVbmdOx1f"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"NjcsXorkJlmSQ"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"ZwyQewYNwZ8XZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"51vtw0UTdVc229K"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"XVH5QrP6Ix0LvPu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"YX5Zut0pAdRCNv"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"EwUAAzTNt6L7Zj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"1gHWo2AwFbR"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"JkPFKrHdWiK"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"NPfFsJxwOIzXKy"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"j8momgZktj86MP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"wiwzpONiiNcSN4D"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"mm8nSj4s9s685rG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"fmcwlaIqKcvKU"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"jpdiSi8NL1RP3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"1wPUtAYJoMqry4"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"0xrcJNl1ZuqLUL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"vL2rhFJfefag2JA"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"1XIX2fcyS0htkIj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"wVWlndjzUOp2RH"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"AujQyQGORoR6sf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"wFXXL"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"5GJMj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"nmsneL5tBfk"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"LfXNkEOT3JI"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"ktb8N4dBz6hX1K"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"5IRFRnaC2eIuYS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"b48See9FgfPYZZm"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"oRRVoEkxiNbCBNe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"Wn0JYmGR246mG"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"qZuKKH0SNOKcs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"TlBqCBORxjSKyCF"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"B224krllJxAJXtP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"xqGjzpMloaW2XIC"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"OcZzt9SNxsJh36U"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"zkQ8wBX5JxaFWN7"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"5WcfmVGjCdYAw4E"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"text":"{\n  \"title\":
+        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_0a091f1f54f473470068f2a3632e148197b3c94e60e4941d40","object":"response","created_at":1760732003,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_0ff76143e6db39820068f803a25d848193b4d07b3fdd32a831","object":"response","created_at":1761084322,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":277,"input_tokens_details":{"cached_tokens":0},"output_tokens":42,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":319},"user":null,"metadata":{}}}
@@ -505,13 +499,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 990274cb7b76f8d1-SEA
+      - 99240e565e2ec4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:23 GMT
+      - Tue, 21 Oct 2025 22:05:22 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -527,15 +521,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '86'
+      - '292'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '93'
+      - '302'
       x-request-id:
-      - req_87473a689e2b4a7ca41d21ce90fb6fa2
+      - req_8af04be9d62b4b4eb96c4cd1805a7369
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/sync.yaml
@@ -7,9 +7,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
@@ -19,12 +19,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1090'
+      - '1138'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -52,23 +49,23 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RU247bOAx9z1cIep4Udq5OHrdAgQGKYi9Ft2inMGiLzqiRJVWiBs0O8u+F5MSX
-        TAf7lvCYR4fkIZ9njHEp+J5xh96WGWzr7WZTFVWR4xrrLNsUzQIWTVY0UBf5brPb4U6s1k3RLIsV
-        VsjvIoWpvmNNVxqj/SVeOwRCUULE8u0m2y7zoigS5gko+JhTm9YqJBRdUgX18eBM0FFXA8pjF5ZK
-        SX3ge/Y8Y4wxbuGELuYLfEJlLDo+Y+ycPkbnTMR0UCoFpL6+UgokkMpPUU8u1CSNnsRb+FmaQDZQ
-        SeaIL0EyRpU1qCldawSqqOxgab4y80W2WM2zYp5tLu1KlHzPvqZKunr6STT163PI8wZXcQ6wWxXr
-        TGS7Yp0vFwiJOJHQyWKiCToVlOQN8GttTyC4Q2hRU8KfH7j0lX7g+weezbeb9XKe59ti/vmBn4eU
-        yF52wtPPj+pv8/7T2xWYH39p9d/i87388O+Xd27I0NAmgQeksjLmWErdGJ7Q84yxb6lFFhwohWra
-        YXKhM4N1+CRN8OXVb52EfgLWmdZSWUP9iOURT2PMIXijJ1bCpjGORh/FRoW2BXfN7J3loUE6lVKg
-        JtlInLjMo3uSNZYkr85sICjiF8Mbh+MiCFuLDiikcP4mu0R/0qCsMa6F4f9ovt+90eVl8brmXYQ/
-        oauMlxSl8xaFDO2wGF07H42sEwkEMrwH/EtL3rppGKNAXztpU3DP+HtjjixYFifK4kSjbmk0q07s
-        /p8/Prz5PwP0cBx9i4TOj8ruZmrRkcRpPO6Nr/RNLEqXpNI79xG+uwEvdXly0Qkj8Nz/Pg853OGP
-        IB2KvkPjp/vAt1EGCCFjA0D9ORbeH7QbIeNJjp5OAtNpTYk3W0LGlsocrDNV5M76oB0bygVdw3VO
-        Qnqo1PXWBg8HHNwm9eTULfLN3UtgdECfhytQP6IYMrOJI29P6GL5O+B3vP2uvkZNhkCNmXe91YOf
-        LmeLBAIIIv95dv4FAAD//wMAZfFGI/wGAAA=
+        H4sIAAAAAAAAAwAAAP//hFTbbtswDH3PVwh6bgrbaRwnj8UwoF03bNiwC9bCkC061SJLmkQVC4r8
+        +yA58SVdsbeExzw6JA/5PCOECk43hFpwpkzWa8iqKge+KKomWSZJXjRFsijSvMiLIl2vKhZjVZ0t
+        13lW5PQiUOjqF9R4otHKQRevLTAEXrKApas8TYqrrFhHzCFD70JOrVsjAYF3SRWrd1urvQq6GiYd
+        dGEhpVBbuiHPM0IIoYbtwYZ8Dk8gtQFLZ4Qc4sdgrQ6Y8lLGgFCnV0oOyIR0U9Sh9TUKrSbxlv0p
+        tUfjsUS9g5cgai3LmskpXas5yKBsa3B+pedZkl3Nk2KenNoVKemG/IyVdPX0k2jq1+eQraq0jnMA
+        vlwtEr7MIWNFuojEkQT3BiKNV7GgKG+AX2t7BJnd+hYURvz5ngpXqXu6uafJfJUvF/M0XRXz7/f0
+        MKQE9rITHn++vXnz5fbz7e127d/fLb69W+8W1+7H109DhmJtFLgFLCutd6VQjaYRPcwIeYgtMswy
+        KUFOO4zWd2YwFp6E9q48+a2T0E/AWN0aLGtWP0K5g/0Ys8CcVhMrQdNoi6OPQqN82zJ7yuyd5VgD
+        uC8FB4WiETBxmQP7JGooUZyc2TAvkR4Nry2Mi0BoDViGPobTy+QY/YODskbblg3/R/P95bQqj4vX
+        Ne8o/AlspZ3AIJ22wIVvh8Xo2vmoRR1JmEdNe8C9tOS5m4YxcnC1FSYGN4Teab0j3pAwURImGnQL
+        rUi1Jzefrz9c/s8APRxG3wKCdaOyu5kasChgGg974yp1FgvSBcr4zk2AL87AY10ObXDCCDz0vw9D
+        DrXw2wsLvO/Q+Ok+8DDKYJyL0AAmP46F9wftTMh4kqOno8B4WmPi2ZagNqXUW2N1FbiTPmjGhrJe
+        1ew0Jy4cq+Tp1nrHtjC4TajJqcvS/OIlMDqgz8MVqB+BD5nJxJHnJzRb/Av4F2+/q69Ro0Ymx8zr
+        3ureTZezBWScIQv8h9nhLwAAAP//AwDaGcOv/AYAAA==
     headers:
       CF-RAY:
-      - 990271feff7debfa-SEA
+      - 99240d883c3630e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -76,7 +73,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:11:29 GMT
+      - Tue, 21 Oct 2025 22:04:51 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -92,13 +89,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '996'
+      - '1757'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1001'
+      - '1765'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -112,7 +109,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 32ms
       x-request-id:
-      - req_20d7fa1e177b41ffb6d96c2d5a548ff0
+      - req_30e4c1f1760a46a1a9b5f31c4ecc29d0
     status:
       code: 200
       message: OK
@@ -124,9 +121,9 @@ interactions:
       \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
       \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
       [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"role":"user","content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_TlRoLVC4aoqQnlz2XIiNWZFr","name":"get_book_info","type":"function_call","id":"fc_0a7c766b8b81e5ec0068f2a2f11fe48196a94850d0985132ea","status":"completed"},{"call_id":"call_TlRoLVC4aoqQnlz2XIiNWZFr","output":"Title:
+      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":[{"text":"Please look
+      up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_FIDTJSJJg9uML3WK9k3BsYVQ","name":"get_book_info","type":"function_call","id":"fc_099e2bb6ed38bf050068f803827b1c8197bed5730d56e2a813","status":"completed"},{"call_id":"call_FIDTJSJJg9uML3WK9k3BsYVQ","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
@@ -138,12 +135,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1486'
+      - '1534'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -171,24 +165,24 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RVTW/jNhC951cQPCcLSZYt28cFWmCBtiiwva0LYSSOHG4okiWHwRqB/3tByvpy
-        kpPteTOPw5n36LcHxrgU/Mi4Q2/rDKq22u2afbPPcYttlu32XQFFl0PVZfv8sDtkWVlCecgQuk0p
-        NvwxUpjmJ7Y00hjtcYi3DoFQ1BCxvNpl1Sbf7w8J8wQUfKxpTW8VEoqhqIH25exM0LGvDpTHISyV
-        kvrMj+ztgTHGuIULulgv8BWVsej4A2PXlIzOmYjpoFQKSD2eUgskkMqvUU8utCSNXsV7+FWbQDZQ
-        TeYF34NkjKpbUGu63ghUsbOzpafSPBVZUT5l+6dsdxtXouRH9iPdZLjPtInenz9fRLEptmVaRFXk
-        26bCKs+67VZsE3NioYvFxIPewxln4LOJJ7A1mlDPTS0bW9GO88BfNFWnBNDaEIwz/PHvClTmbJ1p
-        PkAS0ZHxt5Nm7MRJksITP7IT/1N6aozTR/bPM7LfpQbFfuutdHjij0M2BHo2bkj/6kALo9l30AKd
-        N3rKsnBGH5O2ZTmGQqNkm7qtLwiJosiy3Ulf+dTd9fZtapg7o9IQwHvpCTQNyTExJXELDpRCtVYG
-        uTCI2Dp8lSb4evRJnXY+Kcc601uqW2ifsX7ByxJzCN7olQWw64yjRVLccuh7cGPl5AgPHdKllgI1
-        yU7iyh0e3atssSY5OqqDoIb9ck/G4fIShL1FBxRSOP+S3aJpj7fOOuN6mH8v9PPTG13fHoxheLfG
-        X9E1xku6DOIVMvSzoYdxPhvZDvMPZPgE+PdWGk/rgk62noUu0LdO2hQ8Mv6HMS8sWNbET6mHvqXR
-        rLmwb9+//vVlrtTQJ84zUh3T65g+w3H1PRI6v7j2sFOLjiSu49HvvtF3sdh6dEA851uEH+/A2708
-        uaiEBXidZTvXcIf/BelQrHw9Hj0FFo7kIISMAwD197Lx6SG+fw4Wm1wcnRpMfwmp8M4lZGy9eBGy
-        KWiXgnJBDw5NkpQeGjX+R4T0sk1qk3r1RBdV9fgeWDz8k0yS0cRcma0Uef/0l8VHwEe8k1c/oyZD
-        oGZwkx8mqQe/NmePBAIIIv/14fo/AAAA//8DABh0kPC0BwAA
+        H4sIAAAAAAAAA3RVTW8jNwy951cIOieLsT1ObB8XaIEF2qLA9rYuBpwRx9FGI6oSFawR+L8X0ni+
+        nORkm498osj35Lc7IaRW8iCkx+CqYr/HdV0/otrs6rbYFsXjrt0Vm92mVdtit9o/7euyBFWofb0u
+        ikfVyvtEQfVPbHigIRuwjzcegVFVkLDV0+Oq2JXr/TpjgYFjSDUNdc4go+qLamheTp6iTX21YAL2
+        YW2Mtid5EG93QgghHZzRp3qFr2jIoZd3QlxyMnpPCbPRmBzQdjilUsigTViigX1sWJNdxDv4VVFk
+        F7liesH3IBOZqgGzpOtIoUmdnRw/lPSwLtblQ7F7KB6v48qU8iB+5Jv09xk30YXT54vYliU2aRHQ
+        bqHcwK5dFbt6t11n5szCZ4eZB0OAE07AZxPPYEOW0U5NzRtb0A7zwF88VucEsJYYhhn++HcBGjo5
+        T/UHSCY6CPl2tEIcJWs2eJQHcZR/6sA1eXsQ/zyj+F1bMOK3zmmPR3nfZ0PkZ/J9+lcPVpEV38Eq
+        9IHsmOXghCElbctyCMXa6CZ3W50RMkVS9NFe5Njd5fptbFh6MnkIEIIODJb75JSYk6QDD8agWSqD
+        fexF7Dy+aoqhGnxS5Z2PynGeOsdVA80zVi94nmMeIZBdWADbljzPktKWY9eBHypHRwRokc+VVmhZ
+        txoX7gjoX3WDFevBUS1E0+9XBiaP80swdg49cMzh1ZfiGs17vHbWku9g+j3Tz89Atro+GP3wro2/
+        oq8paD734lU6dpOh+3E+k276+UcmOQLhvZWG09pos60noSsMjdcuBw9C/kH0IqITdfrUtu9bkxX1
+        WXz7/vWvL1OlhS5znpCrlF6l9AlOq++Q0YfZtfudOvSscRlPfg+1vYml1pMD0jnfEnx/A17vFdgn
+        JczAyyTbqUZ6/C9qj2rh6+HoMTBzpASldBoAmL/njY8P8e1zMNvk7OjcYP5LyIU3LmFy1exFKMag
+        mwvKR9s7NEtSB6jN8B8R88s2qk3bxRO9fnq6fw/MHv5RJtloaqosFoq8ffrL9UfAR7yjVz+jZmIw
+        E7hZ7Uepx7A0Z4cMChgS/+Xu8j8AAAD//wMAoxuYmbQHAAA=
     headers:
       CF-RAY:
-      - 99027205fdccebfa-SEA
+      - 99240d93ed6f30e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -196,7 +190,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:11:30 GMT
+      - Tue, 21 Oct 2025 22:04:54 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -212,13 +206,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1100'
+      - '2927'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1103'
+      - '3621'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -232,7 +226,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 37ms
       x-request-id:
-      - req_3d35fb176cc440b2a5f8e82a9075b1bd
+      - req_47fbebd8f0164cd7b14f5c03053e634d
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '830'
+      - '878'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,25 +42,25 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xWTY/bNhC9+1cIPK8DWZIte28NegnQFlskRVt0A4GiRjJjimTI4WaNhf97QcrW
-        h9faJr3Z88jH+Xgzo5dFFBFekfuIGLC6iMssLTdJyoDFdEfjON5s64SmGcvX62y72qW7BDb1Ls2y
-        bZXmNNuSO0+hyi/A8EKjpIXOzgxQhKqgHlvlmzhPV7ttHDCLFJ31d5hqtQCEqrtUUnZojHLS+1VT
-        YaEzcyG4bMh99LKIoigimh7B+PsVPIFQGgxZRNEpHAZjlMekEyIYuLy8UlSAlAs7RS0ax5ArObG3
-        9LlQDrXDAtUBXoOolCgYFVO6VlUgvGeNxmWmlkmcZMt4u4w353QFSnIf/RMi6eLpK1Gz+TpUSbKL
-        Qx3ybZLFLN/mdJfEdR2IAwkeNQQaJ0NAwb0Bnkt7AKlpXAsSA/7ySLgt5SO5fyTxMt+s0+VqlW+X
-        fz2S03DFsxed4+Fn3Lg/P63TfSoP376y39eb3fOvf3yTPw83JG2Dgw1gUSp1KLisFQnoaRFFn0OK
-        NDVUCBDTDKNxnRi0gSeunC0ueutc6CugjWo1FoyyPRQHOI4xA9QqOZES1LUyODrkE+XalprLzV5Z
-        ltaAx4JXIJHXHCYqs2CeOIMC+UWZNXUCyVnwysA4CIRWg6Hognn1Lj5bn3HwrFampcP/UX2/WCUL
-        y/bQ0iG3FVhmuPZ1n0QzSvt7pQ4fz7ENquh4hme6HGowyMFO7N4FjgKujCMz+RR+3F2hZ78tGp/7
-        EXganyTU4T707hz7T92B/0mvafMqoDH7Q8BnyLlEaLo5M8PuSsEZDX13BPpWGA/D0ehvf/QH3lzc
-        eJ0Y+Oq4gaqfK5MXb+X4RmLejqYHP4/e7SO6paxRIOclMUJoVXFPTsXDWGth5i+uAgyFDTvG989i
-        hJEnMKWyHH2vkhYq7tphE3TzY684C05Qh4r0gH09g6/H51xvkV+UOkROR36ERX6E+Ub1xSyP0YeP
-        7397918Tr4f9rGsBwdjvbUA/l9+Q1gcPf39//JCawtM3dfBWNeflMF/nQQbDWkClC6EabVTpuePe
-        qMcT1DjZqTbMYG5pKS4fF87SZhhdhMvJbl+l2d1rYPTF8DKsPbaHargZTxR5/c2QpLeAW7z9cpqj
-        RoVUjDxe573UnZ1uoxaQVhTDWD8tTv8CAAD//wMAZcFjiO0JAAA=
+        H4sIAAAAAAAAA5xWTW/bOBC9+1cIPMeFZFu2nNv2FmARBE0PbTeFMJJGMmNKZMihUSPwf1+QsvXh
+        2N52b/Y88nE+3szofRIEjBfsPmAajUrDOFxisoCizOcZRnkYLpMyCefrLMIsT6J1vIYEZmFZhMuy
+        LOIZsDtHIbNXzOlEIxuDrT3XCIRFCg6LVssoTBbzKPaYISBr3J1c1kogYdFeyiDfVlraxvlVgjDY
+        mrkQvKnYffA+CYIgYAr2qN39AncopELNJkFw8IdRa+mwxgrhDbw5vZIWSMCFGaOGtM2Jy2Zkr+FX
+        Ki0pSynJLX4ESUqR5iDGdLUsUDjPKkXThZzOwtliGibTcHlMl6dk98E/PpI2nq4SZX6jDtkMfR1g
+        tYhijFfJGpNiFc88sSehvUJPYxsfkHevh6+l3YOgK1tjQx5/f2HcZM0Lu39h4XS1jOfTKFol028v
+        7NBfcexp67j/Gb6Ktf4RhW+P33Zfd/Xbl3rz43n+8NjfaKD2DlZIaSblNuVNKZlHD5Mg+OlTpECD
+        ECjGGSZtWzEojTsurUlPemtd6CqgtKwVpTnkG0y3uB9iGsHIZiQlLEupaXDIJcrWNejTzU5ZBkqk
+        fcoLbIiXHEcqM6h3PMeU+EmZJVhB7Ch4qXEYBGGtUANZb44+hUfrL+o9K6Wuof8/qO+rkU1q8g3W
+        0Oe2QJNrrlzdR9EM0v5Zyu3zMbZeFS1P/0ybQ4WaOJqR3bnASeCZcWBmX/2PuzP06Lch7XI/AA/D
+        kwwsbXzvXmP/qz3wP+kVVB8CGrI/efwKOW8Iq3bOXGG3meA5+L7bI9wK46k/Gnx3R//gzcmF15nG
+        N8s1Ft1cGb14KccXEnM7mg78OXi3i+iSsgaBHJfEAIGi4I4cxNNQa37mT84C9IX1O8b1z2SAsR3q
+        TBpOrldZjQW3db8J2vmxkTz3ToAlyTrAfJzB5+PzWm+xv6XcBlYFboQFboS5RnXFzPbBw/Pnx0//
+        NfE62M26Ggm1+d0GdHP5hrQeHPz7/fFHavJPX9TBrWpel8P1Ovcy6NcCSZUKWSktM8cddkY1nKDa
+        Nq1q/QzmBjJx+riwBqp+dDHejHZ7NF/cfQQGXwzv/drLN1j0N8ORIs+/GWbzS8Al3m45XaMmSSAG
+        HserTurWjLdRjQQFkB/rh8nhXwAAAP//AwBRBWR37QkAAA==
     headers:
       CF-RAY:
-      - 9902743d6b0d34ef-SEA
+      - 99240e28f8192b1e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -71,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:13:01 GMT
+      - Tue, 21 Oct 2025 22:05:16 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -87,13 +84,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1125'
+      - '883'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1130'
+      - '887'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -107,13 +104,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_b052b76882784cdc8ff9a939218d3dfb
+      - req_4e0c2268de454dc2b714062a4a44d0b3
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_0guWT53h3nkwqcQ569xMUwnD","name":"get_book_info","type":"function_call","id":"fc_0b43b623cec0a9a00068f2a34d22908193978240c787a920ff","status":"completed"},{"call_id":"call_0guWT53h3nkwqcQ569xMUwnD","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_0jl9rZ10qNXvTvmqRmhZS3IN","name":"get_book_info","type":"function_call","id":"fc_0506e84adfc3be1c0068f8039bb2ec8195a7415e5789e8d752","status":"completed"},{"call_id":"call_0jl9rZ10qNXvTvmqRmhZS3IN","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -126,12 +123,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1226'
+      - '1274'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -159,27 +153,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+xWTY/bNhC9+1cQPHsDWdbKH7cu0AIB2iLA5lLEgUCRI5sxRarkcBFj4f9ekLL1
-        4bWNbA855WR53vBxyHkznNcJIVQKuibUgmuKpMzmZZ7OOfCErViSJPmyStk8E5yn2XK2mpdJyXMh
-        smpZ8VmeAp0GClN+A45nGqPdyc4tMARRsIDNFnmymM9Wy1nEHDL0Lqzhpm4UIIh2Ucn4fmuN1yGu
-        iikHrVkqJfWWrsnrhBBCaMMOYMN6AS+gTAOWTgg5Rmew1gRMe6WiQerzLoUAZFK5MerQeo7S6JG9
-        Zt8L47HxWKDZw1sQjVEFZ2pMVxsBKkS2bfAhMw9pkmYPyfIhyU/XFSnpmnyJJ2nP02WidtvbiYBy
-        UfGYiDRdQFVVj49VXmaPZWSOLHhoIPKAc2wLPXDrxiPIjUbQfVDDwEa05/uA79itjg5Ma4PsfIdf
-        vo5AZbaNNeUVJBKtCX3dUJSoYEPXG/qXdFgaq9fk8w7IH1IzRX6vG2lhQ6cbyjzujI2eT5ZpYTR5
-        ZlqAdUZHh4ZtwW3o+jHLwj9fKsljaMUBWFiYJkl+pF0cx9NXFxq1RsXjMuekQ6axdT5O352yarXk
-        sXZWi+pxAVmWzRelEKvlr5T9nJRNTk60YZYpBWpctmh922EaCy/SeFecm1gRs9uVdWNN3WDBGd9B
-        sYfDELPAnNGj/gRVZSwOnEI+fV0ze17ZtSvHKsBDIQVolJWEUetyYF8khwLlud1VzKs2k9ShsTA8
-        BELdgGXoo3n2ITlZY8ZOkVXG1qz/P1DKN2d04fgOatbrTIDjVjYhF6PTEEI1q+O6J2P2z6ez9eJt
-        edYDUYY7bMCiBDeyhxCCki6MAzP9HD+mF+gpboc23P0API6FHtV3h/231uF/0kft3mH/FPEb5FIj
-        bNvH6wb7RS3c26h3Jf8E13fsObmyO7Xwr5cWxKjJdDteu+MrF3P/NB04aDL9ia4pa9ja2sljgDAh
-        ZCBn6tNQa3GQmFwcMCY2Di6hfoYNnr6ALY2TeGj7spC+7seLtn/sjORtw/FoaAe4tw/7OdrK6zhk
-        3Kot+qcxe+IbUoZfqdtCDcksD+Tj89PfH+ib0tsCFsG9CO49HHpdDQjW/WgBSlfqO9L6GOAfr493
-        qSlufVUH97J5Ww6389zLoH8W0DTF4LFLOmMz7KDW61a1sQdLx0p1nlh9fLS79ir1aGCcrRbTt8Bg
-        DO1kEl8W0a9MRoq8HETz/Bpwjbd7nG5Ro0GmejDN553UvRu/RjUgEwxjWz9Ojv8BAAD//wMA0Oxh
-        VEIMAAA=
+        H4sIAAAAAAAAAwAAAP//7FZNb+M2EL37VxA8JwvZVhTbtwZogQXaYoHspVgvhBE5crihSJUcBmss
+        /N8LUrY+EtvY9NBTT5bnDR9nOI/D+TFjjCvJN4w79G2Z3WUFrnKQtVhWOBdZVqzqVbZci+Vqka3m
+        67t1jtWdXC+hgHyZ1/f8JlLY6hsKOtFY47GzC4dAKEuI2Py+mGerfDkvEuYJKPi4Rtim1Ugou0UV
+        iOeds8HEuGrQHjuz0lqZHd+wHzPGGOMt7NHF9RJfUNsWHZ8xdkjO6JyNmAlaJ4Myp11KiQRK+ynq
+        yQVBypqJvYHvpQ3UBirJPuNbkKzVpQA9pWusRB0j27V0m9vbRbbIb7PVbVYcjytR8g37kjLp8ukr
+        0fjdlUJIsUqFgPxeVoWQIq/n1VouEnNioX2LiQe9hx0OwKUTT6CwhtAMQY0Dm9CezgO/U786OYAx
+        luB0hl++TkBtd62z1RkkEW0Y/7HlpEjjlm+2/A/lqbLObNjnJ2S/KQOa/dq0yuGW32w5BHqyLnk+
+        ODDSGvYIRqLz1iSHFnbot3xzl+fxX6i0Eim0co8QFy6yrDjwPo7D8asPjTurU7rgvfIEhjrnw827
+        SyahyPNYsioXdZEvs2pxJ3CB8/9L9t+UbHZ04i040Br19NqSC12HaR2+KBt8eWpiZapuf61bZ5uW
+        SgHiCctn3I8xh+CtmfQnrGvraOQU6xmaBtxpZd+uPNRI+1JJNKRqhZPW5dG9KIElqVO7qyHorpLc
+        k3U4ToKwadEBhWSef8iO1lSxY2S1dQ0M/0dK+eatKb14wgYGnUn0wqk21mKSDWPcQJPWPVj7/HjM
+        bRBvx7MZiTKeYYuOFPqJPYYQlfTKODLzz+nj5hV6jNuTi2c/Ag9ToSf1XWH/pXP4l/RJu1fYPyX8
+        ArkyhLvu8brA/uouXNtocGV/Rdd37Dk7szt3+HdQDuWkyfQ7njvjMwdzPZseHDWZIaNzyhq3tm7y
+        GCEgpYrkoD+NtZYGidmrBFNh0+AS78+4wfMXdJX1ivZdX5YqNMN40fWPJ6tE13ACWd4D/u3Dfoq2
+        DiYNGZfuFv/d2mcWWlbFX2W6ixqLWe3Zx8eHPz/wN1dvh1RG9zK6D3DsdQ0SOv+zF1D5ylyR1scI
+        //z9eJea0tZndXCtmpflcLnOgwyGZ4FsW44eu6w3tuMO6oLpVJt6sPJQ6dPEGtKj3bdXZSYD43x9
+        f/MWGI2hvUzSyyKHldlEka8H0aI4B5zj7R+nS9RkCfQALoplL/Xgp69RgwQSKLX1w+zwDwAAAP//
+        AwBKz78tQgwAAA==
     headers:
       CF-RAY:
-      - 99027445b8d634ef-SEA
+      - 99240e2feda12b1e-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -187,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:13:04 GMT
+      - Tue, 21 Oct 2025 22:05:18 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -203,13 +197,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2276'
+      - '1958'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2282'
+      - '1965'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -223,7 +217,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 33ms
       x-request-id:
-      - req_453588ecd0454c3c94d6802d4186ccd5
+      - req_3e6e230d3d5e4f138c8abed89c26b8b3
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '844'
+      - '892'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,96 +43,96 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f2867689be255460068f2a3b5bd108197a874d2c291b350e4","object":"response","created_at":1760732085,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_008c4d6177f0dd430068f803bac408819686dc4a2781c8edf6","object":"response","created_at":1761084346,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f2867689be255460068f2a3b5bd108197a874d2c291b350e4","object":"response","created_at":1760732085,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_008c4d6177f0dd430068f803bac408819686dc4a2781c8edf6","object":"response","created_at":1761084346,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","type":"function_call","status":"in_progress","arguments":"","call_id":"call_ICStYLn3q6R7vLjGUPsRQE6a","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","type":"function_call","status":"in_progress","arguments":"","call_id":"call_GfbuCcXYgL5vFxE32PPp9kHQ","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"{\"","obfuscation":"R23X3F7IWRdKQc"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"{\"","obfuscation":"NmmtOuNKUqIRZX"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"isbn","obfuscation":"jbnLY6HiQWy6"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"isbn","obfuscation":"c4MFz6sQQmAM"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"\":\"","obfuscation":"0IqHjP3YmKO9I"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"\":\"","obfuscation":"Www68bwZtZBZo"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"0","obfuscation":"L8thDCrlyXww1hm"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"0","obfuscation":"UDEjmQKENFPlcc2"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"-","obfuscation":"hq0tPxkFvoiTD9y"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"-","obfuscation":"Msdtip5I4Ubk5ks"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"765","obfuscation":"d2rD86SKpfAB6"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"765","obfuscation":"CprLWMTnCDvsp"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"3","obfuscation":"aR65Z7wS6szWpJc"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"3","obfuscation":"AOGnNd4AFWewzpY"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"-","obfuscation":"agzHgmqK0GHHA1v"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"-","obfuscation":"DaHChsAsx1moKmn"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"117","obfuscation":"oBOGGPhTv2gHi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"117","obfuscation":"8x2ahkWldyMnP"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"8","obfuscation":"zmDMWGX0rfBEsFK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"8","obfuscation":"7XUyPbPeTN3mLxi"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"-X","obfuscation":"sbSZdaDdaUuepX"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"-X","obfuscation":"4mMhl5BnHODu4L"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"delta":"\"}","obfuscation":"EuP6xFcLNAcRJh"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"delta":"\"}","obfuscation":"vd5TMKiuIH7pMs"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ICStYLn3q6R7vLjGUPsRQE6a","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_GfbuCcXYgL5vFxE32PPp9kHQ","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0f2867689be255460068f2a3b5bd108197a874d2c291b350e4","object":"response","created_at":1760732085,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ICStYLn3q6R7vLjGUPsRQE6a","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_008c4d6177f0dd430068f803bac408819686dc4a2781c8edf6","object":"response","created_at":1761084346,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_GfbuCcXYgL5vFxE32PPp9kHQ","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
 
@@ -143,13 +140,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 990276cf7be1a389-SEA
+      - 99240eeecd683095-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:45 GMT
+      - Tue, 21 Oct 2025 22:05:46 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -165,21 +162,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '94'
+      - '113'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '96'
+      - '117'
       x-request-id:
-      - req_345de22223314f69b3746a280b5545ab
+      - req_743e062d1aa34ef3aa2018f0fd9c5792
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ICStYLn3q6R7vLjGUPsRQE6a","name":"get_book_info","type":"function_call","id":"fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6","status":"completed"},{"call_id":"call_ICStYLn3q6R7vLjGUPsRQE6a","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_GfbuCcXYgL5vFxE32PPp9kHQ","name":"get_book_info","type":"function_call","id":"fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9","status":"completed"},{"call_id":"call_GfbuCcXYgL5vFxE32PPp9kHQ","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -192,12 +189,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '1288'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -226,203 +220,371 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f2867689be255460068f2a3b6ae2881979e2f619827af669c","object":"response","created_at":1760732086,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_008c4d6177f0dd430068f803bbee648196bfec8b8507ec8e9b","object":"response","created_at":1761084348,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f2867689be255460068f2a3b6ae2881979e2f619827af669c","object":"response","created_at":1760732086,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_008c4d6177f0dd430068f803bbee648196bfec8b8507ec8e9b","object":"response","created_at":1761084348,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"WMT0e4DfHnv6vK"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"5AK9iMBDqpg7pm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"hel8C6MKE0K"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"UhInipnY66a"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"neXHYskMPpqQU"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"X3GxYIdtVkkrx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"3ks241JOgqIP"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"cWjpXqITJkk3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"Di03SfGU5GU4"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"Sfoog6iU6EjR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"RIST1OBApkiXddb"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"a8YgzSPvAQbmgLd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"gihd5mTmPg6D"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"8C62H487S4s5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"0M13hGWLD2"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"SrkTLpsoG0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"PoQUe4BXL"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"vKwJ3xUu3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"mQygqvm4jSPsF"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"HXXZUyrhq3rc5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"QlTQs4iATx"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"bFfMPrEr5r"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"3W8QHl25KOxXy"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"VjvIGPhe2528i"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"QQgxiCVD5dRz9N"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"DANPzZtCwUkK3b"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"XdWDTme1lDc"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"cVW1T3VMDjc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"rAu0DShPCdX"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"wXWEbmgdG3t"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"L7i5z2NyJhv"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"lt97mXGmjXp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"8C9gVab7Ij741"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"JgMzJpIZpnlx7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"sV06J6oLMJN"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"WJI5sskQXSQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"6NE5QJP99V5fLW"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"0FpfJKzx6RuVb6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"LtRuYyQbjucsr"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"TDYuISIrK3rch"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"7epyYJl4D6pWqR"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"AJz0HkoroA2dde"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"PsLyC"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"eCoxn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"8UgTFgW8HRK"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"RWgznQ0bElq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"N9uDKIbWwtlb25"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"Cv5t37OZOXi7qp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"pSH3AXInt4GN4"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"g4luldyJmSLao"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"CvpjtMkHQYHAy8N"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"OHNpMBkUtZMJktM"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"oDJO0i4RPxbyTFZ"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"SlF4mp4cgSTPTyR"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":34,"output_index":1,"item":{"id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":35,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"qR2wCDG54fy116"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"uIYZhQk8euM"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"YtCmfI0bESFn6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"eFyT5NdzTTeY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"C6mnWXLIOu4J"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":":","logprobs":[],"obfuscation":"EWntTDqjkYMIEYO"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"5ZPR3vuv6j3s"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"csKvLBjJVi"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"1IxZY8sO2"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"kZkUZEecj10ts"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"vTnzl6rUy3"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"OmjDJMm8xtobd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"bZMILVFwjbcip7"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"rPd7om3bhYR"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"22NWxSFbOHH"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"wTCBkPBAzsa"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"LhPKVD7DUvZwT"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"rmV6E0e541I"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"VrjaWCU2kgUSS1"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"KuElqyuWVEaGk"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"FNRq9enoGfbTiF"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"8ik7m"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"LQWPG7NDRCm"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"G6omg3qRLk1dNJ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"kndubd38mQ7uS"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"dn79SYijlGNY5PG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"mmVik57ZiWqSj4j"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":63,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":64,"item_id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":65,"output_index":1,"item":{"id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_0f2867689be255460068f2a3b6ae2881979e2f619827af669c","object":"response","created_at":1760732086,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.completed","sequence_number":66,"response":{"id":"resp_008c4d6177f0dd430068f803bbee648196bfec8b8507ec8e9b","object":"response","created_at":1761084348,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"},{"id":"msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":197,"input_tokens_details":{"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":263},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990276d55a01a389-SEA
+      - 99240ef5faf93095-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:46 GMT
+      - Tue, 21 Oct 2025 22:05:48 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -438,15 +600,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '112'
+      - '407'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '133'
+      - '421'
       x-request-id:
-      - req_732d18b81b8a48ba955bfe52ad4da4eb
+      - req_3bb6b1d128e44447956fc84b5a975e56
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '844'
+      - '892'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,110 +43,110 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0822e9aa79f336090068f2a3853f008196ba0c0d95fd0d17d9","object":"response","created_at":1760732037,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c4df536f5e319de0068f803a86f988193ab81335adc1dbf3d","object":"response","created_at":1761084328,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0822e9aa79f336090068f2a3853f008196ba0c0d95fd0d17d9","object":"response","created_at":1760732037,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c4df536f5e319de0068f803a86f988193ab81335adc1dbf3d","object":"response","created_at":1761084328,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","type":"function_call","status":"in_progress","arguments":"","call_id":"call_UD9LFETOWfReeJ89TBROECDh","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","type":"function_call","status":"in_progress","arguments":"","call_id":"call_ICOTPIFHgVe7l5McAwKJXgSh","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"{\"","obfuscation":"WxEq37yD06iEXW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"{","obfuscation":"Mip6gAxvmcWqJda"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"isbn","obfuscation":"xXn2IEfVYk5f"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"\"isbn","obfuscation":"kEVSakSurTY"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"\":\"","obfuscation":"4fcjjZFg5Bm42"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"\":","obfuscation":"WKBru1KtpwQu0k"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"0","obfuscation":"zHfvCeTQfFRifFd"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"\"0","obfuscation":"ooSppsnLaJLNKZ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"-","obfuscation":"hYS76Ig1M4j7cie"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"-","obfuscation":"E34q2ayRVwhYxG9"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"765","obfuscation":"1TTjhxm9GejD2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"765","obfuscation":"oSAyQb5jUbKxT"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"3","obfuscation":"p7t7nmobki7HPGT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"3","obfuscation":"f2LtyF2yVkVD6NA"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"-","obfuscation":"Y8sULEs9G6fnaGY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"-","obfuscation":"kZWeDiOPxIww9OT"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"117","obfuscation":"lo7GWheRg3WMY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"117","obfuscation":"Uh65YDWjLehl3"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"8","obfuscation":"aXS8ZpJVrfzLcof"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"8","obfuscation":"FgcPuh7SfTT0Gzk"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"-X","obfuscation":"ypQ5TRx62bSyqu"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"-X","obfuscation":"hg8X0gQ4CJStmj"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"delta":"\"}","obfuscation":"f9Rcnp1LiMmiBe"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"delta":"\"}","obfuscation":"bSiXvifxHbJ2LC"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_UD9LFETOWfReeJ89TBROECDh","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ICOTPIFHgVe7l5McAwKJXgSh","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0822e9aa79f336090068f2a3853f008196ba0c0d95fd0d17d9","object":"response","created_at":1760732037,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_UD9LFETOWfReeJ89TBROECDh","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0c4df536f5e319de0068f803a86f988193ab81335adc1dbf3d","object":"response","created_at":1761084328,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ICOTPIFHgVe7l5McAwKJXgSh","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":39,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":173},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990275a02e6776bc-SEA
+      - 99240e7c2ca7c4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:57 GMT
+      - Tue, 21 Oct 2025 22:05:28 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -165,21 +162,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '260'
+      - '253'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '282'
+      - '270'
       x-request-id:
-      - req_67478fe743f84651a7e1c387eb87f733
+      - req_961c851d49d048a4b30fa1ab8f5945cf
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_UD9LFETOWfReeJ89TBROECDh","name":"get_book_info","type":"function_call","id":"fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8","status":"completed"},{"call_id":"call_UD9LFETOWfReeJ89TBROECDh","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ICOTPIFHgVe7l5McAwKJXgSh","name":"get_book_info","type":"function_call","id":"fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b","status":"completed"},{"call_id":"call_ICOTPIFHgVe7l5McAwKJXgSh","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -192,12 +189,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '1288'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -226,203 +220,203 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0822e9aa79f336090068f2a386750c8196b86ff89bb5aae73f","object":"response","created_at":1760732038,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c4df536f5e319de0068f803ab52448193977f1d3c7340718d","object":"response","created_at":1761084331,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0822e9aa79f336090068f2a386750c8196b86ff89bb5aae73f","object":"response","created_at":1760732038,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c4df536f5e319de0068f803ab52448193977f1d3c7340718d","object":"response","created_at":1761084331,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"h56ckUrCnTvdsz"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"mGjUvVTtSh7S4h"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"6dIx2msnPWM"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"xM9q2hW6zGd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"bgJ5ppltGjw7b"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"hq6vNdn6tAoe5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"VHWOqhz99gB5"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"Rn17lqWqcFD7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"T43XvfVJFqkG"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"HEEOsWkOv9Rf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"FHmA5nvec8ZJr4t"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"x6XBDuV6wDXVR8r"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"LG89BxqSMBsw"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"xmEqoqXV2E2t"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"zftAjoj464"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"GDMp6z78TN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"e1ZCNtJ67"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"VX7Mrq2NE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"jGNBKjAgkqKh3"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"Zu76txcLZ68rN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"zGknLSPmyM"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"lrppDTzlsV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"XsawCbP6jo0rV"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"EjBX0DmCD8IMB"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"uKdtSAxyBG3Jy4"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"boye8Dm0QmzlOZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"CKwe3IC2eoH"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"mUUYXZVttJy"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"srziFUBBL0v"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"fUpSzhVjT9a"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"37KQHJrfsyd"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"l2NlZNNRdIZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"zE83JeLKtM3qF"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"NwlSx7WZ5FiXa"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"Hei8V77HVfp"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"GQQPcnWfOij"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"JfrowaxcJSyRo1"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"ZYmWw9ZPHq0GT7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"RkfNITN8KlUG3"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"nb8FtLqrPlNSm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"N9ilSdEhsM55td"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"nVgmSNYdZ27E1Z"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"8Ngqd"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"zVCEt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"fncn7vuyyec"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"3P4GbgBZ2Kp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"fdNHYQ6aYFnoq4"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"6kcegg1F6ylXLr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"LcvFVBMAUEVUa"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"AijzhHjkp04iY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"P31gtu44rlCGj2N"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"UB60zZuncJOA5Wd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"LzPmhKU1hDVC2bq"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"cJNqqmWWLn8U5jI"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_0822e9aa79f336090068f2a386750c8196b86ff89bb5aae73f","object":"response","created_at":1760732038,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_0c4df536f5e319de0068f803ab52448193977f1d3c7340718d","object":"response","created_at":1761084331,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":192,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":225},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990275a7ed3b76bc-SEA
+      - 99240e8df942c4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:58 GMT
+      - Tue, 21 Oct 2025 22:05:31 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -438,15 +432,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '155'
+      - '600'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '176'
+      - '652'
       x-request-id:
-      - req_3eba50e027d84db897b5334129f85714
+      - req_8019b559527d46fc9bfc18ce1848e2e1
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '830'
+      - '878'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -45,25 +42,25 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xW247bNhB991cQfF4Huvi6bw2KIFsUxQZJii66gUBRI5kxJbLkcBFn4X8vSNm6
-        eK1t0jd7Dnk4lzMzep4RQkVBbwk1YHUWrVarKF4liyRNlimUUbTalAlL4zzf8sUm3kY5zyNYbPmy
-        KOMNLFN64ylU/hU4nmlUY6G1cwMMociYx+L1Klqn8TaNA2aRobP+Dle1loBQtJdyxveVUa7xfpVM
-        WmjNQkrRVPSWPM8IIYRqdgDj7xfwBFJpMHRGyDEcBmOUxxonZTCI5vxKVgAyIe0YtWgcR6Gakb1m
-        3zLlUDvMUO3hJYhKyYwzOaarVQHSe1ZpnC/UPImSxTzazKPVKV2Bkt6Sv0MkbTxdJUo+XQe+2CQb
-        X4dNxLcLnpZ5wQHyvM13IMGDhkDjmhBQcK+Hp9IeQGYqV0ODAX9+pMLmzSO9faTRfL1apvM4Xm/m
-        fz3SY3/Fs2et4+Hnh4df3+nvn9Z6/WA+/JnAb5+54e/vov5Gw+rgYAWY5UrtM9GUigb0OCPkS0iR
-        ZoZJCXKcYTSuFYM28CSUs9lZb60LXQW0UbXGjDO+g2wPhyFmgFnVjKQEZakMDg75RLm6ZuZ8s1OW
-        ZSXgIRMFNChKASOVWTBPgkOG4qzMkjmJ9CR4ZWAYBEKtwTB0wRy/iU7Wb9h7VipTs/7/oL5frWoy
-        y3dQsz63BVhuhPZ1H0UzSPtbpfYfT7H1qmh5+mfaHGowKMCO7N4FgRIujAMz/RR+3FygJ78tGp/7
-        AXgcnqTM4S707hT7L+2B/0mvWfUioCH7fcAnyEWDULVzZoLd5VJwFvruAOy1MO77o+TBH/2JN2dX
-        XqcG/nHCQNHNldGL13J8JTGvR9OBXwbvdhFdU9YgkNOSGCCsKIQnZ/J+qLUw82cXAYbChh3j+2c2
-        wOgTmFxZgb5XaQ2FcHW/Cdr5sVOCByeYQ0U7wL6cwZfjc6q36O9K7YnTxI8w4keYb1RfzPxA7j6+
-        /ePNf028DvazrgYEY3+0Af1cfkVadx7+8f74KTWFp6/q4LVqTsthus69DPq1gEpnUlXaqNxzR51R
-        DyeocU2r2jCDhWW5PH9cOMuqfnRR0Yx2e5wubl4Cgy+G537t8R0U/c1opMjLb4YkvQZc4+2W0xQ1
-        KmRy4PFy3Und2fE2qgFZwTCM9ePs+C8AAAD//wMAbR4kNu0JAAA=
+        H4sIAAAAAAAAA5xWy27bOhDd+ysEruOCfsiWs2u7anFRBOhF0aIpBIocyYwpkSWHRo3A/16QsvVw
+        7Nz27uw55OE8zszoeZIkRApynxALzuQ0W/DVooTNrKB8k6aUrrIyo4uMpemCZ7MN3WzYfAUrKsSS
+        UrFMyV2g0MUTcDzT6MZBa+cWGILIWcBm69WMZsv5JouYQ4behTtc10YBgmgvFYzvKqt9E/wqmXLQ
+        mqVSsqnIffI8SZIkIYYdwIb7AvagtAFLJklyjIfBWh2wxisVDbI5v5ILQCaVG6MOrecodTOy1+xX
+        rj0ajznqHbwEUWuVc6bGdLUWoIJnlcHpUk/ndL6c0mxKV6d0RUpyn3yPkbTxdJUo+e06FLN0lYU6
+        FOl6wTd0kVEh0s18HYkjCR4MRBrfxICiez18K+0RZLbyNTQY8edHIl3RPJL7R0Kn61W6mM5m62z6
+        9ZEc+yuBPW8djz+/FE8oymy7z6r35fZT+VHLAn7uv/U3GlZHByvAvNB6l8um1CSix0mS/IgpMswy
+        pUCNM4zWt2IwFvZSe5ef9da60FXAWF0bzDnjW8h3cBhiFpjTzUhKUJba4uBQSJSva2bPNztlOVYC
+        HnIpoEFZShipzIHdSw45yrMyS+YVkpPgtYVhEAi1AcvQR/PsDT1Zf2HvWaltzfr/g/o+Od3kjm+h
+        Zn1uBThupQl1H0UzSPs7rXefT7H1qmh5+mfaHBqwKMGN7MEFiQoujAMz+Tf+uLtAT347tCH3A/A4
+        PEmYx23s3Vvsb9sD/5PesOpFQEP2h4jfIJcNQtXOmRvsvlCSs9h3B2CvhfHQH02+haN/8ebkyuvE
+        wk8vLYhuroxevJbjK4l5PZoO/DF4t4vomrIGgZyWxABhQshAztTDUGtx5k8uAoyFjTsm9M9kgJE9
+        2EI7iaFXSQ1C+rrfBO382GrJoxPMoyYd4F7O4Mvxeau3yD9a7xJvkjDCkjDCQqOGYhaH5MPnd5/e
+        /NfE6+Aw62pAsO5PGzDM5Vek9SHAf94ff6Wm+PRVHbxWzdtyuF3nXgb9WkBtcqUrY3URuGlnNMMJ
+        an3TqjbOYOlYoc4fF96xqh9dRDaj3T5bLO9eAoMvhud+7fEtiP4mHSny8pthvrgGXOPtltMtatTI
+        1MDjdN1J3bvxNqoBmWAYx/pxcvwNAAD//wMA9T7Tpe0JAAA=
     headers:
       CF-RAY:
-      - 9902730cfa59709c-SEA
+      - 99240dc01eb130e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -71,7 +68,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:12 GMT
+      - Tue, 21 Oct 2025 22:05:00 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -87,13 +84,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '831'
+      - '2027'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '834'
+      - '2034'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -107,13 +104,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_346b5f8b3a9c462281111b6073a9d89f
+      - req_6a75ce557108466aa133471614758ed6
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_QYDFpzT7p7YrQV2eJUcrcHI0","name":"get_book_info","type":"function_call","id":"fc_06660162423253ef0068f2a31c4828819080c94c3fbdceebbe","status":"completed"},{"call_id":"call_QYDFpzT7p7YrQV2eJUcrcHI0","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_Vbjtdf8hv8gCfhNfJoibeqvY","name":"get_book_info","type":"function_call","id":"fc_083c63fe91b0c9550068f8038b15688190b573c90380dd5927","status":"completed"},{"call_id":"call_Vbjtdf8hv8gCfhNfJoibeqvY","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -126,12 +123,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1226'
+      - '1274'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -159,26 +153,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFZNj9s4DL3nVwg6zxSOnXEmue0ALVBgd1Fgelk0hUFbdKKOLHklatBg
-        kP++kJz4I5ME7Z7i8FFPlPhI6m3GGJeCrxm36NoiyfM8mefpIs3ShwzrJMkf6xSyeVUmWfU4XyXl
-        Il1CCos0y/Jlslryu0Bhyh9Y0YnGaIedvbIIhKKAgM2XebLM5qssjZgjIO/Cmso0rUJC0S0qoXrZ
-        WuN1iKsG5bAzS6Wk3vI1e5sxxhhvYY82rBf4isq0aPmMsUN0RmtNwLRXKhqkPu1SCCSQyk1RR9ZX
-        JI2e2Bv4WRhPraeCzAu+B8kYVVSgpnSNEahCZNuW7hfmPk3SxX3yeJ/kx+uKlHzNvsWTdOfpM9G4
-        7fVEiJVIFyERq2oJD8ulyESeZGmVRebIQvsWIw86B1scgGs3HsHKaEI9BDUObEJ7ug/8Sf3q6ABa
-        G4LTHX77PgGV2bbWlBeQSLRm/G3DSZLCDV9v+F/SUWmsXrOvO2SfpAbFPjattLjhdxsOnnbGRs8n
-        C1oYzZ5BC7TO6OjQwhbdhq8fFovwz5dKVjG0Yo8QFqZJkh94H8fh+NWHxq1R8bjgnHQEmjrn4Bid
-        eAsWlEI11QBZ38m1tfgqjXfFqSKKmN1eI601TUtFBdUOixfcjzGL4IyeiB3r2lgaOYV8+qYBe1rZ
-        a99BjbQvpEBNspY4qQOH9lVWWJA81U4NXnWZ5I6MxfEhCJsWLZCP5vmH5GiNGTtGVhvbwPB/pJQf
-        zujCVTtsYNCZQFdZ2YZcTE7DGNfQxHVPxrw8H882iLfjWY9EGe6wRUsS3cQeQghKOjOOzPxr/Lg7
-        Q49xO7Lh7kfgYSr0qL4b7H90Dv+TPmr3BvuXiF8hl5pw23XCK+xntXBro8GV/RNcf2PP2YXducV/
-        vbQoJk2m3/HSHV+4mNun6cFRkxlOdElZ49bWjbERAkLIQA7qy1hrcSrNzg4YExunYKif2Qjjr2hL
-        4yTtu74spG+GWdX1j52RVddwPBneA+79lDhFW3sdJ9a12uJ/GvPCfMvK8Ct1V6ghmeWefX5++vsD
-        f1d6W6QiuBfBfYBDr2uQ0LpfLUDpSn1DWp8D/Ov18Vtqiltf1MGtbF6Xw/U8DzIYxgKZthgNu6Q3
-        tuMOar3uVBt7sHRQqtPzx8eh3bdXqSevj/nq4e49MHrT9DKJk0UMK5OJIs9fNVl2CbjE2w+na9Rk
-        CNQApuljL3XvptOoQQIBFNv6YXb4DwAA//8DAJG0oZaPCgAA
+        H4sIAAAAAAAAA+xWTY/iOBC98yssn+mRA2kI3LalXWmk3dVIPZfVMIocpwIeHDtrl1uDWvz3lR3I
+        Bw1oeg9zmhOhXvm5yvVcrtcJIVSWdE2oBdfkLJuLxbyCVVIwsXp8ZGyRVRmbZyIrHkWWrBgvSraY
+        8TQrl8tsNhd0GihM8Q0EnmmMdtDahQWOUOY8YMlykbAsnTMWMYccvQtrhKkbBQhlu6jgYr+1xusQ
+        V8WVg9YslZJ6S9fkdUIIIbThB7BhfQkvoEwDlk4IOUZnsNYETHulokHq8y55CcilcmPUofUCpdEj
+        e82/58Zj4zFHs4e3IBqjcsHVmK42JagQ2bbBh9Q8zNgsfWDZA1ucjitS0jX5EjNp8+kqUbvt7UKU
+        8+UiC4VYQbosl9k8zRKRrngamSMLHhqIPOAc30IP3DrxCAqjEXQf1DCwEe35POA7dqujA9faID+f
+        4ZevI1CZbWNNcQWJRGtCXzcUJSrY0PWG/iUdFsbqNfm8A/KH1FyR3+tGWtjQ6YZyjztjo+eT5bo0
+        mjxzXYJ1RkeHhm/Bbej6MU3DP18oKWJo+QF4WDhjbHGkXRzH01cXGrVGxXS5c9Ih19g6H6fvLhlU
+        K9aWLMlm85Q9zkSSiGTJfpXs55RscnKiDbdcKVDja4vWtx2msfAijXf5uYnlsbrdtW6sqRvMBRc7
+        yPdwGGIWuDN61J+gqozFgVOop69rbs8ru3bleAV4yGUJGmUlYdS6HNgXKSBHeW53FfeqrSR1aCwM
+        k0CoG7AcfTQnH9jJGit2iqwytub9/4FSvjmjcyd2UPNeZyU4YWUTajHKhhCqeR3XPRmzfz7l1ou3
+        5VkPRBnOsAGLEtzIHkIISrowDsz0c/yYXqCnuB3acPYD8DgWelTfHfbfWof/SR+1e4f9U8RvkEuN
+        sG0frxvsF3fh3ka9K/knuL5jz8mV3amFf720UI6aTLfjtTO+cjD3s+nAQZPpM7qmrGFrayePAcLL
+        UgZyrj4NtRYHiclFgrGwcXAJ92fY4OkL2MI4iYe2L5fS1/140faPnZGibTgeDe0A9/ZhP0dbeR2H
+        jFt3i/5pzJ74hhThV+r2ooZiFgfy8fnp7w/0zdXbAubBPQ/uPRx6XQ0I1v3oBZSu0Hek9THAP34/
+        3qWmuPVVHdyr5m053K5zL4P+WUDT5IPHjnXGZthBrdetamMPlo4X6jyx+vhod+1V6tHAmKyW07fA
+        YAztZBJflrJfyUaKvBxEF4trwDXe7nG6RY0GuerB2WLeSd278WtUA/KSY2zrx8nxPwAAAP//AwCf
+        RfLmQgwAAA==
     headers:
       CF-RAY:
-      - 99027312d99d709c-SEA
+      - 99240dcde98530e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -186,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:14 GMT
+      - Tue, 21 Oct 2025 22:05:03 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -202,13 +197,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1568'
+      - '2831'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1576'
+      - '2837'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -216,13 +211,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799588'
+      - '799553'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 30ms
+      - 33ms
       x-request-id:
-      - req_e201740ad94446b7a1d8c15d7b9be6da
+      - req_0fe391b786e4437ba6f67b4641f59bbb
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,7 +12,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '830'
+      - '878'
       content-type:
       - application/json
       host:
@@ -32,7 +32,7 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '0'
+      - '1'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -42,25 +42,25 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xWTW/jNhC9+1cQPMcLyYotKbdu0cMWRRtge9iiWQgUNZIZUyJLDoM1Av/3gpSt
-        D8dKd3uz55GP8/FmRq8rQqio6AOhBqwuojLLNnWeQFaldRynUbTL6g1LNjEveZbF+S6L4jKvSh5F
-        223Oo4zeeQpVPgPHC43qLPR2boAhVAXzWJzuojSJ8yQNmEWGzvo7XLVaAkLVXyoZPzRGuc77VTNp
-        oTcLKUXX0AfyuiKEEKrZEYy/X8ELSKXB0BUhp3AYjFEe65yUwSC6yytFBciEtHPUonEchepm9pZ9
-        K5RD7bBAdYC3IColC87knK5VFUjvWaNxfa/Wm2hzv46ydbQ7pytQ0gfyd4ikj2eoRM2X67BJfSHi
-        fJcD4zXPq7LaRkm+SQJxIMGjhkDjuhBQcG+El9IeQGYa10KHAX99osKW3RN9eKLROt1tk3Ucp9n6
-        yxM9jVc8e9E7Hn6mapfjL7vk8NwofrTw6+6PPM9+/jLe6FgbHGwAi1KpQyG6WtGAnlaEfA0p0sww
-        KUHOM4zG9WLQBl6Ecra46K13YaiANqrVWHDG91Ac4DjFDDCrupmUoK6VwckhnyjXtsxcbg7KsqwG
-        PBaigg5FLWCmMgvmRXAoUFyUWTMnkZ4FrwxMg0BoNRiGLpjjD9HZ+g1Hz2plWjb+n9T32aqusHwP
-        LRtzW4HlRmhf91k0k7R/VOrw+RzbqIqeZ3ymz6EGgwLszO5dECjhyjgx0z/Dj7sr9Oy3ReNzPwFP
-        05OUOdyH3l1i/6k/8D/pNWveBDRlfwz4ArnoEJp+ziywu1IKzkLfHYG9F8bjeJT85Y/+wJurG69T
-        A/84YaAa5srsxVs5vpGY96MZwK+Td4eIbilrEsh5SUwQVlXCkzP5ONVamPmrqwBDYcOO8f2zmmD0
-        BUyprEDfq7SFSrh23AT9/NgrwYMTzKGiA2DfzuDr8bnUW/Q3pQ7EaeJHGPEjzDeqL2Z5JJ8+f/z9
-        w39NvAH2s64FBGO/twH9XH5HWp88/P398UNqCk/f1MF71VyWw3KdRxmMawGVLqRqtFGl544Go55O
-        UOO6XrVhBgvLSnn5uHCWNePooqKb7fY4ub97C0y+GF7Htcf3UI03o5kir78ZNskt4BbvsJyWqFEh
-        kxOPt+kgdWfn26gFZBXDMNZPq9O/AAAA//8DAIATACXtCQAA
+        H4sIAAAAAAAAA5xW227bOBB991cIfI4LylZlJW9boAUCdBcBukW72BQCRY1k1pTIJYdGjMD/XpCy
+        dXGsbNs3ew55OJczM3peRBERJbmLiAGrc8rLW5pV2SqNOaVQUZpmVUbXt3S9SrIsvt0Uyapar4si
+        rSoGG07JjadQxXfgeKZRrYXOzg0whDJnHos3aUyzZE2TgFlk6Ky/w1WjJSCU3aWC8V1tlGu9XxWT
+        FjqzkFK0NbmLnhdRFEVEswMYf7+EPUilwZBFFB3DYTBGeax1UgaDaM+v5CUgE9JOUYvGcRSqndgb
+        9pQrh9phjmoHL0FUSuacySldo0qQ3rNa4zJRyxVdJUuaLWl6SlegJHfRvyGSLp6+EhWfr0OcpDwJ
+        dSjSmKbVbVzygvJ4HYgDCR40BBrXhoCCewM8l/YAMlO7BloM+PMjEbZoH8ndI6HLTfp2vYzjTbb8
+        +kiOwxXPnneOh59f9l+/bO/f6w+f/xRQqPS+2T1VG5UMN1rWBAdrwLxQapeLtlIkoMdFFH0LKdLM
+        MClBTjOMxnVi0Ab2Qjmbn/XWudBXQBvVaMw541vId3AYYwaYVe1ESlBVyuDokE+Uaxpmzjd7ZVlW
+        AR5yUUKLohIwUZkFsxccchRnZVbMSSQnwSsD4yAQGg2GoQvm+A09WZ9w8KxSpmHD/1F9v1vV5pZv
+        oWFDbkuw3Ajt6z6JZpT2d0rtPp1iG1TR8QzPdDnUYFCAndi9CwIlXBhHZvJ3+HFzgZ78tmh87kfg
+        cXySMIfb0Ltz7H90B36TXrP6RUBj9oeAz5CLFqHu5swMuyuk4Cz03QHYa2E8DEejf/zRX3hzceV1
+        YuA/JwyU/VyZvHgtx1cS83o0Pfht9G4f0TVljQI5LYkRwspSeHImH8ZaCzN/cRFgKGzYMb5/FiOM
+        7MEUygr0vUoaKIVrhk3QzY+tEjw4wRwq0gP25Qy+HJ9zvUU+KrWLnI78CIv8CPON6otZHKL7T+/+
+        evN/E6+H/axrAMHYn21AP5dfkda9h3++P35JTeHpqzp4rZrzcpiv8yCDYS2g0rlUtTaq8Ny0N+rx
+        BDWu7VQbZrCwrJDnjwtnWT2MLiLayW6P18nNS2D0xfA8rD2+hXK4SSeKvPxmWK2vAdd4++U0R40K
+        mRx5/HbTS93Z6TZqAFnJMIz14+L4AwAA//8DAA1SVzftCQAA
     headers:
       CF-RAY:
-      - 99027332ae99eb93-SEA
+      - 99240de4be34c39a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,15 +68,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:18 GMT
+      - Tue, 21 Oct 2025 22:05:05 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        path=/; expires=Fri, 17-Oct-25 20:42:18 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -90,13 +84,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1018'
+      - '1484'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1023'
+      - '1490'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -110,13 +104,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_02150a9cae4041d8bd2833eec9df3d4b
+      - req_14102f8aee854f08aa1c8bf98898d124
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_7o69tE63kjgocyseJ6O998CX","name":"get_book_info","type":"function_call","id":"fc_0b882f93e8d7f1170068f2a3227cbc81969eacfc9dbd503923","status":"completed"},{"call_id":"call_7o69tE63kjgocyseJ6O998CX","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WvXWhIEpFUMiebo6Imkxf7o4","name":"get_book_info","type":"function_call","id":"fc_0cd908f8261c00ef0068f8039146c48197bb6106f91dcb0c13","status":"completed"},{"call_id":"call_WvXWhIEpFUMiebo6Imkxf7o4","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -129,12 +123,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1226'
+      - '1274'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -162,26 +153,26 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFZLj9s2EL77VxA87waStfHr1gVaIEBbBNhcijgQRuLIyyxFsuRwEWPh
-        /16QsvXw2kbSk+X5hsN5fDPDtxljXAq+Ydyht2VWrVbzZl3gSiybPF9m2WLVzKGYF1lerFb5elHl
-        UDcVZMu5WBdLKPhdNGGq71jTyYzRHjt57RAIRQkRy5eLbFnk62KdME9AwccztWmtQkLRHaqgftk5
-        E3T0qwHlsRNLpaTe8Q17mzHGGLewRxfPC3xFZSw6PmPskJTRORMxHZRKAqlPt5QCCaTyU9STCzVJ
-        oyfyFn6UJpANVJJ5wfcgGaPKGtTUXGsEqujZztL9g7mfZ/OH+2x1ny2O6Uom+YZ9TZF08fSVaP3u
-        RiGqJstSISAXGeTNgygqWFRdwpMV2ltMdtB72I2AaxlPYG00oR6cGjs2MXvKB/6g/nRSAK0NwSmH
-        X79NQGV21pnqApIMbRh/23KSpHDLN1v+l/RUGac37Mszsj+kBsV+b610uOV3Ww6Bno1Lmo8OtDCa
-        PYEW6LzRScHCDv2Wbz4+PMR/oVKyTq6Ve4R4cJ5liwPv/Tgcv3rXuDMqhQveS0+gqVOOikmJW3Cg
-        FKopB8iFjq7W4as0wZenjihTdXuOWGdaS2UN9TOWL7gfYw7BGz0hOzaNcTRSivUMbQvudLLnvocG
-        aV9KgZpkI3HSBx7dq6yxJHnqnQaC6irJPRmH4yAIW4sOKCRx/iE7SlPFjp41xrUw/B8x5bs3uvT1
-        M7Yw8Eygr520sRaTaBjjGtp07tGYl6djbAN5OzubESljDi06kugn8uhCZNKZcCTmX9LH3Rl69NuT
-        i7kfgYcp0RP7blj/rVP4n+YTd29Y/5zwK8alJtx1k/CK9bNeuHXRoMr+iaq/cOfswu3c4b9BOhST
-        IdPfeCnHFxJzO5oeHA2ZIaJLzBqPtm6NjRAQQkbjoD6PuZa20uwswFTYtAVj/8xGGH9FVxkvad/N
-        ZSFDO+yqbn48G1l3AyeQ4T3g32+Jk7dN0GljXest/qcxLyxYVsVfqbtGjcWs9uzT0+PfH/i71tsh
-        lVG9jOoDHGddi4TO/2wDSl/pG9T6FOGf749fYlO6+iIPblXzOh2u13mgwbAWyNhytOyyXmjHE9QF
-        3bE2zWDpoVKn509IS7sfr1JPXh/5+uPde2D0pulpkjaLGE5mE0aev2qK4hJwyW6/nK6ZJkOgBnA+
-        X/VUD366jVokEEBprB9mh/8AAAD//wMApk8YC48KAAA=
+        H4sIAAAAAAAAAwAAAP//nFZNj9s4DL3nVwg6zxTO5zi57QAtUGB3UWB6WTSFwVh0okaWtBI1aDDI
+        f19ITvyRSYJ2T3H4qCdKfCT1NmKMS8FXjDv0tshKsczyKp8sxmWWYZVli7zKs+lyXC5mWT5ePuXL
+        aS6mywoz8bQox4I/RAqz+YElnWmM9tjYS4dAKAqI2PhpMc7y2TSbJ8wTUPBxTWlqq5DwRLaBcr91
+        JugYVwXKY2OWSkm95Sv2NmKMMW7hgC6uF/iKylh0fMTYMTmjcyZiOiiVDFKfdykEEkjlh6gnF0qS
+        Rg/sNfwsTCAbqCCzx/cgGaOKEtSQrjYCVYxsa+lxZh4n2WT2mOWP2eJ0XYmSr9i3dJLmPG0mar+9
+        nYgJLMZlSsQTzIUQkON0Pq1gnpgTCx0sJh70HrbYAbduPIGl0YS6C6of2ID2fB/4k9rVyQG0NgTn
+        O/z2fQAqs7XObK4giWjF+NuakySFa75a87+kp41xesW+7pB9khoU+1hb6XDNH9YcAu2MS57PDrQw
+        mr2AFui80cnBwhb9mq/ms1n8FzZKlim04oAQF06ybHHkbRzH01cbGndGpeOC99ITaGqco2Ny4hYc
+        KIVqqAFyoZGrdfgqTfDFuSKKlN1WI9aZ2lJRQrnDYo+HPuYQvNEDsWNVGUc9p5jPUNfgzitb7Xuo
+        kA6FFKhJVhIHdeDRvcoSC5Ln2qkgqCaT3JNx2D8EYW3RAYVkHn/ITtaUsVNklXE1dP97SvnhjS58
+        ucMaOp0J9KWTNuZicBrGuIY6rXs2Zv9yOlsn3oZn1RNlvEOLjiT6gT2GEJV0YeyZ+df08XCBnuL2
+        5OLd98DjUOhJfXfY/2gc/id90u4d9i8Jv0EuNeG26YQ32C9q4d5GnSv7J7r+xp6jK7tzh/8G6VAM
+        mky747U7vnIx90/Tgr0m053omrL6ra0ZYz0EhJCRHNSXvtbSVBpdHDAlNk3BWD+jHsZf0W2Ml3Ro
+        +rKQoe5mVdM/dkaWTcMJZHgL+PdT4hxtFXSaWLdqi/9pzJ4FyzbxV+qmUGMyNwf2+eX57w/8Xelt
+        kYroXkT3Do69rkZC53+1AKXf6DvS+hzhX6+P31JT2vqqDu5l87Ycbue5k0E3FsjYojfsstZo+x3U
+        Bd2oNvVg6WGjzs+fkIZ2216lHrw+xsv5w3ug96ZpZZImi+hWZgNFXr5qptNrwDXedjjdoiZDoDpw
+        MslbqQc/nEY1Egig1NaPo+N/AAAA//8DACHlDsWPCgAA
     headers:
       CF-RAY:
-      - 9902733a2d6aeb93-SEA
+      - 99240dee9ed9c39a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -189,7 +180,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:20 GMT
+      - Tue, 21 Oct 2025 22:05:07 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -205,13 +196,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1544'
+      - '1832'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1570'
+      - '1840'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -225,7 +216,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 30ms
       x-request-id:
-      - req_9fe7ae2a210442749cbc9f20ed2e7935
+      - req_c90979b000b64788b5b4f70f61951001
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async_stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '844'
+      - '892'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,96 +43,96 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_003bcb20887d7f890068f2a38d13248193a336b6d6bf37bf40","object":"response","created_at":1760732045,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0545a869dbbbc5790068f803af34588195849f595c637991bc","object":"response","created_at":1761084335,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_003bcb20887d7f890068f2a38d13248193a336b6d6bf37bf40","object":"response","created_at":1760732045,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0545a869dbbbc5790068f803af34588195849f595c637991bc","object":"response","created_at":1761084335,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","type":"function_call","status":"in_progress","arguments":"","call_id":"call_WQ2jLlhFv3DjImp8sd8BfGHE","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","type":"function_call","status":"in_progress","arguments":"","call_id":"call_UYyQKoFNBN1ycGyyaBW6U21Q","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"{\"","obfuscation":"W6hil1iYyU5KfF"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"{\"","obfuscation":"ZRRSzqalRvtzTg"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"isbn","obfuscation":"mr0dKRXHIt17"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"isbn","obfuscation":"i2I7XnihD1vG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"\":\"","obfuscation":"hemBkY5UqWNwK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"\":\"","obfuscation":"PSOst71r050wC"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"0","obfuscation":"COeRE7TpDmJf2DK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"0","obfuscation":"1Gr9hJiA0gQ3CAF"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"-","obfuscation":"vXgF7dDcKc4zYtl"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"-","obfuscation":"iav0fgKFi6wpslK"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"765","obfuscation":"CHjBA8wKEVF0R"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"765","obfuscation":"LrYDhOHxJT9lE"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"3","obfuscation":"8NFoEZl5ixFBKhW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"3","obfuscation":"d0uUPx7U3fPQEh0"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"-","obfuscation":"QBSNzBYsO4WqOIR"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"-","obfuscation":"aQNGSZTlVEuxGjK"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"117","obfuscation":"3q3VSvvvmyXx2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"117","obfuscation":"FbRKvp8a66oxh"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"8","obfuscation":"g7L4FX8pm0IW40m"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"8","obfuscation":"DWrI8N1bVXdw63Q"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"-X","obfuscation":"IM8XEAr804OUPh"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"-X","obfuscation":"AE7MG4Z9hyEDjm"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"delta":"\"}","obfuscation":"vTQ6XSaEhIfM5b"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"delta":"\"}","obfuscation":"o35h9ocxB91kiC"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WQ2jLlhFv3DjImp8sd8BfGHE","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_UYyQKoFNBN1ycGyyaBW6U21Q","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_003bcb20887d7f890068f2a38d13248193a336b6d6bf37bf40","object":"response","created_at":1760732045,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WQ2jLlhFv3DjImp8sd8BfGHE","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0545a869dbbbc5790068f803af34588195849f595c637991bc","object":"response","created_at":1761084335,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_UYyQKoFNBN1ycGyyaBW6U21Q","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
 
@@ -143,13 +140,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 990275d13a3b76f8-SEA
+      - 99240ea65fb6ded0-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:05 GMT
+      - Tue, 21 Oct 2025 22:05:35 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -165,21 +162,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '165'
+      - '146'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '192'
+      - '175'
       x-request-id:
-      - req_29bf61794eee4826abf788f21557e083
+      - req_5f56b01b619c44348e09156302fa2714
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WQ2jLlhFv3DjImp8sd8BfGHE","name":"get_book_info","type":"function_call","id":"fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183","status":"completed"},{"call_id":"call_WQ2jLlhFv3DjImp8sd8BfGHE","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_UYyQKoFNBN1ycGyyaBW6U21Q","name":"get_book_info","type":"function_call","id":"fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5","status":"completed"},{"call_id":"call_UYyQKoFNBN1ycGyyaBW6U21Q","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -192,12 +189,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '1288'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -226,203 +220,371 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_003bcb20887d7f890068f2a38f447481938c6b76255c031bd5","object":"response","created_at":1760732047,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0545a869dbbbc5790068f803b09bc08195bd5d99d21f497d1d","object":"response","created_at":1761084336,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_003bcb20887d7f890068f2a38f447481938c6b76255c031bd5","object":"response","created_at":1760732047,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0545a869dbbbc5790068f803b09bc08195bd5d99d21f497d1d","object":"response","created_at":1761084336,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"JBIMPyOYLjfkct"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"0sdDLeRTuOMxXg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"YlxPwOdYr38"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"V4XyE3aTuNu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"3598OXcFgujC3"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"1diERTTlxku1A"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"AiPP0ieP1awb"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"39NpvBgPAQ2U"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"PcW5RX5ykS3v"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"XspPuvOsco4A"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"zqnutA0K8KuAPlF"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"K5xksDhEfA3J9Kk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"Uddt42KWgxSD"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"POumPanqp5qp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"IUthWzHbZ7"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"PIhFSPJZCs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"oQbeGvm6y"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"FB9hT7iZb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"4tdFkDS05tOOR"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"e4yoNtksCQZzE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"GVVoc8PXYb"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"Kl5mUlacm9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"mQd3lYk3ipW4W"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"wBlOsXReVWDEN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"NvM4RFJmrCeJ7q"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"8M2PefyZTugNt5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"oeVdojRTwMk"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"G6cx5ydqS0N"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"19xC96cBpTX"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"yKSCLeHoFmO"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"JZ8NAJFEUfQ"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"iyEoFVwHYnX"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"nNi1ttaYotwuV"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"kZgZdvJKMjXhB"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"1sTqRCTc6T0"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"oHD3FhAtSPZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"cHdkwMbdrOYx8Q"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"AhMqQWOiXkJAJa"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"zB6CTACcv0hK6"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"4Gc47XATmyoQM"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"x7wrnBxejSiaOL"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"PlseYIq1UHsQvh"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"hldjJ"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"nf0XF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"GRpNRPAXLCa"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"3pa0wsXkkDA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"m2xRAGBQ3H4s8V"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"boJFW8ozjN1Y34"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"I27xNuaKBxjHg"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"1m258uzhsA4QQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"rYyJHInwxEIWRnC"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"T6tKm6BqFzUVdWM"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"VyRmYnEb0W4XGMJ"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"3iokuNagVcnYNHy"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":34,"output_index":1,"item":{"id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":35,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"1wWhl0b5LJk1S7"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"pHB6mdDqrIf"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"Cc75PCBH1PTzr"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"oDSkMuXLRpAf"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"VmBDQCKb8Nei"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":":","logprobs":[],"obfuscation":"bWbEm5lZGkH59Ne"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"RhyzUJRPme0F"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"rbWOm2nsdt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"4fOP3FOGa"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"vbGrDHGqeVo7t"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"enTO0BiLdR"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"DlNxC04NfFu4e"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"7oxvhISbuD3DX1"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"PUHjteBx8p4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"ILVFyLDq5um"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"Omgjj9cFEHo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"jtbW0HXu9gwIb"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"8L5zu83q4eU"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"6wCginhQQqZAr4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"wGLco9foZsqBh"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"fCIZag2am1lxAp"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"OCLBj"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"hZqTqyYqWPi"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"0EeBYwMtKx3wfE"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"pmIcJ7sZeDzuQ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"dQCpLFZMnuQghZd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"ZoSxkyByrNjFQUW"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":63,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":64,"item_id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":65,"output_index":1,"item":{"id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_003bcb20887d7f890068f2a38f447481938c6b76255c031bd5","object":"response","created_at":1760732047,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.completed","sequence_number":66,"response":{"id":"resp_0545a869dbbbc5790068f803b09bc08195bd5d99d21f497d1d","object":"response","created_at":1761084336,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"},{"id":"msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":197,"input_tokens_details":{"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":263},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990275def93f76f8-SEA
+      - 99240eaf382bded0-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:07 GMT
+      - Tue, 21 Oct 2025 22:05:36 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -438,15 +600,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '199'
+      - '212'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '228'
+      - '223'
       x-request-id:
-      - req_88f306c9cc594109ac30bf2ef2058efc
+      - req_a892093fa4e24b599c16e0544329d0f1
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/stream.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,12 +12,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '844'
+      - '892'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -46,110 +43,110 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0b43fb0f4bd678710068f2a356fbac81969741c64b6d21af64","object":"response","created_at":1760731991,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_078bf5f366416f5b0068f8039e87e88195848631cbf0a45298","object":"response","created_at":1761084318,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0b43fb0f4bd678710068f2a356fbac81969741c64b6d21af64","object":"response","created_at":1760731991,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_078bf5f366416f5b0068f8039e87e88195848631cbf0a45298","object":"response","created_at":1761084318,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","type":"function_call","status":"in_progress","arguments":"","call_id":"call_IxugtwYIfPlbKHwZyyt9jQ3A","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","type":"function_call","status":"in_progress","arguments":"","call_id":"call_aUL5PjVgmSfjO9qo7TxQZ9gl","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"{\"","obfuscation":"mfIibidTGKLLwp"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"{","obfuscation":"DNa6YzAoWo6sRZe"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"isbn","obfuscation":"mn2oePjkff5N"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"\"isbn","obfuscation":"UVdKYNpruEE"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"\":\"","obfuscation":"Z4T0ZzypS6MlC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"\":","obfuscation":"x1SPGPml6FRZw0"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"0","obfuscation":"ZdtyabKATzpHSCi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"\"0","obfuscation":"YDDUrGxVnNw9A7"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"-","obfuscation":"F0hxP9OllIOQ8WR"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"-","obfuscation":"6deNIiaSlkstxY5"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"765","obfuscation":"sXSO42iDY5SVe"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"765","obfuscation":"TJw6llzCZ4xTL"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"3","obfuscation":"5Kh2FcEWJmdlB6d"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"3","obfuscation":"sxIAis4rwEWRs43"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"-","obfuscation":"8NhtAznQ8ujWnHU"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"-","obfuscation":"XjlFxwuzCNGagxg"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"117","obfuscation":"wpzZnC4hKHRY2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"117","obfuscation":"ncWHXbkcrJp94"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"8","obfuscation":"cIbIsnhpFmyNHSj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"8","obfuscation":"N4FlP6nABSMHJN8"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"-X","obfuscation":"vgZ1d8aArcHNjd"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"-X","obfuscation":"cefJ0QyCWRIXRO"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"delta":"\"}","obfuscation":"Ah8CaaVH07LXS8"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"delta":"\"}","obfuscation":"0VnuJYoSmDa4Bh"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_IxugtwYIfPlbKHwZyyt9jQ3A","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_aUL5PjVgmSfjO9qo7TxQZ9gl","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0b43fb0f4bd678710068f2a356fbac81969741c64b6d21af64","object":"response","created_at":1760731991,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_IxugtwYIfPlbKHwZyyt9jQ3A","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_078bf5f366416f5b0068f8039e87e88195848631cbf0a45298","object":"response","created_at":1761084318,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_aUL5PjVgmSfjO9qo7TxQZ9gl","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":39,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":173},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 9902747dfb19c6ba-SEA
+      - 99240e3e5e3cc4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:11 GMT
+      - Tue, 21 Oct 2025 22:05:18 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -165,21 +162,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '262'
+      - '210'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '295'
+      - '222'
       x-request-id:
-      - req_10811f71427d440ba07e1e7803a5fd88
+      - req_f06ead7195a24a85945807a09566227a
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_IxugtwYIfPlbKHwZyyt9jQ3A","name":"get_book_info","type":"function_call","id":"fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d","status":"completed"},{"call_id":"call_IxugtwYIfPlbKHwZyyt9jQ3A","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_aUL5PjVgmSfjO9qo7TxQZ9gl","name":"get_book_info","type":"function_call","id":"fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7","status":"completed"},{"call_id":"call_aUL5PjVgmSfjO9qo7TxQZ9gl","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -192,12 +189,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '1288'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -226,203 +220,203 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0b43fb0f4bd678710068f2a358729c81969f75139912982632","object":"response","created_at":1760731992,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_078bf5f366416f5b0068f803a008708195a6ab8c0f6da6e634","object":"response","created_at":1761084320,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0b43fb0f4bd678710068f2a358729c81969f75139912982632","object":"response","created_at":1760731992,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_078bf5f366416f5b0068f803a008708195a6ab8c0f6da6e634","object":"response","created_at":1761084320,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"WG5SZmqSu1t8Xs"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"bbS0UfMIAGRVx5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"31w71dbrYt2"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"Tnh0diNccy2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"w8DE7oupXGSIC"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"LOgejxiljlUhk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"xbBhhZlKS1an"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"4tfsocCnt06N"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"Toj4svXfIEaX"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"javE7UcZSrvJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"MWq2lyz6ZwDn4qj"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"kFlzhUHiTdtEj5r"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"KjMFIZcdoxcF"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"DvIElPehKYC7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"HSiD12vavY"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"4OOFdcFIpL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"7tnP8NrlV"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"9Og74JWT5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"oDH61FMmaHWdM"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"zyLaBxQUQx6hm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"paeam995CR"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"7GC5TKLkVi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"zj78h3NzDJlmK"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"X2lUBwQbJszWN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"p7SVSGWN87Bp7Q"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"TNBbu25niY6XFi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"tnDIRDffWwY"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"n4ctPCXEZZy"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"fLw6mCmiVlm"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"pyC6fj2rjaz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"HGsNE12t0D3"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"fjmiKZ0OsG4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"zkoDtm9vBtrZz"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"RJJNtHHagsYPf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"C6ld6vXjvjj"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"PlfTMeNA4Xe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"vHRAafk73YNLka"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"p7iwxr35JY7zt5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"SnUXi8hi4ULz0"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"cOe2UvoJA9bBp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"1gJgCsZ6qg2nCN"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"UfP0Q91dxjV1B1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"vDpwN"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"2Jcmz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"t6LRGPT2gUG"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"5K7fsIPVHjT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"lHHnAN6Mb00rzV"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"LGtSeFKGxdaPGl"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"QB0aI6ZZQCOfd"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"YykYnjih0XBGL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"re7KXqPwnaDuNAr"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"eFqiUruvtoCNJvQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"MfUriegQmp2NUYN"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"js5xFzvOEWYDd0R"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_0b43fb0f4bd678710068f2a358729c81969f75139912982632","object":"response","created_at":1760731992,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_078bf5f366416f5b0068f803a008708195a6ab8c0f6da6e634","object":"response","created_at":1761084320,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":192,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":225},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 990274885f4fc6ba-SEA
+      - 99240e47cbcbc4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:12 GMT
+      - Tue, 21 Oct 2025 22:05:20 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -438,15 +432,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '170'
+      - '111'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '189'
+      - '122'
       x-request-id:
-      - req_89045fd0c6a7451da28aaea97e9f3a01
+      - req_48d35bdb390c49adb9db6ace779eeadb
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/sync.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -12,7 +12,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '830'
+      - '878'
       content-type:
       - application/json
       host:
@@ -42,25 +42,25 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xW227bOBB991cIfI4LyZZveds+FE2xKAK0QLtoCmEkjmTGlMglh0GMwP++IGXr
-        4tjZtm/2HPJwLmdm9DKJIiY4u42YQauzmC/iGHmScijWAOs4Xq7LGcwwXZQ8Xieb+SYvYbnc5Os4
-        neWLzYzdeAqVP2JBJxrVWGzthUEg5Bl4LFkt49U8Wa+WAbME5Ky/U6haSyTk7aUcil1llGu8XyVI
-        i61ZSCmait1GL5MoiiKmYY/G3+f4hFJpNGwSRYdwGI1RHmuclMEgmtMrGUcCIe0YtWRcQUI1I3sN
-        z5lypB1lpHb4GiSlZFaAHNPViqP0nlWapqmazuJZOo3X03h5TFegZLfRjxBJG09XibK4XofFYrUJ
-        dciX6SqOi1m6LjdFkiaBOJDQXmOgcU0IKLjXw9fSHkAwlauxoYC/PDBh8+aB3T6weLpaLubTJFmt
-        p98f2KG/4tmz1vHw83k5+/BJfbyrv5FMv8vP1Uo3fCMe+xsN1MHBCinLldploikVC+hhEkU/Q4o0
-        GJAS5TjDZFwrBm3wSShns5PeWhe6Cmijak1ZAcUWsx3uh5hBsKoZSQnLUhkaHPKJcnUN5nSzU5aF
-        EmmfCY4NiVLgSGUWzZMoMCNxUmYJThI7Cl4ZHAZBWGs0QC6Yk3fx0fpMvWelMjX0/wf1fbSqyWyx
-        xRr63HK0hRHa130UzSDt75XafTnG1qui5emfaXOo0ZBAO7J7FwRJPDMOzOxr+HFzhh79tmR87gfg
-        YXiSgaNt6N1r7H+1B/6QXkP1KqAh+33Ar5CLhrBq58wVdpdLUUDouz3CW2Hc90ejf/zR33hzcuF1
-        ZvBfJwzybq6MXryU4wuJeTuaDvw5eLeL6JKyBoEcl8QAAc6FJwd5P9RamPmTswBDYcOO8f0zGWDs
-        CU2urCDfq6xGLlzdb4J2fmyVKIIT4EixDrCvZ/D5+LzWW+xvpXaR05EfYZEfYb5RfTHzfXT35f3n
-        d/838TrYz7oaCY391Qb0c/kNad15+Nf747fUFJ6+qIO3qnldDtfr3MugXwukdCZVpY3KPXfcGfVw
-        ghrXtKoNM1hYyOXp48JZqPrRxUQz2u3JPL15DQy+GF76tVdskfc345Eiz78ZZvNLwCXebjldoyZF
-        IAceL1ad1J0db6MaCThQGOuHyeE/AAAA//8DAN0aXybtCQAA
+        H4sIAAAAAAAAAwAAAP//nFbbjts2EH33Vwh8XgeSfJF23xr0oVskxbYpigTdQKDIkcyYEhlyuIix
+        8L8HpGxdvNY26Zs9hzycy5kZPS+iiAhO7iJiwOoiTnmVpJBt4zxJ0iyN421e5fEqYww2LE9ut/kq
+        Ydv0Ni63PElv1zm58RSq/AIMzzSqtdDZmQGKwAvqsSTbJnG+TvNNwCxSdNbfYarREhB4d6mkbF8b
+        5VrvV0Wlhc4spBRtTe6i50UURRHR9ADG3+fwBFJpMGQRRcdwGIxRHmudlMEg2vMrBQekQtopatE4
+        hkK1E3tDvxXKoXZYoNrDSxCVkgWjckrXKA7Se1ZrXK7VMo3T9TLOl/H2lK5ASe6if0MkXTx9JSo2
+        XwdOYRP7OpTJhmVVtb7ltOI8o4E4kOBBQ6BxbQgouDfAc2kPIDW1a6DFgD8/EmHL9pHcPZJ4mW03
+        q2WSZPny4yM5Dlc8e9E5Hn6yqty5h99j/ts/f+Xvfv3z66f7j++b9fvhRkub4GANWJRK7QvRVooE
+        9LiIos8hRZoaKiXIaYbRuE4M2sCTUM4WZ711LvQV0EY1GgtG2Q6KPRzGmAFqVTuRElSVMjg65BPl
+        moaa881eWZZWgIdCcGhRVAImKrNgngSDAsVZmRV1EslJ8MrAOAiERoOh6II5eROfrN9w8KxSpqHD
+        /1F9v1jVFpbtoBkVn4NlRmhf90k0o7S/VWr/4RTboIqOZ3imy6EGgwLsxO5dECjhwjgyk7/Dj5sL
+        9OS3ReNzPwKP45OEOtyF3p1j/6U78D/pNa1fBDRmfwj4DLloEepuzsywu1IKRkPfHYC+FsbDcDT6
+        5I/+xJuLK68TA1+dMMD7uTJ58VqOryTm9Wh68PPo3T6ia8oaBXJaEiOEci48OZUPY62Fmb+4CDAU
+        NuwY3z+LEUaewJTKCvS9ShrgwjXDJujmx04JFpygDhXpAftyBl+Oz7neIu+U2kdOR36ERX6E+Ub1
+        xSwP0f2Ht3+8+a+J18N+1jWAYOyPNqCfy69I697DP94fP6Wm8PRVHbxWzXk5zNd5kMGwFlDpQqpa
+        G1V67rg36vEENa7tVBtmsLC0lOePC2dpPYwuItrJbk9W65uXwOiL4XlYe2wHfLgZTxR5+c2Qrq4B
+        13j75TRHjQqpHHm8yXqpOzvdRg0g5RTDWD8ujt8BAAD//wMA8KZtMe0JAAA=
     headers:
       CF-RAY:
-      - 990271b2de5bdee2-SEA
+      - 99240d6b7f0230e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,15 +68,9 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:11:17 GMT
+      - Tue, 21 Oct 2025 22:04:46 GMT
       Server:
       - cloudflare
-      Set-Cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        path=/; expires=Fri, 17-Oct-25 20:41:17 GMT; domain=.api.openai.com; HttpOnly;
-        Secure; SameSite=None
-      - _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000;
-        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -90,13 +84,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1605'
+      - '1317'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1610'
+      - '1325'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -110,13 +104,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_53d38c338baa43e985cd9264c0827866
+      - req_f14ae97a53824324a94a38dbb9618815
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"user","content":"Please look up the book with ISBN 0-7653-1178-X
-      and provide detailed info and a recommendation score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_x62FJoHImWtl4XlNg7pnd9ij","name":"get_book_info","type":"function_call","id":"fc_0d500ed14dac8aa80068f2a2e557908193b64700c248f9c141","status":"completed"},{"call_id":"call_x62FJoHImWtl4XlNg7pnd9ij","output":"Title:
+    body: '{"input":[{"content":[{"text":"Please look up the book with ISBN 0-7653-1178-X
+      and provide detailed info and a recommendation score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_cfbhuPJ0dHVR8LDQqYIXMm4M","name":"get_book_info","type":"function_call","id":"fc_02df12e7608112720068f8037dae508196b15c7ff49dafdd7a","status":"completed"},{"call_id":"call_cfbhuPJ0dHVR8LDQqYIXMm4M","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
@@ -129,12 +123,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1226'
+      - '1274'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -162,27 +153,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+xWTY/bNhC9+1cQPHsDydbKWt+6QAsEaIsAm0sRB8JIGtnMUqRKDhcxFv7vBSlb
-        H17byPaQU06W5w0fZziPw3mdMcZFxdeMG7RtHlX3UYRVnFRQZgBZFKVZvYAFpssFRFn8sHxYRtEy
-        w3q1qBLIAPncU+jiG5Z0otHKHu2lQSCscvBYvEqj1TLOVlnALAE569eUumklElbdogLK563RTvm4
-        apAWO7OQUqgtX7PXGWOM8Rb2aPz6Cl9Q6hYNnzF2CM5ojPaYclIGg1CnXfIKCYS0U9SScSUJrSb2
-        Br7n2lHrKCf9jG9B0lrmJcgpXaMrlD6ybUt3ib5bRIvkLsruovR4XIGSr9mXkEmXT1+Jxm5vFALj
-        +8QXolglUVTEWZwUUVKky8AcWGjfYuBBa2GLA3DtxANYakWohqDGgU1oT+eB36lfHRxAKU1wOsMv
-        Xyeg1NvW6OICEojWjL9uOAmSuOHrDf9LWCq0UWv2eYfsD6FAst+bVhjc8PmGg6OdNsHz0YCqtGJP
-        oCo0Vqvg0MIW7Yav75PE/3OFFGUILd8j+IWLKEoPvI/jcPzqQ+NGy5AuWCssgaLO+TB/d8lWWVp0
-        JSsWSbGIkzKBuo7jh18l+zklmx2deAsGpEQ5vbZkXNdhWoMvQjubn5pYHqrbX+vW6KalvIRyh/kz
-        7seYQbBaTfoT1rU2NHLy9XRNA+a0sm9XFmqkfS4qVCRqgZPWZdG8iBJzEqd2V4OTXSW5JW1wnARh
-        06IBcsEcf4iO1lCxY2S1Ng0M/0dK+Wa1ym25wwYGnVVoSyNaX4tJNoxxBU1Y96j189Mxt0G8Hc96
-        JEp/hi0aEmgndh+CV9KZcWTmn8PH/Aw9xm3J+LMfgYep0IP6brD/1jn8T/qg3RvsnwJ+hVwowm33
-        eF1hP7sLtzYaXNk/3vUde84u7M4N/uuEwWrSZPodL53xhYO5nU0PjprMkNElZY1bWzd5jBCoKuHJ
-        QX4aay0MErOzBENhw+Di78+4wfMXNIW2gvZdX66Ea4bxousfOy3KruE40rwH7NuH/RRt7VQYMq7d
-        Lf6n1s/Mtazwv0J1F9UXs9izj0+Pf3/gb67eFin37rl3H2Df6xokNPZHL6CwhbohrY8e/vH78S41
-        ha0v6uBWNa/L4XqdBxkMzwLpNh89dlFvbMcd1DjVqTb0YGGhkKeJ1YVHu2+vQk0GxvhhNX8LjMbQ
-        XibhZamGldFEkeeDaJpeAi7x9o/TNWrSBHIAF+myl7qz09eoQYIKKLT1w+zwHwAAAP//AwByXeI7
-        QgwAAA==
+        H4sIAAAAAAAAA+xWS4/iOBC+8yssn+lRgDQJ3LalXWmk3dVIPZfVMIoqSQU8OHbWLrcGtfjvKzuQ
+        Bw1oeg9zmhOhvnK5Hl+V63XCGBclXzNu0DZZNC+r2RyTZZTOZvNkHkXLtEqjRYKLNErT2WqZJpBA
+        nKzmVVJVMS751JvQ+Tcs6GxGK4utvDAIhGUGHpsly1mUxvN0GTBLQM76M4WuG4mEZXsoh2K/Ndop
+        71cF0mIrFlIKteVr9jphjDHewAGNP1/iC0rdoOETxo5BGY3RHlNOyiAQ6nxLViKBkHaMWjKuIKHV
+        SF7D90w7ahxlpPf4FiStZVaAHJurdYnSe7Zt6CHWD/NoHj9E6UN0TlcwydfsS4ikjaerRG23twtR
+        JYtV5AuxisrisUwTiCGpikURLAcrdGgw2EFrYYs9cCvjASy0IlS9U0PHRmbP+cDv1J0OCqCUJjjn
+        8MvXESj1tjE6v4IEQ2vGXzecBEnc8PWG/yUs5dqoNfu8Q/aHUCDZ73UjDG74dMPB0U6boPlkQJVa
+        sWdQJRqrVVBoYIt2w9ePcez/uVyKIriWHRD8QZ/RI+/8OJ6+Ote40TKEC9YKS6CoVT5O31uyNHpc
+        FrEvGcTJDKDEeQGrpMLVr5L9nJJNTkq8AQNSohy3LRnXTpjG4IvQzmbnIZaF6nZt3RhdN5QVUOww
+        2+NhiBkEq9VoPmFVaUMDJV9PV9dgzie7cWWhQjpkokRFohI4Gl0WzYsoMCNxHncVONlWklvSBodB
+        ENYNGiAXxLMP0UkaKnbyrNKmhv7/gCnfrFaZLXZYQ8+zEm1hRONrMYqGMa6gDueetN4/n2Lrydva
+        WQ9I6XPYoCGBdiT3LngmXQgHYv45fEwv0JPflozP/QA8joke2HfH+m+twv80H7h7x/qngN8wLhTh
+        tn28bli/6IV7F/Wq7B+v+o47J1du5wb/dcJgORoy3Y3XcnwlMfej6cDBkOkjusas4WhrN48BAmUp
+        vHGQn4ZcC4vE5CLAUNiwuPj+GQ54/oIm11bQoZ3LpXB1v16082OnRdEOHEead4B9+7Cfva2cCkvG
+        rd7if2q9Z65huf8Vqm1UX8z8wD4+P/39gb9pvS1S5tUzr97DftbVSGjsjzagsLm6Q62PHv7x/ngX
+        m8LVV3lwr5q36XC7zj0N+meBdJMNHruoEzbDCWqcalkbZrCwkMvzxurCo92NV6FGC+NslUzfAoM1
+        tKNJeFnK/mQ0YuTlIrpcXgOu2e0ep1umSRPIHpwvFx3VnR2/RjUSlEBhrB8nx/8AAAD//wMAMX1z
+        OUIMAAA=
     headers:
       CF-RAY:
-      - 990271be3987dee2-SEA
+      - 99240d745d6130e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +181,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:11:20 GMT
+      - Tue, 21 Oct 2025 22:04:48 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -206,13 +197,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1897'
+      - '2746'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1901'
+      - '2753'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -226,7 +217,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 33ms
       x-request-id:
-      - req_5be7eabec164489dac99dbb067cde268
+      - req_d3b0296f46a24d3aac70bbd42e20f379
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1222'
+      - '1270'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,26 +45,26 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWTW/jNhC951cQOscL2bItO7fuXrptscgiLdCiCQiKHNmsKZEhh2mMwP+9IGV9
-        2XG62QI9WZ7hPM7Me+Tw5YqQRIrkhiQWnKGpEJDnIhULkfElT9N0uSpnLMs4W2Z8NV3nKzFbZIts
-        Np+tslW2zpPrAKGLv4BjC6NrB42dW2AIgrLgm+bLNM+m6+U8+hwy9C7EcF0ZBQiiCSoY322s9nXI
-        q2TKQWOWSsl6k9yQlytCCEkM24MN8QKeQGkDNrki5BAXg7U6+GqvVDTIut2FCkAmlRt7HVrPUep6
-        ZK/YM9UejUeKegfnTtRaUc7UGK7SAlTIbGNwMteTWTqbT9LVJF0e2xUhkxvyZ6ykqadjouSXeSin
-        +XIeeeDrooAsY1Cs50zMI3AEwb2BCOPrWFBMr3dfant0MrvxFdQY/S/3iXRFfZ/c3CfpJF8ussl0
-        mq8mv98nhz4koNMm8fiZfhIl+/rFzrT5+rO/W//4qGX++JPpI2pWxQQ3gLTQekdlXeokeg9XhDzE
-        FhlmmVKgxh1G6xsxGAtPUntHW701KXQMGKsrg5QzvgW6g/3QZ4E5XY+kBGWpLQ4WhUb5qmK2jeyU
-        5VgJuKdSQI2ylDBSmQP7JDlQlK0yS+YVJkfBawvDIhAqA5ahj+bph/RofcY+s1LbivX/B/zGdU3X
-        jhk/gS20kxhyTioQ0lf9iWj6uNWSQ4/eYjGl9N8gYrPdkamo4uZIP3ppO5kkzaJWvL18X9FeR/rb
-        tHclvBuM0kpa5rg2QJtWheumO7JaUdptEX8fRg1x52fw4q6JAMetNNF4Q5JftN4Rb0iohYRawu5S
-        16TYk893H798+DfFd+6g9QoQrBvw3IjYgEUJY3u4KFxRn9hC6hJV3OdzcF+fOI91ObRB+gPnofs+
-        DDrcsd4T3W/dGR4GEUwIGRrA1O0w8e4GP0nkODNOBRATjLMkBg4F/n6OfnNAcCsdCWQT1ASe0TKO
-        RDBkRNbko9a7u+agk4bB8EMYKWXNFGlvl1e4/Bbl/QeGWy4vUfxr/Ph2jocrE+ZxG8fjJfQfmgXf
-        CW/Y5qygIfpt9F8AlzXCphnlF9B9oSSPR43ugb1Vxm2/lPwRlr5jz3cdCjxjo+3xK415u5r/5WiF
-        EXQycFEbqvTGWF0E6LQzmuFssr5uko3TTTpWqPbZ5h3bDEaLrEevpulidn3uGLzFXvoHBd/GUXSM
-        TEcz7vQ1Nstec7yG2439S9CokalBxvmimxXejed8BcjCFRLwD1eHfwAAAP//AwDgbSQ5RwsAAA==
+        H4sIAAAAAAAAA7xW247bNhB991cQel4HkuX7W4KgRdqi2GCTokV2QVDSyGZMkSw53K6z8L8XpKyb
+        L9tsC/TJ8gzncGbOIYfPI0IiXkRrEhmwmsYsnk/LyZzFkM6zuIzj+bJcxulqkc7K6TJZLbIiL9PV
+        rFisZqukmEN04yFU9hVybGCUtEd7boAhFJR5X7KYJ/FymiZJ8Flk6KyPyVWlBSAUdVDG8t3GKCd9
+        XiUTFmozF4LLTbQmzyNCCIk024Px8QU8glAaTDQi5BAWgzHK+6QTIhi4bHahBSDjwg69Fo3LkSs5
+        sFfsiSqH2iFFtYNzJyolaM7EEK5SBQif2UbjeKrGk3gyHcfLcTw/titARmvyJVRS19MyUeYv8FBk
+        UPOwmi/SabqcLfMinRY1cADBvYYA42QoKKTXua+1PTiZ2bgKJAb/833EbSbvo/V9FI8X81k6TpLF
+        cvz7fXToQjw6rRMPn++N+Mg+/7T5+eO3rz+kd9MfEd5/+23/qYuQrAoJbgBpptSOclmqKHgPI0Ie
+        Qos0M0wIEMMOo3G1GLSBR66cpY3e6hRaBrRRlUaas3wLdAf7vs8As0oOpARlqQz2FvlGuapipols
+        lWVZCbinvACJvOQwUJkF88hzoMgbZZbMCYyOglcG+kUgVBoMQxfMyZv4aH3CLrNSmYp1/3v8hnV1
+        144ZP4LJlOXoc44qKLiruhNR93GreA4deoPFhFB/QRGabY9MBRXXR/pPx00rk6he1Ii3k+8F7bWk
+        v0x7W8KrwSituGE2Vxpo3Sp/3bRHVglK2y3C78OgIfb8DF7dNSrA5obrYFyT6BeldsRp4mshvha/
+        O1eSZHvy4e7dr2/+SfGt22u9AgRjezzXItZgkMPQ7i8Km8kTm0+dowj7fPDumxPnsS6Lxku/5zy0
+        34deh1vWO6K7rVvDQy+CFQX3DWDitp94e4OfJHKcGacCCAmGWRIC+wJ/PUefLRDccks82QQVgSc0
+        LEdSMGSES/JOqd1dfdBJzaD/IYyUXDJBmtvlApffo7z/wHDD5TWKP4WP7+e4vzJiDrdhPF5Df1sv
+        +Jfwmm3OCuqj3wb/FXAuETb1KL+C7jLB83DU6B7YS2XcdkvJH37pK/Z81aHAMzaaHl9ozMvV/C9H
+        y4+gk4GLSlOhNtqozEPHrVH3Z5Nxsk42TDduWSaaZ5uzbNMbLVwOXk3JbHJz7ui9xZ67B0W+DaPo
+        GBkPZtzpa2ySXnJcwm3H/jVoVMhEL+PFrJ0Vzg7nfAXI/BXi8Q+jw98AAAD//wMAfV22C0cLAAA=
     headers:
       CF-RAY:
-      - 990273daad14e945-SEA
+      - 99240e109bbdba2a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -75,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:47 GMT
+      - Tue, 21 Oct 2025 22:05:12 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -91,13 +88,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '3236'
+      - '1097'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '3239'
+      - '1104'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -111,15 +108,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 27ms
       x-request-id:
-      - req_6163b6081ef642659578dbe7cef0a655
+      - req_bb72daa67c894e7d83564b005c6dd29c
     status:
       code: 200
       message: OK
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_0CdfaQNr2opQKuS9Hqoi7qJp","name":"get_book_info","type":"function_call","id":"fc_0dde77d0d5d3c6c00068f2a33f176481978c9bbe33aeb94ad4","status":"completed"},{"call_id":"call_0CdfaQNr2opQKuS9Hqoi7qJp","output":"Title:
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_DrlQaUJgKQzjF3S4GteDzVyT","name":"get_book_info","type":"function_call","id":"fc_0a064f26a0e36b0f0068f80397dbe48197b967343858cd34d6","status":"completed"},{"call_id":"call_DrlQaUJgKQzjF3S4GteDzVyT","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
@@ -133,12 +130,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1618'
+      - '1666'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -166,27 +160,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xW227jNhB9z1cQfE4C+RLb8VuDtsACTbHY7G4R1IEwEkc2a4pkyVEaI/C/F6Ss
-        mxMHmxTok+W5HM7MmeHw+YwxLgVfMu7Q2zQRAudzkYgrMclneZIks0Uxhsk0uZospovR9fx6gdfT
-        yWI0EkWWzcScnwcIk/2FOTUwRnus5blDIBQpBN1oPkvmk9H1bBF1noAqH3xyU1qFhKJ2yiDfrp2p
-        dIirAOWxFkulpF7zJXs+Y4wxbmGHLvgLfERlLDp+xtg+GqNzJuh0pVQUSN2ckgokkMoPtZ5clZM0
-        eiAv4Sk1FdmKUjJbfKkkY1SagxrClUagCpGtLV1MzcU4GU8vksVFMjuUK0LyJfszZlLn0zJR5Kd5
-        GM2KRR54yBbjbFLgYnSVjMQEauAIQjuLEabSMaEYXqc+VfaoBLeuStQU9c8rTpIUrvhyxW+lp8w4
-        vWRfN8h+lRoU+6W00uGKn684VLQxLlreONDCaHYHWqDzRkcDC2v0K768mk7DvypTMocY3g4hOI6T
-        ZLbvIglBp3U94ud8C9k92W8Svt/jl/z2y8Srn2+v/+g8NJQx7zQtpQOfG4tpYVwJFDqwZdGoNOXR
-        Z3/G2EPkw4IDpVAN6SRX1Z1nHT5KU/m0ae46sJZu60xpKc0h32C6xV1f5xC80YO+xaIwjnpGgZWq
-        LME1nm0beyiQdqkUqEkWEgct7dE9yhxTks0YFFAp4ofpMg77SRCWFh1QFcWjy+QgfaIusrpc7f9e
-        M0W7umqHiB/RZcZLCjHzEoWsym786jpujMyxQ2+wQCnzD4pYbH/gL45MfX/8XUnX9iSvjZpJ6Wbl
-        lUZvW6HXDGukNDNmm0pdGH7Q788/BvbDnVX3FmMPg4L4lwN/8lQu0OdO2ihcMv6bMVtWWRZyYSGX
-        cLo0mmU79unu5vfLl3MwTL1Vh14vkdD5Hs91E1t0JHEoD7eSz/SRLIQeroZwzqegPj9SHvLy5ELr
-        95T79nvfq3DLekd0d3QreOh5gBAyFADU537g7bo4CuSwoI4bIAYYF1d07Df4+zn65pHRRnoWyGZk
-        GD6Rg5yYAAImNbsxZntXDzqrGQw/DFgRr9Pmdrn82J32HxhuuDxF8df48eMc9y0Pq+EN9J9qgw/C
-        x8XyBvrnqD8BLjXhun43nEA/WlRvHdSZsvtg+o4z3zUU9IKNpsavFObtbP6X0Qor6GjhkrGpMmvr
-        TBagk1Zo+7vJVboONm436SFTzRux8rDurRapB0+08Why/lLRe/g9d8+MfBNX0cEzGey446ffdPqa
-        4jXcdu2fgiZDoHoRX83bXVH54Z4vkSBcIQF/f7b/FwAA//8DALam4dy0CwAA
+        H4sIAAAAAAAAA7xWW2/rNgx+768Q/NwWTuKmTt7WYRsKbN0B2mE7WAqDtulEiyxpEtWdnCL/fZAc
+        39KmOO2APcXh5RPJjxT1fMZYxMtoySKDVmcxxPOkms4hxtk8j6s4nqdVGs8WaVpcF+lkcb2Y5cl8
+        Eie4uE7SvEyjcw+h8r+woBZGSYuNvDAIhGUGXje5nk/iNJlNpkFnCchZ71OoWgskLBunHIrt2ign
+        fVwVCIuNmAvB5TpasuczxhiLNOzQeP8Sn1AojSY6Y2wfjNEY5XXSCREEXLanZCUScGHHWkvGFcSV
+        HMlr+JIpR9pRRmqLL5WklMgKEGO4WpUofGRrTReJupjG0+QiTi/i+aFcATJasj9DJk0+HRNVcZqH
+        RREvUs9DenV1lVQpzOJ5OU2TJAAHENppDDBOhoRCeL36VNmDEsza1Sgp6J9XEXESuIqWq+gXbilX
+        Ri7ZwwbZj1yCYD/UmhtcReerCBxtlAmWNwZkqSS7B1misUoGAw1rtKtoeZUk/p/LBS8ghLdD8I7T
+        OJ7v+0h80FlTj/D5693D3Zoeqp++fsU6nSTf159vfy8mf/QeEuqQd5bV3IAtlMasUqYG8h3YsahE
+        lkXBZ3/G2GPgQ4MBIVCM6STjms7TBp+4cjZrm7sJrKNbG1VrygooNphtcTfUGQSr5KhvsaqUoYGR
+        Z8XVNZjWs2tjCxXSLuMlSuIVx1FLWzRPvMCMeDsGFThB0WG6lMFhEoS1RgPkgnhyGR+kX6iPrClX
+        93/QTMGuqdoh4ic0ubKcfMxRjSV3dT9+TR03ihfYo7dYIIT6B8tQbHvgL4xMc3/87bjpejJqjNpJ
+        6WfllUbvWmHQDGukLFdqm3FZqeig359/DOybO6vpLcYeRwWxLwf+5KlRibYwXAfhkkU/K7VlTjOf
+        C/O5+NO5kizfsdv7m7vLl3MwTr1T+16vkdDYAc9NE2s0xHEs97eSzeWRzIfurwZ/zq1Xnx8pD3lZ
+        Mr71B8p9970fVLhjvSe6P7oTPA48oCy5LwCIT8PAu3VxFMhhQR03QAgwLK7gOGzw93P0m0VGG26Z
+        J5uRYviFDBTESiBgXLIbpbb3zaCzhkH/w4BV4Tptb5fLj91p/4HhlstTFD+Ej2/neGh5WA1voH/X
+        GHwQPiyWN9A/Bf0JcC4J18274QT60aJ666DelH32pu84811DQS/YaGv8SmHezuZ/GS2/go4WLimd
+        CbXWRuUeOu6EeribjJNNsGG7cQu5aN+IzsJ6sFq4HD3RppPZ+UvF4OH33D8zik1YRQfPeLTjjp9+
+        SfKa4jXcbu2fgiZFIAYRX113u8LZ8Z6vkcBfIR5/f7b/FwAA//8DAHp5ASW0CwAA
     headers:
       CF-RAY:
-      - 990273ef8ebfe945-SEA
+      - 99240e18ca37ba2a-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -194,7 +188,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:12:49 GMT
+      - Tue, 21 Oct 2025 22:05:14 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -210,13 +204,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1561'
+      - '1807'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1566'
+      - '1816'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -230,7 +224,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 32ms
       x-request-id:
-      - req_c98dbad2dbaa48cf8c01845e5dbe1d2e
+      - req_aa69dbd18fdc4bd9888d1a11901695c4
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async_stream.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1236'
+      - '1284'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,7 +46,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_02ad8eee9a92579d0068f2a3a566fc8197b77fbde230b575e7","object":"response","created_at":1760732069,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_04e81f6bc0c6efc10068f803b833a481908027609d818cb4db","object":"response","created_at":1761084344,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -57,7 +54,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_02ad8eee9a92579d0068f2a3a566fc8197b77fbde230b575e7","object":"response","created_at":1760732069,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_04e81f6bc0c6efc10068f803b833a481908027609d818cb4db","object":"response","created_at":1761084344,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -65,82 +62,82 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","type":"function_call","status":"in_progress","arguments":"","call_id":"call_EhKsDFiHlPWDhy7EAKIYBTwa","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","type":"function_call","status":"in_progress","arguments":"","call_id":"call_ne0YY1KW7rsADxc2M7EmH4kI","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"{\"","obfuscation":"lRiP2rF7XwUXow"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"{\"","obfuscation":"4IW316pDUi5Hfv"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"isbn","obfuscation":"6tgz0qCHBQB1"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"isbn","obfuscation":"1GEyNKyNj79o"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"\":\"","obfuscation":"sBXmB4JaDBJEH"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"\":\"","obfuscation":"c34kEni5zoc9F"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"0","obfuscation":"MlRUk6oN56vsf8m"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"0","obfuscation":"3WNu0jqNyG7Mi03"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"-","obfuscation":"ko75JB7URZqdm0g"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"-","obfuscation":"MeaIKltM7opjUoI"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"765","obfuscation":"tRJV3BRpHJH5T"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"765","obfuscation":"0mJZFUQohxN5B"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"3","obfuscation":"aeU2LjU5dnujdlC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"3","obfuscation":"SMumo3k17JeGgkU"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"-","obfuscation":"xT8xOz4ifNTVBL7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"-","obfuscation":"67Uv6SlNVkp9sml"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"117","obfuscation":"5nICkY9NAqUrO"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"117","obfuscation":"XBRKzTNQv3CWw"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"8","obfuscation":"KqzUHyAxLXiWmSV"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"8","obfuscation":"anp0VPhpYBYURoi"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"-X","obfuscation":"R65wYJ1bY7rFB0"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"-X","obfuscation":"Vdfi7K0H4ksFKG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"delta":"\"}","obfuscation":"9DMdfxV8rmxQKw"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"delta":"\"}","obfuscation":"R91ndyB3nV2Yok"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EhKsDFiHlPWDhy7EAKIYBTwa","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ne0YY1KW7rsADxc2M7EmH4kI","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_02ad8eee9a92579d0068f2a3a566fc8197b77fbde230b575e7","object":"response","created_at":1760732069,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EhKsDFiHlPWDhy7EAKIYBTwa","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_04e81f6bc0c6efc10068f803b833a481908027609d818cb4db","object":"response","created_at":1761084344,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ne0YY1KW7rsADxc2M7EmH4kI","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":152,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":175},"user":null,"metadata":{}}}
@@ -149,13 +146,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 990276693875c371-SEA
+      - 99240eddf9e2753e-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:29 GMT
+      - Tue, 21 Oct 2025 22:05:44 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -171,23 +168,23 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '83'
+      - '143'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '99'
+      - '154'
       x-request-id:
-      - req_7e6cda5eefea4f7298dd52d0e0fff799
+      - req_fbb5a4d3a48a4d239a87fb07c62abb56
     status:
       code: 200
       message: OK
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EhKsDFiHlPWDhy7EAKIYBTwa","name":"get_book_info","type":"function_call","id":"fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92","status":"completed"},{"call_id":"call_EhKsDFiHlPWDhy7EAKIYBTwa","output":"Title:
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_ne0YY1KW7rsADxc2M7EmH4kI","name":"get_book_info","type":"function_call","id":"fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0","status":"completed"},{"call_id":"call_ne0YY1KW7rsADxc2M7EmH4kI","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
@@ -201,12 +198,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1632'
+      - '1680'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=4160xIBh8lKhLZuQNHLiVZZHrpTf7fXTSydhFWAvtac-1760731938-1.0.1.1-RAh37BuWJ1CiwZUsOyzB4cjKKxBr7O7cTQaEnsAxIOEsL.U9zDg_tJKebjoiGngLncxB0vq6AHHFKPNnyRCGeC3s7ohJzCQY.gZ9BA8pF14;
-        _cfuvid=Uozr1Dz.1JiboNSsHtjGdudE1BeOQ.Barpiu2emmad4-1760731938824-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -235,7 +229,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_02ad8eee9a92579d0068f2a3a665788197aa8b9b1b8041318e","object":"response","created_at":1760732070,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_04e81f6bc0c6efc10068f803b930188190ac91be18552dc815","object":"response","created_at":1761084345,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -243,7 +237,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_02ad8eee9a92579d0068f2a3a665788197aa8b9b1b8041318e","object":"response","created_at":1760732070,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_04e81f6bc0c6efc10068f803b930188190ac91be18552dc815","object":"response","created_at":1761084345,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -251,164 +245,164 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","type":"function_call","status":"in_progress","arguments":"","call_id":"call_6fnBO6kiYT9r7w8szE0MUlTc","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","type":"function_call","status":"in_progress","arguments":"","call_id":"call_QeInmocTvaZdqriB6Retk0OU","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"{\"","obfuscation":"iVeCZCwxOnOZCg"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"{\"","obfuscation":"EpHpcSW9X73MWW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"title","obfuscation":"JlVWeCZbgAj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"title","obfuscation":"pOZOQV1nDVy"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"\":\"","obfuscation":"OTW9FmKWYVzv3"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"\":\"","obfuscation":"GVW5dNgrNvhC9"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"Mist","obfuscation":"xQ0Uitk6l210"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"Mist","obfuscation":"6uxw6EvT6M0R"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"born","obfuscation":"ANcar9W4ShZz"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"born","obfuscation":"uIuCx3cOSy5b"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":":","obfuscation":"1hr9Qrl5NFKez8l"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":":","obfuscation":"phuyLh3385IwHfG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"
-        The","obfuscation":"6UyeWIXIG5gw"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"
+        The","obfuscation":"p0tnqELOA426"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"
-        Final","obfuscation":"Wd10SpE3LC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"
+        Final","obfuscation":"phSRqGSOLW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"
-        Empire","obfuscation":"tkKuhYKzC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"
+        Empire","obfuscation":"00vnk7uK6"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"\",\"","obfuscation":"K9tBcMH5pfXZN"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"\",\"","obfuscation":"8miFNxX3EVRpv"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"author","obfuscation":"5RjgOArR9M"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"author","obfuscation":"4Y4TyBukQ7"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"\":\"","obfuscation":"r3M6hF4RUDHvT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"\":\"","obfuscation":"bKNVTThTVzG66"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"Br","obfuscation":"HHXb3YsYfR0tcJ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"Br","obfuscation":"8Lvbx3QEcXGRyk"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"andon","obfuscation":"bzO9JRbjzys"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"andon","obfuscation":"FMlYaLFfWew"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"
-        Sand","obfuscation":"DzxQ92c93In"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"
+        Sand","obfuscation":"TNyA6lgGaal"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"erson","obfuscation":"4YdbRNw0wMi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"erson","obfuscation":"f8Qprda8Tqd"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"\",\"","obfuscation":"oUk7EXWcPOec2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"\",\"","obfuscation":"vh5U1rNzhjvnc"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"pages","obfuscation":"Xu0AqRjWWyF"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"pages","obfuscation":"vaCarjniWm6"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"\":","obfuscation":"QoBDGDneiYgW5Q"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"\":","obfuscation":"hBXuCfxkipzy2p"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"544","obfuscation":"WYKGe2JiXunDs"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"544","obfuscation":"0OPZ7w513CNx8"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":",\"","obfuscation":"PXQmUBTk0Yp9sl"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":",\"","obfuscation":"fjTS4YO50vMpHl"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"publication","obfuscation":"EMtOy"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"publication","obfuscation":"3APqz"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"_year","obfuscation":"pt4I0zbaDsG"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"_year","obfuscation":"q7Fm615dx1k"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"\":","obfuscation":"eIrf3XkPGpImwK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"\":","obfuscation":"ftcqjunrGgYnto"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"200","obfuscation":"d50YnPwHRxs4v"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"200","obfuscation":"wLQnaq58Qq2GZ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"6","obfuscation":"73q6sH7plgTcsy1"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"6","obfuscation":"X19zxXw7RfKHfhL"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"delta":"}","obfuscation":"hcKAtkcnSqBMWSJ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"delta":"}","obfuscation":"ghXqbZE88OxU5RY"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","output_index":0,"arguments":"{\"title\":\"Mistborn:
+        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","output_index":0,"arguments":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_6fnBO6kiYT9r7w8szE0MUlTc","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_QeInmocTvaZdqriB6Retk0OU","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_02ad8eee9a92579d0068f2a3a665788197aa8b9b1b8041318e","object":"response","created_at":1760732070,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_6fnBO6kiYT9r7w8szE0MUlTc","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_04e81f6bc0c6efc10068f803b930188190ac91be18552dc815","object":"response","created_at":1761084345,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_QeInmocTvaZdqriB6Retk0OU","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":213,"input_tokens_details":{"cached_tokens":0},"output_tokens":44,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257},"user":null,"metadata":{}}}
@@ -417,13 +411,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 9902766f2d58c371-SEA
+      - 99240ee4f852753e-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:14:30 GMT
+      - Tue, 21 Oct 2025 22:05:45 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -439,15 +433,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '395'
+      - '95'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '424'
+      - '107'
       x-request-id:
-      - req_3475494e49144c7a8474361cd0fe2443
+      - req_034ba820f84a477794b3e9c225417297
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/stream.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1236'
+      - '1284'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -49,7 +46,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a687746ec3796fe0068f2a36ec5f48194b79dd44d81d75243","object":"response","created_at":1760732014,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_05c98fe93bf42dbf0068f803a4ab34819098ea62ad271e0cce","object":"response","created_at":1761084324,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -57,7 +54,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a687746ec3796fe0068f2a36ec5f48194b79dd44d81d75243","object":"response","created_at":1760732014,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_05c98fe93bf42dbf0068f803a4ab34819098ea62ad271e0cce","object":"response","created_at":1761084324,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -65,82 +62,82 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","type":"function_call","status":"in_progress","arguments":"","call_id":"call_EUpPd1zspWqxQVBzskOK77AE","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","type":"function_call","status":"in_progress","arguments":"","call_id":"call_1fg5q1oL0b4WfrZQ0JBaOw0P","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"{\"","obfuscation":"iloXY2WalTS2pk"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"{\"","obfuscation":"QJ5Eyk822238jt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"isbn","obfuscation":"2ra9uhHVfPTH"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"isbn","obfuscation":"bTYEJPtaqw4R"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"\":\"","obfuscation":"EKEQ4OpdLS6YT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"\":\"","obfuscation":"xeXXAHLb8jLmo"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"0","obfuscation":"LnCzkVbcRKqERiU"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"0","obfuscation":"I6ILwp3vdx7rBIF"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"-","obfuscation":"JCE0LAr9whyiAC7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"-","obfuscation":"MM3xb7nYVCZupiE"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"765","obfuscation":"qUWx3le2dNRXf"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"765","obfuscation":"xWlayeam04UAe"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"3","obfuscation":"vnO3xj0lhOhmTBd"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"3","obfuscation":"GuNY517BfHDTY48"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"-","obfuscation":"zO2H8Ien5A7GgCi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"-","obfuscation":"e63gjiN8CSP9wdL"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"117","obfuscation":"Cjkam9Rt22ELL"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"117","obfuscation":"NEceH80Z01YYP"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"8","obfuscation":"mAvcI8zRqzLjasX"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"8","obfuscation":"zbCJE58QphquXcY"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"-X","obfuscation":"oriVRpFBZ0Dq8i"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"-X","obfuscation":"DONegIbnuczNy4"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"delta":"\"}","obfuscation":"E4F1diU2Wx1wSL"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"delta":"\"}","obfuscation":"KontdSadKkquMh"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EUpPd1zspWqxQVBzskOK77AE","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_1fg5q1oL0b4WfrZQ0JBaOw0P","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0a687746ec3796fe0068f2a36ec5f48194b79dd44d81d75243","object":"response","created_at":1760732014,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EUpPd1zspWqxQVBzskOK77AE","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_05c98fe93bf42dbf0068f803a4ab34819098ea62ad271e0cce","object":"response","created_at":1761084324,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_1fg5q1oL0b4WfrZQ0JBaOw0P","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":152,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":175},"user":null,"metadata":{}}}
@@ -149,13 +146,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 99027513cd1ce17a-SEA
+      - 99240e64bf03c4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:34 GMT
+      - Tue, 21 Oct 2025 22:05:24 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -171,23 +168,23 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '162'
+      - '110'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '173'
+      - '129'
       x-request-id:
-      - req_444dcfbd66ec425dbbf8ee43b02d151d
+      - req_a21e87e1d68f4d5eacf03640ac658b80
     status:
       code: 200
       message: OK
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EUpPd1zspWqxQVBzskOK77AE","name":"get_book_info","type":"function_call","id":"fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e","status":"completed"},{"call_id":"call_EUpPd1zspWqxQVBzskOK77AE","output":"Title:
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_1fg5q1oL0b4WfrZQ0JBaOw0P","name":"get_book_info","type":"function_call","id":"fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100","status":"completed"},{"call_id":"call_1fg5q1oL0b4WfrZQ0JBaOw0P","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
@@ -201,12 +198,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1632'
+      - '1680'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -235,7 +229,7 @@ interactions:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0a687746ec3796fe0068f2a3701fbc819480db2dfa73dda5de","object":"response","created_at":1760732016,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_05c98fe93bf42dbf0068f803a61d1881908b192a0aad1124cb","object":"response","created_at":1761084326,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -243,7 +237,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0a687746ec3796fe0068f2a3701fbc819480db2dfa73dda5de","object":"response","created_at":1760732016,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_05c98fe93bf42dbf0068f803a61d1881908b192a0aad1124cb","object":"response","created_at":1761084326,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -251,164 +245,164 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","type":"function_call","status":"in_progress","arguments":"","call_id":"call_Sz68GhAUAvwpVT01l6Z8Ovez","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","type":"function_call","status":"in_progress","arguments":"","call_id":"call_Sl3GfUD0tqZi9IVnViLlqciN","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"{\"","obfuscation":"pxaPnQlGT4d7YM"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"{\"","obfuscation":"OU0hRWokQEuv27"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"title","obfuscation":"o0XWWsn9d9O"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"title","obfuscation":"PV7Q4DkobOn"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"\":\"","obfuscation":"kv4ocO1wxlv5c"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"\":\"","obfuscation":"yZgkUHaBx4n6w"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"Mist","obfuscation":"weDjN1kDWb9c"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"Mist","obfuscation":"iAobcRFS4NwT"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"born","obfuscation":"iqflwPsKHEbC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"born","obfuscation":"CYSBHUUyf6iy"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":":","obfuscation":"KKc7tbLUC0CXubF"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":":","obfuscation":"p8QK8mFad9yJKtl"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"
-        The","obfuscation":"YSCqwBc3N50E"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"
+        The","obfuscation":"keuV9MuIcytt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"
-        Final","obfuscation":"H37Xap5SzI"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"
+        Final","obfuscation":"VydSVRJCcf"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"
-        Empire","obfuscation":"Twnv8EnrB"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"
+        Empire","obfuscation":"eBwpZwLDZ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"\",\"","obfuscation":"nQPpUZN94qkPT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"\",\"","obfuscation":"RHEv72ItUf5Zf"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"author","obfuscation":"4fcinnPGA9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"author","obfuscation":"SgIrWEb0jU"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"\":\"","obfuscation":"23mZPF7FPWoqQ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"\":\"","obfuscation":"744pwPggaAd6a"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"Br","obfuscation":"HcHj17rvCioYVB"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"Br","obfuscation":"Y8fOpxnhTmmgSM"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"andon","obfuscation":"BlgJHDzZu6q"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"andon","obfuscation":"Kt97xDi2xht"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"
-        Sand","obfuscation":"vzjGMLW6jtT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"
+        Sand","obfuscation":"vRJ0AeiZpjQ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"erson","obfuscation":"VC3kQc10t9p"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"erson","obfuscation":"fG3QoTpBcK4"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"\",\"","obfuscation":"ZKld3PHf9W7lA"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"\",\"","obfuscation":"wo0krju3Jhdnx"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"pages","obfuscation":"uYvY5kquemW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"pages","obfuscation":"GSmdGpsKoPd"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"\":","obfuscation":"lIsf6p82s9wf6u"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"\":","obfuscation":"8y9FH383QdUFO7"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"544","obfuscation":"bCdUuj3yJXE8i"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"544","obfuscation":"jkIZNCD9WzSZH"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":",\"","obfuscation":"Hy6aqOQX0Icn9t"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":",\"","obfuscation":"di4ah8Uxj2Iiwy"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"publication","obfuscation":"YWFW7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"publication","obfuscation":"5WnY0"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"_year","obfuscation":"NudnfykJ3Em"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"_year","obfuscation":"5KbdXuRvLdn"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"\":","obfuscation":"ufAzJC3ke9wCZI"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"\":","obfuscation":"lIOEGdjn24doCP"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"200","obfuscation":"aXbUSSmc9Yumj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"200","obfuscation":"Y933S7NfmbVkZ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"6","obfuscation":"sTORE9iZUUvJPOm"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"6","obfuscation":"c9uRWdYeEjddcN0"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"delta":"}","obfuscation":"bKNdiuAQeNaqbfT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"delta":"}","obfuscation":"VvMiu6TsF34Ezcv"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","output_index":0,"arguments":"{\"title\":\"Mistborn:
+        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","output_index":0,"arguments":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_Sz68GhAUAvwpVT01l6Z8Ovez","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_Sl3GfUD0tqZi9IVnViLlqciN","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_0a687746ec3796fe0068f2a3701fbc819480db2dfa73dda5de","object":"response","created_at":1760732016,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_Sz68GhAUAvwpVT01l6Z8Ovez","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_05c98fe93bf42dbf0068f803a61d1881908b192a0aad1124cb","object":"response","created_at":1761084326,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_Sl3GfUD0tqZi9IVnViLlqciN","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":213,"input_tokens_details":{"cached_tokens":0},"output_tokens":44,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257},"user":null,"metadata":{}}}
@@ -417,13 +411,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 9902751c6f92e17a-SEA
+      - 99240e6d9b03c4cb-SEA
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 17 Oct 2025 20:13:36 GMT
+      - Tue, 21 Oct 2025 22:05:26 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -439,15 +433,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '75'
+      - '318'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '83'
+      - '352'
       x-request-id:
-      - req_ddaa6d6d8bd54ddaa98fdb7a8e4ceb0e
+      - req_360ad7fac49b4f28b93d05397c33a9d4
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/sync.yaml
@@ -1,9 +1,9 @@
 interactions:
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      score","type":"input_text"}],"role":"user","type":"message"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -15,12 +15,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1222'
+      - '1270'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -48,26 +45,26 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xW227bOBB9z1cQeo4LKbYcO28NukCDLhYB2gX2koAYUSOba0pUyWE2buB/X5Cy
-        br6kzS6wT5Znhoczcw45fLlgLJJ5dMMig7bm8XyaTxfz2WKxBJjNizieL4ormMZZjOlikSxTSKb5
-        VYKz61k6R0zz6NJD6OwvFNTC6MpiYxcGgTDn4H3J9Ty+nibLJA0+S0DO+jVCl7VCwj1YBmKzMtpV
-        Pq8ClMXGLJWS1Sq6YS8XjDEW1bBF49fn+IRK12iiC8Z2IRiN0d5XOaWCQVbtLjxHAqns2GvJOEFS
-        VyN7Cc9cO6odcdIbPHaS1ooLUGO4UueofGarmiYzPbmKr2aTeDGJ5/t2Bcjohv0ZKmnq6ZgoxCs8
-        LOfz2POwEGkqEiHEEmZ5CssAHEBoW2OAcVUoKKTXu8+1PTjBrFyJFQX/y0MkbVY9RDcPUTy5nqfT
-        SZJcLya/PUS7folH503i4fP9t5++TFOb/aHubj/a9Uf9SX369uHrql9RQRkSXCHxTOsNl1Who+Dd
-        XTD2GFpUgwGlUI07TMY1YqgNPkntLG/11qTQMVAbXdbEBYg18g1uhz6DYHU1khIWhTY0CPKNcmUJ
-        pl3ZKctCgbTlMseKZCFxpDKL5kkK5CRbZRbgFEV7wWuDwyIIyxoNkAvm5F28tz5Tn1mhTQn9/wG/
-        Ia7p2j7jJzSZtpJ8zlGJuXRlfyKaPq61FNijt1iglP4b89Bsu2cqqLg50l+dNJ1MoiaoFW8v3xPa
-        60h/nfauhDeDcV5KA1boGnnTKn/ddEdWK867LcLv46gh9vgMnt01ytEKI+tgvGHRz1pvmKuZr4X5
-        WvzuUlcs27K7z7e/vPue4ju313qJhMYOeG5EXKMhiWO7vyhsVh3YfOqSVNjnzrsvD5z7uiwZL/2B
-        c9d97wYd7ljvie637gyPgxWQ59I3ANT9MPHuBj9IZD8zDgUQEgyzJCwcCvztHP1qkdFaWubJZqQZ
-        PpMBQSwHAiYrdqv15nNz0FnDoP9hwApZgWLt7XKCyx9R3n9guOXyHMVfwsePczyMjMDROozHc+jv
-        m4B/CV/D6qigIfp98J8BlxXhqhnlZ9BdpqQIR41vEV4r474PZb/70Dfs+aZDQUdstD0+0ZjXq/lf
-        jpYfQQcDl3TNlV7VRmceOu6M9XA2GVc1yYbpJi1kqn22OQurwWiR1ejVlKRXl8eOwVvspX9QiHUY
-        RfuV8WjGHb7GpstTjlO43dg/B02aQA0yXibdrHB2POdLJPBXiMffXez+AQAA//8DAK3ABwlHCwAA
+        H4sIAAAAAAAAA7xWTW/jNhC9+1cQOscLybYs2bfupV20aANsF2jQBAQljWTWlMiSwzRu4P++IGV9
+        +SPdtEBPlmc4jzPzHjl8nRES8CLYkkCDUTSMN5tNGrEkjLM0XpRhuE7LNFymSbxepWm0WWVlloTr
+        EBZRmKRJngd3DkJmf0COHYxsDLT2XANDKChzvihZR2G6Wmxi7zPI0BoXk8taCUAo2qCM5ftKS9u4
+        vEomDLRmLgRvqmBLXmeEEBIodgDt4gt4BiEV6GBGyNEvBq2l8zVWCG/gTbcLLQAZF2bqNahtjlw2
+        E3vNXqi0qCxSlHu4dKKUguZMTOFqWYBwmVUK5ys5X4SL1TxM5+H61C4PGWzJ776Stp6eiTJ/g4cy
+        THPPwyIOIc+iksGyCMONB/YgeFDgYWzjC/LpDe5bbfdOpitbQ4Pe//oYcJM1j8H2MQjnyTpezqMo
+        See/PQbHIcSh0zZx/xn/IOxDUnFc/f1jGbMvS/Vgv/+lPgwRDat9ghUgzaTcU96UMvDe44yQJ98i
+        xTQTAsS0w6htKwal4ZlLa2intzaFngGlZa2Q5izfAd3DYezTwIxsJlKCspQaR4tco2xdM91F9soy
+        rAQ8UF5Ag7zkMFGZAf3Mc6DIO2WWzAoMToKXGsZFINQKNEPrzdGH8GR9wSGzUuqaDf9H/Pp1bddO
+        GT+DzqTh6HIOaii4rYcT0fZxJ3kOA3qHxYSQf0Hhm21OTHkVt0f6T8t1L5OgXdSJd5DvFe31pL9N
+        e1/Cu8EorblmJpcKaNsqd930R1YKSvst/O/TpCHm8gze3DUowOSaK2/ckuAnKffEKuJqIa4WtzuX
+        DckO5NPnjz9/+CfF926n9RoQtBnx3IpYgUYOU7u7KEzWnNlc6hyF3+eTc9+dOU91GdRO+iPnsf8+
+        jjrcsz4QPWzdG55GEawouGsAE/fjxPsb/CyR08w4F4BP0M8SHzgW+Ps5+mKA4I4b4sgmKAm8oGY5
+        koIhI7whH6Xcf24POmkZdD+EkZI3TJDudrnC5bco7z8w3HF5i+Jf/ce3czxeGTCLOz8eb6F/1y74
+        l/CKVRcFjdHvvf8GOG8QqnaU30C3meC5P2r0AOytMu6HpeTBLX3Hnu86FHjBRtfjK415u5r/5Wi5
+        EXQ2cFEqKmSltMwcdNgb1Xg2adu0yfrpxg3LRPdss4ZVo9HCm8mrKYoXd5eO0VvsdXhQ5Ds/ik6R
+        4WTGnb/GFstrjmu4/di/BY0SmRhlnMT9rLBmOudrQOauEId/nB2/AgAA//8DABFlydtHCwAA
     headers:
       CF-RAY:
-      - 990272a4ab0bdee8-SEA
+      - 99240dad583530e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -75,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:11:55 GMT
+      - Tue, 21 Oct 2025 22:04:56 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -91,13 +88,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '836'
+      - '942'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '839'
+      - '948'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -111,15 +108,15 @@ interactions:
       x-ratelimit-reset-tokens:
       - 27ms
       x-request-id:
-      - req_75e90188d49847b5a424f92023574abc
+      - req_85f1bd379fcd4d169334412f5dd43c45
     status:
       code: 200
       message: OK
 - request:
     body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"role":"user","content":"Please
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":[{"text":"Please
       look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_AzET35sbZlIBHshHoKlKzDqg","name":"get_book_info","type":"function_call","id":"fc_063d3864889aa46f0068f2a30b966081958c55c1ccc9a4d5a9","status":"completed"},{"call_id":"call_AzET35sbZlIBHshHoKlKzDqg","output":"Title:
+      score","type":"input_text"}],"role":"user","type":"message"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_5HluY7git4zKf5aU3pYuGOmy","name":"get_book_info","type":"function_call","id":"fc_0599981a705b852f0068f80387f08c8194b250ecb1fae3d009","status":"completed"},{"call_id":"call_5HluY7git4zKf5aU3pYuGOmy","output":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","type":"function_call_output"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
@@ -133,12 +130,9 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1618'
+      - '1666'
       content-type:
       - application/json
-      cookie:
-      - __cf_bm=z6OWAIzSLe5LkkQmaAXjDNc116oWzShe77fOqxhV0gY-1760731877-1.0.1.1-ZlJClvYxDeu_3aIbZiiAZuXEqmJ6myHNAnwNjidJCmRNCqlAbBQ6y3ornWsrU4C6B_dtddpkKj8egGJGu4L4It28co51MJu1HrvzJ6EYxbU;
-        _cfuvid=J0NeTDSLZT7CeCVRwKnAcAQ3wGMI.jE9fiP0UUFQtwc-1760731877993-0.0.1.1-604800000
       host:
       - api.openai.com
       user-agent:
@@ -166,27 +160,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWS2/jNhC+51cQPDuB7CiO7NsG7RaL7SOLbA/FOhBG0shmTZEsOUpjBP7vC1LW
-        y4mDTQr0ZHkeH2fmm+Hw6YwxLgq+ZNyiM2k0vywuk3mcJAuAeF5G0TwpZ3AZ5dF1nCTTxdViBtHV
-        7DpHhHmE85hPPITO/sacWhitHDby3CIQFil43fR6Hl1fThfTedA5Aqqd98l1ZSQSFo1TBvl2bXWt
-        fFwlSIeNWEgp1Jov2dMZY4xxAzu03r/AB5TaoOVnjO2DMVqrvU7VUgaBUO0paYEEQrqx1pGtcxJa
-        jeQVPKa6JlNTSnqLz5WktUxzkGO4ShcofWRrQ+exPp9Fs/g8Ss6j+aFcAZIv2beQSZNPx0SZv8JD
-        UpSR5yEryzIv8kWUX5aLZJEE4ABCO4MBplYhoRBerz5V9qAEu64rVBT0TytOgiSu+HLFfxOOMm3V
-        kn3dIPsoFEj2c2WExRWfrDjUtNE2WN5YUIVW7A5UgdZpFQwMrNGt+PIqjv2/OpMihxDeDsE7zqJo
-        vu8j8UGnTT3C5+L2J/nZzf74opMvDx9p/ctjtP0sYtN7KKhC3mlaCQsu1wbTUtsKyHdgx6KWacqD
-        z/6MsfvAhwELUqIc00m2bjrPWHwQunZp29xNYB3dxurKUJpDvsF0i7uhziI4rUZ9i2WpLQ2MPCt1
-        VYFtPbs2dlAi7VJRoCJRChy1tEP7IHJMSbRjUEItiR+mS1scJkFYGbRAdRBPL6KD9JH6yJpydf8H
-        zRTsmqodIn5Am2knyMfMKyxEXfXj19Rxo0WOPXqLBVLqf7EIxXYH/sLINPfHP7WwXU/yxqidlH5W
-        Xmj0rhUGzbBGSjOtt6lQpeYH/X7yPrAf7qymtxi7HxXEPR/4k6fyAl1uhQnCJeO/ar1ltWE+F+Zz
-        8acLrVi2Y5/ubn6/eD4H49Q7te/1CgmtG/DcNLFBSwLHcn8ruUwdyXzo/mrw53zy6smR8pCXI+tb
-        f6Dcd9/7QYU71nui+6M7wf3AA4pC+AKAvB0G3q2Lo0AOC+q4AUKAYXEFx2GDv52jPx0y2gjHPNmM
-        NMNHspATK4CACcVutN7eNYPOGgb9DwNWhuu0vV0u3nen/QeGWy5PUfw1fPw4x0PLw2p4Bf1DY/BO
-        +LBYXkG/DfoT4EIRrpt3wwn0o0X12kG9KfvLm77hzDcNBT1jo63xC4V5PZv/ZbT8CjpauKRNKvXa
-        WJ156KgTmuFusrVqgg3bTTjIZPtGrB2sB6tFqNETbTaNJs8Vg4ffU//MyDdhFR08o9GOO376xfFL
-        ipdwu7V/Cpo0gRxEfBV3u6J24z1fIYG/Qjz+/mz/HQAA//8DAE8wTSC0CwAA
+        H4sIAAAAAAAAA7xW227jNhB9z1cQenYCyZGvbw22LQL0sovsFlvUgTCSRjZrilTJYRo38L8XpO5O
+        HGxSoE+W53I4M2eGw6cLxgKeB2sWaDRVEs5Wq9UygkU4S5ezaRGG82WxDK+Xy8U1hMtoFafX8TRN
+        F2m8iPMonObBxEGo9E/MqIVR0mAtzzQCYZ6A00WLeRQu4+lq7nWGgKxxPpkqK4GEDVgK2X6rlZUu
+        rgKEwVrMheByG6zZ0wVjjAUVHFA7/xwfUKgKdXDB2NEbo9bK6aQVwgu4bE9JciTgwoy1hrTNiCs5
+        kpfwmChLlaWE1B6fK0kpkWQgxnClylG4yLYVXcbqchpO48tweRnOm3J5yGDN/vCZ1Pl0TBTZeR5W
+        URTHnodVBGmYRzCfQZzPCg/sQehQoYex0ifkw+vV58rulaC3tkRJXv+0CYiTwE2w3gQ/c0Op0nLN
+        Pu+Q/cAlCPZ9WXGNm2CyCcDSTmlveaNB5kqyO5A5aqOkN6hgi2YTrGdx7P7ZVPAMfHgHBOc4DcP5
+        sY/EBZ3U9fCfxT8fwq9f9r9+mKmv0Y+r20/wyf6Gleo9JJQ+7yQpuQaTqQqTQukSyHVgx6ISSRJ4
+        n+MFY/eejwo0CIFiTCdpW3depfGBK2uStrnrwDq6K63KipIMsh0mezwMdRrBKDnqWywKpWlg5Fix
+        ZQm69eza2ECBdEh4jpJ4wXHU0gb1A88wId6OQQFWUNBMl9I4TIKwrFADWS+OrsJG+kh9ZHW5uv+D
+        ZvJ2ddWaiB9Qp8pwcjEHJebclv341XXcKZ5hj95igRDqb8x9sU3Dnx+Z+v74y3Ld9WRQG7WT0s/K
+        C43etcKgGbZISarUPuGyUEGjP07eB/bNnVX3FmP3o4KY5wN/9tQgR5NpXnnhmgU/KbVntmIuF+Zy
+        cadzJVl6YLd3N79cPZ+Dceqd2vV6iYTaDHium7hCTRzHcncrmVSeyFzo7mpw59w69eRE2eRlSLvW
+        HyiP3fdxUOGO9Z7o/uhOcD/wgDznrgAgPg4D79bFSSDNgjptAB+gX1zecdjgb+foi0FGO26YI5uR
+        YvhIGjJiORAwLtmNUvu7etBZzaD7YcAKf522t8vV++60/8Bwy+U5ij/7j2/neGjZrIZX0L+rDd4J
+        7xfLK+gfvf4MOJeE2/rdcAb9ZFG9dlBvyn53pm84801DQc/YaGv8QmFez+Z/GS23gk4WLqkqEWpb
+        aZU66LATVsPdpK2sg/XbjRtIRftGtAa2g9XC5eiJNo2uJ88Vg4ffU//MyHZ+FTWe4WjHnT794vgl
+        xUu43do/B02KQAwini26XWHNeM+XSOCuEId/vDj+CwAA//8DAPGZDh60CwAA
     headers:
       CF-RAY:
-      - 990272aabb88dee8-SEA
+      - 99240db44d9f30e1-SEA
       Connection:
       - keep-alive
       Content-Encoding:
@@ -194,7 +188,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 20:11:57 GMT
+      - Tue, 21 Oct 2025 22:04:57 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -210,13 +204,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1211'
+      - '1329'
       openai-project:
       - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1217'
+      - '1335'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -224,13 +218,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799573'
+      - '799570'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
       - 32ms
       x-request-id:
-      - req_6e3fa022fe834499b3feaad1747cfeb3
+      - req_980caf329a3f4079a0076ab827f76e3a
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/snapshots/test_call/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/openai_responses_gpt_4o_snapshots.py
@@ -16,16 +16,16 @@ sync_snapshot = snapshot(
             "messages": [
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
-                    content=[Text(text="4200 + 42 is 4242.")],
+                    content=[Text(text="4200 + 42 equals 4242.")],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0dd4d7c7953cdc350068f2974a56b081908ae3b07c4d73c2d7",
+                            "id": "msg_0c52b236fa88b5390068f8033193b481959d4a63cabd933023",
                             "content": [
                                 {
                                     "annotations": [],
-                                    "text": "4200 + 42 is 4242.",
+                                    "text": "4200 + 42 equals 4242.",
                                     "type": "output_text",
                                     "logprobs": [],
                                 }
@@ -57,7 +57,7 @@ async_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0c9b1376dac632050068f2974ff7b88196befe9451216b2bf0",
+                            "id": "msg_0880d0e77f674ebd0068f80332dde481978c5e28070332da5b",
                             "content": [
                                 {
                                     "annotations": [],
@@ -92,7 +92,7 @@ stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0a457f78f810604b0068f29756e5d4819781bffda073f1c224",
+                            "id": "msg_03fa6638755bf2280068f8033404a8819684c851a3df14d87d",
                             "content": [
                                 {
                                     "annotations": [],
@@ -128,7 +128,7 @@ async_stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_01c3c1bd01a071710068f2975bb39c81978b53bd51c43b4c69",
+                            "id": "msg_0132776d8f7a56760068f80335d90c8197852aa069280c95cd",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_responses_gpt_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_responses_gpt_5_snapshots.py
@@ -26,36 +26,34 @@ sync_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Counting primes with substring**
+**Counting primes with substring 79**
 
-I need to figure out which prime numbers under 400 contain the substring "79" in their decimal representation. That means I should look for numbers like 79 itself and those including it as a consecutive pair of digits. The potential candidates are 79, 179, 279, and 379—I'll be focusing on that range to find the relevant primes. It seems I have a clear path to check for those specific patterns in decimal numbers.\
+I’m considering how to count prime numbers below 400 that contain "79" as a substring. This includes 79 itself and numbers like 179, 197, 279, and 379. I also need to note that numbers like 790-799 aren't relevant since they exceed 400. I’ll check the prime status for 79, 179, 279, and 379 since those are my candidates. 79 is prime, but I’ll verify the others next!\
 """
                         ),
                         Thought(
                             thought="""\
-**Determining prime candidates**
+**Verifying primes containing 79**
 
-So, I'm refining my list of numbers under 400 that contain "79." The only valid candidates are 79, 179, 279, and 379. I need to check which of these are prime. \n\
+I’ve confirmed that 79 is prime! Now for 179, I’ll check its divisibility. The square root is about 13.38, so I’ll check primes up to that. It turns out 179 is not divisible by primes like 2, 3, 5, 7, 11, and 13, so it’s also prime. \n\
 
-I know 79 is prime. Now, for 179, I'll check primality by testing divisibility against primes up to the square root, which is about 13.38. It turns out 179 isn't divisible by any of those primes, confirming it's also prime! But 279 is definitely not prime, as it divides by 3. So I've narrowed it down effectively!\
+Then I checked 279 and found it's divisible by 3, meaning it's composite, so not prime. Finally, I verified that 379 is prime too. Thus, the primes below 400 that contain "79" are 79, 179, and 379—totaling three primes!\
 """
                         ),
                         Thought(
                             thought="""\
-**Verifying primality of candidates**
+**Confirming valid primes containing 79**
 
-I need to check if 379 is prime. The square root is about 19.46, so I’ll test it against primes up to that point. It turns out 379 is indeed prime because it’s not divisible by any of those smaller primes.
+I initially thought that 197 contained "79," but it actually has "97," so it doesn’t count. Checking other numbers, like 297 and 97, confirms they don't have "79" either. So the total should still be 3 primes. \n\
 
-So, the primes under 400 that contain the substring “79” are 79, 179, and 379—making a total of three. I confirmed that post separation, digits won't count as "79", ensuring only those with consecutive digits qualify!\
+I already confirmed 79, 179, and 379 are primes, while 279 is composite. Also, I made sure none of the other numbers like 397 or 971 contain "79." Hence, my final answer is indeed just 3.\
 """
                         ),
                         Thought(
                             thought="""\
-**Confirming final count of primes**
+**Finalizing prime count**
 
-The count of primes containing the substring "79" remains at 3. I’ve double-checked for other combinations under 400, confirming that valid three-digit forms are limited to [1-3]79, and there aren't any valid two-digit candidates aside from 79 itself.
-
-I also re-checked the primality of both 179 and 379, confirming they are indeed prime. So, I can confidently provide the answer as “3” without any additional details.\
+I really want to make sure I’m accurate, so I'm triple-checking the primality of 179 and 379. Confirming they’re both indeed prime, I can confidently say the final output is 3. Just to keep it straightforward, I’ll write only the number without any extra text or punctuation. So, the answer is simply 3.\
 """
                         ),
                         Text(text="3"),
@@ -64,43 +62,41 @@ I also re-checked the primality of both 179 and 379, confirming they are indeed 
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0082116a5a2628830068f2975e0e08819087ca8472035130bd",
+                            "id": "rs_06f07415cc51b60b0068f805cc49288194a3d87ba669ed07ea",
                             "summary": [
                                 {
                                     "text": """\
-**Counting primes with substring**
+**Counting primes with substring 79**
 
-I need to figure out which prime numbers under 400 contain the substring "79" in their decimal representation. That means I should look for numbers like 79 itself and those including it as a consecutive pair of digits. The potential candidates are 79, 179, 279, and 379—I'll be focusing on that range to find the relevant primes. It seems I have a clear path to check for those specific patterns in decimal numbers.\
+I’m considering how to count prime numbers below 400 that contain "79" as a substring. This includes 79 itself and numbers like 179, 197, 279, and 379. I also need to note that numbers like 790-799 aren't relevant since they exceed 400. I’ll check the prime status for 79, 179, 279, and 379 since those are my candidates. 79 is prime, but I’ll verify the others next!\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Determining prime candidates**
+**Verifying primes containing 79**
 
-So, I'm refining my list of numbers under 400 that contain "79." The only valid candidates are 79, 179, 279, and 379. I need to check which of these are prime. \n\
+I’ve confirmed that 79 is prime! Now for 179, I’ll check its divisibility. The square root is about 13.38, so I’ll check primes up to that. It turns out 179 is not divisible by primes like 2, 3, 5, 7, 11, and 13, so it’s also prime. \n\
 
-I know 79 is prime. Now, for 179, I'll check primality by testing divisibility against primes up to the square root, which is about 13.38. It turns out 179 isn't divisible by any of those primes, confirming it's also prime! But 279 is definitely not prime, as it divides by 3. So I've narrowed it down effectively!\
+Then I checked 279 and found it's divisible by 3, meaning it's composite, so not prime. Finally, I verified that 379 is prime too. Thus, the primes below 400 that contain "79" are 79, 179, and 379—totaling three primes!\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Verifying primality of candidates**
+**Confirming valid primes containing 79**
 
-I need to check if 379 is prime. The square root is about 19.46, so I’ll test it against primes up to that point. It turns out 379 is indeed prime because it’s not divisible by any of those smaller primes.
+I initially thought that 197 contained "79," but it actually has "97," so it doesn’t count. Checking other numbers, like 297 and 97, confirms they don't have "79" either. So the total should still be 3 primes. \n\
 
-So, the primes under 400 that contain the substring “79” are 79, 179, and 379—making a total of three. I confirmed that post separation, digits won't count as "79", ensuring only those with consecutive digits qualify!\
+I already confirmed 79, 179, and 379 are primes, while 279 is composite. Also, I made sure none of the other numbers like 397 or 971 contain "79." Hence, my final answer is indeed just 3.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Confirming final count of primes**
+**Finalizing prime count**
 
-The count of primes containing the substring "79" remains at 3. I’ve double-checked for other combinations under 400, confirming that valid three-digit forms are limited to [1-3]79, and there aren't any valid two-digit candidates aside from 79 itself.
-
-I also re-checked the primality of both 179 and 379, confirming they are indeed prime. So, I can confidently provide the answer as “3” without any additional details.\
+I really want to make sure I’m accurate, so I'm triple-checking the primality of 179 and 379. Confirming they’re both indeed prime, I can confidently say the final output is 3. Just to keep it straightforward, I’ll write only the number without any extra text or punctuation. So, the answer is simply 3.\
 """,
                                     "type": "summary_text",
                                 },
@@ -108,7 +104,7 @@ I also re-checked the primality of both 179 and 379, confirming they are indeed 
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_0082116a5a2628830068f29776713c81908d61359ae89236b5",
+                            "id": "msg_06f07415cc51b60b0068f805e2fba881948846b29140f987ce",
                             "content": [
                                 {
                                     "annotations": [],
@@ -136,12 +132,12 @@ I also re-checked the primality of both 179 and 379, confirming they are indeed 
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0082116a5a2628830068f29777f1cc8190b6645119f231c826",
+                            "id": "rs_06f07415cc51b60b0068f805e460908194a0c4fa08136cc2d1",
                             "summary": [],
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_0082116a5a2628830068f29778213c819093fe79c7e69b1024",
+                            "id": "msg_06f07415cc51b60b0068f805e4c8e88194ad593187c2e4e6d2",
                             "content": [
                                 {
                                     "annotations": [],
@@ -181,34 +177,41 @@ async_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Counting primes with substring "79"**
+**Counting prime numbers with substring 79**
 
-I need to find the count of prime numbers below 400 that have the substring "79" in their decimal representation. The substring can appear in 2- or 3-digit numbers. The 2-digit number is just 79. For 3-digit numbers, valid forms are 179, 279, and 379 since they include "79" but must be less than 400. The 790-799 range is excluded as they exceed 400. So, I think we only have four numbers to consider.\
+I need to count the prime numbers less than 400 that contain '79' as a substring. First, I'll look at two-digit primes, and '79' itself qualifies, so that's one. For three-digit primes, '79' would need to be in the first two digits, like 79x where x is a digit, but that wouldn’t give us valid numbers since 790 to 799 are all above 400. So, my count will only include '79', making it one valid prime.\
 """
                         ),
                         Thought(
                             thought="""\
-**Checking primes with “79” substring**
+**Identifying primes with substring 79**
 
-I’m considering candidates with the substring "79" below 400. So far, these are 79, 179, 279, and 379. I noted that "79" can't appear crossing digit boundaries, and the range 790-799 exceeds 400, so those won’t work. Now, I need to determine which of these are prime numbers. \n\
-
-79 is known to be prime. After testing 179, it’s also prime since it’s not divisible by any primes up to its square root. However, 279 is divisible by 3, so it’s not prime. Next, I’ll check 379.\
+I’m figuring out which three-digit numbers under 400 can contain '79' as a substring. The only way is if '79' is at the end, so that gives us numbers like 179, 279, and 379, alongside the two-digit prime 79. I realized I can't use patterns like '7 9' with a zero in between, as the substring must be contiguous. I’ll definitely count the primes among 79, 179, 279, and 379, ensuring I stick to the correct substring.\
 """
                         ),
                         Thought(
                             thought="""\
-**Finalizing prime count**
+**Testing for prime candidates**
 
-I’m testing whether 379 is prime by checking divisibility with primes up to 19. It’s not even, the sum of its digits (19) isn’t a multiple of 3, and it’s not divisible by 5, 7, 11, 13, 17, or 19. So, it’s confirmed as prime. \n\
+I’m checking candidates under 400 for containing '79' as a substring, which leaves me with 79, 179, 279, and 379. I realize they can’t be non-adjacent since the substring must be contiguous. \n\
 
-From my candidates, I find that 79, 179, and 379 are all prime, totaling three primes. I also double-checked for any other numbers containing "79" but none match. So, the answer remains three!\
+Next, I need to test their primality. I find 79 is prime. For 179, I check divisibility with primes up to its square root and conclude it's prime as it isn't divisible by any of those. 279 is composite due to being divisible by 3. Lastly, I start checking 379 for primality too.\
 """
                         ),
                         Thought(
                             thought="""\
-**Confirming final count**
+**Verifying primality of candidates**
 
-I checked the number 397, which doesn't contain the substring "79." The only candidates below 400 with "79" are 79, 179, and 379. While 279 is included, it's not prime. Just to ensure accuracy, I also looked at numbers like 197 that don't contain "79" and confirmed 279 and 297 aren't prime. Since 379 is prime and 790-799 are out of range, my final count of primes is indeed three. I’ll conclude with just the number: 3.\
+I’m checking if 379 is prime by testing its divisibility. The sum of digits (3+7+9) is 19, which isn't a multiple of 3, so it’s not divisible by 3. Next, I check against primes: it’s not divisible by 5, 7, 11, 13, 17, or 19. Therefore, 379 must be prime. So far, I have three primes: 79, 179, and 379. I double-check for any three-digit numbers containing '79' before confirming that those candidates are indeed limited to just these three.\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Finalizing the count of prime numbers**
+
+I’m working to confirm whether there are any negative numbers or primes below 400, as primes are only positive. I check 97 for containing '79' but it doesn’t. I confirm that 179, which includes '79' at positions 2-3, and 379 are indeed valid candidates. I also verify that they are both primes, including 79 itself. \n\
+
+I consider other two-digit numbers below 80 and eliminate 197 and 297 since they don’t contain '79'. In the end, I am confident that there are exactly three primes containing '79': 79, 179, and 379.\
 """
                         ),
                         Text(text="3"),
@@ -217,41 +220,49 @@ I checked the number 397, which doesn't contain the substring "79." The only can
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0cce3b068d5493670068f297e2d0d481969c0a486c14f78ad6",
+                            "id": "rs_0a89598bcef3516f0068f806003de88190861147afb4b7e891",
                             "summary": [
                                 {
                                     "text": """\
-**Counting primes with substring "79"**
+**Counting prime numbers with substring 79**
 
-I need to find the count of prime numbers below 400 that have the substring "79" in their decimal representation. The substring can appear in 2- or 3-digit numbers. The 2-digit number is just 79. For 3-digit numbers, valid forms are 179, 279, and 379 since they include "79" but must be less than 400. The 790-799 range is excluded as they exceed 400. So, I think we only have four numbers to consider.\
+I need to count the prime numbers less than 400 that contain '79' as a substring. First, I'll look at two-digit primes, and '79' itself qualifies, so that's one. For three-digit primes, '79' would need to be in the first two digits, like 79x where x is a digit, but that wouldn’t give us valid numbers since 790 to 799 are all above 400. So, my count will only include '79', making it one valid prime.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Checking primes with “79” substring**
+**Identifying primes with substring 79**
 
-I’m considering candidates with the substring "79" below 400. So far, these are 79, 179, 279, and 379. I noted that "79" can't appear crossing digit boundaries, and the range 790-799 exceeds 400, so those won’t work. Now, I need to determine which of these are prime numbers. \n\
-
-79 is known to be prime. After testing 179, it’s also prime since it’s not divisible by any primes up to its square root. However, 279 is divisible by 3, so it’s not prime. Next, I’ll check 379.\
+I’m figuring out which three-digit numbers under 400 can contain '79' as a substring. The only way is if '79' is at the end, so that gives us numbers like 179, 279, and 379, alongside the two-digit prime 79. I realized I can't use patterns like '7 9' with a zero in between, as the substring must be contiguous. I’ll definitely count the primes among 79, 179, 279, and 379, ensuring I stick to the correct substring.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Finalizing prime count**
+**Testing for prime candidates**
 
-I’m testing whether 379 is prime by checking divisibility with primes up to 19. It’s not even, the sum of its digits (19) isn’t a multiple of 3, and it’s not divisible by 5, 7, 11, 13, 17, or 19. So, it’s confirmed as prime. \n\
+I’m checking candidates under 400 for containing '79' as a substring, which leaves me with 79, 179, 279, and 379. I realize they can’t be non-adjacent since the substring must be contiguous. \n\
 
-From my candidates, I find that 79, 179, and 379 are all prime, totaling three primes. I also double-checked for any other numbers containing "79" but none match. So, the answer remains three!\
+Next, I need to test their primality. I find 79 is prime. For 179, I check divisibility with primes up to its square root and conclude it's prime as it isn't divisible by any of those. 279 is composite due to being divisible by 3. Lastly, I start checking 379 for primality too.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Confirming final count**
+**Verifying primality of candidates**
 
-I checked the number 397, which doesn't contain the substring "79." The only candidates below 400 with "79" are 79, 179, and 379. While 279 is included, it's not prime. Just to ensure accuracy, I also looked at numbers like 197 that don't contain "79" and confirmed 279 and 297 aren't prime. Since 379 is prime and 790-799 are out of range, my final count of primes is indeed three. I’ll conclude with just the number: 3.\
+I’m checking if 379 is prime by testing its divisibility. The sum of digits (3+7+9) is 19, which isn't a multiple of 3, so it’s not divisible by 3. Next, I check against primes: it’s not divisible by 5, 7, 11, 13, 17, or 19. Therefore, 379 must be prime. So far, I have three primes: 79, 179, and 379. I double-check for any three-digit numbers containing '79' before confirming that those candidates are indeed limited to just these three.\
+""",
+                                    "type": "summary_text",
+                                },
+                                {
+                                    "text": """\
+**Finalizing the count of prime numbers**
+
+I’m working to confirm whether there are any negative numbers or primes below 400, as primes are only positive. I check 97 for containing '79' but it doesn’t. I confirm that 179, which includes '79' at positions 2-3, and 379 are indeed valid candidates. I also verify that they are both primes, including 79 itself. \n\
+
+I consider other two-digit numbers below 80 and eliminate 197 and 297 since they don’t contain '79'. In the end, I am confident that there are exactly three primes containing '79': 79, 179, and 379.\
 """,
                                     "type": "summary_text",
                                 },
@@ -259,7 +270,7 @@ I checked the number 397, which doesn't contain the substring "79." The only can
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_0cce3b068d5493670068f297f4a230819685891308a6bd86b0",
+                            "id": "msg_0a89598bcef3516f0068f80618665481908cc3b7de80178617",
                             "content": [
                                 {
                                     "annotations": [],
@@ -287,12 +298,12 @@ I checked the number 397, which doesn't contain the substring "79." The only can
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0cce3b068d5493670068f297f637a08196a1deefce5fbb267b",
+                            "id": "rs_0a89598bcef3516f0068f8061a76148190a099a4d1da62de36",
                             "summary": [],
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_0cce3b068d5493670068f297f670f48196bf265dc9b289138d",
+                            "id": "msg_0a89598bcef3516f0068f8061a98fc8190a29901783e2f8f19",
                             "content": [
                                 {
                                     "annotations": [],
@@ -331,48 +342,45 @@ stream_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Finding primes with substring "79"**
-
-I’m looking for prime numbers under 400 that contain the substring "79." First, the only 2-digit prime is 79 itself, giving me one candidate. \n\
-
-For 3-digit primes, I considered numbers of the form 79x, but those fall outside the 400 limit, so there are none. \n\
-
-Then I checked numbers like x79, where x can be 1-3. This gives me candidates: 179, 279, and 379, which I need to verify for primality. \n\
-
-Finally, I realized that "79" must be adjacent, ruling out non-adjacent digits.\
-"""
-                        ),
-                        Thought(
-                            thought="""\
-**Testing candidates for primality**
-
-I’ve established that only adjacent digits matter for the "79" substring. There’s also a possibility of having "79" in the middle of a 3-digit number, but those options are limited. My candidates are 79, 179, 279, and 379, and I need to test the primality of 179, 279, and 379.
-
-Starting with 179, after checking divisibility against primes up to around 13, I find it’s prime. For 279, since the sum of digits equals 18, it’s divisible by 3, so it’s not prime. \n\
-
-Finally, I check 379, and it doesn’t seem divisible by the primes I tested either.\
-"""
-                        ),
-                        Thought(
-                            thought="""\
 **Counting primes with "79"**
 
-After testing, I confirmed that 379 is also prime. So far, I have 79, 179, and 379 as primes, making a count of three. \n\
-
-I wondered if there are any other numbers under 400 with the substring "79." Well, I already included 79, and I considered 297, but it contains "97," not "79." \n\
-
-I realized my criteria for 3-digit numbers can only lead to x79 or 79x, but those like 79x (790 or higher) exceed 400. My total remains three primes: I’ll double-check to ensure there are no others under 400. \n\
-
-After confirming, I finalize the answer as "3."\
+I need to find the count of prime numbers less than 400 that include the substring "79." This means identifying primes below 400 with "79" in their decimal representation. First, I recognize the prime numbers: 79, 179, 279, and 379. I realize that numbers like 790 and above are out of scope. Also, the three-digit formats with "79" can only be those I mentioned since there are no other candidates. Now, I'll compute the total.\
 """
                         ),
                         Thought(
                             thought="""\
-**Finalizing the count**
+**Identifying candidates with "79"**
 
-I'm checking the user’s request for numbers "below 400." Typically, that means less than 400, so 79 is definitely included in my count. I want to be accurate here. \n\
+To find numbers containing "79," I can check two patterns: hundreds=7 and tens=9 (like 79y) or tens=7 and ones=9 (like x79). For numbers under 400, the candidates are 79, 179, 279, and 379. The pattern 79y only applies to numbers 790-799, which are above 400. I realize 297 doesn't fit as it contains "97," not "79." So, now I need to confirm whether 79, 179, and 379 are prime. I'll start checking them!\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Checking divisibility of candidates**
 
-Since I found three prime numbers containing the substring "79" (79, 179, and 379), I can confidently say the answer is exactly "3." I'll make sure to keep it clear, just providing that number, with no additional text.\
+I’m testing the primes I found: first, 179. With a rough estimate of the square root at about 13.38, I check divisibility by common primes. It's not divisible by 2, 3, 5, 7, 11, or 13, confirming that 179 is prime.
+
+Next, I check 279. Since its digits add up to 18, it's divisible by 3, so it's not prime.
+
+Finally, for 379, the square root is roughly 19.4. I check divisibility with primes, and it's not divisible, thus 379 is prime. So the primes under 400 containing "79" are 79, 179, and 379, but I’ll double-check for any others!\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Finalizing findings on "79"**
+
+I’m reviewing potential candidates for containing "79" under 400. The two-digit option is simply 79. For three-digit numbers, I explore configurations like x79, which gives me 179, 279, and 379. \n\
+
+I realize hundreds can compose numbers like 790-799, but they exceed 400, so they don’t count. For the substring "79," it has to be consecutive from left to right. So, the valid primes containing "79" that I found are solely 79, 179, 279, and 379. I think I've covered everything!\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Consolidating prime count**
+
+It looks like I have three primes under 400 that contain the substring "79": 79, 179, and 379. I double-check that 279, though it has "79," is not prime. \n\
+
+I confirm that 179 and 379 are indeed prime by testing their divisibility against smaller primes. 379 passes these checks too. I also make sure that "79" doesn't appear in numbers like 2979 since it’s over 400. The final count remains at 3, which I’ll present as just "3" without any extra punctuation.\
 """
                         ),
                         Text(text="3"),
@@ -381,55 +389,53 @@ Since I found three prime numbers containing the substring "79" (79, 179, and 37
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_00c8480f43d079250068f297ab91608195931c432c34fd7b8e",
+                            "id": "rs_0d570aae5ddaa59f0068f805e626dc81969cdef1d79ac82a5c",
                             "summary": [
-                                {
-                                    "text": """\
-**Finding primes with substring "79"**
-
-I’m looking for prime numbers under 400 that contain the substring "79." First, the only 2-digit prime is 79 itself, giving me one candidate. \n\
-
-For 3-digit primes, I considered numbers of the form 79x, but those fall outside the 400 limit, so there are none. \n\
-
-Then I checked numbers like x79, where x can be 1-3. This gives me candidates: 179, 279, and 379, which I need to verify for primality. \n\
-
-Finally, I realized that "79" must be adjacent, ruling out non-adjacent digits.\
-""",
-                                    "type": "summary_text",
-                                },
-                                {
-                                    "text": """\
-**Testing candidates for primality**
-
-I’ve established that only adjacent digits matter for the "79" substring. There’s also a possibility of having "79" in the middle of a 3-digit number, but those options are limited. My candidates are 79, 179, 279, and 379, and I need to test the primality of 179, 279, and 379.
-
-Starting with 179, after checking divisibility against primes up to around 13, I find it’s prime. For 279, since the sum of digits equals 18, it’s divisible by 3, so it’s not prime. \n\
-
-Finally, I check 379, and it doesn’t seem divisible by the primes I tested either.\
-""",
-                                    "type": "summary_text",
-                                },
                                 {
                                     "text": """\
 **Counting primes with "79"**
 
-After testing, I confirmed that 379 is also prime. So far, I have 79, 179, and 379 as primes, making a count of three. \n\
-
-I wondered if there are any other numbers under 400 with the substring "79." Well, I already included 79, and I considered 297, but it contains "97," not "79." \n\
-
-I realized my criteria for 3-digit numbers can only lead to x79 or 79x, but those like 79x (790 or higher) exceed 400. My total remains three primes: I’ll double-check to ensure there are no others under 400. \n\
-
-After confirming, I finalize the answer as "3."\
+I need to find the count of prime numbers less than 400 that include the substring "79." This means identifying primes below 400 with "79" in their decimal representation. First, I recognize the prime numbers: 79, 179, 279, and 379. I realize that numbers like 790 and above are out of scope. Also, the three-digit formats with "79" can only be those I mentioned since there are no other candidates. Now, I'll compute the total.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Finalizing the count**
+**Identifying candidates with "79"**
 
-I'm checking the user’s request for numbers "below 400." Typically, that means less than 400, so 79 is definitely included in my count. I want to be accurate here. \n\
+To find numbers containing "79," I can check two patterns: hundreds=7 and tens=9 (like 79y) or tens=7 and ones=9 (like x79). For numbers under 400, the candidates are 79, 179, 279, and 379. The pattern 79y only applies to numbers 790-799, which are above 400. I realize 297 doesn't fit as it contains "97," not "79." So, now I need to confirm whether 79, 179, and 379 are prime. I'll start checking them!\
+""",
+                                    "type": "summary_text",
+                                },
+                                {
+                                    "text": """\
+**Checking divisibility of candidates**
 
-Since I found three prime numbers containing the substring "79" (79, 179, and 379), I can confidently say the answer is exactly "3." I'll make sure to keep it clear, just providing that number, with no additional text.\
+I’m testing the primes I found: first, 179. With a rough estimate of the square root at about 13.38, I check divisibility by common primes. It's not divisible by 2, 3, 5, 7, 11, or 13, confirming that 179 is prime.
+
+Next, I check 279. Since its digits add up to 18, it's divisible by 3, so it's not prime.
+
+Finally, for 379, the square root is roughly 19.4. I check divisibility with primes, and it's not divisible, thus 379 is prime. So the primes under 400 containing "79" are 79, 179, and 379, but I’ll double-check for any others!\
+""",
+                                    "type": "summary_text",
+                                },
+                                {
+                                    "text": """\
+**Finalizing findings on "79"**
+
+I’m reviewing potential candidates for containing "79" under 400. The two-digit option is simply 79. For three-digit numbers, I explore configurations like x79, which gives me 179, 279, and 379. \n\
+
+I realize hundreds can compose numbers like 790-799, but they exceed 400, so they don’t count. For the substring "79," it has to be consecutive from left to right. So, the valid primes containing "79" that I found are solely 79, 179, 279, and 379. I think I've covered everything!\
+""",
+                                    "type": "summary_text",
+                                },
+                                {
+                                    "text": """\
+**Consolidating prime count**
+
+It looks like I have three primes under 400 that contain the substring "79": 79, 179, and 379. I double-check that 279, though it has "79," is not prime. \n\
+
+I confirm that 179 and 379 are indeed prime by testing their divisibility against smaller primes. 379 passes these checks too. I also make sure that "79" doesn't appear in numbers like 2979 since it’s over 400. The final count remains at 3, which I’ll present as just "3" without any extra punctuation.\
 """,
                                     "type": "summary_text",
                                 },
@@ -437,7 +443,7 @@ Since I found three prime numbers containing the substring "79" (79, 179, and 37
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_00c8480f43d079250068f297bd2e7881959d4a40334d943244",
+                            "id": "msg_0d570aae5ddaa59f0068f805fd69dc8196abef9dd9abd7dabf",
                             "content": [
                                 {
                                     "annotations": [],
@@ -465,12 +471,12 @@ Since I found three prime numbers containing the substring "79" (79, 179, and 37
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_00c8480f43d079250068f297be563c819585de932de447cba0",
+                            "id": "rs_0d570aae5ddaa59f0068f805fed3b48196bc6af574f1c25cb9",
                             "summary": [],
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_00c8480f43d079250068f297be8238819593d2dbf1908f29a8",
+                            "id": "msg_0d570aae5ddaa59f0068f805ff17688196a618955940b59149",
                             "content": [
                                 {
                                     "annotations": [],
@@ -510,38 +516,37 @@ async_stream_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Counting primes with "79"**
+**Counting primes with substring "79"**
 
-I need to find primes under 400 that contain the substring "79". First, I think of 79 itself, then 179, and check if 197 doesn’t count since it has "97". I realize 279 isn't prime, and 379 seems to be prime. However, 479 and any number in the 790s are greater than 400. Therefore, the only prime under 100 containing "79" is just 79. It's quite a specific search!\
+I need to find primes below 400 that include "79" as a substring. I should consider 2-digit and 3-digit primes since they can both fall under 400. The substring length is 2, so the candidates would include 79, 179, and 279. While checking, I realized 197 doesn't qualify, as it contains "97" instead. Primes like 379 qualify, but primes above 400, like 479, will be excluded. The candidates that remain need careful consideration.\
 """
                         ),
                         Thought(
                             thought="""\
-**Finding primes with "79"**
+**Identifying primes with "79"**
 
-I’m examining the numbers between 100 and 199 to see which contain "79," and I find that only 179 fits because it's the only one with "79" in the last digits. I'll confirm that 179 is prime — and it is!
-
-Next, looking in the range of 200 to 299, I see that 279 is composite, as it’s divisible by 3. In this range, there are no additional candidates. Lastly, for 300 to 399, I found 379 and confirmed it’s prime too. So, 179 and 379 are our primes!\
+I'm examining numbers like 297 and 379 in relation to the substring "79." I realized that 179 qualifies because it contains "79" across its digits. 279 and 379 also meet the criteria. As I continue, I note that while numbers from 790 to 799 contain "79" at the beginning, they exceed 400, so I must exclude them. However, I confirm primes like 797 exist within this range but can’t be counted due to the limit.\
 """
                         ),
                         Thought(
                             thought="""\
-**Confirming prime counts with "79"**
+**Checking primes containing "79"**
 
-I’m considering numbers like 790, which is over 400. I check other primes like 97, 197, 297, and 397, but they don’t contain "79." The only primes that do are 79, 179, and 379. I realize that only two-digit primes are relevant, as numbers like 790-799 exceed 400.
-
-I’ve confirmed that 279 isn’t prime, but 179 and 379 are. It seems the total count of primes with "79" is three. I wonder if there are any other numbers I might have missed, like 97.\
+I'm narrowing down candidates for primes below 400 that include "79." Since those must be 2-digit or 3-digit numbers, I find that only two-digit 79 and three-digit numbers like 179, 279, and 379 qualify. I’ll also check numbers less than 100, confirming that only 79 fits the criteria. Now, I’ll assess the primality of 79, 179, 279, and 379. Starting with 79, I see that it's indeed prime, which is great! Next, I need to check 179’s primality with some divisibility tests.\
 """
                         ),
                         Thought(
                             thought="""\
-**Confirming prime counts with "79"**
+**Confirming prime numbers**
 
-I realize 79 reversed doesn't count, so I'm confirming the three primes identified: 79, 179, and 379. \n\
+I've confirmed that 79 and 179 are primes. For 279, its digits add up to 18, making it divisible by 3, so it’s not prime. Now, I check 379: its square root is about 19.4. Testing divisibility, it checks out—none of the prime numbers divide it evenly, so 379 is prime as well. Thus, I have three primes: 79, 179, and 379, with 279 as composite. I'll double-check for any other primes below 400 containing "79" as a substring. It looks like any variations are above 400.\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Finalizing the prime count**
 
-First, I check 79 and confirm it’s prime. For 179, I find that it passes checks for primes under its square root, so it’s also prime. 279 is composite since it's divisible by 3. I’ve previously confirmed that 379 is prime, leaving the total count as three. I reflect on whether numbers with leading zeros count but decide against it. \n\
-
-So, the answer is simply "3."\
+I’ve confirmed that there are no 4-digit numbers below 400, and leading zeros don’t count. So, the total number of primes containing "79" is 3. I double-check other possibilities but affirm that numbers like 97 and 197 don’t fit, and although 397 has "39" and "97", it’s not relevant. I see that primes must have the digits "7" and "9" together, so there aren’t any other configurations. Therefore, the answer remains 3.\
 """
                         ),
                         Text(text="3"),
@@ -550,45 +555,45 @@ So, the answer is simply "3."\
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_02f178f89a7dc2940068f2980af9c081939c98cd23b6fe897e",
+                            "id": "rs_0d5e81a1d6cbde120068f8061c9f54819793e5e1048b39836c",
                             "summary": [
                                 {
                                     "text": """\
-**Counting primes with "79"**
+**Counting primes with substring "79"**
 
-I need to find primes under 400 that contain the substring "79". First, I think of 79 itself, then 179, and check if 197 doesn’t count since it has "97". I realize 279 isn't prime, and 379 seems to be prime. However, 479 and any number in the 790s are greater than 400. Therefore, the only prime under 100 containing "79" is just 79. It's quite a specific search!\
+I need to find primes below 400 that include "79" as a substring. I should consider 2-digit and 3-digit primes since they can both fall under 400. The substring length is 2, so the candidates would include 79, 179, and 279. While checking, I realized 197 doesn't qualify, as it contains "97" instead. Primes like 379 qualify, but primes above 400, like 479, will be excluded. The candidates that remain need careful consideration.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Finding primes with "79"**
+**Identifying primes with "79"**
 
-I’m examining the numbers between 100 and 199 to see which contain "79," and I find that only 179 fits because it's the only one with "79" in the last digits. I'll confirm that 179 is prime — and it is!
-
-Next, looking in the range of 200 to 299, I see that 279 is composite, as it’s divisible by 3. In this range, there are no additional candidates. Lastly, for 300 to 399, I found 379 and confirmed it’s prime too. So, 179 and 379 are our primes!\
+I'm examining numbers like 297 and 379 in relation to the substring "79." I realized that 179 qualifies because it contains "79" across its digits. 279 and 379 also meet the criteria. As I continue, I note that while numbers from 790 to 799 contain "79" at the beginning, they exceed 400, so I must exclude them. However, I confirm primes like 797 exist within this range but can’t be counted due to the limit.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Confirming prime counts with "79"**
+**Checking primes containing "79"**
 
-I’m considering numbers like 790, which is over 400. I check other primes like 97, 197, 297, and 397, but they don’t contain "79." The only primes that do are 79, 179, and 379. I realize that only two-digit primes are relevant, as numbers like 790-799 exceed 400.
-
-I’ve confirmed that 279 isn’t prime, but 179 and 379 are. It seems the total count of primes with "79" is three. I wonder if there are any other numbers I might have missed, like 97.\
+I'm narrowing down candidates for primes below 400 that include "79." Since those must be 2-digit or 3-digit numbers, I find that only two-digit 79 and three-digit numbers like 179, 279, and 379 qualify. I’ll also check numbers less than 100, confirming that only 79 fits the criteria. Now, I’ll assess the primality of 79, 179, 279, and 379. Starting with 79, I see that it's indeed prime, which is great! Next, I need to check 179’s primality with some divisibility tests.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Confirming prime counts with "79"**
+**Confirming prime numbers**
 
-I realize 79 reversed doesn't count, so I'm confirming the three primes identified: 79, 179, and 379. \n\
+I've confirmed that 79 and 179 are primes. For 279, its digits add up to 18, making it divisible by 3, so it’s not prime. Now, I check 379: its square root is about 19.4. Testing divisibility, it checks out—none of the prime numbers divide it evenly, so 379 is prime as well. Thus, I have three primes: 79, 179, and 379, with 279 as composite. I'll double-check for any other primes below 400 containing "79" as a substring. It looks like any variations are above 400.\
+""",
+                                    "type": "summary_text",
+                                },
+                                {
+                                    "text": """\
+**Finalizing the prime count**
 
-First, I check 79 and confirm it’s prime. For 179, I find that it passes checks for primes under its square root, so it’s also prime. 279 is composite since it's divisible by 3. I’ve previously confirmed that 379 is prime, leaving the total count as three. I reflect on whether numbers with leading zeros count but decide against it. \n\
-
-So, the answer is simply "3."\
+I’ve confirmed that there are no 4-digit numbers below 400, and leading zeros don’t count. So, the total number of primes containing "79" is 3. I double-check other possibilities but affirm that numbers like 97 and 197 don’t fit, and although 397 has "39" and "97", it’s not relevant. I see that primes must have the digits "7" and "9" together, so there aren’t any other configurations. Therefore, the answer remains 3.\
 """,
                                     "type": "summary_text",
                                 },
@@ -596,7 +601,7 @@ So, the answer is simply "3."\
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_02f178f89a7dc2940068f2981f63a881938f1f5b380b083869",
+                            "id": "msg_0d5e81a1d6cbde120068f8063464b881978c693fc3d8ac0e33",
                             "content": [
                                 {
                                     "annotations": [],
@@ -619,21 +624,21 @@ So, the answer is simply "3."\
                     ]
                 ),
                 AssistantMessage(
-                    content=[Text(text="I don't remember.")],
+                    content=[Text(text="I don’t remember.")],
                     provider="openai:responses",
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_02f178f89a7dc2940068f2983c9de08193b5562b3fdec4d315",
+                            "id": "rs_0d5e81a1d6cbde120068f80635fc608197be10fd4acfbce705",
                             "summary": [],
                             "type": "reasoning",
                         },
                         {
-                            "id": "msg_02f178f89a7dc2940068f2983cd9508193bbecf71995719523",
+                            "id": "msg_0d5e81a1d6cbde120068f806362144819791a99b6164e2fae8",
                             "content": [
                                 {
                                     "annotations": [],
-                                    "text": "I don't remember.",
+                                    "text": "I don’t remember.",
                                     "type": "output_text",
                                     "logprobs": [],
                                 }
@@ -647,7 +652,7 @@ So, the answer is simply "3."\
             ],
             "format": None,
             "tools": [],
-            "n_chunks": 6,
+            "n_chunks": 7,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/openai_responses_gpt_4o_snapshots.py
@@ -28,12 +28,12 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_df3svYLONNdt3Qb2FXFeXwZ3",
+                            id="call_VP1Hss5Mco8swJxuCQgAwg1z",
                             name="secret_retrieval_tool",
                             args='{"password":"mellon"}',
                         ),
                         ToolCall(
-                            id="call_JXegss0AyNLShfYnQsxPJn0L",
+                            id="call_PQt2R8pTpPM48nfEVptZquEE",
                             name="secret_retrieval_tool",
                             args='{"password":"radiance"}',
                         ),
@@ -43,18 +43,18 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"password":"mellon"}',
-                            "call_id": "call_df3svYLONNdt3Qb2FXFeXwZ3",
+                            "call_id": "call_VP1Hss5Mco8swJxuCQgAwg1z",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0678b7a1f79ace020068f2990428ec81909e1710e0e4e3401a",
+                            "id": "fc_05a638d56eea032f0068f8033d4fac81979b6232f3344d1333",
                             "status": "completed",
                         },
                         {
                             "arguments": '{"password":"radiance"}',
-                            "call_id": "call_JXegss0AyNLShfYnQsxPJn0L",
+                            "call_id": "call_PQt2R8pTpPM48nfEVptZquEE",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0678b7a1f79ace020068f29904560c819083a6a47c77485600",
+                            "id": "fc_05a638d56eea032f0068f8033d6b8081979644045ac1177e20",
                             "status": "completed",
                         },
                     ],
@@ -62,12 +62,12 @@ sync_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_df3svYLONNdt3Qb2FXFeXwZ3",
+                            id="call_VP1Hss5Mco8swJxuCQgAwg1z",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="call_JXegss0AyNLShfYnQsxPJn0L",
+                            id="call_PQt2R8pTpPM48nfEVptZquEE",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -77,10 +77,10 @@ sync_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Here are the secrets:
+Here are the secrets associated with the passwords:
 
-- For "mellon": Welcome to Moria!
-- For "radiance": Life before Death\
+- **mellon**: "Welcome to Moria!"
+- **radiance**: "Life before Death"\
 """
                         )
                     ],
@@ -88,15 +88,15 @@ Here are the secrets:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0678b7a1f79ace020068f299051d0881909f69455ee8292f19",
+                            "id": "msg_05a638d56eea032f0068f8033e766c81979ea1b4f5aa398368",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-Here are the secrets:
+Here are the secrets associated with the passwords:
 
-- For "mellon": Welcome to Moria!
-- For "radiance": Life before Death\
+- **mellon**: "Welcome to Moria!"
+- **radiance**: "Life before Death"\
 """,
                                     "type": "output_text",
                                     "logprobs": [],
@@ -154,12 +154,12 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_0zCTbx6FQ8k3esy7neFHKDjp",
+                            id="call_HGG1nGDs6kiMDFgFpKarnZx6",
                             name="secret_retrieval_tool",
                             args='{"password":"mellon"}',
                         ),
                         ToolCall(
-                            id="call_a3DD38dIZ9K96s31Lpz58GrI",
+                            id="call_lX21b6EAa5e8ypmLbkM2xKYV",
                             name="secret_retrieval_tool",
                             args='{"password":"radiance"}',
                         ),
@@ -169,18 +169,18 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"password":"mellon"}',
-                            "call_id": "call_0zCTbx6FQ8k3esy7neFHKDjp",
+                            "call_id": "call_HGG1nGDs6kiMDFgFpKarnZx6",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0dc7d3cef7c1431c0068f2990fd68881978b81fcd8142e8363",
+                            "id": "fc_0c4d870f86c990ad0068f80340b18c8196b32f72de4212f9a1",
                             "status": "completed",
                         },
                         {
                             "arguments": '{"password":"radiance"}',
-                            "call_id": "call_a3DD38dIZ9K96s31Lpz58GrI",
+                            "call_id": "call_lX21b6EAa5e8ypmLbkM2xKYV",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0dc7d3cef7c1431c0068f2990ff8c0819789ad43821741a0ce",
+                            "id": "fc_0c4d870f86c990ad0068f80340dc648196be2aca7c3325eebe",
                             "status": "completed",
                         },
                     ],
@@ -188,12 +188,12 @@ async_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_0zCTbx6FQ8k3esy7neFHKDjp",
+                            id="call_HGG1nGDs6kiMDFgFpKarnZx6",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="call_a3DD38dIZ9K96s31Lpz58GrI",
+                            id="call_lX21b6EAa5e8ypmLbkM2xKYV",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -203,10 +203,10 @@ async_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Here are the secrets associated with each password:
+Here are the secrets:
 
-- **mellon**: Welcome to Moria!
-- **radiance**: Life before Death\
+- "mellon": Welcome to Moria!
+- "radiance": Life before Death\
 """
                         )
                     ],
@@ -214,15 +214,15 @@ Here are the secrets associated with each password:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0dc7d3cef7c1431c0068f299112d808197b24e445fcb80e82f",
+                            "id": "msg_0c4d870f86c990ad0068f80342851081968addd63f6fb0a7ce",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-Here are the secrets associated with each password:
+Here are the secrets:
 
-- **mellon**: Welcome to Moria!
-- **radiance**: Life before Death\
+- "mellon": Welcome to Moria!
+- "radiance": Life before Death\
 """,
                                     "type": "output_text",
                                     "logprobs": [],
@@ -279,12 +279,12 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_41CfEqEOHhPeIwSwoLhT7x8y",
+                            id="call_8mWOlD2knIPTChQYr7GQ4Hxi",
                             name="secret_retrieval_tool",
                             args='{"password":"mellon"}',
                         ),
                         ToolCall(
-                            id="call_rprZSnKbUBINpIEDeVwZ3bTN",
+                            id="call_3UNGcrPBkfEG8ueZGjz6s00h",
                             name="secret_retrieval_tool",
                             args='{"password":"radiance"}',
                         ),
@@ -294,18 +294,18 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"password":"mellon"}',
-                            "call_id": "call_41CfEqEOHhPeIwSwoLhT7x8y",
+                            "call_id": "call_8mWOlD2knIPTChQYr7GQ4Hxi",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0888af4740f553150068f2991f6f948195bff3a4a088b1994e",
+                            "id": "fc_08622b4f543dc1510068f803450d1c819686d379e0da7b29d8",
                             "status": "completed",
                         },
                         {
                             "arguments": '{"password":"radiance"}',
-                            "call_id": "call_rprZSnKbUBINpIEDeVwZ3bTN",
+                            "call_id": "call_3UNGcrPBkfEG8ueZGjz6s00h",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0888af4740f553150068f2991f84108195bf556ee9ddb31f6e",
+                            "id": "fc_08622b4f543dc1510068f803457c7081969163370cc2f28787",
                             "status": "completed",
                         },
                     ],
@@ -313,12 +313,12 @@ stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_41CfEqEOHhPeIwSwoLhT7x8y",
+                            id="call_8mWOlD2knIPTChQYr7GQ4Hxi",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="call_rprZSnKbUBINpIEDeVwZ3bTN",
+                            id="call_3UNGcrPBkfEG8ueZGjz6s00h",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -328,7 +328,7 @@ stream_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Here are the secrets associated with the passwords:
+Here are the secrets for the provided passwords:
 
 - **mellon**: Welcome to Moria!
 - **radiance**: Life before Death\
@@ -339,12 +339,12 @@ Here are the secrets associated with the passwords:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0888af4740f553150068f299207a98819598f085926027eddb",
+                            "id": "msg_08622b4f543dc1510068f80346cd088196a0679646c918d73a",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-Here are the secrets associated with the passwords:
+Here are the secrets for the provided passwords:
 
 - **mellon**: Welcome to Moria!
 - **radiance**: Life before Death\
@@ -405,12 +405,12 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_e9IFshyCDcsOO3BqCLkU1m3R",
+                            id="call_q1t9XZMJIkrsHvmorg22clzL",
                             name="secret_retrieval_tool",
                             args='{"password":"mellon"}',
                         ),
                         ToolCall(
-                            id="call_Vmt8WWTUEzCQGmrrMtWYP1Yr",
+                            id="call_5l4sCPMYHaNlQDLW5DoksdHs",
                             name="secret_retrieval_tool",
                             args='{"password":"radiance"}',
                         ),
@@ -420,18 +420,18 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"password":"mellon"}',
-                            "call_id": "call_e9IFshyCDcsOO3BqCLkU1m3R",
+                            "call_id": "call_q1t9XZMJIkrsHvmorg22clzL",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0f52f42decbdc1ed0068f2992bd6c48196a0d3120f7d8bc429",
+                            "id": "fc_00c4f15a862212440068f8034908948193b1effcabcb862cb5",
                             "status": "completed",
                         },
                         {
                             "arguments": '{"password":"radiance"}',
-                            "call_id": "call_Vmt8WWTUEzCQGmrrMtWYP1Yr",
+                            "call_id": "call_5l4sCPMYHaNlQDLW5DoksdHs",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0f52f42decbdc1ed0068f2992bf3b48196a3cd4b48032593ca",
+                            "id": "fc_00c4f15a862212440068f803492f848193aea4fcadd7119614",
                             "status": "completed",
                         },
                     ],
@@ -439,12 +439,12 @@ async_stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_e9IFshyCDcsOO3BqCLkU1m3R",
+                            id="call_q1t9XZMJIkrsHvmorg22clzL",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="call_Vmt8WWTUEzCQGmrrMtWYP1Yr",
+                            id="call_5l4sCPMYHaNlQDLW5DoksdHs",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -454,10 +454,10 @@ async_stream_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Here are the secrets:
+The secrets associated with the passwords are:
 
-- For "mellon": Welcome to Moria!
-- For "radiance": Life before Death\
+- "mellon": Welcome to Moria!
+- "radiance": Life before Death\
 """
                         )
                     ],
@@ -465,15 +465,15 @@ Here are the secrets:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0f52f42decbdc1ed0068f2992d02688196b4453f9dff18fb02",
+                            "id": "msg_00c4f15a862212440068f8034ad20c8193bdbd6456240d2773",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-Here are the secrets:
+The secrets associated with the passwords are:
 
-- For "mellon": Welcome to Moria!
-- For "radiance": Life before Death\
+- "mellon": Welcome to Moria!
+- "radiance": Life before Death\
 """,
                                     "type": "output_text",
                                     "logprobs": [],
@@ -509,7 +509,7 @@ Here are the secrets:
                     "strict": False,
                 }
             ],
-            "n_chunks": 28,
+            "n_chunks": 29,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_max_tokens/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/openai_responses_gpt_4o_snapshots.py
@@ -20,7 +20,7 @@ sync_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Sure! Here is a list of all 50 U.S. states:
+Sure! Here is a list of all U.S. states:
 
 1. Alabama
 2. Alaska
@@ -30,7 +30,8 @@ Sure! Here is a list of all 50 U.S. states:
 6. Colorado
 7. Connecticut
 8. Delaware
-9. Florida\
+9. Florida
+10\
 """
                         )
                     ],
@@ -38,12 +39,12 @@ Sure! Here is a list of all 50 U.S. states:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0a62663f7e8935920068f29939b5b481978a0b8d08aa8c0516",
+                            "id": "msg_0d9d0b2116b143860068f8034d1d988196beb058f5a88102c3",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-Sure! Here is a list of all 50 U.S. states:
+Sure! Here is a list of all U.S. states:
 
 1. Alabama
 2. Alaska
@@ -53,7 +54,8 @@ Sure! Here is a list of all 50 U.S. states:
 6. Colorado
 7. Connecticut
 8. Delaware
-9. Florida\
+9. Florida
+10\
 """,
                                     "type": "output_text",
                                     "logprobs": [],
@@ -84,7 +86,7 @@ async_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Certainly! Here is a list of all U.S. states:
+Sure! Here are all 50 U.S. states:
 
 1. Alabama
 2. Alaska
@@ -95,7 +97,7 @@ Certainly! Here is a list of all U.S. states:
 7. Connecticut
 8. Delaware
 9. Florida
-10\
+10.\
 """
                         )
                     ],
@@ -103,12 +105,12 @@ Certainly! Here is a list of all U.S. states:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0e327036bc0ec30d0068f299404a0881978496022bdae018ca",
+                            "id": "msg_0b61c3328a7b09430068f8034fd05481948786754d24dba12d",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-Certainly! Here is a list of all U.S. states:
+Sure! Here are all 50 U.S. states:
 
 1. Alabama
 2. Alaska
@@ -119,7 +121,7 @@ Certainly! Here is a list of all U.S. states:
 7. Connecticut
 8. Delaware
 9. Florida
-10\
+10.\
 """,
                                     "type": "output_text",
                                     "logprobs": [],
@@ -187,7 +189,7 @@ async_stream_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Sure! Here is a list of all U.S. states:
+Certainly! Here is a list of all U.S. states:
 
 1. Alabama
 2. Alaska

--- a/python/tests/e2e/output/snapshots/test_refusal/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/openai_responses_gpt_4o_snapshots.py
@@ -23,15 +23,17 @@ sync_snapshot = snapshot(
                     ]
                 ),
                 AssistantMessage(
-                    content=[Text(text="I'm sorry, I can't assist with that.")],
+                    content=[
+                        Text(text="I'm very sorry, but I can't assist with that.")
+                    ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0a2dbf61ade398920068f2995a4f8881979a9040b8b5e40cf0",
+                            "id": "msg_0ce4d43fa47651100068f80355fe1c8196b2753b0f7c095c90",
                             "content": [
                                 {
-                                    "refusal": "I'm sorry, I can't assist with that.",
+                                    "refusal": "I'm very sorry, but I can't assist with that.",
                                     "type": "refusal",
                                 }
                             ],
@@ -76,17 +78,15 @@ async_snapshot = snapshot(
                     ]
                 ),
                 AssistantMessage(
-                    content=[
-                        Text(text="I'm very sorry, but I can't assist with that.")
-                    ],
+                    content=[Text(text="I'm sorry, I can't assist with that.")],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0ce20fa12eeb06da0068f299636a4c8197b7ce6a2345505b97",
+                            "id": "msg_0e8958dc3c84cef50068f80357d0d88195b3c3d39c8a071cc2",
                             "content": [
                                 {
-                                    "refusal": "I'm very sorry, but I can't assist with that.",
+                                    "refusal": "I'm sorry, I can't assist with that.",
                                     "type": "refusal",
                                 }
                             ],
@@ -135,7 +135,7 @@ stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0d307ea79b8492ae0068f2996d405c8193aa9833a826dc4889",
+                            "id": "msg_0edcfeff84266d190068f803590d3c8190a1af4876795cc844",
                             "content": [
                                 {
                                     "refusal": "I'm sorry, I can't assist with that.",
@@ -188,7 +188,7 @@ async_stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_06d822a78d98cd140068f29979192481968491870837de3f34",
+                            "id": "msg_0a8eae9955c3c5800068f8035a9c748196937adc321714932d",
                             "content": [
                                 {
                                     "refusal": "I'm sorry, I can't assist with that.",

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/openai_responses_gpt_4o_snapshots.py
@@ -93,7 +93,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_05dc1affd4c2e1a70068f2a20f37a48196a31e941a28eb5801",
+                            "id": "msg_0a53cf08735fb2ae0068f8035e83bc8196ab2df3ece700ea5f",
                             "content": [
                                 {
                                     "annotations": [],
@@ -288,7 +288,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_01d989b385e7efe30068f2a22af958819090d76fe43d042bf6",
+                            "id": "msg_00a6ad29bfd84f820068f80367d73c819393819818825fe9ff",
                             "content": [
                                 {
                                     "annotations": [],
@@ -482,7 +482,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_067340a8a7e35f8c0068f2a250234c8190bd8f3120538c1b1d",
+                            "id": "msg_03f41696973a6d8d0068f8036f70a8819087abb8dee363a2ff",
                             "content": [
                                 {
                                     "annotations": [],
@@ -677,7 +677,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0d25d69e230eec080068f2a26b0a30819782b7b8ca95defbc3",
+                            "id": "msg_0a64bcf7080344d50068f8037761248190a71cb2b0cde43fb4",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/output/snapshots/test_structured_output/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/openai_responses_gpt_4o_snapshots.py
@@ -31,7 +31,7 @@ sync_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0042a48f4da778790068f2a21f2c348194acefef95a938a8b8",
+                            "id": "msg_0f3b1d977766c14b0068f80362e734819389c975d9dd8fc290",
                             "content": [
                                 {
                                     "annotations": [],
@@ -110,7 +110,7 @@ async_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_01ed6b0e77d5e3240068f2a23ff1ec8195998cc1be001309c9",
+                            "id": "msg_0857ddf524ed193b0068f8036bf2208196b55b5dcdcce4203a",
                             "content": [
                                 {
                                     "annotations": [],
@@ -188,7 +188,7 @@ stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_074f4c09fc7a83d90068f2a25f134c8195a63698925c50b356",
+                            "id": "msg_0fffcf2aa365083f0068f803732ca0819381ed4189d97bfad1",
                             "content": [
                                 {
                                     "annotations": [],
@@ -267,7 +267,7 @@ async_stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_00206770ae6f24940068f2a27d282881959e876d95d8f06939",
+                            "id": "msg_0b77cd22d17623de0068f8037bd2e48193a161eba521e3f299",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_responses_gpt_4o_snapshots.py
@@ -31,7 +31,7 @@ sync_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0c2289756368e4100068f2a20761d481908183d623a093f4ba",
+                            "id": "msg_0cabb11fc07acc4c0068f8035c6ea8819389e04e635b3e291a",
                             "content": [
                                 {
                                     "annotations": [],
@@ -110,7 +110,7 @@ async_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_082bd9f23ee997d50068f2a2247dec8193b489da6fd9e64b88",
+                            "id": "msg_0fef2d0a40e8ddce0068f803653e4881978a321cb774edf9a6",
                             "content": [
                                 {
                                     "annotations": [],
@@ -188,7 +188,7 @@ stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_098ca2b269dd8cfc0068f2a248752881939c211842a42438eb",
+                            "id": "msg_01661eb21b60990b0068f8036d6438819499e13251ee0f1b54",
                             "content": [
                                 {
                                     "annotations": [],
@@ -267,7 +267,7 @@ async_stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_083abf2d6b19e9580068f2a2640f988197a6fc8c48dcbc93fa",
+                            "id": "msg_06a8e02841f7033d0068f8037570e88196971d14638379d62f",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_responses_gpt_4o_snapshots.py
@@ -38,10 +38,10 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}',
-                            "call_id": "call_SkRJ6UtPnWHNuor3HoDHfg5s",
+                            "call_id": "call_NeErs3GCt2bIKqMSShXfO1sY",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_0270d694b22223f00068f2a2176b608196aa2cf01ccab20e7a",
+                            "id": "fc_0e480c8adf8eb5c20068f803607d9c8195a03883f0a4db9316",
                             "status": "completed",
                         }
                     ],
@@ -115,10 +115,10 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}',
-                            "call_id": "call_sYSXvdEs7DUis1gJXkajuq6U",
+                            "call_id": "call_naaqsvA0zq0UveL6zXb2CY8i",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_03a6ac6360e28def0068f2a234dcec819088299f55bb8c2954",
+                            "id": "fc_0ce5d44531554bb20068f8036a0e98819083b9120bfed2c4ee",
                             "status": "completed",
                         }
                     ],
@@ -191,10 +191,10 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}',
-                            "call_id": "call_C0TOrhWCBNLp9UbAf10piLEw",
+                            "call_id": "call_o6re0ta2aiEIVoIVb6IrXvPI",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_061b9976bdef3a610068f2a257c5e88190a7c8381ad8032bd7",
+                            "id": "fc_0eb5ded1c000ab800068f8037189488194a838af4e0149e6e8",
                             "status": "completed",
                         }
                     ],
@@ -268,10 +268,10 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}',
-                            "call_id": "call_5UNI9XXSutzQOPMwZuA0kuqM",
+                            "call_id": "call_DVo9TZdjZg2XHAJmEfmNEz3E",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_07336285d624a39c0068f2a2748ef08190b24d77f3692adf84",
+                            "id": "fc_099be5393fd430750068f80379d6e08197b39ee2a8d956d17c",
                             "status": "completed",
                         }
                     ],

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_responses_gpt_4o_snapshots.py
@@ -62,7 +62,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_TlRoLVC4aoqQnlz2XIiNWZFr",
+                            id="call_FIDTJSJJg9uML3WK9k3BsYVQ",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -72,10 +72,10 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_TlRoLVC4aoqQnlz2XIiNWZFr",
+                            "call_id": "call_FIDTJSJJg9uML3WK9k3BsYVQ",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0a7c766b8b81e5ec0068f2a2f11fe48196a94850d0985132ea",
+                            "id": "fc_099e2bb6ed38bf050068f803827b1c8197bed5730d56e2a813",
                             "status": "completed",
                         }
                     ],
@@ -83,7 +83,7 @@ Respond only with valid JSON that matches this exact schema:
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_TlRoLVC4aoqQnlz2XIiNWZFr",
+                            id="call_FIDTJSJJg9uML3WK9k3BsYVQ",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -106,7 +106,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0a7c766b8b81e5ec0068f2a2f23254819697215b7e710f55d5",
+                            "id": "msg_099e2bb6ed38bf050068f8038544ec8197af5a43a8f108b852",
                             "content": [
                                 {
                                     "annotations": [],
@@ -257,7 +257,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_smEZJKpXhjNduFPjfIbxZoEe",
+                            id="call_bymFbcxb8UJWhlbJBfE4IyhL",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -267,10 +267,10 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_smEZJKpXhjNduFPjfIbxZoEe",
+                            "call_id": "call_bymFbcxb8UJWhlbJBfE4IyhL",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_00ca1457a4fdd8740068f2a32d82c081939c1e9a9ea46ef36f",
+                            "id": "fc_0d31684a7919915c0068f80394a76481958b86f12f9af50f3d",
                             "status": "completed",
                         }
                     ],
@@ -278,7 +278,7 @@ Respond only with valid JSON that matches this exact schema:
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_smEZJKpXhjNduFPjfIbxZoEe",
+                            id="call_bymFbcxb8UJWhlbJBfE4IyhL",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -301,7 +301,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_00ca1457a4fdd8740068f2a32edc608193b350ab046617ec4a",
+                            "id": "msg_0d31684a7919915c0068f8039578888195ae9360ef9a19a0be",
                             "content": [
                                 {
                                     "annotations": [],
@@ -451,7 +451,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_D4nyNr9jTi00FFRjW885O8Rm",
+                            id="call_2INHCCeQ8YZLZ5y7szu4oLAu",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -461,10 +461,10 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_D4nyNr9jTi00FFRjW885O8Rm",
+                            "call_id": "call_2INHCCeQ8YZLZ5y7szu4oLAu",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0a091f1f54f473470068f2a362a8908197a6d4153b656e6af0",
+                            "id": "fc_0ff76143e6db39820068f803a1e6e48193bd272f4e9d4f0bd0",
                             "status": "completed",
                         }
                     ],
@@ -472,7 +472,7 @@ Respond only with valid JSON that matches this exact schema:
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_D4nyNr9jTi00FFRjW885O8Rm",
+                            id="call_2INHCCeQ8YZLZ5y7szu4oLAu",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -495,7 +495,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0a091f1f54f473470068f2a36399fc81978eab22e8b49d9ee9",
+                            "id": "msg_0ff76143e6db39820068f803a3e1188193b5b74aab12cf9ea5",
                             "content": [
                                 {
                                     "annotations": [],
@@ -646,7 +646,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_5tpYH2kVrLA3lru58ufOs4ws",
+                            id="call_bYchQSy9hJphpJ5Kqqfnyhcr",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -656,10 +656,10 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_5tpYH2kVrLA3lru58ufOs4ws",
+                            "call_id": "call_bYchQSy9hJphpJ5Kqqfnyhcr",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0f36bbfa154ea31e0068f2a39aeba881909a20e63b6eda3505",
+                            "id": "fc_00ca34419d991c140068f803b5492481978bc39acc2949c18c",
                             "status": "completed",
                         }
                     ],
@@ -667,7 +667,7 @@ Respond only with valid JSON that matches this exact schema:
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_5tpYH2kVrLA3lru58ufOs4ws",
+                            id="call_bYchQSy9hJphpJ5Kqqfnyhcr",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -690,7 +690,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0f36bbfa154ea31e0068f2a39bc2288190b0f5fc43a6c70d1d",
+                            "id": "msg_00ca34419d991c140068f803b6a10c8197b28c925dbebdf7c8",
                             "content": [
                                 {
                                     "annotations": [],

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_responses_gpt_4o_snapshots.py
@@ -26,7 +26,7 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_QYDFpzT7p7YrQV2eJUcrcHI0",
+                            id="call_Vbjtdf8hv8gCfhNfJoibeqvY",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -36,10 +36,10 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_QYDFpzT7p7YrQV2eJUcrcHI0",
+                            "call_id": "call_Vbjtdf8hv8gCfhNfJoibeqvY",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_06660162423253ef0068f2a31c4828819080c94c3fbdceebbe",
+                            "id": "fc_083c63fe91b0c9550068f8038b15688190b573c90380dd5927",
                             "status": "completed",
                         }
                     ],
@@ -47,7 +47,7 @@ sync_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_QYDFpzT7p7YrQV2eJUcrcHI0",
+                            id="call_Vbjtdf8hv8gCfhNfJoibeqvY",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -57,13 +57,16 @@ sync_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
+                        ),
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        ),
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_06660162423253ef0068f2a31d9d2481909c7a577d3d6032c3",
+                            "id": "msg_083c63fe91b0c9550068f8038d376881909e47d783481c49a4",
                             "content": [
                                 {
                                     "annotations": [],
@@ -75,7 +78,21 @@ sync_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        }
+                        },
+                        {
+                            "id": "msg_083c63fe91b0c9550068f8038ef9088190918234052c11c170",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
                     ],
                 ),
             ],
@@ -142,7 +159,7 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_0guWT53h3nkwqcQ569xMUwnD",
+                            id="call_0jl9rZ10qNXvTvmqRmhZS3IN",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -152,10 +169,10 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_0guWT53h3nkwqcQ569xMUwnD",
+                            "call_id": "call_0jl9rZ10qNXvTvmqRmhZS3IN",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0b43b623cec0a9a00068f2a34d22908193978240c787a920ff",
+                            "id": "fc_0506e84adfc3be1c0068f8039bb2ec8195a7415e5789e8d752",
                             "status": "completed",
                         }
                     ],
@@ -163,7 +180,7 @@ async_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_0guWT53h3nkwqcQ569xMUwnD",
+                            id="call_0jl9rZ10qNXvTvmqRmhZS3IN",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -182,7 +199,7 @@ async_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0b43b623cec0a9a00068f2a34eb7fc8193b227efff55f6b45b",
+                            "id": "msg_0506e84adfc3be1c0068f8039cdc808195a47db6cdc4f1b9d2",
                             "content": [
                                 {
                                     "annotations": [],
@@ -196,7 +213,7 @@ async_snapshot = snapshot(
                             "type": "message",
                         },
                         {
-                            "id": "msg_0b43b623cec0a9a00068f2a34f98c4819397f57e44437bdd98",
+                            "id": "msg_0506e84adfc3be1c0068f8039da6448195b4cf6430b25ce2e1",
                             "content": [
                                 {
                                     "annotations": [],
@@ -274,7 +291,7 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_UD9LFETOWfReeJ89TBROECDh",
+                            id="call_ICOTPIFHgVe7l5McAwKJXgSh",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -284,10 +301,10 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_UD9LFETOWfReeJ89TBROECDh",
+                            "call_id": "call_ICOTPIFHgVe7l5McAwKJXgSh",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0822e9aa79f336090068f2a385ff14819693e23b76c02195a8",
+                            "id": "fc_0c4df536f5e319de0068f803a99e5081939e447b2e43f4b20b",
                             "status": "completed",
                         }
                     ],
@@ -295,7 +312,7 @@ stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_UD9LFETOWfReeJ89TBROECDh",
+                            id="call_ICOTPIFHgVe7l5McAwKJXgSh",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -311,7 +328,7 @@ stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0822e9aa79f336090068f2a38838888196b307c953e30e5c07",
+                            "id": "msg_0c4df536f5e319de0068f803aca81c81939053fa768ac82983",
                             "content": [
                                 {
                                     "annotations": [],
@@ -390,7 +407,7 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_ICStYLn3q6R7vLjGUPsRQE6a",
+                            id="call_GfbuCcXYgL5vFxE32PPp9kHQ",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -400,10 +417,10 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_ICStYLn3q6R7vLjGUPsRQE6a",
+                            "call_id": "call_GfbuCcXYgL5vFxE32PPp9kHQ",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0f2867689be255460068f2a3b657c88197b9596f9cd1e01fb6",
+                            "id": "fc_008c4d6177f0dd430068f803bb86e08196be7c23112728d0b9",
                             "status": "completed",
                         }
                     ],
@@ -411,7 +428,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_ICStYLn3q6R7vLjGUPsRQE6a",
+                            id="call_GfbuCcXYgL5vFxE32PPp9kHQ",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -421,13 +438,16 @@ async_stream_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
+                        ),
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        ),
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0f2867689be255460068f2a3b742608197b16f2e0fe7341f4a",
+                            "id": "msg_008c4d6177f0dd430068f803bd517081969b93116e0901b607",
                             "content": [
                                 {
                                     "annotations": [],
@@ -439,7 +459,21 @@ async_stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        }
+                        },
+                        {
+                            "id": "msg_008c4d6177f0dd430068f803be68148196a5dc2a50856d7d78",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
                     ],
                 ),
             ],
@@ -485,7 +519,7 @@ async_stream_snapshot = snapshot(
                     "strict": False,
                 }
             ],
-            "n_chunks": 29,
+            "n_chunks": 58,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_responses_gpt_4o_snapshots.py
@@ -26,7 +26,7 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_x62FJoHImWtl4XlNg7pnd9ij",
+                            id="call_cfbhuPJ0dHVR8LDQqYIXMm4M",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -36,10 +36,10 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_x62FJoHImWtl4XlNg7pnd9ij",
+                            "call_id": "call_cfbhuPJ0dHVR8LDQqYIXMm4M",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0d500ed14dac8aa80068f2a2e557908193b64700c248f9c141",
+                            "id": "fc_02df12e7608112720068f8037dae508196b15c7ff49dafdd7a",
                             "status": "completed",
                         }
                     ],
@@ -47,7 +47,7 @@ sync_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_x62FJoHImWtl4XlNg7pnd9ij",
+                            id="call_cfbhuPJ0dHVR8LDQqYIXMm4M",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -66,7 +66,7 @@ sync_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0d500ed14dac8aa80068f2a2e6e1548193b7400b1814b04b63",
+                            "id": "msg_02df12e7608112720068f8037f7390819690dc5d87a4a7fc3c",
                             "content": [
                                 {
                                     "annotations": [],
@@ -80,7 +80,7 @@ sync_snapshot = snapshot(
                             "type": "message",
                         },
                         {
-                            "id": "msg_0d500ed14dac8aa80068f2a2e786b48193bb24b214c4aff119",
+                            "id": "msg_02df12e7608112720068f8038056c48196a471aade2ca97fe9",
                             "content": [
                                 {
                                     "annotations": [],
@@ -159,7 +159,7 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_7o69tE63kjgocyseJ6O998CX",
+                            id="call_WvXWhIEpFUMiebo6Imkxf7o4",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -169,10 +169,10 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_7o69tE63kjgocyseJ6O998CX",
+                            "call_id": "call_WvXWhIEpFUMiebo6Imkxf7o4",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0b882f93e8d7f1170068f2a3227cbc81969eacfc9dbd503923",
+                            "id": "fc_0cd908f8261c00ef0068f8039146c48197bb6106f91dcb0c13",
                             "status": "completed",
                         }
                     ],
@@ -180,7 +180,7 @@ async_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_7o69tE63kjgocyseJ6O998CX",
+                            id="call_WvXWhIEpFUMiebo6Imkxf7o4",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -196,7 +196,7 @@ async_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0b882f93e8d7f1170068f2a323bf008196ba1d0a1f4d3ba6be",
+                            "id": "msg_0cd908f8261c00ef0068f80392a61c819787a5ddda8e353fa5",
                             "content": [
                                 {
                                     "annotations": [],
@@ -274,7 +274,7 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_IxugtwYIfPlbKHwZyyt9jQ3A",
+                            id="call_aUL5PjVgmSfjO9qo7TxQZ9gl",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -284,10 +284,10 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_IxugtwYIfPlbKHwZyyt9jQ3A",
+                            "call_id": "call_aUL5PjVgmSfjO9qo7TxQZ9gl",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0b43fb0f4bd678710068f2a357d2348196bf435e544d71d71d",
+                            "id": "fc_078bf5f366416f5b0068f8039f62ac8195831cdfa99560cec7",
                             "status": "completed",
                         }
                     ],
@@ -295,7 +295,7 @@ stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_IxugtwYIfPlbKHwZyyt9jQ3A",
+                            id="call_aUL5PjVgmSfjO9qo7TxQZ9gl",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -311,7 +311,7 @@ stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0b43fb0f4bd678710068f2a359c0608196bf9ee0484f43f7b3",
+                            "id": "msg_078bf5f366416f5b0068f803a0c0848195aefa51099efbb69d",
                             "content": [
                                 {
                                     "annotations": [],
@@ -390,7 +390,7 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_WQ2jLlhFv3DjImp8sd8BfGHE",
+                            id="call_UYyQKoFNBN1ycGyyaBW6U21Q",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -400,10 +400,10 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_WQ2jLlhFv3DjImp8sd8BfGHE",
+                            "call_id": "call_UYyQKoFNBN1ycGyyaBW6U21Q",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_003bcb20887d7f890068f2a38e9a5c81938921dfb7c2fc2183",
+                            "id": "fc_0545a869dbbbc5790068f803b00c0081958b874eed17e438e5",
                             "status": "completed",
                         }
                     ],
@@ -411,7 +411,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_WQ2jLlhFv3DjImp8sd8BfGHE",
+                            id="call_UYyQKoFNBN1ycGyyaBW6U21Q",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -421,13 +421,16 @@ async_stream_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
+                        ),
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        ),
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_003bcb20887d7f890068f2a390560081938c96429f36f9e3be",
+                            "id": "msg_0545a869dbbbc5790068f803b1b2f881958cd94d4fe3ceb9d2",
                             "content": [
                                 {
                                     "annotations": [],
@@ -439,7 +442,21 @@ async_stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        }
+                        },
+                        {
+                            "id": "msg_0545a869dbbbc5790068f803b2f37081959a6b906af07dbabe",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
                     ],
                 ),
             ],
@@ -485,7 +502,7 @@ async_stream_snapshot = snapshot(
                     "strict": False,
                 }
             ],
-            "n_chunks": 29,
+            "n_chunks": 58,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_responses_gpt_4o_snapshots.py
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_AzET35sbZlIBHshHoKlKzDqg",
+                            id="call_5HluY7git4zKf5aU3pYuGOmy",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -42,10 +42,10 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_AzET35sbZlIBHshHoKlKzDqg",
+                            "call_id": "call_5HluY7git4zKf5aU3pYuGOmy",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_063d3864889aa46f0068f2a30b966081958c55c1ccc9a4d5a9",
+                            "id": "fc_0599981a705b852f0068f80387f08c8194b250ecb1fae3d009",
                             "status": "completed",
                         }
                     ],
@@ -53,7 +53,7 @@ sync_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_AzET35sbZlIBHshHoKlKzDqg",
+                            id="call_5HluY7git4zKf5aU3pYuGOmy",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -70,10 +70,10 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_9PDlKs2OQo8QvFtgGx0kKi4p",
+                            "call_id": "call_fzD0XUkOD5oX1G9IQaQuVepo",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_063d3864889aa46f0068f2a30c8df08195bfffcdc90c3f9898",
+                            "id": "fc_0599981a705b852f0068f8038911448194b91ab0d1a65a4d5f",
                             "status": "completed",
                         }
                     ],
@@ -147,7 +147,7 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_0CdfaQNr2opQKuS9Hqoi7qJp",
+                            id="call_DrlQaUJgKQzjF3S4GteDzVyT",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -157,10 +157,10 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_0CdfaQNr2opQKuS9Hqoi7qJp",
+                            "call_id": "call_DrlQaUJgKQzjF3S4GteDzVyT",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0dde77d0d5d3c6c00068f2a33f176481978c9bbe33aeb94ad4",
+                            "id": "fc_0a064f26a0e36b0f0068f80397dbe48197b967343858cd34d6",
                             "status": "completed",
                         }
                     ],
@@ -168,7 +168,7 @@ async_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_0CdfaQNr2opQKuS9Hqoi7qJp",
+                            id="call_DrlQaUJgKQzjF3S4GteDzVyT",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -185,10 +185,10 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_7kabYtpUiaVYeRcMR3slDM9W",
+                            "call_id": "call_ONTNgtTfGzzem814CmYIWc1X",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_0dde77d0d5d3c6c00068f2a3416f8c8197b82b3fe81501d3a6",
+                            "id": "fc_0a064f26a0e36b0f0068f80399c098819785554f8a306d2844",
                             "status": "completed",
                         }
                     ],
@@ -261,7 +261,7 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_EUpPd1zspWqxQVBzskOK77AE",
+                            id="call_1fg5q1oL0b4WfrZQ0JBaOw0P",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -271,10 +271,10 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_EUpPd1zspWqxQVBzskOK77AE",
+                            "call_id": "call_1fg5q1oL0b4WfrZQ0JBaOw0P",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0a687746ec3796fe0068f2a36fad30819492a92873df01ed4e",
+                            "id": "fc_05c98fe93bf42dbf0068f803a54d3c81909a13299414385100",
                             "status": "completed",
                         }
                     ],
@@ -282,7 +282,7 @@ stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_EUpPd1zspWqxQVBzskOK77AE",
+                            id="call_1fg5q1oL0b4WfrZQ0JBaOw0P",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -299,10 +299,10 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_Sz68GhAUAvwpVT01l6Z8Ovez",
+                            "call_id": "call_Sl3GfUD0tqZi9IVnViLlqciN",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_0a687746ec3796fe0068f2a370a93881949e435b052667319e",
+                            "id": "fc_05c98fe93bf42dbf0068f803a6ffb08190a3feb3ff9e61c64a",
                             "status": "completed",
                         }
                     ],
@@ -376,7 +376,7 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_EhKsDFiHlPWDhy7EAKIYBTwa",
+                            id="call_ne0YY1KW7rsADxc2M7EmH4kI",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -386,10 +386,10 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_EhKsDFiHlPWDhy7EAKIYBTwa",
+                            "call_id": "call_ne0YY1KW7rsADxc2M7EmH4kI",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_02ad8eee9a92579d0068f2a3a5e34481978a2bbd9361116f92",
+                            "id": "fc_04e81f6bc0c6efc10068f803b8bbc88190b786a50d061178a0",
                             "status": "completed",
                         }
                     ],
@@ -397,7 +397,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_EhKsDFiHlPWDhy7EAKIYBTwa",
+                            id="call_ne0YY1KW7rsADxc2M7EmH4kI",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -414,10 +414,10 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_6fnBO6kiYT9r7w8szE0MUlTc",
+                            "call_id": "call_QeInmocTvaZdqriB6Retk0OU",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_02ad8eee9a92579d0068f2a3a755b4819789a3d778bf6da5d6",
+                            "id": "fc_04e81f6bc0c6efc10068f803b9bf6c81908d9b458c080805b1",
                             "status": "completed",
                         }
                     ],

--- a/python/tests/llm/clients/openai/test_responses_client.py
+++ b/python/tests/llm/clients/openai/test_responses_client.py
@@ -25,7 +25,11 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
         {
             "model": "gpt-4o",
             "input": [
-                {"role": "user", "content": "Hello there"},
+                {
+                    "role": "user",
+                    "content": [{"text": "Hello there", "type": "input_text"}],
+                    "type": "message",
+                },
                 {"role": "assistant", "content": "General "},
                 {"role": "assistant", "content": "Kenobi"},
             ],
@@ -48,7 +52,11 @@ def test_prepare_message_multiple_system_messages() -> None:
         {
             "model": "gpt-4o",
             "input": [
-                {"role": "user", "content": "Hello there"},
+                {
+                    "role": "user",
+                    "content": [{"text": "Hello there", "type": "input_text"}],
+                    "type": "message",
+                },
                 {"role": "developer", "content": "Be concise."},
                 {"role": "developer", "content": "On second thought, be verbose."},
             ],


### PR DESCRIPTION
This refactors openai:responses message encoding so that when multiple
pieces of content may be organized into the same message (eg multiple
text pieces in one user message), they will be combined rather than
emitting separate messages for each content piece.

Due to limitations in the api design, this mostly applies to user
messages rather than assistant messages.