### PR TITLE
Implement the GrokClient

### DIFF
--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -18,6 +18,7 @@ from .openai import (
     OpenAIResponsesModelId,
 )
 from .providers import PROVIDERS, ModelId, Provider, client, get_client
+from .xai import GrokClient, GrokModelId
 
 __all__ = [
     "PROVIDERS",
@@ -31,6 +32,8 @@ __all__ = [
     "ClientT",
     "GoogleClient",
     "GoogleModelId",
+    "GrokClient",
+    "GrokModelId",
     "ModelId",
     "OpenAICompletionsClient",
     "OpenAICompletionsModelId",

--- a/python/mirascope/llm/clients/providers.py
+++ b/python/mirascope/llm/clients/providers.py
@@ -55,6 +55,13 @@ from .openai import (
     get_responses_client as get_openai_responses_client,
     responses_client as openai_responses_client,
 )
+from .xai import (
+    GrokClient,
+    GrokModelId,
+    clear_cache as clear_grok_cache,
+    client as grok_client,
+    get_client as get_grok_client,
+)
 
 Provider: TypeAlias = Literal[
     "anthropic",  # AnthropicClient
@@ -66,6 +73,7 @@ Provider: TypeAlias = Literal[
     "openai:completions",  # OpenAICompletionsClient
     "openai:responses",  # OpenAIResponsesClient
     "openai",  # Alias for "openai:responses"
+    "xai",  # GrokClient
 ]
 PROVIDERS = get_args(Provider)
 
@@ -76,6 +84,7 @@ ModelId: TypeAlias = (
     | AzureOpenAICompletionsModelId
     | AzureOpenAIResponsesModelId
     | GoogleModelId
+    | GrokModelId
     | OpenAIResponsesModelId
     | OpenAICompletionsModelId
     | str
@@ -147,6 +156,12 @@ PROVIDER_INFO: dict[Provider, ProviderInfo] = {
         "get_client": get_openai_responses_client,
         "client": openai_responses_client,
     },
+    "xai": {
+        "name": "xai",
+        "clear_cache": clear_grok_cache(),
+        "get_client": get_grok_client,
+        "client": grok_client
+    }
 }
 
 
@@ -204,6 +219,12 @@ def get_client(
     ...
 
 
+@overload
+def get_client(provider: Literal["xai"]) -> GrokClient:
+    """Get a Grok client instance."""
+    ...
+
+
 def get_client(
     provider: Provider,
 ) -> (
@@ -213,6 +234,7 @@ def get_client(
     | AzureOpenAICompletionsClient
     | AzureOpenAIResponsesClient
     | GoogleClient
+    | GrokClient
     | OpenAICompletionsClient
     | OpenAIResponsesClient
 ):
@@ -345,6 +367,16 @@ def client(
     ...
 
 
+@overload
+def client(
+    provider: Literal["xai"],
+    *,
+    api_key: str | None = None,
+) -> GrokClient:
+    """Create a cached Grok client with the given parameters."""
+    ...
+
+
 def client(
     provider: Provider,
     *,
@@ -358,6 +390,7 @@ def client(
     | AzureOpenAICompletionsClient
     | AzureOpenAIResponsesClient
     | GoogleClient
+    | GrokClient
     | OpenAICompletionsClient
     | OpenAIResponsesClient
 ):

--- a/python/mirascope/llm/clients/xai/__init__.py
+++ b/python/mirascope/llm/clients/xai/__init__.py
@@ -1,0 +1,6 @@
+"""xAI Grok client implementation."""
+
+from .clients import GrokClient, clear_cache, client, get_client
+from .model_ids import GrokModelId
+
+__all__ = ["GrokClient", "GrokModelId", "clear_cache", "client", "get_client"]

--- a/python/mirascope/llm/clients/xai/_utils/__init__.py
+++ b/python/mirascope/llm/clients/xai/_utils/__init__.py
@@ -1,0 +1,12 @@
+from .decode import decode_async_stream, decode_response, decode_stream
+from .encode import encode_message, encode_messages, encode_request, encode_tools
+
+__all__ = [
+    "decode_async_stream",
+    "decode_response",
+    "decode_stream",
+    "encode_message",
+    "encode_messages",
+    "encode_request",
+    "encode_tools",
+]

--- a/python/mirascope/llm/clients/xai/_utils/decode.py
+++ b/python/mirascope/llm/clients/xai/_utils/decode.py
@@ -1,0 +1,341 @@
+"""Message decoding utilities for xAI SDK."""
+
+from collections.abc import AsyncIterator, Iterator, Sequence
+from dataclasses import asdict
+from typing import Protocol, TypedDict
+
+from xai_sdk import chat as xai_chat
+from xai_sdk.proto import sample_pb2
+
+from ....content import (
+    AssistantContentPart,
+    Text,
+    TextChunk,
+    TextEndChunk,
+    TextStartChunk,
+    Thought,
+    ThoughtChunk,
+    ThoughtEndChunk,
+    ThoughtStartChunk,
+    ToolCall,
+    ToolCallChunk,
+    ToolCallEndChunk,
+    ToolCallStartChunk,
+)
+from ....messages import AssistantMessage
+from ....responses import (
+    AsyncChunkIterator,
+    ChunkIterator,
+    FinishReason,
+    FinishReasonChunk,
+    RawMessageChunk,
+    RawStreamEventChunk,
+)
+from ..model_ids import GrokModelId
+
+
+class ToolCallFunction(Protocol):
+    """Protocol for tool call function structure."""
+
+    @property
+    def name(self) -> str: ...
+
+    @property
+    def arguments(self) -> str: ...
+
+
+class XAIToolCall(Protocol):
+    """Protocol for xAI SDK ToolCall structure."""
+
+    @property
+    def id(self) -> str: ...
+
+    @property
+    def function(self) -> ToolCallFunction: ...
+
+
+class ToolCallData(TypedDict):
+    """Type for accumulated tool call data."""
+
+    name: str
+    args: str
+
+
+def _build_tool_calls_raw_message(
+    tool_calls_data: dict[str, ToolCallData] | Sequence[XAIToolCall],
+) -> list[dict[str, dict[str, str] | str]]:
+    """Build raw_message tool_calls structure from tool calls data."""
+    if isinstance(tool_calls_data, dict):
+        return [
+            {
+                "id": tc_id,
+                "function": {
+                    "name": tc_data["name"],
+                    "arguments": tc_data["args"],
+                },
+            }
+            for tc_id, tc_data in tool_calls_data.items()
+        ]
+    else:
+        return [
+            {
+                "id": tc.id,
+                "function": {
+                    "name": tc.function.name,
+                    "arguments": tc.function.arguments,
+                },
+            }
+            for tc in tool_calls_data
+        ]
+
+
+def _finalize_stream_content(
+    accumulated_content: list[AssistantContentPart],
+    current_text: str,
+    current_thought: str,
+    current_tool_calls: dict[str, ToolCallData],
+    finish_reason: FinishReason | None,
+) -> Iterator[
+    ThoughtEndChunk
+    | TextEndChunk
+    | ToolCallEndChunk
+    | FinishReasonChunk
+    | RawMessageChunk
+]:
+    """Finalize accumulated content and yield end chunks."""
+    if current_thought:
+        yield ThoughtEndChunk()
+        accumulated_content.append(Thought(thought=current_thought))
+
+    if current_text:
+        yield TextEndChunk()
+        accumulated_content.append(Text(text=current_text))
+
+    for tc_id, tc_data in current_tool_calls.items():
+        yield ToolCallEndChunk(id=tc_id)
+        accumulated_content.append(
+            ToolCall(id=tc_id, name=tc_data["name"], args=tc_data["args"])
+        )
+
+    if finish_reason:
+        yield FinishReasonChunk(finish_reason=finish_reason)
+
+    raw_message: dict = {
+        "content": [asdict(part) for part in accumulated_content],
+    }
+    if current_tool_calls:
+        raw_message["tool_calls"] = _build_tool_calls_raw_message(current_tool_calls)
+
+    yield RawMessageChunk(raw_message=raw_message)
+
+
+async def _finalize_async_stream_content(
+    accumulated_content: list[AssistantContentPart],
+    current_text: str,
+    current_thought: str,
+    current_tool_calls: dict[str, ToolCallData],
+    finish_reason: FinishReason | None,
+) -> AsyncIterator[
+    ThoughtEndChunk
+    | TextEndChunk
+    | ToolCallEndChunk
+    | FinishReasonChunk
+    | RawMessageChunk
+]:
+    """Finalize accumulated content and yield end chunks (async version)."""
+    if current_thought:
+        yield ThoughtEndChunk()
+        accumulated_content.append(Thought(thought=current_thought))
+
+    if current_text:
+        yield TextEndChunk()
+        accumulated_content.append(Text(text=current_text))
+
+    for tc_id, tc_data in current_tool_calls.items():
+        yield ToolCallEndChunk(id=tc_id)
+        accumulated_content.append(
+            ToolCall(id=tc_id, name=tc_data["name"], args=tc_data["args"])
+        )
+
+    if finish_reason:
+        yield FinishReasonChunk(finish_reason=finish_reason)
+
+    raw_message: dict = {
+        "content": [asdict(part) for part in accumulated_content],
+    }
+    if current_tool_calls:
+        raw_message["tool_calls"] = _build_tool_calls_raw_message(current_tool_calls)
+
+    yield RawMessageChunk(raw_message=raw_message)
+
+
+def decode_response(
+    response: xai_chat.Response, model_id: GrokModelId
+) -> tuple[AssistantMessage, FinishReason | None]:
+    """Convert an xAI SDK response to Mirascope AssistantMessage."""
+    content_parts: list[AssistantContentPart] = []
+
+    if response.reasoning_content:
+        content_parts.append(Thought(thought=response.reasoning_content))
+
+    if response.content:
+        content_parts.append(Text(text=response.content))
+
+    if response.tool_calls:
+        for tool_call in response.tool_calls:
+            content_parts.append(
+                ToolCall(
+                    id=tool_call.id,
+                    name=tool_call.function.name,
+                    args=tool_call.function.arguments,
+                )
+            )
+
+    finish_reason: FinishReason | None = None
+    if response.finish_reason in (
+        sample_pb2.REASON_MAX_LEN,
+        sample_pb2.REASON_MAX_CONTEXT,
+    ):
+        finish_reason = FinishReason.MAX_TOKENS
+
+    raw_message: dict = {
+        "content": [asdict(part) for part in content_parts],
+    }
+    if response.tool_calls:
+        raw_message["tool_calls"] = _build_tool_calls_raw_message(response.tool_calls)
+
+    assistant_message = AssistantMessage(
+        content=content_parts,
+        provider="xai",
+        model_id=model_id,
+        raw_message=raw_message,
+    )
+
+    return assistant_message, finish_reason
+
+
+def decode_stream(
+    xai_stream: Iterator[tuple[xai_chat.Response, xai_chat.Chunk]],
+    model_id: GrokModelId,
+) -> ChunkIterator:
+    """Returns a ChunkIterator converted from an xAI SDK stream."""
+    accumulated_content: list[AssistantContentPart] = []
+    current_text = ""
+    current_thought = ""
+    current_tool_calls: dict[str, ToolCallData] = {}
+    finish_reason: FinishReason | None = None
+
+    for _response, chunk in xai_stream:
+        yield RawStreamEventChunk(raw_stream_event=chunk)
+
+        if chunk.reasoning_content:
+            if not current_thought:
+                yield ThoughtStartChunk()
+            yield ThoughtChunk(delta=chunk.reasoning_content)
+            current_thought += chunk.reasoning_content
+
+        if chunk.content:
+            if not current_text:
+                yield TextStartChunk()
+            yield TextChunk(delta=chunk.content)
+            current_text += chunk.content
+
+        if chunk.tool_calls:
+            for tc_delta in chunk.tool_calls:
+                tc_id = tc_delta.id
+                if not tc_id:
+                    continue
+                if tc_id not in current_tool_calls:
+                    tc_name = tc_delta.function.name if tc_delta.function else ""
+                    current_tool_calls[tc_id] = {
+                        "name": tc_name,
+                        "args": "",
+                    }
+                    yield ToolCallStartChunk(id=tc_id, name=tc_name)
+
+                if tc_delta.function and tc_delta.function.arguments:
+                    args_delta = tc_delta.function.arguments
+                    current_tool_calls[tc_id]["args"] += args_delta
+                    yield ToolCallChunk(id=tc_id, delta=args_delta)
+
+        if (
+            chunk.choices
+            and chunk.choices[0].finish_reason
+            and (
+                chunk.choices[0].finish_reason == sample_pb2.REASON_MAX_LEN
+                or chunk.choices[0].finish_reason == sample_pb2.REASON_MAX_CONTEXT
+            )
+        ):
+            finish_reason = FinishReason.MAX_TOKENS
+
+    yield from _finalize_stream_content(
+        accumulated_content,
+        current_text,
+        current_thought,
+        current_tool_calls,
+        finish_reason,
+    )
+
+
+async def decode_async_stream(
+    xai_stream: AsyncIterator[tuple[xai_chat.Response, xai_chat.Chunk]],
+    model_id: GrokModelId,
+) -> AsyncChunkIterator:
+    """Returns an AsyncChunkIterator converted from an xAI SDK async stream."""
+    accumulated_content: list[AssistantContentPart] = []
+    current_text = ""
+    current_thought = ""
+    current_tool_calls: dict[str, ToolCallData] = {}
+    finish_reason: FinishReason | None = None
+
+    async for _response, chunk in xai_stream:
+        yield RawStreamEventChunk(raw_stream_event=chunk)
+
+        if chunk.reasoning_content:
+            if not current_thought:
+                yield ThoughtStartChunk()
+            yield ThoughtChunk(delta=chunk.reasoning_content)
+            current_thought += chunk.reasoning_content
+
+        if chunk.content:
+            if not current_text:
+                yield TextStartChunk()
+            yield TextChunk(delta=chunk.content)
+            current_text += chunk.content
+
+        if chunk.tool_calls:
+            for tc_delta in chunk.tool_calls:
+                tc_id = tc_delta.id
+                if not tc_id:
+                    continue
+                if tc_id not in current_tool_calls:
+                    tc_name = tc_delta.function.name if tc_delta.function else ""
+                    current_tool_calls[tc_id] = {
+                        "name": tc_name,
+                        "args": "",
+                    }
+                    yield ToolCallStartChunk(id=tc_id, name=tc_name)
+
+                if tc_delta.function and tc_delta.function.arguments:
+                    args_delta = tc_delta.function.arguments
+                    current_tool_calls[tc_id]["args"] += args_delta
+                    yield ToolCallChunk(id=tc_id, delta=args_delta)
+
+        if (
+            chunk.choices
+            and chunk.choices[0].finish_reason
+            and (
+                chunk.choices[0].finish_reason == sample_pb2.REASON_MAX_LEN
+                or chunk.choices[0].finish_reason == sample_pb2.REASON_MAX_CONTEXT
+            )
+        ):
+            finish_reason = FinishReason.MAX_TOKENS
+
+    async for chunk in _finalize_async_stream_content(
+        accumulated_content,
+        current_text,
+        current_thought,
+        current_tool_calls,
+        finish_reason,
+    ):
+        yield chunk

--- a/python/mirascope/llm/clients/xai/_utils/encode.py
+++ b/python/mirascope/llm/clients/xai/_utils/encode.py
@@ -1,0 +1,325 @@
+"""Message encoding utilities for xAI SDK."""
+
+from collections.abc import Sequence
+from typing import Literal, TypedDict
+from typing_extensions import Required
+
+from xai_sdk import chat as xai_chat
+from xai_sdk.chat import chat_pb2
+
+from ....content import ContentPart
+from ....exceptions import FeatureNotSupportedError, FormattingModeNotSupportedError
+from ....formatting import (
+    Format,
+    FormattableT,
+    _utils as _formatting_utils,
+    resolve_format,
+)
+from ....messages import AssistantMessage, Message, SystemMessage, UserMessage
+from ....tools import FORMAT_TOOL_NAME, BaseToolkit, ToolSchema
+from ...base import Params, _utils as _base_utils
+from ..model_ids import GrokModelId
+
+UNKNOWN_TOOL_ID = "xai_unknown_tool_id"
+
+
+class ChatCreateKwargs(TypedDict, total=False):
+    """Kwargs for xAI chat.create method."""
+
+    model: Required[str]
+    messages: Required[list[chat_pb2.Message]]
+    tools: list[chat_pb2.Tool] | None
+    tool_choice: chat_pb2.ToolChoice | str | None
+    temperature: float
+    max_tokens: int
+    top_p: float
+    seed: int
+    stop: list[str]
+    reasoning_effort: str
+    response_format: str
+
+
+def encode_tools(tools: Sequence[ToolSchema] | None) -> list[chat_pb2.Tool]:
+    """Convert Mirascope tools to xAI SDK tool format."""
+    if not tools:
+        return []
+
+    xai_tools: list[chat_pb2.Tool] = []
+    for tool in tools:
+        parameters = tool.parameters.model_dump(by_alias=True, exclude_none=True)
+
+        xai_tool = xai_chat.tool(
+            name=tool.name,
+            description=tool.description or "",
+            parameters=parameters,
+        )
+        xai_tools.append(xai_tool)
+
+    return xai_tools
+
+
+def _encode_content_part(part: ContentPart) -> chat_pb2.Content | chat_pb2.Message:
+    """Returns xAI SDK Content or Message from Mirascope content part."""
+    if part.type == "text":
+        return xai_chat.text(part.text)
+    elif part.type == "image":
+        raise FeatureNotSupportedError(
+            "image",
+            "xai",
+            message=(
+                "This Grok model does not support image inputs. "
+                "Use grok-2-vision for image understanding, or download the image locally and convert it to text instead."
+            ),
+        )
+    elif part.type == "audio":
+        raise NotImplementedError("Audio content not supported by xAI SDK")
+    elif part.type == "document":
+        raise NotImplementedError("Document content not supported by xAI SDK")
+    elif part.type == "tool_output":
+        return xai_chat.tool_result(str(part.value))
+    else:
+        raise NotImplementedError(f"Unsupported content type: {part.type}")
+
+
+def encode_message(
+    message: Message, *, encode_thoughts: bool = False
+) -> chat_pb2.Message | list[chat_pb2.Message]:
+    """Convert a Mirascope Message to xAI SDK message format."""
+    if isinstance(message, SystemMessage):
+        return xai_chat.system(xai_chat.text(message.content.text))
+    elif isinstance(message, UserMessage):
+        tool_outputs = [part for part in message.content if part.type == "tool_output"]
+        other_parts = [part for part in message.content if part.type != "tool_output"]
+
+        messages = []
+
+        if other_parts:
+            content_parts = []
+            for part in other_parts:
+                converted = _encode_content_part(part)
+                if converted is not None:
+                    content_parts.append(converted)
+
+            if content_parts:
+                messages.append(xai_chat.user(*content_parts))
+            else:
+                messages.append(xai_chat.user(xai_chat.text("")))
+
+        for tool_output in tool_outputs:
+            messages.append(xai_chat.tool_result(str(tool_output.value)))
+
+        if not messages:
+            return xai_chat.user(xai_chat.text(""))
+        elif len(messages) == 1:
+            return messages[0]
+        else:
+            return messages
+    elif isinstance(message, AssistantMessage):
+        if (
+            message.provider == "xai"
+            and message.raw_message
+            and isinstance(message.raw_message, dict)
+            and not encode_thoughts
+            and "tool_calls" in message.raw_message
+        ):
+            msg = chat_pb2.Message()
+            msg.role = chat_pb2.MessageRole.ROLE_ASSISTANT
+
+            content_list = message.raw_message.get("content", [])
+            if isinstance(content_list, list):
+                for content_dict in content_list:
+                    if not isinstance(content_dict, dict):
+                        continue
+                    if content_dict.get("type") == "text":
+                        text_val = content_dict.get("text")
+                        if isinstance(text_val, str):
+                            msg.content.append(xai_chat.text(text_val))
+                    elif content_dict.get("type") == "thought":
+                        thought_val = content_dict.get("thought")
+                        if isinstance(thought_val, str):
+                            msg.reasoning_content = thought_val
+
+            tool_calls_list = message.raw_message.get("tool_calls", [])
+            if isinstance(tool_calls_list, list):
+                for tc_dict in tool_calls_list:
+                    if not isinstance(tc_dict, dict):
+                        continue
+                    tc_id = tc_dict.get("id")
+                    tc_function = tc_dict.get("function")
+                    if isinstance(tc_id, str) and isinstance(tc_function, dict):
+                        func_name = tc_function.get("name")
+                        func_args = tc_function.get("arguments")
+                        if isinstance(func_name, str) and isinstance(func_args, str):
+                            tc = chat_pb2.ToolCall()
+                            tc.id = tc_id
+                            tc.function.name = func_name
+                            tc.function.arguments = func_args
+                            msg.tool_calls.append(tc)
+
+            return msg
+
+        parts = []
+        for part in message.content:
+            if part.type == "text":
+                parts.append(xai_chat.text(part.text))
+            elif part.type == "tool_call":
+                parts.append(xai_chat.text(f"[Tool call: {part.name}]"))
+            elif part.type == "thought" and encode_thoughts:
+                parts.append(xai_chat.text(f"**Thinking:** {part.thought}"))
+
+        if not parts:
+            parts = [xai_chat.text("")]
+
+        return xai_chat.assistant(*parts)
+    else:
+        raise ValueError(f"Unknown message type: {type(message)}")
+
+
+def encode_messages(
+    messages: Sequence[Message], *, encode_thoughts: bool = False
+) -> list[chat_pb2.Message]:
+    """Convert a sequence of Mirascope Messages to xAI SDK message format."""
+    result = []
+    for msg in messages:
+        encoded = encode_message(msg, encode_thoughts=encode_thoughts)
+        if isinstance(encoded, list):
+            result.extend(encoded)
+        else:
+            result.append(encoded)
+    return result
+
+
+def _map_params_to_kwargs(params: Params, *, model_id: GrokModelId) -> dict:
+    """Returns xAI SDK chat.create() kwargs from Mirascope Params."""
+    kwargs = {}
+
+    if "temperature" in params:
+        kwargs["temperature"] = params["temperature"]
+    if "max_tokens" in params:
+        kwargs["max_tokens"] = params["max_tokens"]
+    if "top_p" in params:
+        kwargs["top_p"] = params["top_p"]
+    if "seed" in params:
+        kwargs["seed"] = params["seed"]
+    if "stop_sequences" in params:
+        kwargs["stop"] = params["stop_sequences"]
+    thinking = params.get("thinking")
+    if thinking is True:
+        raise FeatureNotSupportedError(
+            "thinking",
+            "xai",
+            model_id=model_id,
+            message=(
+                "xAI Grok models do not currently support the thinking parameter "
+                "(the API will reject requests that include reasoning_effort)."
+            ),
+        )
+
+    return kwargs
+
+
+def _apply_format(
+    *,
+    format: type[FormattableT] | Format[FormattableT] | None,
+    model_id: GrokModelId,
+    tools: list[chat_pb2.Tool],
+    messages: Sequence[Message],
+) -> tuple[Format[FormattableT] | None, list[chat_pb2.Tool], Sequence[Message], dict]:
+    """Returns tuple of (resolved_format, updated_tools, updated_messages, format_kwargs)."""
+    format = resolve_format(format, default_mode="tool")
+    format_kwargs = {}
+
+    if format is None:
+        return None, tools, messages, format_kwargs
+
+    if format.mode == "strict":
+        raise FormattingModeNotSupportedError(
+            formatting_mode="strict", provider="xai", model_id=model_id
+        )
+    elif format.mode == "json":
+        raise FeatureNotSupportedError(
+            "structured_output_json",
+            "xai",
+            message="Grok JSON format output may deviate from expected schema; use tool mode or strict mode instead.",
+        )
+    elif format.mode == "tool":
+        format_tool_schema = _formatting_utils.create_tool_schema(format)
+        format_tool = encode_tools([format_tool_schema])[0]
+
+        has_tool_outputs = any(
+            isinstance(msg, UserMessage)
+            and any(part.type == "tool_output" for part in msg.content)
+            for msg in messages
+        )
+
+        if tools:
+            tools = list(tools) + [format_tool]
+            if has_tool_outputs:
+                tool_choice = chat_pb2.ToolChoice()
+                tool_choice.mode = chat_pb2.TOOL_MODE_REQUIRED
+                tool_choice.function_name = FORMAT_TOOL_NAME
+                format_kwargs["tool_choice"] = tool_choice
+        else:
+            tools = [format_tool]
+            tool_choice = chat_pb2.ToolChoice()
+            tool_choice.mode = chat_pb2.TOOL_MODE_REQUIRED
+            tool_choice.function_name = FORMAT_TOOL_NAME
+            format_kwargs["tool_choice"] = tool_choice
+
+        if format.formatting_instructions:
+            messages = _base_utils.add_system_instructions(
+                messages, format.formatting_instructions
+            )
+
+    return format, tools, messages, format_kwargs
+
+
+def encode_request(
+    *,
+    model_id: GrokModelId,
+    messages: Sequence[Message],
+    tools: Sequence[ToolSchema] | BaseToolkit | None,
+    format: type[FormattableT] | Format[FormattableT] | None,
+    params: Params,
+    provider: Literal["xai"],
+) -> tuple[Sequence[Message], Format[FormattableT] | None, dict]:
+    """Encode request for xAI Grok API.
+
+    Args:
+        model_id: Model identifier.
+        messages: Messages to send.
+        tools: Optional tools.
+        format: Optional response format.
+        params: Additional parameters.
+        provider: Provider name.
+
+    Returns:
+        Tuple of (input_messages, resolved_format, create_kwargs).
+    """
+    input_messages = list(messages)
+    encode_thoughts = params.get("encode_thoughts_as_text") is True
+
+    if tools is None:
+        tool_list = None
+    elif isinstance(tools, BaseToolkit):
+        tool_list = tools.tools
+    else:
+        tool_list = list(tools)
+    xai_tools = encode_tools(tool_list)
+
+    format, xai_tools, input_messages, format_kwargs = _apply_format(
+        format=format,
+        model_id=model_id,
+        tools=xai_tools,
+        messages=input_messages,
+    )
+
+    xai_messages = encode_messages(input_messages, encode_thoughts=encode_thoughts)
+
+    create_kwargs = _map_params_to_kwargs(params, model_id=model_id)
+    create_kwargs.update(format_kwargs)
+    create_kwargs["model"] = model_id
+    create_kwargs["messages"] = xai_messages
+    create_kwargs["tools"] = xai_tools if xai_tools else None
+
+    return input_messages, format, create_kwargs

--- a/python/mirascope/llm/clients/xai/clients.py
+++ b/python/mirascope/llm/clients/xai/clients.py
@@ -1,0 +1,854 @@
+"""Grok client implementation."""
+
+import os
+from collections.abc import Sequence
+from contextvars import ContextVar
+from functools import lru_cache
+from typing import TYPE_CHECKING, overload
+from typing_extensions import Unpack
+
+from xai_sdk import AsyncClient, Client
+
+from ...context import Context, DepsT
+from ...formatting import Format, FormattableT
+from ...messages import Message
+from ...responses import (
+    AsyncContextResponse,
+    AsyncContextStreamResponse,
+    AsyncResponse,
+    AsyncStreamResponse,
+    ContextResponse,
+    ContextStreamResponse,
+    Response,
+    StreamResponse,
+)
+from ...tools import (
+    AsyncContextTool,
+    AsyncContextToolkit,
+    AsyncTool,
+    AsyncToolkit,
+    ContextTool,
+    ContextToolkit,
+    Tool,
+    Toolkit,
+)
+from ..base import BaseClient, Params
+from . import _utils
+from .model_ids import GrokModelId
+
+if TYPE_CHECKING:
+    from ..providers import Provider
+
+GROK_CLIENT_CONTEXT: ContextVar["GrokClient | None"] = ContextVar(
+    "GROK_CLIENT_CONTEXT", default=None
+)
+
+
+@lru_cache(maxsize=256)
+def _grok_singleton(api_key: str | None) -> "GrokClient":
+    """Return a cached Grok client instance for the given parameters."""
+    return GrokClient(api_key=api_key)
+
+
+def clear_cache() -> None:
+    """Clear the cached Grok client singletons."""
+    _grok_singleton.cache_clear()
+
+
+def client(*, api_key: str | None = None) -> "GrokClient":
+    """Create or retrieve a Grok client with the given parameters.
+
+    If a client has already been created with these parameters, it will be
+    retrieved from cache and returned.
+
+    Args:
+        api_key: API key for authentication. If None, uses XAI_API_KEY env var.
+
+    Returns:
+        A Grok client instance.
+    """
+    api_key = api_key or os.getenv("XAI_API_KEY")
+    return _grok_singleton(api_key)
+
+
+def get_client() -> "GrokClient":
+    """Retrieve the current Grok client from context, or a global default.
+
+    Returns:
+        The current Grok client from context if available, otherwise
+        a global default client based on environment variables.
+    """
+    ctx_client = GROK_CLIENT_CONTEXT.get()
+    return ctx_client or client()
+
+
+class GrokClient(BaseClient[GrokModelId, Client, AsyncClient, "GrokClient"]):
+    """The client for the xAI Grok LLM model."""
+
+    @property
+    def _context_var(self) -> ContextVar["GrokClient | None"]:
+        return GROK_CLIENT_CONTEXT
+
+    @property
+    def provider(self) -> "Provider":
+        """Return the provider name for this client."""
+        return "xai"
+
+    def __init__(self, *, api_key: str | None = None) -> None:
+        """Initialize the Grok client.
+
+        Args:
+            api_key: API key for authentication. If None, uses XAI_API_KEY env var.
+        """
+        self.client = Client(api_key=api_key)
+        self.async_client = AsyncClient(api_key=api_key)
+
+    @overload
+    def call(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> Response:
+        """Generate an `llm.Response` without a response format."""
+        ...
+
+    @overload
+    def call(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> Response[FormattableT]:
+        """Generate an `llm.Response` with a response format."""
+        ...
+
+    @overload
+    def call(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> Response | Response[FormattableT]:
+        """Generate an `llm.Response` with an optional response format."""
+        ...
+
+    def call(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> Response | Response[FormattableT]:
+        """Generate an `llm.Response` by synchronously calling the xAI Grok API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.Response` object containing the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        chat = self.client.chat.create(**create_kwargs)
+        xai_response = chat.sample()
+
+        assistant_message, finish_reason = _utils.decode_response(
+            xai_response, model_id
+        )
+
+        return Response(
+            raw=xai_response,
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            assistant_message=assistant_message,
+            finish_reason=finish_reason,
+            format=format,
+        )
+
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT, None]:
+        """Generate an `llm.ContextResponse` without a response format."""
+        ...
+
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT, FormattableT]:
+        """Generate an `llm.ContextResponse` with a response format."""
+        ...
+
+    @overload
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
+        """Generate an `llm.ContextResponse` with an optional response format."""
+        ...
+
+    def context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
+        """Generate an `llm.ContextResponse` by synchronously calling the xAI Grok API.
+
+        Args:
+            ctx: Context object with dependencies for tools.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.ContextResponse` object containing the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        chat = self.client.chat.create(**create_kwargs)
+        xai_response = chat.sample()
+
+        assistant_message, finish_reason = _utils.decode_response(
+            xai_response, model_id
+        )
+
+        return ContextResponse(
+            raw=xai_response,
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            assistant_message=assistant_message,
+            finish_reason=finish_reason,
+            format=format,
+        )
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse:
+        """Generate an `llm.AsyncResponse` without a response format."""
+        ...
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncResponse[FormattableT]:
+        """Generate an `llm.AsyncResponse` with a response format."""
+        ...
+
+    @overload
+    async def call_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Generate an `llm.AsyncResponse` with an optional response format."""
+        ...
+
+    async def call_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Generate an `llm.AsyncResponse` by asynchronously calling the xAI Grok API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.AsyncResponse` object containing the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        async_client = self.async_client
+        chat = async_client.chat.create(**create_kwargs)
+        xai_response = await chat.sample()
+
+        assistant_message, finish_reason = _utils.decode_response(
+            xai_response, model_id
+        )
+
+        return AsyncResponse(
+            raw=xai_response,
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            assistant_message=assistant_message,
+            finish_reason=finish_reason,
+            format=format,
+        )
+
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT, None]:
+        """Generate an `llm.AsyncContextResponse` without a response format."""
+        ...
+
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT, FormattableT]:
+        """Generate an `llm.AsyncContextResponse` with a response format."""
+        ...
+
+    @overload
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
+        """Generate an `llm.AsyncContextResponse` with an optional response format."""
+        ...
+
+    async def context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
+        """Generate an `llm.AsyncContextResponse` by asynchronously calling the xAI Grok API.
+
+        Args:
+            ctx: Context object with dependencies for tools.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.AsyncContextResponse` object containing the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        async_client = self.async_client
+        chat = async_client.chat.create(**create_kwargs)
+        xai_response = await chat.sample()
+
+        assistant_message, finish_reason = _utils.decode_response(
+            xai_response, model_id
+        )
+
+        return AsyncContextResponse(
+            raw=xai_response,
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            assistant_message=assistant_message,
+            finish_reason=finish_reason,
+            format=format,
+        )
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> StreamResponse:
+        """Stream an `llm.StreamResponse` without a response format."""
+        ...
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> StreamResponse[FormattableT]:
+        """Stream an `llm.StreamResponse` with a response format."""
+        ...
+
+    @overload
+    def stream(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> StreamResponse | StreamResponse[FormattableT]:
+        """Stream an `llm.StreamResponse` with an optional response format."""
+        ...
+
+    def stream(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> StreamResponse | StreamResponse[FormattableT]:
+        """Generate an `llm.StreamResponse` by synchronously streaming from the xAI Grok API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.StreamResponse` object for iterating over the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        chat = self.client.chat.create(**create_kwargs)
+        xai_stream = chat.stream()
+
+        chunk_iterator = _utils.decode_stream(xai_stream, model_id)
+
+        return StreamResponse(
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            chunk_iterator=chunk_iterator,
+            format=format,
+        )
+
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT]:
+        """Stream an `llm.ContextStreamResponse` without a response format."""
+        ...
+
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT, FormattableT]:
+        """Stream an `llm.ContextStreamResponse` with a response format."""
+        ...
+
+    @overload
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
+        """Stream an `llm.ContextStreamResponse` with an optional response format."""
+        ...
+
+    def context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
+        """Generate an `llm.ContextStreamResponse` by synchronously streaming from the xAI Grok API.
+
+        Args:
+            ctx: Context object with dependencies for tools.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.ContextStreamResponse` object for iterating over the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        chat = self.client.chat.create(**create_kwargs)
+        xai_stream = chat.stream()
+
+        chunk_iterator = _utils.decode_stream(xai_stream, model_id)
+
+        return ContextStreamResponse(
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            chunk_iterator=chunk_iterator,
+            format=format,
+        )
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse:
+        """Stream an `llm.AsyncStreamResponse` without a response format."""
+        ...
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse[FormattableT]:
+        """Stream an `llm.AsyncStreamResponse` with a response format."""
+        ...
+
+    @overload
+    async def stream_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
+        """Stream an `llm.AsyncStreamResponse` with an optional response format."""
+        ...
+
+    async def stream_async(
+        self,
+        *,
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
+        """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the xAI Grok API.
+
+        Args:
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.AsyncStreamResponse` object for asynchronously iterating over the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        async_client = self.async_client
+        chat = async_client.chat.create(**create_kwargs)
+        xai_stream = chat.stream()
+
+        chunk_iterator = _utils.decode_async_stream(xai_stream, model_id)
+
+        return AsyncStreamResponse(
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            chunk_iterator=chunk_iterator,
+            format=format,
+        )
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextStreamResponse[DepsT]:
+        """Stream an `llm.AsyncContextStreamResponse` without a response format."""
+        ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT],
+        **params: Unpack[Params],
+    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
+        """Stream an `llm.AsyncContextStreamResponse` with a response format."""
+        ...
+
+    @overload
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None,
+        **params: Unpack[Params],
+    ) -> (
+        AsyncContextStreamResponse[DepsT]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Stream an `llm.AsyncContextStreamResponse` with an optional response format."""
+        ...
+
+    async def context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: GrokModelId,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> (
+        AsyncContextStreamResponse[DepsT]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Generate an `llm.AsyncContextStreamResponse` by asynchronously streaming from the xAI Grok API.
+
+        Args:
+            ctx: Context object with dependencies for tools.
+            model_id: Model identifier to use.
+            messages: Messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+            **params: Additional parameters to configure output (e.g. temperature). See `llm.Params`.
+
+        Returns:
+            An `llm.AsyncContextStreamResponse` object for asynchronously iterating over the LLM-generated content.
+        """
+        input_messages, format, create_kwargs = _utils.encode_request(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            params=params,
+            provider="xai",
+        )
+
+        async_client = self.async_client
+        chat = async_client.chat.create(**create_kwargs)
+        xai_stream = chat.stream()
+
+        chunk_iterator = _utils.decode_async_stream(xai_stream, model_id)
+
+        return AsyncContextStreamResponse(
+            provider=self.provider,
+            model_id=model_id,
+            params=params,
+            tools=tools,
+            input_messages=input_messages,
+            chunk_iterator=chunk_iterator,
+            format=format,
+        )

--- a/python/mirascope/llm/clients/xai/model_ids.py
+++ b/python/mirascope/llm/clients/xai/model_ids.py
@@ -1,0 +1,19 @@
+"""Grok registered LLM models."""
+
+from typing import Literal, TypeAlias
+
+GrokModelId: TypeAlias = (
+    Literal[
+        "grok-4",
+        "grok-4-fast",
+        "grok-3",
+        "grok-3-mini",
+        "grok-code-fast-1",
+        "grok-2-vision",
+        "grok-2-latest",
+        "grok-2",
+        "grok-2-image-1212",
+    ]
+    | str
+)
+"""The Grok model ids registered with Mirascope."""


### PR DESCRIPTION
### TL;DR

Add support for xAI's Grok models to Mirascope.

### What changed?

- Added a new `GrokClient` implementation for xAI's Grok models
- Implemented message conversion utilities between Mirascope and xAI SDK formats
- Added Grok model IDs including `grok-3`, `grok-2-vision`, `grok-2-latest`, and `grok-2`
- Integrated the client with Mirascope's provider system
- Added xAI SDK as an optional dependency in pyproject.toml

### How to test?

1. Install Mirascope with the xAI extra: `pip install "mirascope[xai]"`
2. Set your xAI API key: `export XAI_API_KEY=your_api_key`
3. Use the client in your code:
```python
from mirascope.llm import GrokClient, GrokModelId
from mirascope.llm.messages import UserMessage

client = GrokClient()
response = client.call(
    model_id=GrokModelId.GROK_3,
    messages=[UserMessage("Hello, how are you?")]
)
print(response.content)
```

### Why make this change?

This change expands Mirascope's model support to include xAI's Grok models, giving users more options for LLM providers. Grok models have unique capabilities and this integration allows Mirascope users to leverage them within the same familiar interface used for other providers.