### PR TITLE
Support concurrent tool call streaming with ID-based tracking

### DIFF
--- a/python/mirascope/llm/clients/anthropic/_utils/decode.py
+++ b/python/mirascope/llm/clients/anthropic/_utils/decode.py
@@ -159,7 +159,9 @@ class _AnthropicChunkProcessor:
                         f"Received input_json_delta for {self.current_block_param['type']} block"
                     )
                 self.accumulated_tool_json += delta.partial_json
-                yield ToolCallChunk(delta=delta.partial_json)
+                yield ToolCallChunk(
+                    id=self.current_block_param["id"], delta=delta.partial_json
+                )
             elif delta.type == "thinking_delta":
                 if self.current_block_param["type"] != "thinking":  # pragma: no cover
                     raise RuntimeError(
@@ -196,7 +198,7 @@ class _AnthropicChunkProcessor:
                     if self.accumulated_tool_json
                     else {}
                 )
-                yield ToolCallEndChunk()
+                yield ToolCallEndChunk(id=self.current_block_param["id"])
             elif block_type == "thinking":
                 yield ThoughtEndChunk()
             else:

--- a/python/mirascope/llm/clients/openai/responses/_utils/decode.py
+++ b/python/mirascope/llm/clients/openai/responses/_utils/decode.py
@@ -142,9 +142,9 @@ class _OpenAIResponsesChunkProcessor:
                     )
                     self.current_content_type = "tool_call"
             elif event.type == "response.function_call_arguments.delta":
-                yield ToolCallChunk(delta=event.delta)
+                yield ToolCallChunk(id=self.current_tool_call_id, delta=event.delta)
             elif event.type == "response.function_call_arguments.done":
-                yield ToolCallEndChunk()
+                yield ToolCallEndChunk(id=self.current_tool_call_id)
                 self.current_content_type = None
             elif (
                 event.type == "response.reasoning_text.delta"

--- a/python/mirascope/llm/content/tool_call.py
+++ b/python/mirascope/llm/content/tool_call.py
@@ -47,7 +47,9 @@ class ToolCallChunk:
     type: Literal["tool_call_chunk"] = "tool_call_chunk"
 
     content_type: Literal["tool_call"] = "tool_call"
-    """The type of content reconstructed by this chunk."""
+
+    id: str
+    """The unique identifier for the tool call this chunk belongs to."""
 
     delta: str
     """The incremental json args added in this chunk."""
@@ -60,4 +62,6 @@ class ToolCallEndChunk:
     type: Literal["tool_call_end_chunk"] = "tool_call_end_chunk"
 
     content_type: Literal["tool_call"] = "tool_call"
-    """The type of content reconstructed by this chunk."""
+
+    id: str
+    """The unique identifier for the tool call being ended."""

--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -214,7 +214,9 @@ class BaseStreamResponse(
         self.messages = list(input_messages) + [self._assistant_message]
 
         self._chunk_iterator = chunk_iterator
-        self._current_content: Text | Thought | ToolCall | None = None
+        self._current_text: Text | None = None
+        self._current_thought: Thought | None = None
+        self._current_tool_calls_by_id: dict[str, ToolCall] = {}
 
         self._processing_format_tool: bool = False
 
@@ -256,89 +258,82 @@ class BaseStreamResponse(
         self, chunk: TextStartChunk | TextChunk | TextEndChunk
     ) -> None:
         if chunk.type == "text_start_chunk":
-            if self._current_content:
+            if self._current_text is not None:
                 raise RuntimeError(
                     "Received text_start_chunk while processing another chunk"
                 )
-            self._current_content = Text(text="")
+            self._current_text = Text(text="")
             # Text gets included in content even when unfinished.
-            self._content.append(self._current_content)
-            self._texts.append(self._current_content)
+            self._content.append(self._current_text)
+            self._texts.append(self._current_text)
 
         elif chunk.type == "text_chunk":
-            if self._current_content is None or self._current_content.type != "text":
+            if self._current_text is None:
                 raise RuntimeError("Received text_chunk while not processing text.")
-            self._current_content.text += chunk.delta
+            self._current_text.text += chunk.delta
 
         elif chunk.type == "text_end_chunk":
-            if self._current_content is None or self._current_content.type != "text":
+            if self._current_text is None:
                 raise RuntimeError("Received text_end_chunk while not processing text.")
-            self._current_content = None
+            self._current_text = None
 
     def _handle_thought_chunk(
         self, chunk: ThoughtStartChunk | ThoughtChunk | ThoughtEndChunk
     ) -> None:
         if chunk.type == "thought_start_chunk":
-            if self._current_content:
+            if self._current_thought is not None:
                 raise RuntimeError(
                     "Received thought_start_chunk while processing another chunk"
                 )
-            self._current_content = Thought(thought="")
+            self._current_thought = Thought(thought="")
             # Thoughts get included even when unfinished.
-            self._content.append(self._current_content)
-            self._thoughts.append(self._current_content)
+            self._content.append(self._current_thought)
+            self._thoughts.append(self._current_thought)
 
         elif chunk.type == "thought_chunk":
-            if self._current_content is None or self._current_content.type != "thought":
+            if self._current_thought is None:
                 raise RuntimeError(
                     "Received thought_chunk while not processing thought."
                 )
-            self._current_content.thought += chunk.delta
+            self._current_thought.thought += chunk.delta
 
         elif chunk.type == "thought_end_chunk":
-            if self._current_content is None or self._current_content.type != "thought":
+            if self._current_thought is None:
                 raise RuntimeError(
                     "Received thought_end_chunk while not processing thought."
                 )
-            self._current_content = None
+            self._current_thought = None
 
     def _handle_tool_call_chunk(
         self, chunk: ToolCallStartChunk | ToolCallChunk | ToolCallEndChunk
     ) -> None:
         if chunk.type == "tool_call_start_chunk":
-            if self._current_content:
-                raise RuntimeError(
-                    "Received tool_call_start_chunk while processing another chunk"
-                )
-            self._current_content = ToolCall(
+            tool_call = ToolCall(
                 id=chunk.id,
                 name=chunk.name,
                 args="",
             )
+            self._current_tool_calls_by_id[chunk.id] = tool_call
 
         elif chunk.type == "tool_call_chunk":
-            if (
-                self._current_content is None
-                or self._current_content.type != "tool_call"
-            ):
+            tool_call = self._current_tool_calls_by_id.get(chunk.id)
+            if tool_call is None:
                 raise RuntimeError(
-                    "Received tool_call_chunk while not processing tool call."
+                    f"Received tool_call_chunk for unknown tool call id: {chunk.id}"
                 )
-            self._current_content.args += chunk.delta
+            tool_call.args += chunk.delta
 
         elif chunk.type == "tool_call_end_chunk":
-            if (
-                self._current_content is None
-                or self._current_content.type != "tool_call"
-            ):
+            tool_call = self._current_tool_calls_by_id.get(chunk.id)
+            if tool_call is None:
                 raise RuntimeError(
-                    "Received tool_call_end_chunk while not processing tool call."
+                    f"Received tool_call_end_chunk for unknown tool call id: {chunk.id}"
                 )
-            if not self._current_content.args:
-                self._current_content.args = "{}"
-            self._content.append(self._current_content)
-            self._tool_calls.append(self._current_content)
-            self._current_content = None
+            if not tool_call.args:
+                tool_call.args = "{}"
+            self._content.append(tool_call)
+            self._tool_calls.append(tool_call)
+            del self._current_tool_calls_by_id[chunk.id]
 
     def _pretty_chunk(self, chunk: AssistantContentChunk, spacer: str) -> str:
         match chunk.type:


### PR DESCRIPTION
### TL;DR

Added support for parallel tool calls in streaming responses by tracking tool calls by ID.

### What changed?

- Added an `id` field to `ToolCallChunk` and `ToolCallEndChunk` classes to uniquely identify tool calls
- Modified the stream response handler to track tool calls by ID in a dictionary (`_current_tool_calls_by_id`)
- Updated the tool call handling logic to support processing multiple tool calls in parallel
- Updated error messages to be more specific about which tool call ID is causing issues
- Updated all test cases to include the required ID field in tool call chunks

### How to test?

- Run the existing test suite to verify that all tool call functionality works correctly
- Test scenarios with multiple concurrent tool calls to ensure they are properly tracked and processed
- Verify error handling by testing with unknown tool call IDs

### Why make this change?

This change enables proper handling of parallel tool calls in streaming responses. By tracking tool calls by their unique IDs rather than using a single `_current_content` reference, the system can now process multiple tool calls simultaneously without losing track of their state. This is particularly important for complex interactions where multiple tools might be called in parallel by the LLM.