### PR TITLE
Add shared LLM client cache clearing utilities for tests

### DIFF
--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -7,6 +7,7 @@ from .anthropic import (
 from .azure_openai.completions import AzureOpenAICompletionsClient
 from .azure_openai.responses import AzureOpenAIResponsesClient
 from .base import BaseClient, ClientT, Params
+from .cache import clear_all_client_caches
 from .google import GoogleClient, GoogleModelId
 from .openai import (
     OpenAICompletionsClient,
@@ -33,6 +34,7 @@ __all__ = [
     "OpenAIResponsesModelId",
     "Params",
     "Provider",
+    "clear_all_client_caches",
     "client",
     "get_client",
 ]

--- a/python/mirascope/llm/clients/anthropic/__init__.py
+++ b/python/mirascope/llm/clients/anthropic/__init__.py
@@ -1,25 +1,27 @@
 """Anthropic client implementation."""
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import AnthropicClient, client, get_client
+    from .clients import AnthropicClient, clear_cache, client, get_client
     from .model_ids import AnthropicModelId
 else:
     try:
-        from .clients import AnthropicClient, client, get_client
+        from .clients import AnthropicClient, clear_cache, client, get_client
         from .model_ids import AnthropicModelId
     except ImportError:  # pragma: no cover
         from .._missing_import_stubs import create_client_stub, create_import_error_stub
 
         AnthropicClient = create_client_stub("anthropic", "AnthropicClient")
         AnthropicModelId = str
+        clear_cache = create_import_error_stub("anthropic", "AnthropicClient")
         client = create_import_error_stub("anthropic", "AnthropicClient")
         get_client = create_import_error_stub("anthropic", "AnthropicClient")
 
 __all__ = [
     "AnthropicClient",
     "AnthropicModelId",
+    "clear_cache",
     "client",
     "get_client",
 ]

--- a/python/mirascope/llm/clients/anthropic/clients.py
+++ b/python/mirascope/llm/clients/anthropic/clients.py
@@ -72,6 +72,12 @@ def client(
     return _anthropic_singleton(api_key, base_url)
 
 
+def clear_cache() -> None:
+    """Clear the cached Anthropic client singletons and reset context."""
+    _anthropic_singleton.cache_clear()
+    ANTHROPIC_CLIENT_CONTEXT.set(None)
+
+
 def get_client() -> "AnthropicClient":
     """Retrieve the current Anthropic client from context, or a global default.
 

--- a/python/mirascope/llm/clients/azure_openai/completions/__init__.py
+++ b/python/mirascope/llm/clients/azure_openai/completions/__init__.py
@@ -3,11 +3,16 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import AzureOpenAICompletionsClient, client, get_client
+    from .clients import AzureOpenAICompletionsClient, clear_cache, client, get_client
     from .model_ids import AzureOpenAICompletionsModelId
 else:
     try:
-        from .clients import AzureOpenAICompletionsClient, client, get_client
+        from .clients import (
+            AzureOpenAICompletionsClient,
+            clear_cache,
+            client,
+            get_client,
+        )
         from .model_ids import AzureOpenAICompletionsModelId
     except ImportError:  # pragma: no cover
         from ..._missing_import_stubs import (
@@ -19,12 +24,14 @@ else:
             "openai", "AzureOpenAICompletionsClient"
         )
         AzureOpenAICompletionsModelId = str
+        clear_cache = create_import_error_stub("openai", "AzureOpenAICompletionsClient")
         client = create_import_error_stub("openai", "AzureOpenAICompletionsClient")
         get_client = create_import_error_stub("openai", "AzureOpenAICompletionsClient")
 
 __all__ = [
     "AzureOpenAICompletionsClient",
     "AzureOpenAICompletionsModelId",
+    "clear_cache",
     "client",
     "get_client",
 ]

--- a/python/mirascope/llm/clients/azure_openai/completions/clients.py
+++ b/python/mirascope/llm/clients/azure_openai/completions/clients.py
@@ -141,6 +141,12 @@ def client(
     )
 
 
+def clear_cache() -> None:
+    """Clear the cached Azure OpenAI Completions client singletons and reset context."""
+    _azure_completions_singleton.cache_clear()
+    AZURE_OPENAI_COMPLETIONS_CLIENT_CONTEXT.set(None)
+
+
 def get_client() -> "AzureOpenAICompletionsClient":
     """Get the current `AzureOpenAICompletionsClient` from context."""
     current_client = AZURE_OPENAI_COMPLETIONS_CLIENT_CONTEXT.get()

--- a/python/mirascope/llm/clients/azure_openai/responses/__init__.py
+++ b/python/mirascope/llm/clients/azure_openai/responses/__init__.py
@@ -3,11 +3,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import AzureOpenAIResponsesClient, client, get_client
+    from .clients import AzureOpenAIResponsesClient, clear_cache, client, get_client
     from .model_ids import AzureOpenAIResponsesModelId
 else:
     try:
-        from .clients import AzureOpenAIResponsesClient, client, get_client
+        from .clients import AzureOpenAIResponsesClient, clear_cache, client, get_client
         from .model_ids import AzureOpenAIResponsesModelId
     except ImportError:  # pragma: no cover
         from ..._missing_import_stubs import (
@@ -19,12 +19,14 @@ else:
             "openai", "AzureOpenAIResponsesClient"
         )
         AzureOpenAIResponsesModelId = str
+        clear_cache = create_import_error_stub("openai", "AzureOpenAIResponsesClient")
         client = create_import_error_stub("openai", "AzureOpenAIResponsesClient")
         get_client = create_import_error_stub("openai", "AzureOpenAIResponsesClient")
 
 __all__ = [
     "AzureOpenAIResponsesClient",
     "AzureOpenAIResponsesModelId",
+    "clear_cache",
     "client",
     "get_client",
 ]

--- a/python/mirascope/llm/clients/azure_openai/responses/clients.py
+++ b/python/mirascope/llm/clients/azure_openai/responses/clients.py
@@ -141,6 +141,12 @@ def client(
     )
 
 
+def clear_cache() -> None:
+    """Clear the cached Azure OpenAI Responses client singletons and reset context."""
+    _azure_responses_singleton.cache_clear()
+    AZURE_OPENAI_RESPONSES_CLIENT_CONTEXT.set(None)
+
+
 def get_client() -> "AzureOpenAIResponsesClient":
     """Get the current `AzureOpenAIResponsesClient` from context."""
     current_client = AZURE_OPENAI_RESPONSES_CLIENT_CONTEXT.get()

--- a/python/mirascope/llm/clients/cache.py
+++ b/python/mirascope/llm/clients/cache.py
@@ -1,0 +1,23 @@
+"""Utilities for managing cached LLM client singletons."""
+
+from .anthropic import clear_cache as clear_anthropic_cache
+from .azure_openai.completions import clear_cache as clear_azure_completions_cache
+from .azure_openai.responses import clear_cache as clear_azure_responses_cache
+from .google import clear_cache as clear_google_cache
+from .openai import (
+    clear_completions_cache as clear_openai_completions_cache,
+    clear_responses_cache as clear_openai_responses_cache,
+)
+
+__all__ = ["clear_all_client_caches"]
+
+
+def clear_all_client_caches() -> None:
+    """Clear caches for all registered LLM client implementations."""
+
+    clear_anthropic_cache()
+    clear_azure_completions_cache()
+    clear_azure_responses_cache()
+    clear_google_cache()
+    clear_openai_completions_cache()
+    clear_openai_responses_cache()

--- a/python/mirascope/llm/clients/google/__init__.py
+++ b/python/mirascope/llm/clients/google/__init__.py
@@ -3,18 +3,25 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import GoogleClient, client, get_client
+    from .clients import GoogleClient, clear_cache, client, get_client
     from .model_ids import GoogleModelId
 else:
     try:
-        from .clients import GoogleClient, client, get_client
+        from .clients import GoogleClient, clear_cache, client, get_client
         from .model_ids import GoogleModelId
     except ImportError:  # pragma: no cover
         from .._missing_import_stubs import create_client_stub, create_import_error_stub
 
         GoogleClient = create_client_stub("google", "GoogleClient")
         GoogleModelId = str
+        clear_cache = create_import_error_stub("google", "GoogleClient")
         client = create_import_error_stub("google", "GoogleClient")
         get_client = create_import_error_stub("google", "GoogleClient")
 
-__all__ = ["GoogleClient", "GoogleModelId", "client", "get_client"]
+__all__ = [
+    "GoogleClient",
+    "GoogleModelId",
+    "clear_cache",
+    "client",
+    "get_client",
+]

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -71,6 +71,12 @@ def client(
     return _google_singleton(api_key, base_url)
 
 
+def clear_cache() -> None:
+    """Clear the cached Google client singletons and reset context."""
+    _google_singleton.cache_clear()
+    GOOGLE_CLIENT_CONTEXT.set(None)
+
+
 def get_client() -> "GoogleClient":
     """Retrieve the current Google client from context, or a global default.
 

--- a/python/mirascope/llm/clients/openai/__init__.py
+++ b/python/mirascope/llm/clients/openai/__init__.py
@@ -3,12 +3,14 @@
 from .completions import (
     OpenAICompletionsClient,
     OpenAICompletionsModelId,
+    clear_cache as clear_completions_cache,
     client as completions_client,
     get_client as get_completions_client,
 )
 from .responses import (
     OpenAIResponsesClient,
     OpenAIResponsesModelId,
+    clear_cache as clear_responses_cache,
     client as responses_client,
     get_client as get_responses_client,
 )
@@ -18,6 +20,8 @@ __all__ = [
     "OpenAICompletionsModelId",
     "OpenAIResponsesClient",
     "OpenAIResponsesModelId",
+    "clear_completions_cache",
+    "clear_responses_cache",
     "completions_client",
     "get_completions_client",
     "get_responses_client",

--- a/python/mirascope/llm/clients/openai/completions/__init__.py
+++ b/python/mirascope/llm/clients/openai/completions/__init__.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import OpenAICompletionsClient, client, get_client
+    from .clients import OpenAICompletionsClient, clear_cache, client, get_client
     from .model_ids import OpenAICompletionsModelId
 else:
     try:
-        from .clients import OpenAICompletionsClient, client, get_client
+        from .clients import OpenAICompletionsClient, clear_cache, client, get_client
         from .model_ids import OpenAICompletionsModelId
     except ImportError:  # pragma: no cover
         from ..._missing_import_stubs import (
@@ -17,12 +17,14 @@ else:
             "openai", "OpenAICompletionsClient"
         )
         OpenAICompletionsModelId = str
+        clear_cache = create_import_error_stub("openai", "OpenAICompletionsClient")
         client = create_import_error_stub("openai", "OpenAICompletionsClient")
         get_client = create_import_error_stub("openai", "OpenAICompletionsClient")
 
 __all__ = [
     "OpenAICompletionsClient",
     "OpenAICompletionsModelId",
+    "clear_cache",
     "client",
     "get_client",
 ]

--- a/python/mirascope/llm/clients/openai/completions/clients.py
+++ b/python/mirascope/llm/clients/openai/completions/clients.py
@@ -42,6 +42,12 @@ def client(
     return _openai_singleton(api_key, base_url)
 
 
+def clear_cache() -> None:
+    """Clear the cached OpenAI Completions client singletons and reset context."""
+    _openai_singleton.cache_clear()
+    OPENAI_COMPLETIONS_CLIENT_CONTEXT.set(None)
+
+
 def get_client() -> "OpenAICompletionsClient":
     """Retrieve the current OpenAI client from context, or a global default.
 

--- a/python/mirascope/llm/clients/openai/responses/__init__.py
+++ b/python/mirascope/llm/clients/openai/responses/__init__.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import OpenAIResponsesClient, client, get_client
+    from .clients import OpenAIResponsesClient, clear_cache, client, get_client
     from .model_ids import OpenAIResponsesModelId
 else:
     try:
-        from .clients import OpenAIResponsesClient, client, get_client
+        from .clients import OpenAIResponsesClient, clear_cache, client, get_client
         from .model_ids import OpenAIResponsesModelId
     except ImportError:  # pragma: no cover
         from ..._missing_import_stubs import (
@@ -15,12 +15,14 @@ else:
 
         OpenAIResponsesClient = create_client_stub("openai", "OpenAIResponsesClient")
         OpenAIResponsesModelId = str
+        clear_cache = create_import_error_stub("openai", "OpenAIResponsesClient")
         client = create_import_error_stub("openai", "OpenAIResponsesClient")
         get_client = create_import_error_stub("openai", "OpenAIResponsesClient")
 
 __all__ = [
     "OpenAIResponsesClient",
     "OpenAIResponsesModelId",
+    "clear_cache",
     "client",
     "get_client",
 ]

--- a/python/mirascope/llm/clients/openai/responses/clients.py
+++ b/python/mirascope/llm/clients/openai/responses/clients.py
@@ -31,6 +31,12 @@ def client(
     return _openai_responses_singleton(api_key, base_url)
 
 
+def clear_cache() -> None:
+    """Clear the cached OpenAI Responses client singletons and reset context."""
+    _openai_responses_singleton.cache_clear()
+    OPENAI_RESPONSES_CLIENT_CONTEXT.set(None)
+
+
 def get_client() -> "OpenAIResponsesClient":
     """Get the current `OpenAIResponsesClient` from context."""
     current_client = OPENAI_RESPONSES_CLIENT_CONTEXT.get()

--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -13,6 +13,7 @@ from typing import Any, TypedDict, get_args
 import pytest
 
 from mirascope import llm
+from mirascope.llm.clients import clear_all_client_caches
 
 SENSITIVE_HEADERS = [
     # Common API authentication headers
@@ -110,6 +111,12 @@ def sanitize_request(request: Any) -> Any:  # noqa: ANN401
                 request.headers[req_header] = "<filtered>"
 
     return request
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _clear_client_caches() -> None:
+    """Ensure cached LLM client singletons do not bleed across e2e test modules."""
+    clear_all_client_caches()
 
 
 @pytest.fixture(scope="session")

--- a/python/tests/llm/clients/openai/test_responses_client.py
+++ b/python/tests/llm/clients/openai/test_responses_client.py
@@ -3,6 +3,7 @@
 from inline_snapshot import snapshot
 
 from mirascope import llm
+from mirascope.llm.clients import clear_all_client_caches
 from mirascope.llm.clients.openai.responses._utils import encode_request
 
 
@@ -91,6 +92,8 @@ def test_context_manager() -> None:
 
 def test_client_caching() -> None:
     """Test that client() returns cached instances for identical parameters."""
+    clear_all_client_caches()
+
     client1 = llm.client(
         "openai:responses", api_key="test-key", base_url="https://api.example.com"
     )


### PR DESCRIPTION
### TL;DR

Added cache clearing functionality for LLM client singletons to improve test isolation and provide a way to reset client state.

### What changed?

- Added `clear_cache()` methods to all LLM client implementations (Anthropic, Azure OpenAI, Google, OpenAI)
- Created a new `cache.py` module with a `clear_all_client_caches()` function that clears all client caches at once
- Exposed the cache clearing functions through appropriate `__init__.py` files
- Added an autouse pytest fixture in `tests/e2e/conftest.py` that clears client caches before and after each e2e test

### How to test?

1. Import and call `clear_all_client_caches()` in a test or application code
2. Verify that subsequent client creation returns fresh instances
3. Run e2e tests to confirm they execute correctly with the new cache clearing fixture

### Why make this change?

This change improves test isolation by ensuring that cached LLM client singletons don't persist between tests, which could lead to test interference. It also provides a way for users to explicitly reset client state when needed, such as when changing API keys or endpoints during runtime.