### PR TITLE
Add provider name comments

### DIFF
--- a/python/mirascope/llm/clients/providers.py
+++ b/python/mirascope/llm/clients/providers.py
@@ -35,10 +35,10 @@ from .openai import (
 )
 
 Provider: TypeAlias = Literal[
-    "anthropic",
+    "anthropic",  # AnthropicClient
     "azure-openai:completions",  # AzureOpenAICompletionsClient
     "azure-openai:responses",  # AzureOpenAIResponsesClient
-    "google",
+    "google",  # GoogleClient
     "openai:completions",  # OpenAICompletionsClient
     "openai:responses",  # OpenAIResponsesClient
     "openai",  # Alias for "openai:responses"


### PR DESCRIPTION
### TL;DR

Added comments to clarify client class associations for Anthropic and Google providers in the `Provider` type alias.

### What changed?

Added inline comments to the `Provider` type alias in `providers.py` to explicitly indicate which client class is associated with the "anthropic" and "google" providers, similar to the existing comments for other providers.

- Added `# AnthropicClient` comment for the "anthropic" provider
- Added `# GoogleClient` comment for the "google" provider

### How to test?

No functional testing is required as this is a documentation change. You can verify that the comments are correctly aligned with the actual implementation by checking that:

1. The "anthropic" provider is indeed handled by `AnthropicClient`
2. The "google" provider is indeed handled by `GoogleClient`

### Why make this change?

This change improves code readability and consistency by ensuring all providers in the type alias have comments indicating their associated client classes. This makes it easier for developers to understand which client implementation will be used for each provider without having to search through the codebase.