### PR TITLE
Centralize provider registry to simplify adding new providers

### DIFF
--- a/python/mirascope/llm/clients/cache.py
+++ b/python/mirascope/llm/clients/cache.py
@@ -1,13 +1,6 @@
 """Utilities for managing cached LLM client singletons."""
 
-from .anthropic import clear_cache as clear_anthropic_cache
-from .azure_openai.completions import clear_cache as clear_azure_completions_cache
-from .azure_openai.responses import clear_cache as clear_azure_responses_cache
-from .google import clear_cache as clear_google_cache
-from .openai import (
-    clear_completions_cache as clear_openai_completions_cache,
-    clear_responses_cache as clear_openai_responses_cache,
-)
+from .providers import PROVIDER_INFO
 
 __all__ = ["clear_all_client_caches"]
 
@@ -15,9 +8,5 @@ __all__ = ["clear_all_client_caches"]
 def clear_all_client_caches() -> None:
     """Clear caches for all registered LLM client implementations."""
 
-    clear_anthropic_cache()
-    clear_azure_completions_cache()
-    clear_azure_responses_cache()
-    clear_google_cache()
-    clear_openai_completions_cache()
-    clear_openai_responses_cache()
+    for provider_info in PROVIDER_INFO.values():
+        provider_info["clear_cache"]()


### PR DESCRIPTION
### TL;DR

Refactored LLM client cache management to use a centralized provider registry.

### What changed?

- Created a `PROVIDER_REGISTRY` dictionary in `providers.py` that maps provider names to their information, including cache clearing functions
- Modified `clear_all_client_caches()` to iterate through the registry instead of calling each cache clearing function individually
- Added a `ProviderInfo` TypedDict to properly type the registry entries
- Moved cache clearing function imports from `cache.py` to `providers.py`

### How to test?

1. Verify that `clear_all_client_caches()` still clears all provider caches
2. Test with different LLM providers to ensure caches are properly cleared
3. Check that the registry contains all expected providers

### Why make this change?

This change centralizes provider management, making it easier to add new providers without modifying multiple files. The registry approach eliminates the need to update the cache clearing function every time a new provider is added, improving maintainability and reducing the risk of bugs when extending the system.