### PR TITLE
Fix invalid chunk sequence handling in stream responses

### DIFF
--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -262,6 +262,14 @@ class BaseStreamResponse(
                 raise RuntimeError(
                     "Received text_start_chunk while processing another chunk"
                 )
+            if self._current_thought is not None:
+                raise RuntimeError(
+                    "Received text_start_chunk while processing another chunk"
+                )
+            if self._current_tool_calls_by_id:
+                raise RuntimeError(
+                    "Received text_start_chunk while processing another chunk"
+                )
             self._current_text = Text(text="")
             # Text gets included in content even when unfinished.
             self._content.append(self._current_text)
@@ -282,6 +290,14 @@ class BaseStreamResponse(
     ) -> None:
         if chunk.type == "thought_start_chunk":
             if self._current_thought is not None:
+                raise RuntimeError(
+                    "Received thought_start_chunk while processing another chunk"
+                )
+            if self._current_text is not None:
+                raise RuntimeError(
+                    "Received thought_start_chunk while processing another chunk"
+                )
+            if self._current_tool_calls_by_id:
                 raise RuntimeError(
                     "Received thought_start_chunk while processing another chunk"
                 )
@@ -308,6 +324,14 @@ class BaseStreamResponse(
         self, chunk: ToolCallStartChunk | ToolCallChunk | ToolCallEndChunk
     ) -> None:
         if chunk.type == "tool_call_start_chunk":
+            if self._current_text is not None:
+                raise RuntimeError(
+                    "Received tool_call_start_chunk while processing another chunk"
+                )
+            if self._current_thought is not None:
+                raise RuntimeError(
+                    "Received tool_call_start_chunk while processing another chunk"
+                )
             tool_call = ToolCall(
                 id=chunk.id,
                 name=chunk.name,


### PR DESCRIPTION
### TL;DR

Added additional validation to prevent mixing different chunk types in stream responses.

### What changed?

Enhanced the stream response handling to prevent mixing different chunk types (text, thought, tool call) during processing. Added runtime error checks to ensure that when starting a new chunk of one type, there are no active chunks of other types being processed.

Specifically:
- Added checks in `_handle_text_chunk` to verify no active thought or tool calls exist
- Added checks in `_handle_thought_chunk` to verify no active text or tool calls exist
- Added checks in `_handle_tool_call_chunk` to verify no active text or thought exists
- Fixed test assertions to check `_current_text` instead of `_current_content`

### How to test?

Run the existing test suite for stream responses, particularly focusing on tests that involve mixed chunk types to ensure proper error handling.

```
python -m pytest python/tests/llm/responses/test_stream_response.py -v
```

### Why make this change?

This change improves error handling and prevents potential data corruption by ensuring that different chunk types (text, thought, tool calls) are not processed simultaneously. This maintains the integrity of the response structure and makes debugging easier by providing clear error messages when invalid chunk sequences are encountered.