### PR TITLE
Add previous_response_id support for OpenAI Responses API

### DIFF
--- a/python/tests/e2e/input/cassettes/test_resume_with_override_thinking_and_tools/openai_completions_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_resume_with_override_thinking_and_tools/openai_completions_gpt_4o.yaml
@@ -20,6 +20,8 @@ interactions:
       - api.anthropic.com
       user-agent:
       - Anthropic/Python 0.64.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -37,7 +39,7 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
       x-stainless-timeout:
       - '600'
     method: POST
@@ -45,28 +47,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//bFRdj6o4AP0rDS97NzojIPiV7IOICoKo+DluNnMLVAqWgrQFdTL/fePs
-        zuxOcp/anp5zetrk9E3K8ggRaSCFBIoIPbGcUsSftCdVVnVZVzSpKSWRNJAyFr/KylLU6dDfFJu0
-        h4W/P8GbeQuR1JT4rUAPFmIMxg+gzMkDgIwljEPKpaYU5pQjyqXBn2+ffI4Tek5o/HD4nA6kDUZA
-        MFSChAHIHiA45SXgGAFFljkGkyTIKQzDBFCRBah8BjbAsEIAgpOgIU9yCmAFEwIDgkAICUER+Bnm
-        WSE4ej0lwU/AMeQghBT8i3640194gx/KU0IjdEXR78/gKxqGDBRlXiURij60rEBhckpCUEEiEKB/
-        KLLcBCz/ikbIB69EF5GUKAIFLGGGOCoZ4DnI4PmfDF8XeMR+lpoSS2IKuSgf7zUuV+bo/GKPjHjk
-        nIcVTDv3moSjA+73+mZ6CmfOFdMx0b3VUIOLuX9p0eN99ELxcnLYhZPOYk4wWW5bsdPAdy/do5dW
-        e9W13FU155eyXd+y1ji+dQJFcxdovVLqXTVRNWh6janO3RclEDcDh1q8tutscUgrseezoHFtuzvF
-        nBeHc6D4/e64Xfs3mzXczdWddYu+O0SBSfdaZE/4jOvVZntxNNkp2Oje0HYHC9W4NDP3fljkPb03
-        UyfW+i5WRXmpt+5wGUDlDNnI2oy5ctTROmxz7IvpzEdHrxhte6oxQeO1VZVOqunGurSuzpaVQR9t
-        +zNjGq3j6N4KYydK22519m1cDi8dz5722jieqqHTIRN1iNodpW44yLARtVK91zfrvjhlUcdLO9nG
-        qzx1b4Rm4B8pbRw0PiS9q43IUWbGtBtU4m5cd91kWXUbnnrZB4mbdXpLq72FRmqqrbUTLreBZeis
-        0r0Ogdd6Pe/49vHWwnG7TWR0WM03cmqlluVolS1PiMg0NKu9VrdczDVzSGcjS1zVfteqMRrv7kM/
-        0lz9sjptSuXSP0cTk5TjrtGY7LApe1s/MxyzOIcrNXwZxdRpCP+uNtx9yz5elntRRsluacSG9N78
-        r4fo+mjoxzCQ7N8I+daLX7fuo5S3XDx/c8pz8ioY+vw3HmvxKivbysVjVajHaRgl2MOHbabUhdSU
-        KMweuv+V8yGlheDS4E2i0kCR5ff3v5oS43nxWiLIcvr9nI8Nhi4C/U1H2esgDMNA+F08Z6AUBvIy
-        luWclIo0RW7CgvLuKKCKP7Hed2dPd1lBPteUHNXHDvnb8xSX5Yy8kj+Me0cqGsFqkF40/nTsNm6Q
-        8I9t2f4Al4gZJomP86//RYf4TZujpZZ3aRhPjlbYdVJwmWDkqc9nEAvU2h0AAP//AwCo1eVDrwUA
-        AA==
+        H4sIAAAAAAAAA2xUbY+qOBj9K00/7Q3OCIKvyf2gKC+KOr6LezemQMFqaYECCpP57xvn7tzdm+y3
+        PqfnnJ48yek7jHmAKRxAn6IiwC+CM4bzF+2lJbfaclvRYAOSAA5gLKKzrGzY9mSQuWu1YnNTYy9c
+        KRuDwAbMqwQ/WVgIFGHYgBmnTwAJQUSOWA4b0OcsxyyHgz/fv/j5hbAbYdHT4es4gNsLBoXAGSAC
+        IPEEQcgzkF8wUGQ5vwCDeJwh3yeAFbGHs1dggwsqMUAgLJifE86AjyjFAfgBfR4nRY7PIfF+QJBf
+        UA58xMA/8Kcr+x9P8IfyQliAHzj49gp+RbogAZKMlyTAwadWJNgnIfFBiWiBAfuuyHIDCP4rEqWf
+        vAynBclwABKUoRjnOBMg5yBGt58Zfgv+ChtQkIihvMiee5qkfKzfXFtfR/rsNhwepF4YbVhGraob
+        CQWHt7ju0wTfh2FkX3es6eyou6Zpb1GWB2knE9kYSeZb2qp6qaRJlTnprvxwNe/xbu1Q+1hTQidR
+        vZSkuRkG3X75yLzRxkfjSR2t50rbvcfOyFC7JbHvzdjoGt3+vnkip6UkS2Kz0++VNK/Xbf8e+onv
+        Ke3ZPUpzEl9cVfNdKWXoJiwnLTVyssgsmeiSbZSb0jxavLVt6m+6t5XcdLN01rJVrvNqO9vdqbrk
+        S7lSV/V0Uk3WwtjQu3UwvErFmTktDni+X3BHPi7ixdiyzW1vV9f6dDW6a3EWu9N9sVzriTZd6ZjL
+        zt0KRWa0m87BbI+O2O3rgWd3em5huM1QsTS9Vq9Vi4vSwPlNM9DK6RT4EI+ssPbVdVZL5opvda2F
+        DzXrO3NF9h/m6pH37dhiotURatLxvf1yPxpVptLCWCXLcjWbGEZG1851NU2LA15ETt/e7WfxXOU3
+        tbzs59ueMcvYzZmZVZlp+3oYqx6r92GQWIV9iovNQ52eaHrvCjos1Hwe2p0xrYa2LY+3Q1OXnVln
+        WqG+GXMaTo4ENf1pIIpssbv0ZVNjSYe7vfXVHE6+w4/Gv53jnJ4Lgb+a/ZyLs6w4R88dP9bXyomu
+        89J/2+N6V1mwARmKn7r/9OgpZUmRw8E7ZHCgyPLHx18NKHKenDOMBGe/v/N5IXBaYOZjOGAFpQ1Y
+        fP4Ug/efVuec3zATcKCprQb0kX/B57+VXJSaCMoS8agqDGDyRamJKbjkYHpBFqQWZKTmphYl5sSb
+        5mKqR8gaZqDL1uoo5ZeWIAsZGpnoKBWnFpVlJqfGl2SmFilZKYEKuJTEohSl2loAAAAA//8DACYL
+        qNxRBQAA
     headers:
       CF-RAY:
-      - 990243793fccc3a1-SEA
+      - 999534b749de9d35-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -74,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:46 GMT
+      - Tue, 04 Nov 2025 15:39:48 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -88,57 +89,57 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-17T19:39:44Z'
+      - '2025-11-04T15:39:47Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-17T19:39:46Z'
+      - '2025-11-04T15:39:48Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-17T19:39:43Z'
+      - '2025-11-04T15:39:45Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-17T19:39:44Z'
+      - '2025-11-04T15:39:47Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CUDLYGidW9tEdFJB1xh9D
+      - req_011CUo6oSKzjXanL2eCHkoFs
+      retry-after:
+      - '14'
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
-      via:
-      - 1.1 google
       x-envoy-upstream-service-time:
-      - '3244'
+      - '3539'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"messages":[{"role":"user","content":"What is the 100th fibonacci number?"},{"role":"assistant","content":"I''ll
-      compute the 100th Fibonacci number for you.","tool_calls":[{"id":"toolu_01UvLhE2u2ZGcdihNhXUm1wp","type":"function","function":{"name":"compute_fib","arguments":"{\"n\":
-      100}"}}]},{"role":"tool","content":"218922995834555169026","tool_call_id":"toolu_01UvLhE2u2ZGcdihNhXUm1wp"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"compute_fib","description":"Compute
+    body: '{"messages":[{"role":"user","content":"What is the 100th fibonacci number?"},{"role":"assistant","content":null,"tool_calls":[{"id":"toolu_01LXbYDxRjyLgjMvcPVezUyH","type":"function","function":{"name":"compute_fib","arguments":"{\"n\":
+      100}"}}]},{"role":"tool","content":"218922995834555169026","tool_call_id":"toolu_01LXbYDxRjyLgjMvcPVezUyH"}],"model":"gpt-4o","tools":[{"type":"function","function":{"name":"compute_fib","description":"Compute
       the nth Fibonacci number (1-indexed).","parameters":{"properties":{"n":{"title":"N","type":"integer"}},"required":["n"],"additionalProperties":false,"type":"object"},"strict":false}}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '677'
+      - '631'
       content-type:
       - application/json
       cookie:
-      - __cf_bm=bqAuKHQq_WDoddjc_8n4ZVETbcYhyNCTv6mLZp6hopY-1760729941-1.0.1.1-RLGJrXs96ZY4dJMtqAfrv.hqBx36iattz6ZmbRDi2GSgIeUjf7W73fme4aMKCNhVTf7Ql5Kr6DhrTAdt1gY20p3yrJuUEqWGP9Od4Q58C5Q;
-        _cfuvid=mdcfYnlzNel6gz4BdSZjRIMc0.ltGGjbt3mn9dSlDeI-1760727600979-0.0.1.1-604800000
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -160,23 +161,23 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFJNb9wgEL37VyDOOMJk17veWz7anHKpcqgURRYLY5ssBgQ4aRXtf4+w
-        N2unTaVeOMyb93hvZt4yhLCSeIew6HgUvdP5zY8Db38eWq7a+286PFw/X71W8u72evN6f4tJYtj9
-        M4j4wboQtncaorJmgoUHHiGpFpuSblhVbcsR6K0EnWiti/nK5oyyVU63OS1PxM4qAQHv0GOGEEJv
-        45ssGgm/8A5R8lHpIQTeAt6dmxDC3upUwTwEFSI3EZMZFNZEMKPrhw5QQWns0He1t4YLoZAZ+j14
-        pAJixZZUjJGqWpPt5Yqs12tSlBWhrLxYCnpohsBTHjNovQC4MTbyNI8xytMJOZ7Na9s6b/fhDypu
-        lFGhqz3wYE0yGqJ1eESPGUJP45CGT7mx87Z3sY72AON3BS0nPTyvZUbZ5QmMNnK9YLGKfKFXS4hc
-        6bAYMxZcdCBn6rwTPkhlF0C2SP23m6+0p+TKtP8jPwNCgIsga+dBKvE58dzmIV3tv9rOUx4N4wD+
-        RQmoowKfNiGh4YOeDgqH3yFCXzfKtOCdV9NVNa5uylXDKsobhrNj9g4AAP//AwAraaGHXgMAAA==
+        H4sIAAAAAAAAAwAAAP//jFJNb9UwELznV1g+O1Xivny9I1QcKkAgEBJFVeQ4m8TFsS17g0DV++8o
+        yetLCkXi4sPOznhmdx8jQqhq6ZFQOQiUo9Px6683H98+3EBzq8P77u6DRuTvbsOXSb7ynyibGbZ5
+        AIlPrCtpR6cBlTUrLD0IhFk1LXLOi6QoqwUYbQt6pvUO44ONecIPcVLGSX4mDlZJCPRIvkWEEPK4
+        vLNF08JPeiQJe6qMEILogR4vTYRQb/VcoSIEFVAYpGwDpTUIZnH9eQCSJgkO5I1qrBFSKmKmsQFP
+        VCA8LVnFOauqjJXXB5ZlGUvziiU8v9oLeuimIOY8ZtJ6BwhjLIp5HkuU+zNyupjXtnfeNuEPKu2U
+        UWGoPYhgzWw0oHV0QU8RIffLkKZnuanzdnRYo/0Oy3dVusrRbSsbyK/PIFoUequn6YG9IFe3gELp
+        sJsylUIO0G7UbSViapXdAdEu9N9uXtJegyvT/4/8BkgJDqGtnYdWyeeJtzYP89H+q+0y5MUwDeB/
+        KAk1KvDzIlroxKTXe6LhV0AY606ZHrzzaj2qztWy6dKizLK8oNEp+g0AAP//AwAfMYM4XQMAAA==
     headers:
       CF-RAY:
-      - 9902438e59d6c4cb-SEA
+      - 999534ceceb7686f-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -184,9 +185,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:39:47 GMT
+      - Tue, 04 Nov 2025 15:39:50 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=gg2yvy1QpZzyHOjWpImzq.jJoaYO.po1uOaVUXL6CW4-1762270790-1.0.1.1-7E5WeWPts3aqJLzrHeboAwJCf1CfN4HpsGgqrjEh6h.D82Dk2gQ6hjisiTUodNljtJVLxwu45h.wmRr1VuNFLEDQhwuemnkeIdF3bpWJTIA;
+        path=/; expires=Tue, 04-Nov-25 16:09:50 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=RlhqD3nR_G65TZ.0GjaIpBlnJCqDOT9RpiJKgligYn0-1762270790118-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -202,13 +209,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '766'
+      - '396'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '794'
+      - '622'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -218,13 +225,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799970'
+      - '799982'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 2ms
+      - 1ms
       x-request-id:
-      - req_59de396370604c0abd09a04dd4e100d0
+      - req_01540da7ed1e4da99f50063848adb513
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o.yaml
@@ -20,6 +20,8 @@ interactions:
       - api.anthropic.com
       user-agent:
       - Anthropic/Python 0.64.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -37,7 +39,7 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
       x-stainless-timeout:
       - '600'
     method: POST
@@ -45,27 +47,27 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA2xUW4/qNhj8K5afehR2SbILAaQ+ECCwgYRbuISeamUSkxgcO4mdC6z2v1dwuttW
-        6ps9nhmPLc33ARMeYgp7MKCoCPGT4Ixh+fT6pKt6S21pr7ABSQh7MBHRu6oNLJ7XeTTNeMdrn4lR
-        raaG04ENKK8pvrOwECjCsAFzTu8AEoIIiZiEDRhwJjGTsPfHxxdfxoRdCIvuDl/LHvRiDAqBc0AE
-        QOIOghPPgYwx0FRVxsAiR85QEBDAiuSI82fwBmJUYoDAqWCBJJwBVCJC0ZFiECBKcQh+woAnaSHx
-        +4kcf0IgYyRBgBj4G374s/9xB79pT4SFuMbhj2fwHS5GAqQ5L0mIw4dWpDggJxKAEtECA/a7pqoN
-        IPh3OEofvBxnBclxCFKUowRLnAsgOUjQ5VeG7yfcgz/DBhQkYkgW+f3HRvlyOLj4bwMzGkwvA/Em
-        55uJSxjKFbdvUp8pG28w2r629YnW2pNNiOrOzKCx7/RLV9/rfn0LnLAzP0ZxqegOZnHWtDcTrxyW
-        m5dIvnhkvhxFlVnN2y0z3+LlUIS3uUBDe7aku8w9p/vQNM/RmLxVobF1z0ayHWjaxJ1bs8yrs6w5
-        10eromv54ZjMLa9yroUsElsXO9fL8/7bzT1112n/0lqvp6kYqPF+iYKwWsSZvawPQSdGBQ/jaTU9
-        pRfhzxP1aodGqaFVmPcPk9yvTo5Pr+Qa3QLZr1+q2f5mjYzRTTvl9sVSFgefX4z2cGOYzkKvBoq9
-        JmOxCDFyg6uxYmJhrPXmptNmnCndjtKczZy2J21Vej7VcCvTJ+rUok37hSikXI29y7EyFPfUnE3H
-        tafQApHDoq7KYJ3xJSlWm36tetuO0fImk5a18891LVfp3Eq4n7gRndnd84XvA/3w6pVEG6352bR2
-        OxWZSee6W6DRsZmy4XaKj4O9mXPFbo9ZmNaaMWTGK56XXZr0l1mhLh3lmkTOzsQ2vpnlyVhuluND
-        S9OG7ErJ9WVyCVB8DD1t78QkaZM2PXUPRRTESKMz/WBNihs6MCdm465bDzpto4wjE342/mki5/S9
-        EPir7/d98a5qs20Sr9a76ybQcarHx4URTzr3qcBQctf9q1N3KUsLCXsfkMGepqqfn382oJA8fc8x
-        Epz9957HgcBZgVmAYY8VlDZg8ZgfvY9fVn/RUe44AMIwDL1L5g58Fy4TRa2lIiigUNh6d9QB8ROr
-        ny1PNsd5wLRS19SVISvWg61C8jz46ShOrhD3x85sLsDiEaAychu+/ouW/k2ToXmLd6msWkMrdO8t
-        OPZQ6ijfnhN1lNIBAAD//wMA1XR7UGcFAAA=
+        H4sIAAAAAAAAAwAAAP//bFRbr6M2GPwrlp9akXMCITci9YFb7pzcSEKoqqwxDpCATYyBJEfnv1fJ
+        drddqW/+xjPj0SeNP2HGQpLCAcQpKkPyVjBKiXhrv7XkVkfuKG3YgEkIBzAroqOsqPe5cWnZuDs1
+        cDykOgs2er2EDSjuOXmySFGgiMAG5Cx9AqgokkIgKmADYkYFoQIO/vz8wRdxQi8JjZ4OP44D6MYE
+        lAXhICkAKp4gODEOREyAIssiBsMkYBRhnABaZgHh72ACYlQRgDAmRQEEAwicSopFwijAKE1JCL5h
+        luWlIMdTEnwDIkYCYETBP+jLnf6PN/hNeUtoSG4k/P0d/IwWowLknFVJSMKXtsgJTk4JBhVKSwLo
+        H4osN0DBfkZL0xePk2uZcBKCHHGUEUH4K2+GLt8z/BL7HTZgkUQUiZI/92XzlWVeDhNzHZmzi4XG
+        LNDqWGp259N2/y5/YGNvakEnoPN1EoaikrSbms5EoAmSSShzVSVe0UkWu7gVu1rgDYfxZhcaVm9n
+        M7zsT6Xm9GRHt1pF25lpJFK1QCMaTJA1by5vqS5mabL7eDhabk7qR0CI0a+UPdHuu8hvth6dtqUq
+        HVWP413L+jgM2XVsmN7+NCRq+JC6srDqpTkOJbmOnKye5YXpj3tRJ7PP5Wgfy0MjFXZGV9TGlHHX
+        laPTcuqml854WwWToYvk7YjREcZ0GSXhaDFPTP+6PM1Vj8l6cHeqeCPddWeW2ramp9fAsG6MPE75
+        vJJ9iZ0NszyRcZs52m3siMoPrErft+oSr1bVzu3J6WRWufneaZ+763LvsD5nws9lVO9uslik1a7L
+        /HmqGcJg8zD09ts68B8q3zgL434/30P9sH30Nvm6PDT9Ytfn604SbLztQeXDDXfqoRco6qNr2HzB
+        JlpzHKRSqOhqx1eFnLWiNbfdqnbcjNqJIk3W9crrmDOlr10/XOLoTWWtdD2fbrRRb6+ce6qucXl6
+        NqI4jy1ndmAlRn3mtW5X/PCa0165kJrbm13PD75FdivROpDz4zElpzZe2+eiaUQG/Gr820PG0mNZ
+        kB9tf87lUVbc7tqkM52vvNpz9h4lvqlYHDYgRdlT959KPaU0LwUcfEIKB4osf3391YCFYPmRE1Qw
+        +us7r4uCXEtCMYEDWqZpA5av32Pw+d3qKNjlb6XmFStZmRgb6SglJyZnpMYnF6UmgrJHPKoKA5h8
+        UWpiCi45mF6QBakFGam5qUWJOfGmuZjqEbKGGeiytTpK+aUlyEKGRmY6SsWpRWWZyanxJZmpRUpW
+        SqBCLyWxKEWpthYAAAD//wMAzBkAY2UFAAA=
     headers:
       CF-RAY:
-      - 992cb8b41ad5681e-SEA
+      - 999534d6888e9d35-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,7 +75,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:19:49 GMT
+      - Tue, 04 Nov 2025 15:39:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -87,53 +89,57 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-10-22T23:19:47Z'
+      - '2025-11-04T15:39:52Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-10-22T23:19:49Z'
+      - '2025-11-04T15:39:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-10-22T23:19:46Z'
+      - '2025-11-04T15:39:50Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-10-22T23:19:47Z'
+      - '2025-11-04T15:39:52Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CUP6N9csXaUWoVMRzS7zZ
+      - req_011CUo6oomqTgnmhnPSUpfFn
+      retry-after:
+      - '8'
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
-      via:
-      - 1.1 google
       x-envoy-upstream-service-time:
-      - '2810'
+      - '3321'
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"What is the 100th fibonacci number?","role":"user"},{"call_id":"toolu_01LVmhRSWyUc2ep2hbP7hH84","name":"compute_fib","arguments":"{\"n\":
-      100}","type":"function_call"},{"call_id":"toolu_01LVmhRSWyUc2ep2hbP7hH84","output":"218922995834555169026","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"compute_fib","description":"Compute
+    body: '{"input":[{"content":"What is the 100th fibonacci number?","role":"user"},{"call_id":"toolu_01T6RCnKArQXwXMWXneZC1Dr","name":"compute_fib","arguments":"{\"n\":
+      100}","type":"function_call"},{"call_id":"toolu_01T6RCnKArQXwXMWXneZC1Dr","output":"218922995834555169026","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"compute_fib","description":"Compute
       the nth Fibonacci number (1-indexed).","parameters":{"properties":{"n":{"title":"N","type":"integer"}},"required":["n"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '571'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -155,29 +161,29 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RUTY+jOBC951dYnHalpAUECOS60hxHc9jbaIUKXCSeNrbHLrc6GvV/X2HCVzp9
-        g3pVz/Xxqv7sGIsEj84ssuhMHVdZlxYc02Oe5VUTx3FRdlVRVEVSndoyqTLo4rwpjyU2FbRZDtF+
-        oNDNL2xpotHK4WhvLQIhr2HAklORJKc8qeKAOQLybohpdW8kEvIxqIH29WK1V0NeHUiHo1lIKdQl
-        OrM/O8YYiwzc0A7xHN9QaoM22jH2EZzRWj1gyksZDEJNr9QcCYR0W9SR9S0JrTb2Ht5r7cl4qkm/
-        4meQtJZ1C3JL12uOcsjsYuiQ6UMap9khLg9xcW9XoIzO7GeoZKxnnkTvLl8P4pQe83gYRHUsm6rp
-        jqc0PWYlrwJzYKGbwcCDzsEFF+Crjgew1YpQLUmtE9vQTv3Ad5qjgwMopQmmHv78bwNKfTFWN0+Q
-        QHRm0b9XZEkc05V9E41W0LaCKd83aJlwLE3KfZWm+6rK9+Ux2+d5vk+Kah+nxUs0033cv+YXIqtl
-        yBqcE45A0eg8OAanyIAFKVFuR0nWj6ozFt+E9q6ehF2HIc2jNlb3huoW2ivWr3hbYxbBabXRLHad
-        trRyGsbi+x7sFDlL2EGHdKsFR0WiE7iRs0P7JlqsSUwr0IGX40AiR9riugjC3qAF8sGcvMR3a2j8
-        PbNO2x6W/9XAg9/YtXvGb2gb7QTdRplx4ftl9cY+XrVox8Z70tEMuM+in57pvAoLuEiSo2utMMF4
-        ZtE/ujeekNEVmXomk7+Sg1Ac35H//bKwKOhx0rwnrDvRLOAw/R4JrVtVPo7VoCWBW/tA92AYKhA0
-        iuz7ZiFWtQlFeBnv06NU566OcsXfXljkmzUMr85/q+2JgHMxtAfkj3XC89F8XN3xTO8e3o0cWRHO
-        dwh8WBDSpl5tbzwbzVpL1qsWpklx4aCR0z334QrNQhNqc07LbP/ZvrrRs07CivElMN5I8vFKp9kz
-        4BnvvKVfUZMmkAuYxOWsde+2a9kjAQeCgf9j9/E/AAAA//8DAORAvgZfBwAA
+        H4sIAAAAAAAAA3RUwW7jOAy95ysEn2aApJAdJ7F7HWCPiz3MbbAwaIlONJUlrUQVDQb994Xl2LHT
+        9mbzUU8U+R7/bBjLlMyeWeYxuIYjVBUehKwPdV6ecs6PNYccy1oWOa/yel/BHnN5PAHHFo81ZtuB
+        wra/UdBEY024xYVHIJQNDFh+OhbFiZ/qfcICAcUwnBG2dxoJ5XioBfFy9jaaoa4OdMAxrLRW5pw9
+        sz8bxhjLHFzRD+clvqK2Dn22Yew9JaP3dsBM1DoFlJluaSQSKB3WaCAfBSlrVvEe3hobyUVqyL7g
+        R5Cs1Y0AvabrrUQ9VHZ2tCvtruBFuePVjh9v7UqU2TP7lV4yvmeeRB/OXw8CDuVJDINoOe9Oh72o
+        4Zh3+7JKzImFrg4TD4YAZ7wDX3U8gcIaQnMvalnYinbqB77RfDolgDGWYOrhr39XoLZn5237CZKI
+        nln284Is55wu7C/VWgNCKGZi36JnKrAir7Z1UWzr+rCt9uX2cDhs82O95cXxKZvp3m9f8w2ZtzpV
+        DSGoQGBoTB4SU1LmwIPWqNejJB9H1TmPr8rG0EzCbtKQ5lE7b3tHjQBxweYFr19iHof2KmuWGR4h
+        WLNSNXad9bRIGgYX+x78xD2LPECHdG2UHIg7hSvBB/SvSmBDajJJB1GPI8sCWY/LZxL2Dj1QTOH8
+        id+iaTS3yjrre7j/LySR8sa+3ip+Rd/aoOg6ClGq2N/NOXb6YpUYRxPJZjMQPtpiuqaLJln0LlqJ
+        QXjlbm3NftjeRUJGF2TmMyF9y3fKSHxD+f3pzmKgx8kVkbDpVHsHB330SOjD4uXjcB16UriOD3QP
+        geEFikYZ/r2yzOJtyhCexw32KOa5q6Og8b+oPMqVUdOt89/CXxlIqYb2gP5nWfC8Vh/NPS7yzcO9
+        WSCv0oJPBx8sRNY1C3/zOeiWWvLRCJgmJVWAVk8bP6Y9NQtNmdXCrcrtx/hii886SUaT94N8JcnH
+        PV6UnwGf8c4u/YqaLIG+gzmvZq3HsLZljwQSCAb+9837/wAAAP//AwDflhYdgQcAAA==
     headers:
       CF-RAY:
-      - 992cb8c6c86c31ba-SEA
+      - 999534ecae736877-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -185,9 +191,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:19:51 GMT
+      - Tue, 04 Nov 2025 15:39:54 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=SG9hB1k87BO2qvrebVdNFqjYM_HftNDaxjjYMpzDvno-1762270794-1.0.1.1-45ECrOprHaD0bTSbnIJw2IcetaL1taw1G1w_4mZuPBsUVmaT1RAW1U26J5tDQoVOgQg9SXSwgtw3cwrqihCNjE.m2nSb9uWjNy5L_r8TECE;
+        path=/; expires=Tue, 04-Nov-25 16:09:54 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=S_DX1Z13X2G0yzMp1IIszOjqTQITGGeiFbzvxrL175Q-1762270794675-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -201,13 +213,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1510'
+      - '799'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1515'
+      - '803'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -221,7 +233,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 22ms
       x-request-id:
-      - req_f79e0d9201a2443c83bb2eadd79e5a48
+      - req_69a335cdb4f94e7f8cf72a15c4d0b533
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/openai_completions_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/openai_completions_gpt_4o.yaml
@@ -11,6 +11,8 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
@@ -18,8 +20,7 @@ interactions:
       content-type:
       - application/json
       cookie:
-      - __cf_bm=dpcBUMDlZkeBLoHYBw.4ZYlc.pQvdgur8AegFBCVJX0-1760730639-1.0.1.1-MsdinmhuZ.XUXOeAjVE4KGnmpQmkJnpoIt.fbiU.dgNifWtaCmYdfycX3OpHS0oND3b636EJz.Lzc.Mwj86g97Auvp2Vx6D_nRedw7YI8AI;
-        _cfuvid=BnM7U9ocUs2eWW70xHGpJAEAaNMbtStvfIxK06a3UCM-1760730639443-0.0.1.1-604800000
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -41,26 +42,26 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/chat/completions
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//jFPvT9swEP3ev8K6z+3UUkhRvk0FBgjY1jGmaUWRcS6piWNb9oUfqvq/
-        T3agSYFJy4fIunfv7t3zeT1gDGQOKQOx4iRqq0bzRaUWk8nR9fTksnpS05vzn/PT+gJpfmK/wzAw
-        zN09CnplfRKmtgpJGt3CwiEnDFUns2Q8m46Tg2kEapOjCrTS0mjfjPbGe/uj8eFonLwQV0YK9JCy
-        PwPGGFvHf5Coc3yClI2Hr5EaveclQrpNYgycUSEC3HvpiWuCYQcKowl1UK0bpXoAGaMywZXqGrff
-        unfufOJKZWc398n8RzU+evgiqpvKPT6eF78vkutev7b0s42CikaLrT89fBtP3zRjDDSvIzfLaum4
-        F8ZiVhhXcyLMM9OQbSiL2rM3ZRkD7sqmRk1hJFgvgSQpXEK6hOvTY3b1+fKYfT1h4fzr7OpoCcMl
-        8IZWxsWcb5ycFBVbGFoVjfcRd5ykLpeQzjaw024z+Oh823PYYdF4rt5bz7U2xIMD0fvbF2SzvWZl
-        SuvMnX9DhUJq6VeZQ+6je+DJ2FZWkBCbQ7OzIWCdqW2wrMLYbrJ/2NaDboE7dO9l14AMcdVjJa+s
-        nXpZjsRlXKHt1gouVph31G57eZNL0wMGvanfq/modju51OX/lO8AIdCG9bEOcyl2J+7SHIb3/a+0
-        rctRMHh0D1JgRhJduIkcC96o9umBf/aEdVZIXaKzTsb3B4XNxF0xmR0eHCQzGGwGfwEAAP//AwAO
-        6+5miAQAAA==
+        H4sIAAAAAAAAAwAAAP//jFPbbtswDH3PVwh8TgY3yK1+23rBOmDdVhRIi6UQVJl2tMqSINFruyD/
+        PkhOY6ftgPnBEHh4yMMjajNgDFQBOQO5FiRrp0cnt6c/rvBKLR+X5YX+dHudVU9PjdbiJLM3MIwM
+        e/8LJb2wPkhbO42krGlh6VEQxqpH89l4PM/mx9ME1LZAHWmVo9HEjsbZeDLKFqNstiOurZIYIGc/
+        B4wxtkn/KNEU+AQ5y4YvkRpDEBVCvk9iDLzVMQIiBBVIGIJhB0prCE1UbRqtewBZq7kUWneN22/T
+        O3c+Ca25my7Pjm/wz2wSMvN4MfW0/FKF8/tev7b0s0uCysbIvT89fB/PXzVjDIyoE5fzWnkRpHXI
+        S+trQYQFtw25hnjSzl+VZQyEr5oaDcWRYLMCUqRxBfkKrj+fscuPX8/Yt3MWz8uLy9MVDFcgGlpb
+        n3K+C/JKPrArS+uyCSHhXpAy1Qry+RYO2m0H753veg57LJsg9FvrhTGWRHQgeX+3Q7b7a9a2ct7e
+        h1dUKJVRYc09ipDcg0DWtbKihNQcmoMNAedt7aJlD5jaHU0WbT3oFrhDx7tdA7IkdI81e2Ed1OMF
+        klBphfZbK4VcY9FRu+0VTaFsDxj0pn6r5r3a7eTKVP9TvgOkRBfXx3kslDycuEvzGN/3v9L2LifB
+        END/VhI5KfTxJgosRaPbpwfhORDWvFSmQu+8Su8PSsfFfLGQU4FlBoPt4C8AAAD//wMAWuTWoIgE
+        AAA=
     headers:
       CF-RAY:
-      - 990253d33b4f38ba-SEA
+      - 999534f369fe686f-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,9 +69,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Fri, 17 Oct 2025 19:50:53 GMT
+      - Tue, 04 Nov 2025 15:39:56 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=7DPR4WHwNn6C0T._RjduWUtJ_r8yDTBXjk5z8p2mVQ8-1762270796-1.0.1.1-kNsvGYjNPRSHEVAZBx7Z4x9xfDxDs_2qk0wI7osDAGgVJ0cfNlD6j.WD5TOgfWUaW4Y8iJLrZugESK0EHBvGTkLS1mss1d_iDVsfZT3sWZ0;
+        path=/; expires=Tue, 04-Nov-25 16:09:56 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=Yypc530WHlPXLvEKtnJjx8U7dc8zaoJCEQdUt2kLHgM-1762270796304-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -86,13 +93,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '684'
+      - '523'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1108'
+      - '848'
       x-openai-proxy-wasm:
       - v0.1
       x-ratelimit-limit-requests:
@@ -108,7 +115,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 4ms
       x-request-id:
-      - req_0af8c369d83e42aabe24bc81163004ad
+      - req_266e13f07662477289567622c291a444
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o.yaml
@@ -10,12 +10,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '830'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -37,31 +41,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xV227bOBB991cQfE4KyXHky1uL7WILdJOizWJRrAthTI5srilSSw6DpIH/fUHK
-        liXHLtA+WZ7DOZzLGc7LiDGuJF8w7tA3ZZblMJF5Vcgqn85mRZYVs2peFPPVLP7P5xOoptNZJm5y
-        IYvxzWTMryKFXf2Lgg401nhs7cIhEMoSIpZPizyf3ubz24R5Ago++ghbNxoJZeu0ArFdOxtMjKsC
-        7bE1K62VWfMFexkxxhhv4Bld9Jf4iNo26PiIsV06jM7ZiJmgdTIoc7illEigtB+inlwQpKwZ2Gt4
-        Km2gJlBJdouvQbJWlwL0kK62EnWMbN3Q9cRej7Px5DqbXWfFvlyJki/YPymTNp+uE5W43AdZTG9T
-        H2arm1U2ETf5WMpbOZ8n4kRCzw0mmmBSQim8I3yp7AkEtw41Gkr4y5KTIo1Lvljyhz/es7u3f75n
-        97+z+P33h7vflvxqySHQxrp05hOQU2LLPlvaVMH7hDsgZdZLvpjujvfEkMo22/R5B1/ww/3Xj372
-        QF+Nz/Mv99nH7/r70cNAnbIqy1o58MI2WFbW1UBRX12PrC5Lnnx2I8a+pWo34EBr1MNmkQutrhqH
-        j8oGXx6k2wbWNbNxtm6oFCA2WG7xuY85BG/NQJVYVdZR71CseahrcAfPTqQeKqTnUkk0pCqFA8F6
-        dI9KYEnqIPIKgia+nx3rsJ8EYd2gAwrJnL/J9tYnOkbWlqv735NKOtdWbR/xI7qV9YpizLxGqUJ9
-        HK62jhurBB7ZT2W3b93PNu54g389HxfuYLE6XjjVJOOC8b88MtoozyIRI8vwiRwIYhIImDLsnbVb
-        1oYRfxiwShnQ7KCBN7+mvM4paq5GQud79W7F1KAjhUN7zC2O2omxZ+YP6ePqBN0XxJOLIuyBu/7J
-        /ZD+gP1te+AX6dsZ/wH95/bABXplCNft693xj87cxB3+F5RD2SljcM+5jM+F2Zm+9ahBShXVA/pT
-        v0Xd+jkJeb/wRicxpkqlRRgn8+QdItuU2q4bZ1eROuuMTX9kXTACDjqWysNKHxZj8LDuTZwyg72U
-        T4qr10Bv270cX1+xQXn0zAajf7rvxvk54Bxv9xpeoiZLoHsRF9Nu4oMfPn81EsRhjfy70e5/AAAA
-        //8DADKXny+pCAAA
+        H4sIAAAAAAAAAwAAAP//nFVLj+I4EL7zKyyfu0dJoAPhNq/VzmFnZ+ehPiyjqHAqwYsTZ+wyatTi
+        v4/sQEhoGGnnRKiv6nM9vrKfJ4xxWfAl4wZtm0fFQzydZw8P5UMM6wijKM0iiHEmFslCLOJslk2n
+        mZhGxSKJknKdlPzOU+j1fyjoRKMbi51dGATCIgePxfM0SebRPEsDZgnIWR8jdN0qJCy6oDWIbWW0
+        a3xeJSiLnVkqJZuKL9nzhDHGeAt7ND6+wB0q3aLhE8YOwRmN0R5rnFLBIJvTKXmBBFLZMWrJOEFS
+        NyN7DU+5dtQ6yklv8SVIWqtcgBrT1bpA5TOrWrqf6fskSmb30eI+So/tCpR8yf4NlXT19JMoxe05
+        FPMoC3OALE0XWTRN40LAOooCcSChfYuBxjWhoJDeGb7V9gCCqVyNDQX8ecVJksIVX6741z/fs4+v
+        /3rP/v6D+e/HDx/frfjdioOjjTbB5xOQkWLLPmvalM7agBsg2VQrvpwfzuf4lPKu2vC5pW9f3nx5
+        /KHqt7GsP+yTp3/E7jGuzhEN1KGqPK+lASt0i3mpTQ3k9dXPSKs85yHmMGHse+h2CwaUQjUeFhnX
+        6ao1uJPa2fwk3S6xfpit0XVLuQCxwXyL+5uYQcLGd3zoYRCsbka6xbLUhgZOfiqursGcuHsZWyiR
+        9rksPHEpcSRpi2YnBeYkT2tQglPEj9ulDQ7LJKxbNEAumONX0dH6ROfMuob2/wdiCn5dX48Z79Cs
+        tZXkc+Y1FtLV5/XrOr3RUuCZ/VKYx+H+39GeT7AvN+jGGcx3xwoj2+N8+DeLjDbSMk/ESDN8IgOC
+        WAEETDbsjdZb1qXhfxiwUjag2Eklr35Pm32QV2WNhMYO+t1JqkVDEsd2X5tfxgvjwMy/ho+7C/TY
+        EEvGi3AAHoaexzX+BfvrzuE36btb4Bf0nzuHG/SyIay6+73nn1w5iRv84aTBolfG6JxrFV9Lszd9
+        H1BDUUivHlCfhiPqH6iLlI9P4uQix9Cp8FT6zby4qUi3udJVa/TaU0e9sR2urHGNgJOOC2lhrU5P
+        p7NQDTZONqOXK56ldy+BwXv4fL6fxQaLc2Q0Wv3LFzGJrwHXePvb8BY1aQI1yDid9xvv7Pj6q5HA
+        L6vnP0wOPwEAAP//AwBZcGswywgAAA==
     headers:
       CF-RAY:
-      - 992cb8e84a7831ba-SEA
+      - 999534fd2c806877-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -69,7 +73,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:19:57 GMT
+      - Tue, 04 Nov 2025 15:39:58 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -85,13 +89,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2307'
+      - '1752'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2315'
+      - '1759'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -105,7 +109,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 27ms
       x-request-id:
-      - req_5d831b9fa8d84b2082f3585147187b99
+      - req_9b7f4740c09b45418ab217d6341ca7a6
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_responses_gpt_4o_snapshots.py
@@ -50,6 +50,7 @@ test_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0e123783deb788010068f96c3331a48193b13ccede896854ad",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_responses_gpt_4o_snapshots.py
@@ -49,6 +49,7 @@ test_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0371d245ba0faaf90068f96684b6e48195a8a8b759e2f363de",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_call_with_params/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/openai_responses_gpt_4o_snapshots.py
@@ -43,6 +43,7 @@ test_snapshot = snapshot(
                                 "role": "assistant",
                                 "status": "completed",
                                 "type": "message",
+                                "response_id": "resp_0d902d0e83de5d560068f96688b6f881968f031730e6608227",
                             }
                         ],
                     ),

--- a/python/tests/e2e/input/snapshots/test_resume_with_override/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override/openai_responses_gpt_4o_snapshots.py
@@ -49,6 +49,7 @@ test_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0ebcd1c24e8bcbec0068f9668de228819487e853969f924bba",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_context/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_context/openai_responses_gpt_4o_snapshots.py
@@ -51,6 +51,7 @@ test_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_064abeb5df0d75350068f966915ce88195b717feabec4e5474",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_completions_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_completions_gpt_4o_snapshots.py
@@ -21,11 +21,10 @@ test_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         Thought(
-                            thought="The user is asking for the 100th Fibonacci number. I have a function available called `compute_fib` that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call."
+                            thought='The user is asking for the 100th Fibonacci number. I have a function called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.'
                         ),
-                        Text(text="I'll compute the 100th Fibonacci number for you."),
                         ToolCall(
-                            id="toolu_01UvLhE2u2ZGcdihNhXUm1wp",
+                            id="toolu_01LXbYDxRjyLgjMvcPVezUyH",
                             name="compute_fib",
                             args='{"n": 100}',
                         ),
@@ -36,17 +35,12 @@ test_snapshot = snapshot(
                         "role": "assistant",
                         "content": [
                             {
-                                "signature": "ErQDCkYICBgCKkAvaj6zwlcCXh989DjfcJKxhnEl5NQA4aOMRq/nZzCYnhPFXVcF6OMlhlPU/gK+hzNjWeY/3Q7HLQvMtqr3wym/Egy6b14LOeSQ1wVvF24aDN+G5tLY1buyBhc4gSIwmOXjvuWtJb+x3LV1DMpXkb1R97E3wRyIs+LTxLJ7p9LAebDnW4dIFtJt5vTUqK40KpsCz+4VXHewhrDmLzXOo858J2FHSzuQprqwULAPba1kasCHTEt1Z5eSc3thRuGJReZNpCU82BFeESHvrKj45BSrHxKUsrb9eU9JBGdSgdz/cgKdj3LvkRIhrAq6NIG83hgG2cK6lF2Ae361w+KeBIenHj589Dw9ufmd6Nj6mTNvN2WBcDbRZnn+X4tAl8xIelZ0sBG7bvuzBxV7iPv7+N2qWbiLm68PH3UaBjD2/SKcPUbHB5sv5N6laxwSM6RIZy/hg33l0eXQMT0jHjHHK4vI0Flum4eJwN/7rOM4DAnJCHux297HwheEVzARd4L5qQfTr1q9kdFDlrE7B+FVhD0NURmBKDpkcQ2cYCgnK+uRz2+LW/IZqPWurdiVPBgB",
-                                "thinking": "The user is asking for the 100th Fibonacci number. I have a function available called `compute_fib` that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.",
+                                "signature": "EqoDCkYICRgCKkAAW+8fgSnrlHy7gs1efkmz9lpewAfgIjUn/LUlYRlq8NvvW+U0i0FB+GPq2y8q+4+yGE7QcfQM8o7zLlIXzlilEgzO++MGfd79vxrbBScaDEzgRM15YwmLBF37viIw/mF7F79V/ZiZO+0+sSUCwy+MzR5cwfcpcb15KwgqtimhY34cY+qnaksHLqv4iZHiKpEC+IFvSvGXHo2T/CPCbT+YqSOLR0HvRtyTKUwl3OoO0y3QzJEyERsFSlwHWFby3erGJuWeMVNoL0XNmNDHIGT8UzzCJQBw4mrmYJVuORCp4JQCeo0LwHfsrF5/LWG5BXeY9CdbI68YuFY/f1H4Cz3jy2osvFetk4FaQL6ueWmBHfzc3Rrz+GQoTC42eWzn9LM10cxGQxt9ImHns26s3p6cbVOVBByG12ee3iOvQKEFFrlRLjQJquWeNgL9IUVKmM3ok3vhVMT8FKrnkLKGyvr4VzAm3bnzVfdpHuIZmuSx3JZlqw7slAu3tMfI6DlyAII0DTAGC0LK6Jya9GmolfEXia/cJdsurNUh90G4np6oY8RjGAE=",
+                                "thinking": 'The user is asking for the 100th Fibonacci number. I have a function called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.',
                                 "type": "thinking",
                             },
                             {
-                                "citations": None,
-                                "text": "I'll compute the 100th Fibonacci number for you.",
-                                "type": "text",
-                            },
-                            {
-                                "id": "toolu_01UvLhE2u2ZGcdihNhXUm1wp",
+                                "id": "toolu_01LXbYDxRjyLgjMvcPVezUyH",
                                 "input": {"n": 100},
                                 "name": "compute_fib",
                                 "type": "tool_use",
@@ -57,7 +51,7 @@ test_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="toolu_01UvLhE2u2ZGcdihNhXUm1wp",
+                            id="toolu_01LXbYDxRjyLgjMvcPVezUyH",
                             name="compute_fib",
                             value="218922995834555169026",
                         )

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_responses_gpt_4o_snapshots.py
@@ -21,10 +21,10 @@ test_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         Thought(
-                            thought='The user is asking for the 100th Fibonacci number. I have a function available called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.'
+                            thought="The user is asking for the 100th Fibonacci number. I have access to a function called `compute_fib` that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call."
                         ),
                         ToolCall(
-                            id="toolu_01LVmhRSWyUc2ep2hbP7hH84",
+                            id="toolu_01T6RCnKArQXwXMWXneZC1Dr",
                             name="compute_fib",
                             args='{"n": 100}',
                         ),
@@ -35,12 +35,12 @@ test_snapshot = snapshot(
                         "role": "assistant",
                         "content": [
                             {
-                                "signature": "ErQDCkYICBgCKkCsItOUHNinar+NABlYn+UTCEV462H15XiUdax8L7lhYMAvN2X2YxzcMd8Obghv+2Menhq/JUHTvDvU3gt3TiOQEgwBwO65BrVeQDsdzOsaDJLQlWqNjpXdBBjgGiIwd7VNj7mVC11HNOFLqTxqq/O2ERu9FYdGiOFTwMyutumJ2sWNTrrAIzNf9SpAk5SSKpsC0hXQacdwPhqJQxZc8hauodhKwKfpksYOm0yJd7v1aRdrAZHrYwfMYlyiygzctAx3wLXzFE7Ez1frJkF+PZYok76DU7BMP2wC+JSiGsPdeaNcy7RnsP7S2/U86non+98+/LLM6TtJ0tTYl1e5q2H0KFl/J3i+ivRGTkbw7+Nf/LKGxT+luaiZPxwvcSqoQiuRUAx0TV875THH5FWYjxxtRpOFmoYmNglLJ9jkoXc2Z4Tvi1ESojBFWW0aBm8yWPaEb/pnDVKebCXBro+J6Gndpx17Dn74eOv9lmAQqu0QM+ymgMWBeJezBvf7QUQGZ511Dnyliy3HkcahbdT1XMhim6i6lf9Zugcha1lL2ZFHuzaZnMhnG9NxC867vhgB",
-                                "thinking": 'The user is asking for the 100th Fibonacci number. I have a function available called "compute_fib" that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.',
+                                "signature": "ErQDCkYICRgCKkDaHob9wh+/6LJ48y0NcBWC9b5bnLRiddtv+9x3lKtb9tem+amT31hQnImhTc2hT9bXFFhSVdBD7VEocP8J+/JfEgxw3aUKCBi+vOaGnbIaDL/PxlAtKliVNzM9pCIwzbeeB8v1We9yVgZ/2z54D3153AhhV2DNYFoqHBCXWfFe3dz+60tDwPCHd+0wgMmwKpsCZH7g5mEjuGWh0FBltEmnQnEcnorTT0gfPJTlk5HUvbIFTa0UGonGccnPgidGOLiCZqPfL3Xo0AbyMvhS+yAMKlEE9AlqbBDxoezfpLv0Z+ojBCufeH4oM9xHMtvZbDvAW2wucQQvVT70lIKvTpWM4j6RuWMo8rotZp0awVx0tOlvV6oZLl9BtBoLddXWUwbZz3rSMOByyjydAYUz7SpRuY/ZsV8rR5ibSXUY3rFSrMwFXb13z6BErOoI9/Hbl+d1A35Z3t0m2gRrETvwMTmnEi1+IRwQX5CK189qNTeMA/1R16XZnS9G7W1j73A9r0JjBghphDMKYouca8oX2xqczX/J7uO+/UxEwLYZDeVQt2YejzzJef4cREjs/BgB",
+                                "thinking": "The user is asking for the 100th Fibonacci number. I have access to a function called `compute_fib` that can compute the nth Fibonacci number (1-indexed). The user has provided the specific value n=100, so I have all the required parameters to make the function call.",
                                 "type": "thinking",
                             },
                             {
-                                "id": "toolu_01LVmhRSWyUc2ep2hbP7hH84",
+                                "id": "toolu_01T6RCnKArQXwXMWXneZC1Dr",
                                 "input": {"n": 100},
                                 "name": "compute_fib",
                                 "type": "tool_use",
@@ -51,7 +51,7 @@ test_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="toolu_01LVmhRSWyUc2ep2hbP7hH84",
+                            id="toolu_01T6RCnKArQXwXMWXneZC1Dr",
                             name="compute_fib",
                             value="218922995834555169026",
                         )
@@ -67,7 +67,7 @@ test_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_094f26de235459b00068f9669723508194938b9bf3722348d9",
+                            "id": "msg_0ea88e5cd959147100690a1e4a547c8193b00f753c9a61f348",
                             "content": [
                                 {
                                     "annotations": [],
@@ -79,6 +79,7 @@ test_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0ea88e5cd959147100690a1e49d21081938a3e1d67a0ebe69e",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_responses_gpt_4o_snapshots.py
@@ -60,6 +60,7 @@ lucky number 7.\
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0f6326fa476362700068f96699a51881949de0700a5f997a78",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_responses_gpt_4o_snapshots.py
@@ -48,6 +48,7 @@ lucky number 7.\
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_07e251ec752216f10068f9669e20e88197a6082dab1e90d5e8",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_responses_gpt_4o_snapshots.py
@@ -48,6 +48,7 @@ lucky number 7.\
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_027c5abe12a256120068f9669827588193a1d178c7d455e24e",
                         }
                     ],
                 ),

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_completions_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_completions_gpt_4o_snapshots.py
@@ -39,7 +39,7 @@ lucky number 7.\
                         "annotations": [],
                         "tool_calls": [
                             {
-                                "id": "call_IVj6CSk0DvGckVkrwwJfYL6T",
+                                "id": "call_p5WE9Xez64s0nwI5rtWJgsFb",
                                 "function": {
                                     "arguments": '{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}',
                                     "name": "__mirascope_formatted_output_tool__",

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_responses_gpt_4o_snapshots.py
@@ -37,11 +37,12 @@ lucky number 7.\
                     raw_message=[
                         {
                             "arguments": '{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}',
-                            "call_id": "call_NaSeIOYLs8TtYns11SO0Lzlz",
+                            "call_id": "call_ktUSBSWqlmC1imIy2xQcvW1g",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_001a4d1f6df178860068f9669d675881948b3b04c312dd5d99",
+                            "id": "fc_0d5137955f51ab0e00690a1e4d709c8194a966890361dcab00",
                             "status": "completed",
+                            "response_id": "resp_0d5137955f51ab0e00690a1e4c828c81949339c30d8202fb2f",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async.yaml
@@ -7,12 +7,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '221'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -34,41 +38,46 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA6xXTW/bOBC951dMdSkQKIHkL0U57gLd9aWX7W1dGBQ5srmhSIGk7KpF/vtiSEuW
-        Y6d72F4ch0POx3uPw/GPO4BEiuQZEouu3WasWmAlZhUvZotZXmTZ6qkuV0VZLovZ4ikvl0/LxUII
-        tkS+rGarbJak5MJU/yD3gxujHcZ1bpF5FFtGtrxY5XmxXCzKYHOe+c7RGW6aVqFHEQ9VjL/srOk0
-        5VUz5TAuS6Wk3iXP8OMOACBpWY+Wzgs8oDIt2uQO4DVsRmsN2XSnVFiQeoiyFeiZVO7S6rztuJdG
-        X6w37NvWdL7t/NabF7w2emPUljN16a4xAhVltmv9w/Jhls2WD9nTQ1ac0Aoek2f4OxQSyzkT4X5C
-        A58vs0BDtlzkq2wuOMcZExHu4MT3LUYimDOaABtNrmsaZvsx8DT4xdnTxq3Hb348HnfQyjMk9/dr
-        gdrLupd6B62VDTo4Sr8H11XOW1rdJEW5Se7vN3qj16ARBXgDtdQiHgDdNRVaBwqdA79nGhZZRl88
-        7NkBwe/xjbvHTQJfyN4g0w7W4PamUwK40U4KtGeX8gWhKFPI6WNGH0wLmBflI/zWedDmmMIaLDIl
-        vyMw3b89moGxsJe7PVpgFkEbD6xtleSsUghOah4y7D9aBHNAS8k/wnrTzbK8PCDYTqEA0/ngnRTG
-        NCeU9mjxBA5IFxxLHcvGb4x7MFagfYS/TBogODAlxYBxp0UMRTV7JvUZ6ZDm7ZqTkcPX9P9T//se
-        +cvAO1PS92DqEb+gggvuIyQNKGPCMebHzaHqUyVjGQ7YhHeqgQ8RZR0wD6UGRB7hywjR4PR9HIDy
-        +WRsMEtP8EstSJlRkZFV6WPGkRshD9JJ4rzqA5WuYUqd+Ige86IkV0w5c3LEao/2nPbJhwxYsR0j
-        NUQ/aC88/WmOeEAb0iaX1LSMkx6hQs46R8k5EHJHf1zX0I3Kn1I47iXf04GLbOexcr/v3KSoUZgx
-        5Bqcl0qNFzQkHYR3Qe+8KD/8YhkZXUvbjA0EuOm0/5mARjxvZfcIaziglbVEQdzehvk50q6jyzfs
-        zlKCbJlCkUKep5DPSUQpdYK8jBdSevCd1S5c7HkkKXj+QJl+prYSyphmSVGPGHvaqMuTJFOoSOXD
-        dm88U8SC31tEKinUjAJqY4EJIemNYmrU+rkfBNiuW2a6SaDqPBiteqjpVQW/Nw6HCJ+nbS8vi5BY
-        WYAwI0ahoBScCe5rSfGZdke0VH3082ul8YliyO9vpDE8JUemPWEkTFcpfHhHsHmQBD0l1E8sNkwG
-        rEwNC2rCOnAvUBDzRQrzq0WSAKGRZ9emOfE86je0Mek/uqEpkVTWwJmOu+itVD041o9CCLBddXXK
-        eLinsmmN9adauWJW1n2MdER6dIZ2Sso4+SHeOUW6eFLjPf9ygzsnm1b1sEnm9LL+QdNaCgqpkJ0Z
-        FMX89OKfvn29m3D9ZoJp3O7dEabK8+Wc0wjD8tWMI+ezVbaon0R1PcI06BzbTWab90bGYKRXBLX/
-        7+lmGOiu9Me0Np4NQ+DfXy+Myuxaa6oblkG28xsojdlZo0Jw5pykScDHzbQxbEpaZqlPqcuR0tsu
-        Tr+txYM0ndsOA/Y2YD2OnK01Teu3nPE9bl+wn9rOo+A4O2NdG+sjyEJ2zQmIyYiYxDEZxXmodqxG
-        329lnPwkXgzYDu1Bctx6OQzlNetURDhx3licluOxadEy34Xl/DE7rQYkTznWxjbs/P+EwbBvKsDk
-        gLaid7KflDTmHRHdG8kjBZ03yWg4E5p4024nNGfjYjvN0XaaB5GEKqWjcfD0y6ULch0LkPrih8N8
-        ll6vT36NjGUGEsX5YHZR6tvfI2U2v2W55XgUwvn0U7m68B4eoInz+XKEsXOXjDfomWCeUYTXu9d/
-        AQAA//8DALtXY/hMDgAA
+        H4sIAAAAAAAAA6xXy47rNhLd91fUaNPAhduQ/Ghd9S4PBPBmNskuDgxKLFmMKVJDlux2gvvvgyIl
+        We5HZjF303CLZL3OqVPk3w8AiZLJCyQOfXdI11jLNa63z5ttnq+zNH0uUrFKRbnayK9fsyItcSsz
+        uapllm+KtKiTBZuw5Z9Y0WjGGo/xe+VQEMqD4LUsf16t8myTrsOaJ0G95zOVbTuNhDIeKkV1Ojrb
+        G46rFtpj/Ky0VuaYvMDfDwAASSeu6Pi8xDNq26FLHgC+hc3onOU102sdPigzejlIJKG0v1/15PqK
+        lDV331vxerA9dT0dyJ7w/SJZqw+V0PfmWitRc2THjp62T6t0tX1Kvz6l+VCtYDF5gd9DIjGdGxD+
+        H2AQq+cqwJCnm02dYimzAuXqORgORujaYQRCeGu4YNOS79tWuOvkeO787uyw8UD4StPxuIO/vEDy
+        5ctPtjekzBE6p1r0cFHUgO9LT06Z45cve7M3OzCIEshCxbvHrSVqe4FNmgI1gkCZSvcSgRq8GYB9
+        khfLfQK/8ZYWhfGwA9/YXkuorPFKooPSUgOrJ6mOikAYCevhd/S0hN8aBNO3JTrIC1DkUdegfFxf
+        hCM3qw1WJ1A1ZHmxgBX/CSbzAv7TC63q65K/gvJm36/SrKC5mUujNMLusYWLNRJDDqK0PU0xxTj8
+        AnbgUGj1F4Yk9wlUwoDoOhQOlIGzcMr2HjrrVWDkAsqeuDwmHG0x5DOYg9rZFvIi5TLnRQH4WnHR
+        N2m6hF/tAjRSDNdDbaveg2UXWkl2K5UUhP5fyQTyt8X/z42fkdC1itk3uIp4jKwY0w/wj3nkRfrE
+        8QuHoJxDjWdhCLwyVeDG9dEhHIOgOD5pYoq/WBeYM5qZyMV15sJao683xuyT17xY7JNAKY6Pz2rh
+        CehiIQDl4RL4UCLkxTIScOAoR7l4z48lkytQ3IPwA80iajtoxBkZmwm4kLWlBh1Uti2VEQFl0OqE
+        UORgHXjshGPlHCOS1jwSXKw73Qoya5a298TxcppY9aTOuIR/28sd+pHffJDREFrRFezA9mj01q+1
+        MhKE1tN29NAzrUPRvy9bdhINqfo6icmMmCNjYhGb+VKUlQjrCwPAYGR5JFAMOULwpmdjqmoqi1Rn
+        5VWpEcorrJewA6G9BW3tCQQxvAtu7qoBj9gO0sHbqFHmNPR4kUf3RR59GlQDwIaEMn7o9EjXYHI3
+        4DG4VwzHCyjiUB/pPqoRgI5zjg6zYsHGa8V9dhyElCZpC8pnbl6yvHiJnBEtQovUWMm6d/GzShj7
+        T36z9WJqmiyUNBYq+vu+lPjpltnAiNBckQ0/aKeODS1g93jGsQhMW67B1J+jdAc5MZJ5PZKiFaeg
+        zkCWhOYeoMYhTkODRTykFmrHWxVvQYfBmjDXoX1r61rP50fxmVokBjOg/+lkwyhO4wBz2Dn0aCgI
+        AheYpSUw5u0ICTK2T4Ii+MUwfNjw6z4ZJoCP+jgobq9RAhOHo38vO/skB7b3kbiYYIzsO4H5Ebn5
+        fGiwEnkr37F4auEIDhdwhCYbenQdxDJW5oMp316H24LDNrTOHJxxZN/gQcnorIr8vteW++T7UvIX
+        ZXhojSMjhmjrN5PtLmEOSlq8Sc/nfOCJ5C13cDjwSNHBnRqhZD1ihYlyNNO04R4RRYd7X/mxMXyM
+        5Raz8uBJBWl3GISsFZLjcTwApJLs3Z7RRQU0V9a5Y7zfveEheBKOptUxkRjebIiGwR6ho8Z6vLuj
+        cOFCcfV1AbuY0RnhjE7VaixluOjNCfSureNlZzivNTik3sVS12w9Zv8C+2R9z43h1x8PM6a8uZK3
+        /vjpnbz6ukmzlO/kRZXWq+et3K5qrLJ8/f5O3qL34oizG/knb6CwyGxBQ//7uj6+UN6xVxhjo5iw
+        j9//uFvU9tg5W36wMpJ+/UGVpuic1cG58F55EobiZt4YNiV8g9Ea9f0biVwfn3OdwzNfcw/ji/EQ
+        aj29oTpn244OlagaPJzw+umaQ66Ssma+4/b6mZ6LWNfWUYRBqr4dSjV7FSXxZYjy9o70oka6HlS8
+        oii8e1N6dGdV4YHU+A6tRa8jBokn63CeMGHboRPUh8/ZMh2+hloPMfJAEbf/ZxiHfXOKJmd0JWvt
+        dZbSFHeseWNVFUHqySbTwg3yhGx3mBEhnT528xhdbyoxlDiRyotSj4/1PhB6SkCZu7fyerV4/332
+        AJ/SDFDK28H0LtW3T/BstVp/tPSR5YkJ8+PZ8539cA+Yr2+3UyV7fw96iySkIME+vj18+y8AAAD/
+        /wMAAUaQ4EIRAAA=
     headers:
       CF-RAY:
-      - 992cbf1deda68157-SEA
+      - 999543ccd938685f-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -76,9 +85,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:24:33 GMT
+      - Tue, 04 Nov 2025 15:50:32 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=u2PJrffSZMlLhwqcxdts4VK3eqeeuiBaHdAeW_jfmPo-1762271432-1.0.1.1-B0hFkbNuOB7uW3gQjzJLlDIal28iudMINyx2HxtmQE2fWVBZxzWIG95x8Df5cyoJ9bZS6amVLgYCScYAXCu_z3JwyP_vbokPJvjSgs1QAyU;
+        path=/; expires=Tue, 04-Nov-25 16:20:32 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=XCzwAIV20pgz9XeiXkqB9gndJDTNuPQlP8yQ3tw9rXA-1762271432688-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -92,13 +107,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '24147'
+      - '29486'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '24152'
+      - '29490'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -106,55 +121,34 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '1999314'
+      - '1998994'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 20ms
+      - 30ms
       x-request-id:
-      - req_92e8961e4ea946dba297ab65259a5057
+      - req_ec32f1c7ff054f39bbfff7536a24c0bf
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"input\":[{\"content\":\"How many primes below 400 contain 79 as a substring?
-      Answer ONLY with the number, not sharing which primes they are.\",\"role\":\"user\"},{\"id\":\"rs_0ab4ebd2bc7242170068f96799c350819580541603dcce2ade\",\"summary\":[{\"text\":\"**Identifying
-      primes with substring \\\"79\\\"**\\n\\nI need to find prime numbers less than
-      400 that have the substring \\\"79.\\\" That means I should consider numbers
-      like 79, 179, 279, and 379. But now, I realize any numbers like 790 or higher
-      are not applicable since they're over 400. I\u2019ve ruled out any instances
-      where \\\"79\\\" is not in that exact order. So, the valid primes under 400
-      containing \\\"79\\\" are 79, 179, 279, and 379.\",\"type\":\"summary_text\"},{\"text\":\"**Checking
-      primality of numbers with \\\"79\\\"**\\n\\nI\u2019m looking at numbers that
-      contain \\\"79\\\" as a substring and checking if they are prime. The valid
-      numbers are 79, 179, 279, and 379. \\n\\nFor 79, it is indeed prime since it\u2019s
-      not divisible by any small primes. \\n\\n179 is also prime after checking divisibility
-      against smaller primes. \\n\\nHowever, 279 is composite because its digits sum
-      to 18, which is divisible by 3, and thus it\u2019s ruled out. \\n\\nI still
-      need to check the primality of 379!\",\"type\":\"summary_text\"},{\"text\":\"**Confirming
-      prime counts with \\\"79\\\"**\\n\\nI\u2019m checking the primality of 379.
-      I verified it against smaller primes: it isn\u2019t divisible by 2, 3, 5, 7,
-      11, 13, 17, or 19. So, it turns out 379 is prime!\\n\\nNow, counting the primes:
-      we have 79, 179, and 379, bringing the total to three. I checked for additional
-      numbers under 400 with the substring \\\"79,\\\" but only found those three.
-      Numbers like 197 and 97 don\u2019t count, so the final answer is three.\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing
-      prime count**\\n\\nI want to double-check the primality of 179. It has a remainder
-      of 4 when divided by 7, 3 when divided by 11, and 10 when divided by 13, confirming
-      that it's prime. So, I can confidently say we have three primes under 400. It\u2019s
-      important to clarify that we're looking for primes strictly less than 400. \\n\\nThe
-      final answer is simply \\\"3.\\\" Great, let's go with that!\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0ab4ebd2bc7242170068f967b1153c8195a162cecc2604f8db\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\",\"role\":\"user\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"}}"
+    body: '{"input":[{"content":"If you remember what the primes were, then share
+      them, or say ''I don''t remember.''","role":"user"}],"model":"gpt-5","previous_response_id":"resp_03efd3e35645773100690a20ab24d88190be5d1d2fd174909f","reasoning":{"effort":"minimal"}}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '2522'
+      - '251'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -176,27 +170,28 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xU247iMAx95yuqvOzLMGoLtMAf7DeMRpWbuEyW3JQ4aNCIf181hV52mH0DH/v0
-        2MfO1yrLmBTsmDGPwTU5tFtsRdnyutyWRZ3n1b47VHVbtBvI98Vh14p9t4e82mJdljUc2EtPYds/
-        yOlBY03AIc49AqFooMeKuiqKeretNwkLBBRDX8OtdgoJxVDUAj+fvI2m19WBCjiEpVLSnNgx+1pl
-        WZYxB1f0fb3ACyrr0LNVlt1SMnpve8xEpVJAmsdXGoEEUoUlGshHTtKaRVzDZ2MjuUgN2TN+B8la
-        1XBQSzptBape2cnRercu83K3zvfrvL5PKzGyY/aWGhnamYwIP9tQQseTDSCKncihg67iyA9FIk4k
-        dHU4GAHBmn5gIxSi1uCv/YffU+z28kyADqf/KBD7IinYH6oSNlhtsCpzsSu/K9AYApxw9v0fHE8g
-        t4bQTFOZC1vQPvzATxqrUwIYYwkeHr69L0BlT87b9gmSiI4Z+50Ja35R5lGjbtG/sjHrdv81FjJv
-        VRIDIchAYGhI7hNTEnPgQSlUyw0hH4dldh4v0sbQPO6lSbMfN8h5qx01HPgHNme8zrHJ2fEUsOus
-        T11oaaQGdZ/MzPK+fDyPAB3StZECDclO4uJUAvqL5NiQfJxXB1ENw2aBrMd5J4TaoQeKKVy85vdo
-        GupdXme9hun/zMyUN99FdkHf2iDpOqyQkFFPZz0M88NKPkw/kmUjMHnLyLpm5ng+Bt1co4+Gp31J
-        XcoArXq8QTFt7tiANIsnoCpfvsdn78rYZvJPTIX5otV/X5YifwY84x1X4CdqsgRqAutyHGEMS7c1
-        Eggg6Olvq9tfAAAA//8DAK5EiJUSBgAA
+        H4sIAAAAAAAAAwAAAP//jFTBbqMwEL3nK5Ave2lWBhIg+YP9hqpCgz2k3hob2eOoUZV/X9kkBLbt
+        am8wb+Z5PO+NPzZZxpRkx4w59GPLS+xlieW+2u3rusw5rw4cCi4aWedNkx94AwesyoPIZSXkTnL2
+        FCls9xsF3Wms8TjFhUMglC1ELK+roqjzXVkkzBNQ8LFG2GHUSCinog7E28nZYGJfPWiPU1hprcyJ
+        HbOPTZZlGRvhgi7WSzyjtiM6tsmya0pG52zETNA6BZS5n9JKJFDar1FPLghS1qziA7y3NtAYqCX7
+        hp9Bsla3AvSabrASdezsNNJ2vy14sd/yZsvr27QSIztmz+ki03UeQvjvZThUUu6iDFA3vAJRyqbJ
+        mxJEIk4kdBlxEgK8NXFgM+TDMIC7xINfUuz69FUDgz/9o4OubETsoAPZ8x4rLoQAua8+dzCg93DC
+        xfnfKJ5AYQ2heUxl2diK9q4HvtNcnRLAGEtw1/D5ZQVqexqd7b5AEtExY78yac0PyhwOOHTofrI5
+        63r7mguZszo1A94rT2BoSo6JKYmN4EBr1GuHkAuTmUeHZ2WDb+/70v7HFkJX7GTawg73MpdFL/N6
+        d+CHnt1I7TBSK0C8YvuGl6UlV5jDOGplzTLjYZh5w7DvrUvDGZRRA+jbwBdOiuXz1nnokS6tkpG9
+        V7jaQI/urAS2pO5b20PQk4bMk3W4HBDhMKIDCimc/+S3aNLq1l5v3QCP/4VHUt7S4uyMrrNe0WVy
+        plRheLwWk0avVolJ1ECWzcDDMozs2C6MxOfguOzRBSPgNl0mlYdO35+2kBZivoAyq5elKp4+xxfP
+        1XzNpKJ8FPLVVf9+sHL+FfAV72yB76jJEugHWBfzCINfqz0ggQSCSH/dXP8AAAD//wMAX5kzxmkG
+        AAA=
     headers:
       CF-RAY:
-      - 992cbfb62cd38157-SEA
+      - 999544868bd5685f-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -204,7 +199,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:24:35 GMT
+      - Tue, 04 Nov 2025 15:50:34 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -220,13 +215,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1568'
+      - '1721'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1575'
+      - '1726'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -240,7 +235,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_e04b6104977a44c8a9c7c979c4107b65
+      - req_129cee75e1344cb68053ee815b3430e8
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/async_stream.yaml
@@ -7,12 +7,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '235'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -34,1097 +38,1121 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_00b850169f72b9300068f967b3efc88194826c101238508994\",\"object\":\"response\",\"created_at\":1761175476,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_00b850169f72b9300068f967b3efc88194826c101238508994\",\"object\":\"response\",\"created_at\":1761175476,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Counting\",\"obfuscation\":\"6blNKT\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        substring\",\"obfuscation\":\"Svk817\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        primes\",\"obfuscation\":\"SeeGNDe6M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"RBzfOcKPgzP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        need\",\"obfuscation\":\"EI54Jj66pVv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        to\",\"obfuscation\":\"QLSvCGsus3Uoe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        count\",\"obfuscation\":\"WuFCkMo2Oi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"NR6vD75P5Od5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"hlRQxHgxst\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"gv0m4Pyl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        less\",\"obfuscation\":\"sZ58PrQFU1e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        than\",\"obfuscation\":\"Lc8V6l1f6rO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"ORuGm8GTEf0O\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        that\",\"obfuscation\":\"R5Alu5td3Ps\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        contain\",\"obfuscation\":\"TBydV4Fn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"71Ynyr7a4NZRPK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"FAw9ILgiEy1xgj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"X9aC9plO6N9JE8C\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        as\",\"obfuscation\":\"W97vhIqzoGW2c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        a\",\"obfuscation\":\"YjzcXr7XB1wCWH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        substring\",\"obfuscation\":\"WmEwVL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"ydK54TfzDj6SqD8\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        which\",\"obfuscation\":\"Hf3GScSC9r\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        means\",\"obfuscation\":\"Hk3yRCI50f\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"PX9hJXfVfY7G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        digits\",\"obfuscation\":\"dZKGZ2x3T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        should\",\"obfuscation\":\"7KtDwro8N\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        include\",\"obfuscation\":\"L18fRlQy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"FyrB8fr0CpGd7p\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"9mIPNDENK00l2C\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"mXGCQ85dOarh6Jb\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        together\",\"obfuscation\":\"hEGLHJK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"R0yFpt1wp4MGhnn\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\n\\nOkay\",\"obfuscation\":\"IG3fe8Qpv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"hZmka7Gz9618z9J\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        so\",\"obfuscation\":\"ltt1MXlEAOXgB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"ySnr1jHDefQs3x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        start\",\"obfuscation\":\"lqw65Tqy6u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        with\",\"obfuscation\":\"vzVi1TuvtW4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"FpMqa8cNbqoMZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"KbnbdplzSazJVur\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        which\",\"obfuscation\":\"w2vzITmQFR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        is\",\"obfuscation\":\"uM1bJgV5UJj2u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"dvlzSyN2vE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"6FbK4Mndn8n1ZVH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        Next\",\"obfuscation\":\"2fWfLmDLRS8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        is\",\"obfuscation\":\"F8sravIFCEOB9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        179\",\"obfuscation\":\"nNey19vtuSD4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\";\",\"obfuscation\":\"tRA3iTGLdiYGJIY\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        that\",\"obfuscation\":\"MJfSzPAcvoK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        also\",\"obfuscation\":\"LXG8geSkVB9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        works\",\"obfuscation\":\"1MU1aoGcql\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        since\",\"obfuscation\":\"2G2raU9vVw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        it\",\"obfuscation\":\"NPiE9jnmGQS1q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        has\",\"obfuscation\":\"suOOuKGxzpRn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\\"\",\"obfuscation\":\"jjnQSFFMXM9ZYk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"hUAFGTU5GcZMAQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"QYfVrbpkWP4dtrz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        at\",\"obfuscation\":\"GyfKnUdAheyGX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"GZ6FK1089dZT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        end\",\"obfuscation\":\"NoTBbFQSjjVm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"1OwDSe1kpPoQvNU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        For\",\"obfuscation\":\"Khf3tNP2I6yg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        197\",\"obfuscation\":\"tMUaolKyqKL9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"oPECMjptFnyVWvX\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        it\",\"obfuscation\":\"U6qxSKsU8qVe6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        doesn\",\"obfuscation\":\"EOj7M3f3qW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019t\",\"obfuscation\":\"VUSKlSZLyDJJLd\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        count\",\"obfuscation\":\"sWOzcvi67W\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        because\",\"obfuscation\":\"TPApm0uh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"XhpvGAvZVybC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        digits\",\"obfuscation\":\"bxcUdS9L2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        are\",\"obfuscation\":\"AKFo9zh8984T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        1\",\"obfuscation\":\"tXkSgBQfm7PaZw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-\",\"obfuscation\":\"fDuYeOegKBa9UVH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"9\",\"obfuscation\":\"7Ir1YWD1P96l15A\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-\",\"obfuscation\":\"0MID2Sjxr72x5Z9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"7\",\"obfuscation\":\"WolO85RxxMG6HkC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"HjIaAVHqwKcyqhz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"QDMp7xFFwVSOs5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        check\",\"obfuscation\":\"RUJ7yMVta9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        others\",\"obfuscation\":\"H2Qogw9xA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        too\",\"obfuscation\":\"z5LBFRWPeaTg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"DY9dc5py1F1KSYP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        like\",\"obfuscation\":\"5SO1IxQK1wS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        279\",\"obfuscation\":\"HdzGwLmnMyrX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"Jdhzg6oYKZPXtYE\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        379\",\"obfuscation\":\"5KCEcfCmNhoZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2014\",\"obfuscation\":\"ZYqngLbRpcxmYLu\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"actually\",\"obfuscation\":\"IpYiXVHU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"iZ57FRVV9TGQIFy\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        379\",\"obfuscation\":\"euhEW4useRrX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        works\",\"obfuscation\":\"Pf59ZdJQyI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":97,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2014\",\"obfuscation\":\"aJ2ljrh7mrI8MaI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":98,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"now\",\"obfuscation\":\"TcmGugzQdGPyq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":99,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        for\",\"obfuscation\":\"jFsTsY8gXari\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        others\",\"obfuscation\":\"3Thr5w5ha\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        up\",\"obfuscation\":\"zQErlbLCV5hGM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        to\",\"obfuscation\":\"sEDywQp7J4HO7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        399\",\"obfuscation\":\"TnkgyWKX44jX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":104,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"MV3AHHh6sMJ0lbA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":105,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        \\n\\nBut\",\"obfuscation\":\"ia3RxmQVS6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":106,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        793\",\"obfuscation\":\"7gx338TgbGUx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":107,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        is\",\"obfuscation\":\"bfMwItwdYZkSc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        over\",\"obfuscation\":\"0OsFEes4fNv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        my\",\"obfuscation\":\"K3RQyjDN5J5km\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":110,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        limit\",\"obfuscation\":\"sOqCotTMhV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":111,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"pSres9LAnFRpXaD\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":112,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        so\",\"obfuscation\":\"oachLJDpjgMHl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":113,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"GSue4LKZYDagG8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019ll\",\"obfuscation\":\"w2OEnxDby7vZr\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        focus\",\"obfuscation\":\"8EDKYMx25B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        only\",\"obfuscation\":\"LPAiUuoR6kt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        on\",\"obfuscation\":\"Ur39QeYorCpR1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"Azog8T5Q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        below\",\"obfuscation\":\"WOZqAjGtgE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"pjRPZB91W217\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"bRBR6tAHBbWby13\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":122,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Counting
-        substring primes**\\n\\nI need to count the prime numbers less than 400 that
-        contain \\\"79\\\" as a substring, which means the digits should include \\\"79\\\"
-        together. \\n\\nOkay, so I start with 79, which is prime. Next is 179; that
-        also works since it has \\\"79\\\" at the end. For 197, it doesn\u2019t count
-        because the digits are 1-9-7. I check others too, like 279, 379\u2014actually,
-        379 works\u2014now for others up to 399. \\n\\nBut 793 is over my limit, so
-        I\u2019ll focus only on numbers below 400.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":123,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
-        substring primes**\\n\\nI need to count the prime numbers less than 400 that
-        contain \\\"79\\\" as a substring, which means the digits should include \\\"79\\\"
-        together. \\n\\nOkay, so I start with 79, which is prime. Next is 179; that
-        also works since it has \\\"79\\\" at the end. For 197, it doesn\u2019t count
-        because the digits are 1-9-7. I check others too, like 279, 379\u2014actually,
-        379 works\u2014now for others up to 399. \\n\\nBut 793 is over my limit, so
-        I\u2019ll focus only on numbers below 400.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
-        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":124,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Analy\",\"obfuscation\":\"Umy8Lj3tG\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":126,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"zing\",\"obfuscation\":\"xEXEPDfVDtKL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":127,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"t8KZBUSxsU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":128,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        candidates\",\"obfuscation\":\"LEfOt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"PbqKIbJZVPj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019m\",\"obfuscation\":\"iAJJevFk2gO3fL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        looking\",\"obfuscation\":\"R3btNVzz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        into\",\"obfuscation\":\"ViHxJdGaF8a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        numbers\",\"obfuscation\":\"x31rmtPf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        with\",\"obfuscation\":\"DpdveZHzuE7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\\"\",\"obfuscation\":\"o3ZdGvhJZvnHY7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"aswMSUPE36qRWE\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"nnO7W4qCJXsaHvG\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        in\",\"obfuscation\":\"qIxvKZtk8F1kR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        them\",\"obfuscation\":\"JvgetaUTpPL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"muGct48LundlM9Y\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        For\",\"obfuscation\":\"3zDvh3zMhg5x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        three\",\"obfuscation\":\"S6G5dwU2fj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"-digit\",\"obfuscation\":\"OnThV6IM6H\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        numbers\",\"obfuscation\":\"eDIKDgoj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        below\",\"obfuscation\":\"iQxWX4bbZF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        400\",\"obfuscation\":\"oHlcQ1CeDqEm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"2GcWW01p99RXRnL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"zlY6GJPkvNthDS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        see\",\"obfuscation\":\"cnQFVTLbXFOt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        patterns\",\"obfuscation\":\"4s1Qh1l\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\":\",\"obfuscation\":\"oRtrU7p3o93igdV\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        those\",\"obfuscation\":\"MH1pzh95P6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        ending\",\"obfuscation\":\"9VAnAlwa3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        in\",\"obfuscation\":\"n4V5R0qFvtxpy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        79\",\"obfuscation\":\"VXIz3th3agMBK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        (\",\"obfuscation\":\"gDrQqmA0WmV1eC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"like\",\"obfuscation\":\"p1hYylqmBRac\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"URlQ33KDVTsq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"M1NQ3kmjFFSffbP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"So8LBjG7rSxF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"r5u98Ox3oQ3MIHZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"z58raO4Ur6mr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\")\",\"obfuscation\":\"6NmJQnqSqzgWdNB\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"T1IzoIfdzkrI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        starting\",\"obfuscation\":\"Zg6rrQF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        with\",\"obfuscation\":\"l6IuoGSimnJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        79\",\"obfuscation\":\"xxiaKe3RFNyzm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        don\",\"obfuscation\":\"Nm00T4JBR0wz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019t\",\"obfuscation\":\"Z1L9yc5F9hAmgN\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        count\",\"obfuscation\":\"axppT0mfri\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        since\",\"obfuscation\":\"CfAQViuK6w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        they\",\"obfuscation\":\"oICSwc1kFps\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        exceed\",\"obfuscation\":\"3xSnAPLpx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        400\",\"obfuscation\":\"GyasZsdCuonl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"9YFnBnxefsVAzt6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\n\\nThe\",\"obfuscation\":\"Nvmko47eAt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        only\",\"obfuscation\":\"FmNRcqIJPRK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        two\",\"obfuscation\":\"pILHXjPvPyF8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"-digit\",\"obfuscation\":\"llIHhJmQtL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        option\",\"obfuscation\":\"DA7zxzESS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"mynwKyIPP3xuL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        79\",\"obfuscation\":\"8tSIUBB3Rs41H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        itself\",\"obfuscation\":\"oGPH0B6we\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"N2CBs88bV7KeEBX\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"GHCYfm3MNR9JFt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        already\",\"obfuscation\":\"K2Ep1VF4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        checked\",\"obfuscation\":\"tfHFPNbb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"WiA22lWMjvsa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        endings\",\"obfuscation\":\"PCEXt8vW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\";\",\"obfuscation\":\"vbz1Px9ayBrVaey\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        now\",\"obfuscation\":\"XmYgdKFnC374\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"TSgnfzzcKcCf0G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        realize\",\"obfuscation\":\"TD8gh0gA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"uv5towR2idOL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        isn't\",\"obfuscation\":\"A0t7cka9M4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"OcR2zRYEn5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        because\",\"obfuscation\":\"VBIGxxSq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it's\",\"obfuscation\":\"3lbxamOg2Ag\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        divisible\",\"obfuscation\":\"smwKr1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        by\",\"obfuscation\":\"UdhAAMnf3swxD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        3\",\"obfuscation\":\"5o6mtM4F5X6Z4s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"w8ecACe7yfU8AVk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        So\",\"obfuscation\":\"pF1geSQV6ZuuU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"rRICrGNoGzoqmIP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":205,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"FL0HhQJYszXsSc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":206,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        need\",\"obfuscation\":\"FoYRd1Q836I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":207,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"ENhqLXWiIf8iz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        verify\",\"obfuscation\":\"j7KmfKlbR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        if\",\"obfuscation\":\"IHYuf3qAmcFlw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"netj5rDGODhJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"92vaoLMfmrHaz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"ogaZkHkXq6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        next\",\"obfuscation\":\"N8eBYYDuEBR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"GBloAcUPwdKAf9S\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":215,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\n\\nThat\",\"obfuscation\":\"xnTdEdhLZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":216,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        nar\",\"obfuscation\":\"9SHsr24y5bij\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":217,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"rows\",\"obfuscation\":\"hpwtsY2WAPkj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        down\",\"obfuscation\":\"vqtsQKxexv4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        my\",\"obfuscation\":\"T4xbYuXlZZwvC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        candidates\",\"obfuscation\":\"hgHcD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        for\",\"obfuscation\":\"RNLBEVCm9Ogc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primes\",\"obfuscation\":\"UxZqrx5zA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":223,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        containing\",\"obfuscation\":\"pRrh0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":224,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        \\\"\",\"obfuscation\":\"S8kyJZ2VOD95UU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":225,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"dGFUI1U7nezXhI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":226,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"!\",\"obfuscation\":\"5xWrWtBqDI98vj\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":227,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Analyzing
-        prime candidates**\\n\\nI\u2019m looking into numbers with \\\"79\\\" in them.
-        For three-digit numbers below 400, I see patterns: those ending in 79 (like
-        179, 279, 379) and starting with 79 don\u2019t count since they exceed 400.
-        \\n\\nThe only two-digit option is 79 itself. I already checked the endings;
-        now I realize 279 isn't prime because it's divisible by 3. So, I need to verify
-        if 379 is prime next. \\n\\nThat narrows down my candidates for primes containing
-        \\\"79\\\"!\"}\n\nevent: response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":228,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Analyzing
-        prime candidates**\\n\\nI\u2019m looking into numbers with \\\"79\\\" in them.
-        For three-digit numbers below 400, I see patterns: those ending in 79 (like
-        179, 279, 379) and starting with 79 don\u2019t count since they exceed 400.
-        \\n\\nThe only two-digit option is 79 itself. I already checked the endings;
-        now I realize 279 isn't prime because it's divisible by 3. So, I need to verify
-        if 379 is prime next. \\n\\nThat narrows down my candidates for primes containing
-        \\\"79\\\"!\"}}\n\nevent: response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":229,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":230,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Ver\",\"obfuscation\":\"SqGOD6FQ1OJ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":231,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ifying\",\"obfuscation\":\"udMo9JftZL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":232,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"kCYJW6sF3n\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":233,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"dTB36Sju\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":234,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"mjn5TmNDP7q\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019m\",\"obfuscation\":\"qH0ZoNTMPzHoXK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        testing\",\"obfuscation\":\"gz4cnR1l\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        if\",\"obfuscation\":\"btN8ScBu1UtFp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"XGJGZmBf5Nit\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"NZJyIlLa9oD9h\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"Z9Tib6heKg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"c1VAefmFxVNgMxC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        The\",\"obfuscation\":\"jBG9otSjyUCC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        square\",\"obfuscation\":\"gBGHGDqXe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        root\",\"obfuscation\":\"aGuUZC9qqka\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"9K7N0OSrd7zJ2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        around\",\"obfuscation\":\"lWIXIQBQW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        19\",\"obfuscation\":\"4NvNKvHBRfqIs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"rJ2IgeOkkz8h1Zq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"4\",\"obfuscation\":\"HGDaGUrYziKmC0V\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"R5INMnzXZT26JvG\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        so\",\"obfuscation\":\"iebt7JKjyRlQt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"XtpARoHK7EGWDM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019ll\",\"obfuscation\":\"nCDxKGMvRw5se\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        check\",\"obfuscation\":\"fN2rETmzg1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primal\",\"obfuscation\":\"M5VKF9Zox\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ity\",\"obfuscation\":\"yYzXnWlc3SYaC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        against\",\"obfuscation\":\"sK7UdCGC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        smaller\",\"obfuscation\":\"UzfQ9Al1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"RtmW97BUv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        like\",\"obfuscation\":\"Jz0INEqv00Q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        3\",\"obfuscation\":\"UV5b2dlnWpHh0I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"2KVLH9Vk8M2vgzJ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        5\",\"obfuscation\":\"yLP7U9SkyK2TGG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"viIHQAFxiRScChE\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":265,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        7\",\"obfuscation\":\"BUjlV3DoaXVkdr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":266,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"y7qssXdQuYPFL1e\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":267,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        11\",\"obfuscation\":\"7xjNgFs80PGrB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"RzyPNJAcU2tFaxv\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        13\",\"obfuscation\":\"Ov46Ld2bPyn7A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"P4qJ5YrXJtuxcK8\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        17\",\"obfuscation\":\"T9DtDoXAeJeC8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"lpnsa6Y00yf6iGH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"N7zIJ32gQosz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        19\",\"obfuscation\":\"J7zZ21gc2KriW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"29kzHwXN9IAXuSB\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        It\",\"obfuscation\":\"WynivXLfi6Fxo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019s\",\"obfuscation\":\"9oBShTRsponDsf\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        not\",\"obfuscation\":\"l7qkVZYuMMnR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        divisible\",\"obfuscation\":\"9J1IUD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        by\",\"obfuscation\":\"AO6tJhdfp846y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        any\",\"obfuscation\":\"89K38rUVntD8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        of\",\"obfuscation\":\"cja30ih7dS1rM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        those\",\"obfuscation\":\"Wps9SGQRtD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"1s452U1ZF0teHim\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\n\\nNext\",\"obfuscation\":\"54drSybf3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"7CcrUs4MqkkGKbB\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"PLY2p9HzPxN1qX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        check\",\"obfuscation\":\"cCCaOGcl1Q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"QtVMd4i3DXJX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"LeXizaeXiNYDUZp\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"4NDwg3FM5mAo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        it\",\"obfuscation\":\"fvaDLviaa9ohc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019s\",\"obfuscation\":\"tdDN4GL7zASs35\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"BJFLpmDOKr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        too\",\"obfuscation\":\"08VYjgWNvaS3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"me2gyIJbY1S5tjn\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        So\",\"obfuscation\":\"Ctky4FD4C7Nm4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        far\",\"obfuscation\":\"9uL47ayjJl8H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"aOIvPmPGbqNddox\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"yxXkZdaO7tqzr8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        have\",\"obfuscation\":\"OEjAORJ8YdI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"tptNMDBByFY33\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"10sCZJV7Rh8hqAH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"pg1eUxWP7sjj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"mEQtGZ6QBH8s3Gs\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"llsQFvJWXJZE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"tla3j2Ds4Ezy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        as\",\"obfuscation\":\"6jc4rOpEKNLb1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"N1z7O7jiU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"mUhggeepsOJfnHK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"5lMJQI2OI2zHjn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        wonder\",\"obfuscation\":\"HPk6lZgAU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        if\",\"obfuscation\":\"Sb7LqYCpPOOEf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        there\",\"obfuscation\":\"0K5ENZkPvE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"p62Lb7HKCHoC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        others\",\"obfuscation\":\"4y0rphjju\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        below\",\"obfuscation\":\"WfZGLzwdaT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"9aJKwtBegA8O\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"i3ZHAy00LJLEdA9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\n\\nBut\",\"obfuscation\":\"zzYfEs8q27\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        297\",\"obfuscation\":\"QY208FrLcPZt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        doesn\",\"obfuscation\":\"8WQ8JR25kY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019t\",\"obfuscation\":\"w9RsKAW69GNLkU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":324,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        count\",\"obfuscation\":\"5tkIbao4Hc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":325,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"IoWpo26FWmHo9IE\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":326,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        since\",\"obfuscation\":\"dIQ0ctNrpg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":327,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        it\",\"obfuscation\":\"PFg3I64MZcGr1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":328,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        doesn't\",\"obfuscation\":\"ELAmWvVN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":329,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        have\",\"obfuscation\":\"XnthmkBgNCp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":330,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\\"\",\"obfuscation\":\"hx3lQ9FHvYTyCV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":331,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"QyRvPdPJv4WAQP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":332,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\"\",\"obfuscation\":\"pPJUQ8jYC4IvlPu\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":333,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        together\",\"obfuscation\":\"bgT5f94\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":334,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"VXe0xsiHOdnl195\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":335,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"GjlRAbfW17eX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":336,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        790\",\"obfuscation\":\"2fXv4GJi6tkq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":337,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"dN7NFVsEhhQhs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":338,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        over\",\"obfuscation\":\"dNDLefHvfHV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":339,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        my\",\"obfuscation\":\"PFa131fCj4IDB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":340,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        limit\",\"obfuscation\":\"cNwtltQJMV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":341,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"ZxEKjz46lbwjiry\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":342,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        So\",\"obfuscation\":\"zU30wiV8SEscG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":343,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"PxktlwtMFq91uqc\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":344,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"hQ3mv9Ooi5QN9U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":345,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019m\",\"obfuscation\":\"5n92s0YaFrCoJ6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":346,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        stuck\",\"obfuscation\":\"UwgsPeqncY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":347,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        with\",\"obfuscation\":\"xJ7oN7NWVpG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":348,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        those\",\"obfuscation\":\"ZRvr7l2wbo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":349,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        three\",\"obfuscation\":\"u4D7Df4HNM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":350,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"!\",\"obfuscation\":\"M2wyWOntLjpQpMy\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":351,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Verifying
-        prime numbers**\\n\\nI\u2019m testing if 379 is prime. The square root is
-        around 19.4, so I\u2019ll check primality against smaller primes like 3, 5,
-        7, 11, 13, 17, and 19. It\u2019s not divisible by any of those. \\n\\nNext,
-        I check 179, and it\u2019s prime too. So far, I have 79, 179, and 379 as primes.
-        I wonder if there are others below 400. \\n\\nBut 297 doesn\u2019t count,
-        since it doesn't have \\\"79\\\" together, and 790 is over my limit. So, I\u2019m
-        stuck with those three!\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":352,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Verifying
-        prime numbers**\\n\\nI\u2019m testing if 379 is prime. The square root is
-        around 19.4, so I\u2019ll check primality against smaller primes like 3, 5,
-        7, 11, 13, 17, and 19. It\u2019s not divisible by any of those. \\n\\nNext,
-        I check 179, and it\u2019s prime too. So far, I have 79, 179, and 379 as primes.
-        I wonder if there are others below 400. \\n\\nBut 297 doesn\u2019t count,
-        since it doesn't have \\\"79\\\" together, and 790 is over my limit. So, I\u2019m
-        stuck with those three!\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
-        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":353,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":354,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**Final\",\"obfuscation\":\"yP5idxHGf\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":355,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"izing\",\"obfuscation\":\"uV7N1DGxrAl\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":356,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"KRe70mc4js\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":357,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"mlkxRXUHKA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":358,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"nqE4On1jAGi\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":359,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        realize\",\"obfuscation\":\"RIRgQYMS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":360,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"6gXyOQC8gKM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":361,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        since\",\"obfuscation\":\"umj6NuSw94\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":362,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"01NCY3031Jl6iv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":363,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"substring\",\"obfuscation\":\"VUV9CT4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":364,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"nBqnxH3sbjqC13B\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":365,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        refers\",\"obfuscation\":\"ieHuuHO0O\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":366,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        to\",\"obfuscation\":\"UxyGcty50dbjg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":367,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        something\",\"obfuscation\":\"efFkML\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":368,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        contiguous\",\"obfuscation\":\"0C8UY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":369,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"m2xdf3mBsGoeeGA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":370,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        97\",\"obfuscation\":\"J6kiGfffeZD5m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":371,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        can't\",\"obfuscation\":\"xIL2HC6W0u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":372,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"yspwzz0RWw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":373,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        as\",\"obfuscation\":\"gQDewBnbs9Oj9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":374,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"JUXUMwYzDafmcx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":375,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"UNLgUWFIXtqOdp\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":376,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"4YYIFCVIP8ykIg6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":377,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        reversed\",\"obfuscation\":\"pxRS02i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":378,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"r6qWzPoIHROJu6L\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":379,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        So\",\"obfuscation\":\"I2enObkIvApAZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":380,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"HiVONv1fWuVyklG\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":381,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"Xed8vBF4veloT3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":382,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        still\",\"obfuscation\":\"eEmnNn6zUe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":383,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        think\",\"obfuscation\":\"8WFacwoVrb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":384,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        there\",\"obfuscation\":\"fZ4ZX2zkTI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":385,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        are\",\"obfuscation\":\"2sqICQBhxwyf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":386,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        3\",\"obfuscation\":\"Cz6L4saC9mG8lK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":387,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        valid\",\"obfuscation\":\"vAKwBDxwNV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":388,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"pkMkUe2uV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":389,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\":\",\"obfuscation\":\"khbrDGhJc1uIuE5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":390,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        79\",\"obfuscation\":\"J7dY808H88jJq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":391,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"UhujW8NF7k8Qxua\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":392,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        179\",\"obfuscation\":\"wiAIq6hBX779\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":393,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"CCjP5UCCTGN0UEq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":394,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"MNk44qvFPN4q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":395,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"OtAqTrltwBVL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":396,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"q5qqdJDOlYWwt2L\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":397,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"dttjXwivqtcoIQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":398,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        double\",\"obfuscation\":\"NPz6VcLbj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":399,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"-check\",\"obfuscation\":\"KMwBMLtqtu\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":400,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        other\",\"obfuscation\":\"dQOqYUy4dx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":401,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        three\",\"obfuscation\":\"ELYA2KsZ0B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":402,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"-digit\",\"obfuscation\":\"80XP1uJjhG\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":403,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        possibilities\",\"obfuscation\":\"Mr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":404,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        starting\",\"obfuscation\":\"YQB0ze1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":405,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        with\",\"obfuscation\":\"elmVTKKzc4E\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":406,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\\"\",\"obfuscation\":\"RLK9Z8SW93JKNp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":407,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"ENP5Z0D83J1zp0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":408,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\\\"\",\"obfuscation\":\"rNPRPUR9PP8Fz0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":409,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        but\",\"obfuscation\":\"KhvoKa29tKBH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":410,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        none\",\"obfuscation\":\"stdktafoM1M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":411,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        qualify\",\"obfuscation\":\"GU4gtAa4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":412,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        since\",\"obfuscation\":\"fuu9b9CDWo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":413,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        they\",\"obfuscation\":\"4UFKfm02kbm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":414,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019d\",\"obfuscation\":\"nnqNW8MEElfqKe\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":415,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        exceed\",\"obfuscation\":\"2l5eSXBsj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":416,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        400\",\"obfuscation\":\"zvWs3PCWbqbO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":417,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"zAFshJwcCmxMilh\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":418,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\n\\nI\",\"obfuscation\":\"1owd0qYNtHFk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":419,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        confirmed\",\"obfuscation\":\"der61m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":420,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        each\",\"obfuscation\":\"oeIHwe3ZbS5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":421,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        candidate\",\"obfuscation\":\"lf1js1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":422,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\":\",\"obfuscation\":\"qgPIt0ifCOZO5ug\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":423,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        79\",\"obfuscation\":\"F83KgnXrWo2Y3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":424,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"I11VHrPLttPmqzz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":425,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        179\",\"obfuscation\":\"1DWcwQ5aMk5Q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":426,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"282xkCwZnqFIeGL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":427,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"eSfhnvof3pCi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":428,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"jNaAIyRddm89\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":429,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        are\",\"obfuscation\":\"ZeL49wxs32c5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":430,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"ekHSNpe0C\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":431,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"Iis18qbJtgmSA4d\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":432,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        while\",\"obfuscation\":\"iAa6q49lxH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":433,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        279\",\"obfuscation\":\"uHGYiefGUuuL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":434,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        isn\",\"obfuscation\":\"jPs9xhkJ8DoE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":435,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019t\",\"obfuscation\":\"UaQ6tIpWpv41Xg\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":436,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"4Gb5FICU70wMHY9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":437,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        Thus\",\"obfuscation\":\"gtUOfVREjx6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":438,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"7t2OquHmmnUcZPl\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":439,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"CHACpAgDKAul\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":440,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        total\",\"obfuscation\":\"ArrXqMQArV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":441,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        count\",\"obfuscation\":\"fhgEkGD3O1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":442,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        remains\",\"obfuscation\":\"cI5FHcUf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":443,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        three\",\"obfuscation\":\"CAO4VfDUyc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":444,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"U4NhPABO33WLpAj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":445,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"3vf7ABVIsrqZVl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":446,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019ll\",\"obfuscation\":\"ddfThqdyJ8m6a\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":447,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        summarize\",\"obfuscation\":\"SMYlri\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":448,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"smpfvtJxCL0S\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":449,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        answer\",\"obfuscation\":\"u6VrN3VMQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":450,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        as\",\"obfuscation\":\"mZaE3hUY5w75G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":451,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \u201C\",\"obfuscation\":\"XGyY0Zrnr8FCzH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":452,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"3\",\"obfuscation\":\"kfzLIO8SVgiFnFj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":453,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u201D\",\"obfuscation\":\"53x1EADT0daU7M1\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":454,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"9MJKOelZumY0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":455,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        make\",\"obfuscation\":\"Q4cqdYMj9QE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":456,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        sure\",\"obfuscation\":\"WGbnq9MePCo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":457,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        everything\",\"obfuscation\":\"CNkeA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":458,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"oMbw59I17J6Qi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":459,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        accurate\",\"obfuscation\":\"bANA9r9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":460,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"Bjaa04pHRb6jqEO\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":461,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"text\":\"**Finalizing
-        prime count**\\n\\nI realize that since \\\"substring\\\" refers to something
-        contiguous, 97 can't count as \\\"79\\\" reversed. So, I still think there
-        are 3 valid primes: 79, 179, and 379. I double-check other three-digit possibilities
-        starting with \\\"79,\\\" but none qualify since they\u2019d exceed 400. \\n\\nI
-        confirmed each candidate: 79, 179, and 379 are primes, while 279 isn\u2019t.
-        Thus, the total count remains three. I\u2019ll summarize the answer as \u201C3\u201D
-        and make sure everything is accurate.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":462,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"**Finalizing
-        prime count**\\n\\nI realize that since \\\"substring\\\" refers to something
-        contiguous, 97 can't count as \\\"79\\\" reversed. So, I still think there
-        are 3 valid primes: 79, 179, and 379. I double-check other three-digit possibilities
-        starting with \\\"79,\\\" but none qualify since they\u2019d exceed 400. \\n\\nI
-        confirmed each candidate: 79, 179, and 379 are primes, while 279 isn\u2019t.
-        Thus, the total count remains three. I\u2019ll summarize the answer as \u201C3\u201D
-        and make sure everything is accurate.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
-        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":463,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":464,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**Deliver\",\"obfuscation\":\"DvAaDiZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":465,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"ing\",\"obfuscation\":\"iUCLklVOPTtz5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":466,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        the\",\"obfuscation\":\"InNE71hVzIiF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":467,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        answer\",\"obfuscation\":\"f5wJV8ZRl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":468,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**\\n\\nThe\",\"obfuscation\":\"Qz4RB5Mzc\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":469,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        user\",\"obfuscation\":\"N8evkxWNyA7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":470,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        wants\",\"obfuscation\":\"HNtSG8UZZc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":471,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        a\",\"obfuscation\":\"Lt8Kkb5399QVfJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":472,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        straightforward\",\"obfuscation\":\"\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":473,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        response\",\"obfuscation\":\"S2gkRXe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":474,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"0iRP7gbWaRVodkC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":475,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        just\",\"obfuscation\":\"jBYipFkT4RW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":476,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        the\",\"obfuscation\":\"Tq1D4EIlqlAu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":477,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        number\",\"obfuscation\":\"v8Dohgygi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":478,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        without\",\"obfuscation\":\"hsqj3CXS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":479,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        explanations\",\"obfuscation\":\"v6r\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":480,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"0wKAFOPztkSXLDu\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":481,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        I\",\"obfuscation\":\"uA9xfo4XGLSBmg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":482,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        need\",\"obfuscation\":\"HtYpd3RSJ3S\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":483,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        to\",\"obfuscation\":\"A05zmSgQE5poX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":484,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        stick\",\"obfuscation\":\"5QZ3f0kLnX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":485,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        to\",\"obfuscation\":\"ZB8Q29QqMdZnp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":486,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        that\",\"obfuscation\":\"Vwswq5sl1pM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":487,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        and\",\"obfuscation\":\"EVNpH2mxaAfQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":488,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        confirm\",\"obfuscation\":\"EhszKQrG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":489,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        again\",\"obfuscation\":\"DKNKZSX0je\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":490,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\":\",\"obfuscation\":\"tEy5Ug2WPbp0Yio\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":491,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        the\",\"obfuscation\":\"ML1w9bl1vzpB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":492,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        count\",\"obfuscation\":\"nUofYdNVqo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":493,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        is\",\"obfuscation\":\"2XKqIAeu8d0U7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":494,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        indeed\",\"obfuscation\":\"03QEahqRV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":495,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        \\\"\",\"obfuscation\":\"yNk72URczuq0wZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":496,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"3\",\"obfuscation\":\"Lav9pmgcwWqwYk9\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":497,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\\\"\",\"obfuscation\":\"g5uM8tcBYv7cbn\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":498,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        \\n\\nI\",\"obfuscation\":\"eEf45mcBQw13\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":499,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019ll\",\"obfuscation\":\"RDHJwgnVhgdGc\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":500,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        double\",\"obfuscation\":\"b2KP0A9wa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":501,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"-check\",\"obfuscation\":\"CWRqWoZkgj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":502,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        for\",\"obfuscation\":\"TvClkuFBEzdg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":503,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        any\",\"obfuscation\":\"7tOmcYZiMzqR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":504,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        primes\",\"obfuscation\":\"0vjxfULEL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":505,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        like\",\"obfuscation\":\"JoQe2oqwgJt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":506,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        197\",\"obfuscation\":\"GFMXTbBmAYFS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":507,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"E862JkpdyMAyF33\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":508,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        but\",\"obfuscation\":\"5O0GlH14jeGQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":509,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        it\",\"obfuscation\":\"Vhu9RZ28XW4v0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":510,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        doesn't\",\"obfuscation\":\"mpELiJEp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":511,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        have\",\"obfuscation\":\"KxjIxn1LFT6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":512,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        \\\"\",\"obfuscation\":\"Cemuv5u8c3kDuG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":513,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"79\",\"obfuscation\":\"XZQLvCwxjN64NQ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":514,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\\\"\",\"obfuscation\":\"J4jmVkl2rWXRvt\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":515,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        And\",\"obfuscation\":\"VzhHK0hf7PlI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":516,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        297\",\"obfuscation\":\"eYvJjhgTSOuR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":517,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        isn\",\"obfuscation\":\"C8Rd0NvzCbBE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":518,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019t\",\"obfuscation\":\"R0CRVE9bpY9LKW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":519,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        prime\",\"obfuscation\":\"6MQIl2QQWW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":520,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"cV73fcE8NrSJlts\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":521,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        nor\",\"obfuscation\":\"8p896KDsbpx3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":522,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        does\",\"obfuscation\":\"6XC9TkrTL64\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":523,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        it\",\"obfuscation\":\"fEqkp8NvbwtGL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":524,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        contain\",\"obfuscation\":\"588Na4sF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":525,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        the\",\"obfuscation\":\"eoYadWhYSrWY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":526,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        substring\",\"obfuscation\":\"lGAK2X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":527,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"HxY7R0JU0jROHIW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":528,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        So\",\"obfuscation\":\"hXzq3xUddSFVV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":529,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        I\",\"obfuscation\":\"nHU19cwhvdAqhF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":530,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019m\",\"obfuscation\":\"ARQ10ZuuP0H5fA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":531,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        all\",\"obfuscation\":\"R8yotpibgV7U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":532,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        set\",\"obfuscation\":\"x0O8m1YsK8pn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":533,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        to\",\"obfuscation\":\"AgFNYfP2TOqrK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":534,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        deliver\",\"obfuscation\":\"GjbQvjK9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":535,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        the\",\"obfuscation\":\"kVEtY65FNbss\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":536,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        answer\",\"obfuscation\":\"YiOSuPtl3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":537,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        without\",\"obfuscation\":\"py2sM8Mz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":538,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        any\",\"obfuscation\":\"Gdl7Ca4lBrxe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":539,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        additional\",\"obfuscation\":\"FoPNI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":540,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        text\",\"obfuscation\":\"rcayQhOoozS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":541,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"gJYDYHUlW2ngm5V\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":542,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        The\",\"obfuscation\":\"6lyYdxyIJeRQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":543,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        final\",\"obfuscation\":\"x7ABvj0NE0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":544,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        output\",\"obfuscation\":\"3ZhhI5Yas\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":545,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        is\",\"obfuscation\":\"HuejkZdacVHvG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":546,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
-        \\\"\",\"obfuscation\":\"LXrNu9b36JZiU2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":547,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"3\",\"obfuscation\":\"9PyMwvgmE6XPsJz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":548,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\\\"\",\"obfuscation\":\"7NgdQvNhmwHO0F\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":549,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"text\":\"**Delivering
-        the answer**\\n\\nThe user wants a straightforward response, just the number
-        without explanations. I need to stick to that and confirm again: the count
-        is indeed \\\"3.\\\" \\n\\nI\u2019ll double-check for any primes like 197,
-        but it doesn't have \\\"79.\\\" And 297 isn\u2019t prime, nor does it contain
-        the substring. So I\u2019m all set to deliver the answer without any additional
-        text. The final output is \\\"3.\\\"\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":550,\"item_id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"**Delivering
-        the answer**\\n\\nThe user wants a straightforward response, just the number
-        without explanations. I need to stick to that and confirm again: the count
-        is indeed \\\"3.\\\" \\n\\nI\u2019ll double-check for any primes like 197,
-        but it doesn't have \\\"79.\\\" And 297 isn\u2019t prime, nor does it contain
-        the substring. So I\u2019m all set to deliver the answer without any additional
-        text. The final output is \\\"3.\\\"\"}}\n\nevent: response.output_item.done\ndata:
-        {\"type\":\"response.output_item.done\",\"sequence_number\":551,\"output_index\":0,\"item\":{\"id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
-        substring primes**\\n\\nI need to count the prime numbers less than 400 that
-        contain \\\"79\\\" as a substring, which means the digits should include \\\"79\\\"
-        together. \\n\\nOkay, so I start with 79, which is prime. Next is 179; that
-        also works since it has \\\"79\\\" at the end. For 197, it doesn\u2019t count
-        because the digits are 1-9-7. I check others too, like 279, 379\u2014actually,
-        379 works\u2014now for others up to 399. \\n\\nBut 793 is over my limit, so
-        I\u2019ll focus only on numbers below 400.\"},{\"type\":\"summary_text\",\"text\":\"**Analyzing
-        prime candidates**\\n\\nI\u2019m looking into numbers with \\\"79\\\" in them.
-        For three-digit numbers below 400, I see patterns: those ending in 79 (like
-        179, 279, 379) and starting with 79 don\u2019t count since they exceed 400.
-        \\n\\nThe only two-digit option is 79 itself. I already checked the endings;
-        now I realize 279 isn't prime because it's divisible by 3. So, I need to verify
-        if 379 is prime next. \\n\\nThat narrows down my candidates for primes containing
-        \\\"79\\\"!\"},{\"type\":\"summary_text\",\"text\":\"**Verifying prime numbers**\\n\\nI\u2019m
-        testing if 379 is prime. The square root is around 19.4, so I\u2019ll check
-        primality against smaller primes like 3, 5, 7, 11, 13, 17, and 19. It\u2019s
-        not divisible by any of those. \\n\\nNext, I check 179, and it\u2019s prime
-        too. So far, I have 79, 179, and 379 as primes. I wonder if there are others
-        below 400. \\n\\nBut 297 doesn\u2019t count, since it doesn't have \\\"79\\\"
-        together, and 790 is over my limit. So, I\u2019m stuck with those three!\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
-        prime count**\\n\\nI realize that since \\\"substring\\\" refers to something
-        contiguous, 97 can't count as \\\"79\\\" reversed. So, I still think there
-        are 3 valid primes: 79, 179, and 379. I double-check other three-digit possibilities
-        starting with \\\"79,\\\" but none qualify since they\u2019d exceed 400. \\n\\nI
-        confirmed each candidate: 79, 179, and 379 are primes, while 279 isn\u2019t.
-        Thus, the total count remains three. I\u2019ll summarize the answer as \u201C3\u201D
-        and make sure everything is accurate.\"},{\"type\":\"summary_text\",\"text\":\"**Delivering
-        the answer**\\n\\nThe user wants a straightforward response, just the number
-        without explanations. I need to stick to that and confirm again: the count
-        is indeed \\\"3.\\\" \\n\\nI\u2019ll double-check for any primes like 197,
-        but it doesn't have \\\"79.\\\" And 297 isn\u2019t prime, nor does it contain
-        the substring. So I\u2019m all set to deliver the answer without any additional
-        text. The final output is \\\"3.\\\"\"}]}}\n\nevent: response.output_item.added\ndata:
-        {\"type\":\"response.output_item.added\",\"sequence_number\":552,\"output_index\":1,\"item\":{\"id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
-        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":553,\"item_id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":554,\"item_id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"0RpwaOmD8zv3E1d\"}\n\nevent:
-        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":555,\"item_id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
-        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":556,\"item_id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
-        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":557,\"output_index\":1,\"item\":{\"id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
-        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":558,\"response\":{\"id\":\"resp_00b850169f72b9300068f967b3efc88194826c101238508994\",\"object\":\"response\",\"created_at\":1761175476,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
-        substring primes**\\n\\nI need to count the prime numbers less than 400 that
-        contain \\\"79\\\" as a substring, which means the digits should include \\\"79\\\"
-        together. \\n\\nOkay, so I start with 79, which is prime. Next is 179; that
-        also works since it has \\\"79\\\" at the end. For 197, it doesn\u2019t count
-        because the digits are 1-9-7. I check others too, like 279, 379\u2014actually,
-        379 works\u2014now for others up to 399. \\n\\nBut 793 is over my limit, so
-        I\u2019ll focus only on numbers below 400.\"},{\"type\":\"summary_text\",\"text\":\"**Analyzing
-        prime candidates**\\n\\nI\u2019m looking into numbers with \\\"79\\\" in them.
-        For three-digit numbers below 400, I see patterns: those ending in 79 (like
-        179, 279, 379) and starting with 79 don\u2019t count since they exceed 400.
-        \\n\\nThe only two-digit option is 79 itself. I already checked the endings;
-        now I realize 279 isn't prime because it's divisible by 3. So, I need to verify
-        if 379 is prime next. \\n\\nThat narrows down my candidates for primes containing
-        \\\"79\\\"!\"},{\"type\":\"summary_text\",\"text\":\"**Verifying prime numbers**\\n\\nI\u2019m
-        testing if 379 is prime. The square root is around 19.4, so I\u2019ll check
-        primality against smaller primes like 3, 5, 7, 11, 13, 17, and 19. It\u2019s
-        not divisible by any of those. \\n\\nNext, I check 179, and it\u2019s prime
-        too. So far, I have 79, 179, and 379 as primes. I wonder if there are others
-        below 400. \\n\\nBut 297 doesn\u2019t count, since it doesn't have \\\"79\\\"
-        together, and 790 is over my limit. So, I\u2019m stuck with those three!\"},{\"type\":\"summary_text\",\"text\":\"**Finalizing
-        prime count**\\n\\nI realize that since \\\"substring\\\" refers to something
-        contiguous, 97 can't count as \\\"79\\\" reversed. So, I still think there
-        are 3 valid primes: 79, 179, and 379. I double-check other three-digit possibilities
-        starting with \\\"79,\\\" but none qualify since they\u2019d exceed 400. \\n\\nI
-        confirmed each candidate: 79, 179, and 379 are primes, while 279 isn\u2019t.
-        Thus, the total count remains three. I\u2019ll summarize the answer as \u201C3\u201D
-        and make sure everything is accurate.\"},{\"type\":\"summary_text\",\"text\":\"**Delivering
-        the answer**\\n\\nThe user wants a straightforward response, just the number
-        without explanations. I need to stick to that and confirm again: the count
-        is indeed \\\"3.\\\" \\n\\nI\u2019ll double-check for any primes like 197,
-        but it doesn't have \\\"79.\\\" And 297 isn\u2019t prime, nor does it contain
-        the substring. So I\u2019m all set to deliver the answer without any additional
-        text. The final output is \\\"3.\\\"\"}]},{\"id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":1223,\"output_tokens_details\":{\"reasoning_tokens\":1216},\"total_tokens\":1255},\"user\":null,\"metadata\":{}}}\n\n"
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862\",\"object\":\"response\",\"created_at\":1762271435,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862\",\"object\":\"response\",\"created_at\":1762271435,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Counting\",\"obfuscation\":\"yGaTQY\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"2IAbGaUps\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        with\",\"obfuscation\":\"bMbUX1yTNHr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        substring\",\"obfuscation\":\"d4M2UC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"lvAfsKfRuJcWDp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"4k7b9gDGD0bu6V\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"RqQmcMUiCema1xb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"EVjGmQ3hfRj\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        need\",\"obfuscation\":\"RVKEEdAH7qM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        to\",\"obfuscation\":\"mNOW4NDC4pEwU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        count\",\"obfuscation\":\"ucpmfGuWkG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        prime\",\"obfuscation\":\"34LFG7hXAV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"i0W5HLIu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        less\",\"obfuscation\":\"nSJVKmUxqPA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        than\",\"obfuscation\":\"q0T6JlctA42\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"LlQQIQum7KlZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"7jnZhRw3Apr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        contain\",\"obfuscation\":\"RLpFRr16\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"CsrQAHiG56Zowt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"pLUbJZ2ZMlCowj\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\\\"\",\"obfuscation\":\"uWfne0rjUcH7nzw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        as\",\"obfuscation\":\"T5BVXKAVWYwZs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        a\",\"obfuscation\":\"RQZXxPqCnV4yjW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        substring\",\"obfuscation\":\"wX5jm5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"6OM9o524zR98yij\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"FCcdTR6Fgbdn23\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019ll\",\"obfuscation\":\"zRswi23U5XTj6\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        start\",\"obfuscation\":\"7h228E7anO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        by\",\"obfuscation\":\"WYtHZMIMOTa9p\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        considering\",\"obfuscation\":\"IZ4i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        two\",\"obfuscation\":\"UyeyVsA7ka90\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"h5MZhMltOX\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"VhgMMkwcowHt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        three\",\"obfuscation\":\"e9Qzhy5Jvs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"oTFfUTbrpw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"XblwQvv7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"sSYIFlu72Wf1I0y\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        The\",\"obfuscation\":\"Wxdk9HoZshV7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        two\",\"obfuscation\":\"G6wMGuzpOnju\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"CqAaYh3if9\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        number\",\"obfuscation\":\"IZZ2IhUEn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        is\",\"obfuscation\":\"M3h1nnZrOjd0M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        79\",\"obfuscation\":\"YIJpGwGnkytYn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        itself\",\"obfuscation\":\"cds2hru2h\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"xf4oP8O4U3GEpsN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        For\",\"obfuscation\":\"UaxE6UyNq0hK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        three\",\"obfuscation\":\"NXEwZAHNav\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"jurUL2pF1l\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"BuLNEZ4b\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"m7MtunkKzVAhLts\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        anything\",\"obfuscation\":\"VvQ9APc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        in\",\"obfuscation\":\"ysxSyS5YfslCI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"JXT8XP46ZXAC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        form\",\"obfuscation\":\"FSV4JlrMDOk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        of\",\"obfuscation\":\"WCqOwDXvCvgwq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        79\",\"obfuscation\":\"3yGOQJk7HJ7Dk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"x\",\"obfuscation\":\"4HuDtYtP39IyupS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        (\",\"obfuscation\":\"PjZ6oFsPiuxZEK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"like\",\"obfuscation\":\"rJprEnfAzI7p\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        790\",\"obfuscation\":\"WLfr1rsD7rTY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-\",\"obfuscation\":\"okmRQm3FnAS3Fki\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"799\",\"obfuscation\":\"rdNBcIoXuYcah\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\")\",\"obfuscation\":\"CeUytvI4hgBIjk6\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        exceeds\",\"obfuscation\":\"oR5XWMDd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"1e9QWnqVH6Tx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"Ua1VGxQ96im0sT0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        so\",\"obfuscation\":\"XDaHD1FWevuBv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        those\",\"obfuscation\":\"MygB7vt9yN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        don\",\"obfuscation\":\"K4p94mIW9n1Z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019t\",\"obfuscation\":\"cZ91JhbPI0KiMK\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        count\",\"obfuscation\":\"Td4HtCZ19q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"GilgMgKFxWYGlVD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        However\",\"obfuscation\":\"WWQo4Okw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"yPuRYXevribtUlB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"gehFIj2DdjSH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        format\",\"obfuscation\":\"Pc1VCNmAF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        x\",\"obfuscation\":\"qBLvHeS7Z8TJm8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"7yyUewX7IPrSd0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        yields\",\"obfuscation\":\"SSQ47A2sb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        179\",\"obfuscation\":\"wBQDDoFfp7vo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"o6F1eGga8RWTffO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        279\",\"obfuscation\":\"qtdR7ihQqUMO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"EtiWmaoxEQAcj6S\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"FOS24yMJVk7e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        379\",\"obfuscation\":\"553zaT3a2icB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2014all\",\"obfuscation\":\"OmlzkNEY9L51\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        less\",\"obfuscation\":\"6F9qmh6CO1y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        than\",\"obfuscation\":\"MteIQk2yOZl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"z8PiXO3KGCuf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"0JKt2OTbyKWp9L0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"Tb9tlcfU0jMaIA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        have\",\"obfuscation\":\"iedz9j89Gsa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        to\",\"obfuscation\":\"pQLOlFt1qBR0X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":97,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        keep\",\"obfuscation\":\"mBpIz1923aC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":98,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        in\",\"obfuscation\":\"l1pM1JmUepXlS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":99,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        mind\",\"obfuscation\":\"UdvcLpGgXNJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"Qyy2OvH3EVX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"808MZiDqVYTNa1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        need\",\"obfuscation\":\"4g6mjPKhZDJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        to\",\"obfuscation\":\"6V2y8L6LDGj5X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":104,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        check\",\"obfuscation\":\"HbNtlCcxlW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":105,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        which\",\"obfuscation\":\"x1bWWaX0TR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":106,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        of\",\"obfuscation\":\"wbd92DBxBJrKV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":107,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        these\",\"obfuscation\":\"b27CDnbBqT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        are\",\"obfuscation\":\"IsA4RtLFmSl7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        prime\",\"obfuscation\":\"lwAoVzVH9m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":110,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"delta\":\"!\",\"obfuscation\":\"Tu6ZpInybkCftrp\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":111,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to count prime numbers less
+        than 400 that contain \\\"79\\\" as a substring. I\u2019ll start by considering
+        two-digit and three-digit numbers. The two-digit number is 79 itself. For
+        three-digit numbers, anything in the form of 79x (like 790-799) exceeds 400,
+        so those don\u2019t count. However, the format x79 yields 179, 279, and 379\u2014all
+        less than 400. I have to keep in mind that I need to check which of these
+        are prime!\"}\n\nevent: response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":112,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to count prime numbers less
+        than 400 that contain \\\"79\\\" as a substring. I\u2019ll start by considering
+        two-digit and three-digit numbers. The two-digit number is 79 itself. For
+        three-digit numbers, anything in the form of 79x (like 790-799) exceeds 400,
+        so those don\u2019t count. However, the format x79 yields 179, 279, and 379\u2014all
+        less than 400. I have to keep in mind that I need to check which of these
+        are prime!\"}}\n\nevent: response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":113,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Ident\",\"obfuscation\":\"0GliMyBhQ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ifying\",\"obfuscation\":\"WmH494zTjd\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        primes\",\"obfuscation\":\"WZ49b6ElR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        with\",\"obfuscation\":\"UrbL6LZdath\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"Xj5Bt1i8jODVtT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"V1pwFQQkhQ1ula\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"qT0elfouTKWOWDy\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nNext\",\"obfuscation\":\"PUa7mBbi\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":122,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"WPAdjrL3UoDSnCq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":123,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"2i66MoSjo2fqfG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":124,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019m\",\"obfuscation\":\"DD1gRxnmq1eMzG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        looking\",\"obfuscation\":\"GMabXsnW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":126,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        for\",\"obfuscation\":\"cmrd3g5u7rGg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":127,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        numbers\",\"obfuscation\":\"GO9Zq8Nh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":128,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        where\",\"obfuscation\":\"7NZGUQ43yW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"sVOPIJWiOfhO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        hundreds\",\"obfuscation\":\"7ImeN4p\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"UU2mNhA5cL8J\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        tens\",\"obfuscation\":\"0N8kIuZLgZK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        digits\",\"obfuscation\":\"y6Q50zQ1E\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        are\",\"obfuscation\":\"EMQQoBLIjFDH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        7\",\"obfuscation\":\"YgoQ4RRGCsImy0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"5Tes4n98cDSl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        9\",\"obfuscation\":\"ji4KmZIMERpKCa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"jq2SK2cQVh8TuLy\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        For\",\"obfuscation\":\"B14IzI5SAn4P\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        two\",\"obfuscation\":\"jUbzmSPL4ISm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        digits\",\"obfuscation\":\"g3NxsrqKE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"YKg3wgZZ4GbInt7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it's\",\"obfuscation\":\"CruHVAsWK5A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        just\",\"obfuscation\":\"OPTN5vJP91q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"mowJBKxYM6ZEQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"2waj85HxqEj7g5k\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"E1W0a4d1KZb7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        for\",\"obfuscation\":\"fAHLdjF37LtL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        three\",\"obfuscation\":\"avX115NoyK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"-digit\",\"obfuscation\":\"p6wTu2HC5H\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        numbers\",\"obfuscation\":\"APPbx3QT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"1f6lheRLJGdmfeO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I've\",\"obfuscation\":\"teFen0kbkLE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        already\",\"obfuscation\":\"yrwVkhoV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        covered\",\"obfuscation\":\"FA91a0VC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"KhkHgVKNSMu32\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"x\",\"obfuscation\":\"DBdLa5SzkcMpoDq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"D1JKJ7blyLxX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        x\",\"obfuscation\":\"ay2vnkIQBlozkg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"0jtecQbAGjU8mP\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"AvJnBX27Tp3cELs\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\n\\nNow\",\"obfuscation\":\"zYCaLaCLcq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"9g8uIgRPCTNi6eO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        checking\",\"obfuscation\":\"01f3y3z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        297\",\"obfuscation\":\"I9C7Q8rv1x84\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"uvjEZYz69ORlPJb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it\",\"obfuscation\":\"1HHwcFSHF1OTZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        contains\",\"obfuscation\":\"TSY761s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"smtBewfLxbKgxs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"97\",\"obfuscation\":\"4y8S7XDfeeThB0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\\\"\",\"obfuscation\":\"WqnMl64LMtof1I\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        but\",\"obfuscation\":\"GRBcko5Ht5ah\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        not\",\"obfuscation\":\"0d6EAnlAptXY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"W0ve6uFKOkgCqc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"clWHrWdmse97HT\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\\\"\",\"obfuscation\":\"b9cDwLnhLWGguU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        So\",\"obfuscation\":\"WOSqrp6ilGeaZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"QvR7NskJxblaKbe\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"nKEUrcdSGQ6faC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        only\",\"obfuscation\":\"p0rWhCDzgRA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        want\",\"obfuscation\":\"qKLMFNsUePf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"Y5l7VjgEkmg7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        exact\",\"obfuscation\":\"ygpnvZMMMo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"15y37NzOsVLQmn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"SHlWS30y4n6CGk\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"XsTJA8Wb6Oci4Jr\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        in\",\"obfuscation\":\"byn8DxeXjy93H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        order\",\"obfuscation\":\"p1p4ezkBaM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"Tq1lvd48GAfuI2t\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\n\\nThe\",\"obfuscation\":\"311nT9DKTP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        candidates\",\"obfuscation\":\"tqiQ1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        less\",\"obfuscation\":\"orKW2UdLlkq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        than\",\"obfuscation\":\"wGuhtqmEelj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        400\",\"obfuscation\":\"pJ6lJAXrkju0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        with\",\"obfuscation\":\"g5L8Bie2bIc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"GRs1tEbcyUxHVj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"PrLsvUJNvk022w\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"QILnJq59dwlCD52\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        are\",\"obfuscation\":\"CP5CWtsHLFv9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"YBKORc689iPse\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"iTPOXg7BS0bus4e\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        179\",\"obfuscation\":\"vvRWtsOlGjHV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"h2D5X3GuBE1PXOV\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        279\",\"obfuscation\":\"tvTjt8GqMc4X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":205,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"v6yU5IQOlvXRJUu\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":206,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"SunJaSsq6JRS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":207,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        379\",\"obfuscation\":\"ssoPgXDtRX5g\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"XpqGoKSENPN2B5B\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        Additionally\",\"obfuscation\":\"Z3F\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"WgBODznlo6lDaDK\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"3V0XOwNWzEzvhd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        have\",\"obfuscation\":\"YlmkNA51qBQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        ruled\",\"obfuscation\":\"rJHCu9px3s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        out\",\"obfuscation\":\"rqB6Kxfin6AV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":215,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        others\",\"obfuscation\":\"0dB4Y6xom\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":216,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        like\",\"obfuscation\":\"mMD4UB6XVEt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":217,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        709\",\"obfuscation\":\"9MFopuVSbhXI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"SgocIMdZJPzlTw9\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        since\",\"obfuscation\":\"VzXmGmq6v3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it\",\"obfuscation\":\"4E1vSkVIdJtjx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        doesn\",\"obfuscation\":\"gaJzWdeJmi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019t\",\"obfuscation\":\"zxgMhhWGpkHj06\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":223,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        contain\",\"obfuscation\":\"uN0Y8dTV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":224,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"93aew5KBzPLEVE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":225,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"mELqMZPd3kIHia\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":226,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"z1gEuQjv2PITw41\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":227,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        consecut\",\"obfuscation\":\"Uo8yCm1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":228,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ively\",\"obfuscation\":\"Txr8sDTXiOz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":229,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"54AtxkG00NVviVE\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":230,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Identifying
+        primes with \\\"79\\\"**\\n\\nNext, I\u2019m looking for numbers where the
+        hundreds and tens digits are 7 and 9. For two digits, it's just 79, and for
+        three-digit numbers, I've already covered 79x and x79. \\n\\nNow, checking
+        297, it contains \\\"97,\\\" but not \\\"79.\\\" So, I only want the exact
+        \\\"79\\\" in order. \\n\\nThe candidates less than 400 with \\\"79\\\" are
+        79, 179, 279, and 379. Additionally, I have ruled out others like 709, since
+        it doesn\u2019t contain \\\"79\\\" consecutively.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":231,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Identifying
+        primes with \\\"79\\\"**\\n\\nNext, I\u2019m looking for numbers where the
+        hundreds and tens digits are 7 and 9. For two digits, it's just 79, and for
+        three-digit numbers, I've already covered 79x and x79. \\n\\nNow, checking
+        297, it contains \\\"97,\\\" but not \\\"79.\\\" So, I only want the exact
+        \\\"79\\\" in order. \\n\\nThe candidates less than 400 with \\\"79\\\" are
+        79, 179, 279, and 379. Additionally, I have ruled out others like 709, since
+        it doesn\u2019t contain \\\"79\\\" consecutively.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
+        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":232,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":233,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Testing\",\"obfuscation\":\"SLK8i6N\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":234,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primal\",\"obfuscation\":\"b5Hc7P3gt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ity\",\"obfuscation\":\"scoNKr1yyg1ft\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        of\",\"obfuscation\":\"gCQj6l9vwYqFI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        candidates\",\"obfuscation\":\"5qKAP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"sQI1mrdvNyU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        can\",\"obfuscation\":\"NdF11lSBLof6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        rule\",\"obfuscation\":\"tSVZCC71gjV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        out\",\"obfuscation\":\"C1LHt9vfBzXq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        any\",\"obfuscation\":\"QJ0wdtPQEr02\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        four\",\"obfuscation\":\"4sUroeG64At\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"lJys7EZOC1\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        numbers\",\"obfuscation\":\"zKCEMlny\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        since\",\"obfuscation\":\"2MshVdIFIN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        they\",\"obfuscation\":\"iHQHclKa1W6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        exceed\",\"obfuscation\":\"QEWQHETV4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        400\",\"obfuscation\":\"u3yw5OvpZ08D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"ShYTiaS40rFJo9D\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        So\",\"obfuscation\":\"O1Y5fBa48pFK1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"LxWLNTAO5suAsml\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"3rtKLwFQEzbLJ2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        just\",\"obfuscation\":\"0X3XONjBdWu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        need\",\"obfuscation\":\"c6g0d7ctFy1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        to\",\"obfuscation\":\"wWbR4YvFkJTOy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        test\",\"obfuscation\":\"63FlSOuZUf7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"kQRDnAkM30jU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primal\",\"obfuscation\":\"GYDqoesFW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ity\",\"obfuscation\":\"6exqQ052k6HkG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        of\",\"obfuscation\":\"VJDPkwqlBkcky\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"F72iek0QGiVRs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"ALgGQgYKAL9kPTU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"cmzm0rxdp6u2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":265,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"QcYIxeiSqk4FmrZ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":266,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        279\",\"obfuscation\":\"E8cY7Zc3p9xp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":267,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"itkUEqC0HNDGBpS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"755cnOvObq44\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"l1gUfs82Ufdm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"IxRIaC0w1IKbF78\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\n\\nFirst\",\"obfuscation\":\"KTqQZ3F8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"Z1bIhlbOyUmZW42\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"QdaL4ekrWfXsL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"1P4tU3gBVuz1H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"hiiNy7WptN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2014\",\"obfuscation\":\"0bHKhSkr0gQsdxU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"no\",\"obfuscation\":\"0ZDD674FQa28cm\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        doubt\",\"obfuscation\":\"ILNQCgHLvK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        there\",\"obfuscation\":\"TC6dRfXjZ4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"FXEklI43tpm5DLS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        For\",\"obfuscation\":\"pc5kDo9KTWL1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"9ldb7SAyUwU7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"CRQQV4wWV9iM7G8\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"XwvXJiw7QU4Jaw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        check\",\"obfuscation\":\"FKI6GoQuYb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divis\",\"obfuscation\":\"5FXGthpGtb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ibility\",\"obfuscation\":\"TdbgyEzwz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        using\",\"obfuscation\":\"iEhw8KQy9m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"l4ZFivrZx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        up\",\"obfuscation\":\"ZI9xfaYaC7G2t\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        to\",\"obfuscation\":\"JcPHpQAE1LqGI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        around\",\"obfuscation\":\"Zh0c4HUhf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \u221A\",\"obfuscation\":\"FDzpvmtrBKPvHj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"179\",\"obfuscation\":\"adDZxgEFkMae3\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"7BBJWr1lBDmichW\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        confirming\",\"obfuscation\":\"mLLEI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it's\",\"obfuscation\":\"TxD0nsoLqZd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        also\",\"obfuscation\":\"1kgMrewhBmj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"cOyFP201sI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"hi7rgVqFkZ8NdKt\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\n\\nNow\",\"obfuscation\":\"fdACX7QE9i\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"hnyZSgeVf5sbAIo\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        279\",\"obfuscation\":\"Wm9Mi69bBd0u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"zDASaoVqMsgQx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        divisible\",\"obfuscation\":\"vuuZXj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        by\",\"obfuscation\":\"HshIZeR0CAafy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        3\",\"obfuscation\":\"5vbG4u29lRvUFp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        because\",\"obfuscation\":\"zCAQz20R\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"DX7SXImd5Mny\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        sum\",\"obfuscation\":\"60L2AagdHabu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        of\",\"obfuscation\":\"9TpYiFkg1PDAa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        its\",\"obfuscation\":\"2mEfT8VMTa9y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        digits\",\"obfuscation\":\"scFBFSP19\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"j45HnbWcdTwER\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        18\",\"obfuscation\":\"CQVm70dRlt0kf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"mpjiSBroBJj2cc7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        so\",\"obfuscation\":\"T1NaV14IEN75x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it's\",\"obfuscation\":\"cXmwGW09U57\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        not\",\"obfuscation\":\"JIJmaSWEqtlP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"gKDEpcDh2a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"P0diCbkJ3Ml0qAe\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Finally\",\"obfuscation\":\"3fk5PZNw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"tkPI6jh1rny0fM7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":324,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"tQVmzZLfFvjH7X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":325,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        check\",\"obfuscation\":\"9DBTSFGsBe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":326,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"ukKWHMDdEYfN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":327,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        against\",\"obfuscation\":\"eyPDCNp1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":328,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        several\",\"obfuscation\":\"dv2UEZil\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":329,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"ap5nAi6yV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":330,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"BOXeVHCI4uI4q6G\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":331,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"0P9J4UGr7rhs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":332,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it\",\"obfuscation\":\"kUC9cszGvsHod\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":333,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        turns\",\"obfuscation\":\"ObbqxiAaem\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":334,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        out\",\"obfuscation\":\"LxeKem4UxTIo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":335,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        to\",\"obfuscation\":\"Ty92Z2pCZdfiC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":336,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        be\",\"obfuscation\":\"GxMh0cXPNK7L6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":337,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"Dw9ZBYc5Cp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":338,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        as\",\"obfuscation\":\"jLvaODKylpph4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":339,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        well\",\"obfuscation\":\"hWGu7Ut1UOD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":340,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"!\",\"obfuscation\":\"MF5Z2wgnkiYRoHZ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":341,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\n\\nThis\",\"obfuscation\":\"NRKH7wQmt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":342,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        gives\",\"obfuscation\":\"B4CfBV6il2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":343,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        me\",\"obfuscation\":\"Xat7fNEo6gqfV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":344,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        three\",\"obfuscation\":\"EJz8lpM7nh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":345,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"xlfTmCA8w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":346,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\":\",\"obfuscation\":\"6j2J3P7Q4ezZtVD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":347,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"bB70rb0K8K6Lq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":348,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"bvLA6qsk2nRFG1k\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":349,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"PDGgJijwir0n\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":350,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"Y3VCtuKnDOSGrFd\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":351,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"tiYA06PVhBAm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":352,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"NpjW6qOMZ2O1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":353,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"XTg3DYFLSHUdbBO\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":354,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Testing
+        primality of candidates**\\n\\nI can rule out any four-digit numbers since
+        they exceed 400. So, I just need to test the primality of 79, 179, 279, and
+        379. \\n\\nFirst, 79 is prime\u2014no doubt there. For 179, I check divisibility
+        using primes up to around \u221A179, confirming it's also prime. \\n\\nNow,
+        279 is divisible by 3 because the sum of its digits is 18, so it's not prime.
+        Finally, I check 379 against several primes, and it turns out to be prime
+        as well! \\n\\nThis gives me three primes: 79, 179, and 379.\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":355,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Testing
+        primality of candidates**\\n\\nI can rule out any four-digit numbers since
+        they exceed 400. So, I just need to test the primality of 79, 179, 279, and
+        379. \\n\\nFirst, 79 is prime\u2014no doubt there. For 179, I check divisibility
+        using primes up to around \u221A179, confirming it's also prime. \\n\\nNow,
+        279 is divisible by 3 because the sum of its digits is 18, so it's not prime.
+        Finally, I check 379 against several primes, and it turns out to be prime
+        as well! \\n\\nThis gives me three primes: 79, 179, and 379.\"}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":356,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":357,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**Final\",\"obfuscation\":\"5B2A6ZSGN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":358,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        checks\",\"obfuscation\":\"KHeCfW2h9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":359,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        on\",\"obfuscation\":\"sGpaay3MBF7p8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":360,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        candidates\",\"obfuscation\":\"PHKo3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":361,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        with\",\"obfuscation\":\"pAfXZySRv2V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":362,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"Xl6NxcE26d0yyr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":363,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"4hEnLP9hDmM7pz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":364,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"6U3EyeqdfX5Ye3T\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":365,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"1BwcybQrXfD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":366,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019m\",\"obfuscation\":\"PG22k3FXzJZ8kv\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":367,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        going\",\"obfuscation\":\"lpNFPF0N95\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":368,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        over\",\"obfuscation\":\"9JgnXFuQQi7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":369,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        the\",\"obfuscation\":\"gMhqfLR1QDX9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":370,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        numbers\",\"obfuscation\":\"DzNeuH8J\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":371,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        less\",\"obfuscation\":\"O3KewQGekGU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":372,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        than\",\"obfuscation\":\"KWp9nhNgkcM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":373,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        400\",\"obfuscation\":\"n7g0oS36yfJ4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":374,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        again\",\"obfuscation\":\"jC1TZeCJeM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":375,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        for\",\"obfuscation\":\"KKkdSkpiioF4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":376,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        any\",\"obfuscation\":\"bWS1Bhqlk3lU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":377,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        that\",\"obfuscation\":\"ymMRR9BiHpw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":378,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        contain\",\"obfuscation\":\"1DORnErf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":379,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"dMPF8pX8z871lw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":380,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"zBKjHgI8xzIOj1\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":381,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\\\"\",\"obfuscation\":\"DzVlLPnErpvL4p\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":382,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\n\\nChecking\",\"obfuscation\":\"0mCOJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":383,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        297\",\"obfuscation\":\"I81xtOlHo0x1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":384,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"fEKYV3pwN6oc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":385,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        197\",\"obfuscation\":\"0TsDcXMSdpgf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":386,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"x81qeYWEMYgDcJV\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":387,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        neither\",\"obfuscation\":\"DTjIzCZv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":388,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        fit\",\"obfuscation\":\"7Vuq6LHfdEPC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":389,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        since\",\"obfuscation\":\"67wz9DbfO1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":390,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        197\",\"obfuscation\":\"wdu3FvfCQ5Y8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":391,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        has\",\"obfuscation\":\"IkzEpDgxDuXj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":392,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"41RlNLPhaFD1zB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":393,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"19\",\"obfuscation\":\"1Evitq1wwntnP0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":394,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"Ve9PFJeCzes4e61\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":395,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"SRLG7reMMWGP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":396,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        not\",\"obfuscation\":\"XJGE1QENRyUe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":397,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"fRZYNrWWU91od7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":398,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"XrpY9msFGCiVkL\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":399,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\\\"\",\"obfuscation\":\"kFUVOIGH1FyMSn\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":400,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I\",\"obfuscation\":\"LGAYBxlaqczo4b\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":401,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        already\",\"obfuscation\":\"NYw88xCg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":402,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        ruled\",\"obfuscation\":\"VunN1eSpBx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":403,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        out\",\"obfuscation\":\"VX8D1ACZ96Qg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":404,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        279\",\"obfuscation\":\"hekvf2Wz6eB1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":405,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        as\",\"obfuscation\":\"MAVxjzIL9OjyO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":406,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        composite\",\"obfuscation\":\"xlF2Dl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":407,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"PZmQSZ7b5WpEtCF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":408,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"x5GxLzTJjF6U\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":409,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"fMtzHr2TU57G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":410,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        is\",\"obfuscation\":\"2BP0gN63j7tjj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":411,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        prime\",\"obfuscation\":\"AFQQ4R6T1F\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":412,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"XOu7SdRyCPXhq6t\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":413,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        For\",\"obfuscation\":\"PQw1dP6YqLH4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":414,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        other\",\"obfuscation\":\"fjpga7XGvq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":415,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        combinations\",\"obfuscation\":\"UXo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":416,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        like\",\"obfuscation\":\"OxUTcFGi1jA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":417,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"jHmHRyoxswJrKA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":418,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"x\",\"obfuscation\":\"9qyaApcUwsO5tZE\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":419,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"SvNyGlZ1P2AIjw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":420,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"1zI14MQviJzM0k4\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":421,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"gTJwNuvcYBtY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":422,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        patterns\",\"obfuscation\":\"Fe2YCU2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":423,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        with\",\"obfuscation\":\"NkxAkbd2cjk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":424,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"Oc2ueZvd0qGKpC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":425,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"YKKzchVX2ZXJQd\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":426,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\\"\",\"obfuscation\":\"YOJ1TudMUxRdxh5\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":427,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        in\",\"obfuscation\":\"LFuMh3lhYyD4x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":428,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        the\",\"obfuscation\":\"HHQW3Y3XMnr3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":429,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        middle\",\"obfuscation\":\"Wzk7UStrQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":430,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"pXcsFyIldRwEOYM\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":431,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        only\",\"obfuscation\":\"RqUN1bV05ie\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":432,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        179\",\"obfuscation\":\"7rjb88ZSHhdR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":433,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"OBosKXYG9j42f9W\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":434,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        279\",\"obfuscation\":\"rN1v3piveZHB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":435,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"mhebSKw7vhChyxL\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":436,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"KavSIzaMiB9o\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":437,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"dfGb2aTJAb8x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":438,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        qualify\",\"obfuscation\":\"ik7ZMt4I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":439,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"ZZWGHHe1S0Ulfsq\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":440,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        I\",\"obfuscation\":\"GSnWA29eBWEbN3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":441,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        also\",\"obfuscation\":\"bPrchcELQFS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":442,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        remember\",\"obfuscation\":\"bL8VC1n\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":443,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        checking\",\"obfuscation\":\"vMWO5Hn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":444,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        397\",\"obfuscation\":\"FSCwGSxghhuY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":445,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"8o1AUeAEJ3NmVsy\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":446,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        but\",\"obfuscation\":\"cGW4czOYLvXa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":447,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        it\",\"obfuscation\":\"PGhugmvxIjM00\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":448,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        has\",\"obfuscation\":\"W3jb3RGNAsKA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":449,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"CWTaem6vMHm8Bv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":450,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"97\",\"obfuscation\":\"qHwmjhaBQTGiJi\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":451,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\\\"\",\"obfuscation\":\"mCWv2HXSJ2soCa\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":452,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        not\",\"obfuscation\":\"gOpi9sdSrR93\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":453,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        \\\"\",\"obfuscation\":\"Kq1HePlHl4KjPu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":454,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"xGgRkysMiUpD5w\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":455,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\\\"\",\"obfuscation\":\"iFmdye1guecApN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":456,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\\n\\nAfter\",\"obfuscation\":\"1KO4YCYPd\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":457,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        thorough\",\"obfuscation\":\"ZI1IyGI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":458,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        checks\",\"obfuscation\":\"3EtbCHOCu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":459,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"B12a6lhXxvEmpqy\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":460,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        the\",\"obfuscation\":\"3Kjs7HGvmnQ7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":461,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        only\",\"obfuscation\":\"C8WyrGudAx9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":462,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        primes\",\"obfuscation\":\"qRHH1EQSh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":463,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        are\",\"obfuscation\":\"GyrEZqIxhoWU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":464,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        79\",\"obfuscation\":\"iGZp3qherR3FZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":465,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"oWqM5I9JDX84l05\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":466,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        179\",\"obfuscation\":\"fBIoJ7oNV96A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":467,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"k5OfWfDj8McZz69\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":468,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        and\",\"obfuscation\":\"3FYmMtw4UZHk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":469,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        379\",\"obfuscation\":\"NJyKblOW3JeV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":470,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"OVLd4Tf7CWXHPit\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":471,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        totaling\",\"obfuscation\":\"CIJisBR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":472,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
+        three\",\"obfuscation\":\"NSnFbPvAqc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":473,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"muGoSe44jitYPMO\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":474,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"text\":\"**Final
+        checks on candidates with \\\"79\\\"**\\n\\nI\u2019m going over the numbers
+        less than 400 again for any that contain \\\"79.\\\" \\n\\nChecking 297 and
+        197, neither fit since 197 has \\\"19\\\" and not \\\"79.\\\" I already ruled
+        out 279 as composite, and 379 is prime. For other combinations like \\\"x79\\\"
+        and patterns with \\\"79\\\" in the middle, only 179, 279, and 379 qualify.
+        I also remember checking 397, but it has \\\"97,\\\" not \\\"79.\\\"\\n\\nAfter
+        thorough checks, the only primes are 79, 179, and 379, totaling three.\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":475,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"**Final
+        checks on candidates with \\\"79\\\"**\\n\\nI\u2019m going over the numbers
+        less than 400 again for any that contain \\\"79.\\\" \\n\\nChecking 297 and
+        197, neither fit since 197 has \\\"19\\\" and not \\\"79.\\\" I already ruled
+        out 279 as composite, and 379 is prime. For other combinations like \\\"x79\\\"
+        and patterns with \\\"79\\\" in the middle, only 179, 279, and 379 qualify.
+        I also remember checking 397, but it has \\\"97,\\\" not \\\"79.\\\"\\n\\nAfter
+        thorough checks, the only primes are 79, 179, and 379, totaling three.\"}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":476,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":477,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**Confirm\",\"obfuscation\":\"r76HwGu\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":478,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"ing\",\"obfuscation\":\"onP9hRNrwddn0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":479,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        substring\",\"obfuscation\":\"OKLUWS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":480,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        criteria\",\"obfuscation\":\"kOu7ts3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":481,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"DaU0ryP12n2\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":482,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        realize\",\"obfuscation\":\"pytmjWpq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":483,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"YHptICrF5YG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":484,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"iVnWhpMgj0xaiB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":485,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"substring\",\"obfuscation\":\"AujO3GJ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":486,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"AqdBIzGlphgplkV\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":487,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        means\",\"obfuscation\":\"Rp88DI73IG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":488,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"lpaLhMnRJF7po8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":489,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019m\",\"obfuscation\":\"fWApNqJTc7iHy6\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":490,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        only\",\"obfuscation\":\"QRdBVC7U1xW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":491,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        looking\",\"obfuscation\":\"4iIBs50k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":492,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        for\",\"obfuscation\":\"fY7Nr1FlrpNG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":493,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        consecutive\",\"obfuscation\":\"TNNf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":494,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        digits\",\"obfuscation\":\"xf8ZuoaR9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":495,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"qiJuuZDhxrXvJVU\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":496,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        So\",\"obfuscation\":\"ON9dV7wff4v9X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":497,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"nUP0jETOldug452\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":498,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"HjKZptKSOlO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":499,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        confirms\",\"obfuscation\":\"ZbjOewM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":500,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        my\",\"obfuscation\":\"id8cUhQHxSaq2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":501,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        answer\",\"obfuscation\":\"PMFAlrMEU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":502,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        is\",\"obfuscation\":\"cBPJa7E8cz1oO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":503,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        just\",\"obfuscation\":\"K7jv88O8qS5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":504,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        3\",\"obfuscation\":\"OdOS9o5jimDMJM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":505,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"tZ1qE8wtzXpm2dp\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":506,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\n\\nStill\",\"obfuscation\":\"0XBL9gQd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":507,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"e270idWhcVOn2Vf\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":508,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I\",\"obfuscation\":\"hhMoWp7Z6juZmK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":509,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        want\",\"obfuscation\":\"FgiqMwzJHxJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":510,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        to\",\"obfuscation\":\"63OzeZpjIBlPm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":511,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        double\",\"obfuscation\":\"pyVPxuTgA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":512,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"-check\",\"obfuscation\":\"bRdLd6xbed\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":513,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        any\",\"obfuscation\":\"iNKOYY5CJWTz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":514,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        other\",\"obfuscation\":\"hdSdGAWVVh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":515,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        potential\",\"obfuscation\":\"HyUXqT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":516,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        candidates\",\"obfuscation\":\"X7IQl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":517,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        like\",\"obfuscation\":\"Ps5Bq8xRle9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":518,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        179\",\"obfuscation\":\"2vx2tIiQWkPM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":519,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"hyJiou6FSND3BQF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":520,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        197\",\"obfuscation\":\"EFhVNPoQOzMf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":521,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"jBO9brrP8XXTbqn\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":522,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        279\",\"obfuscation\":\"QLQLtk9xSTMi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":523,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"lG0LxockM7fYbwY\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":524,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        297\",\"obfuscation\":\"W2qPC1fpT0YT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":525,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"teI0jbZfzaqs485\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":526,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        379\",\"obfuscation\":\"CyVLvnpQPFqv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":527,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"rt8YICoIYoh0J63\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":528,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        and\",\"obfuscation\":\"u1UqQ8iYk00D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":529,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        397\",\"obfuscation\":\"vrmkEthDAUQS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":530,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"hWMADWyr7BglU8P\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":531,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        However\",\"obfuscation\":\"LZ9gpRRZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":532,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"ChiVj6L1dOe2gN9\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":533,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        they\",\"obfuscation\":\"heLRxzcsbqN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":534,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        don't\",\"obfuscation\":\"t07rz30iTO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":535,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        have\",\"obfuscation\":\"zFGIT4ZEXfj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":536,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        the\",\"obfuscation\":\"ATU4mnUYahZZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":537,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        consecutive\",\"obfuscation\":\"zcb4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":538,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\\"\",\"obfuscation\":\"fZlAhnJL1f3V5h\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":539,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"79\",\"obfuscation\":\"yfhJ5SdrBPIFc3\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":540,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\\\"\",\"obfuscation\":\"NnZDk0A15xhgjVb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":541,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        pairs\",\"obfuscation\":\"HrFFb0Mg8Z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":542,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\".\",\"obfuscation\":\"0UMkURjt7MCC9XN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":543,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        \\n\\nTherefore\",\"obfuscation\":\"DpS9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":544,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\",\",\"obfuscation\":\"j9tJehcsng5Fc2L\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":545,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        I'm\",\"obfuscation\":\"S4bXeAaRXPdT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":546,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        confident\",\"obfuscation\":\"rtfrm4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":547,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        in\",\"obfuscation\":\"0owrdi7wsgeH8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":548,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        concluding\",\"obfuscation\":\"DH8J0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":549,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        that\",\"obfuscation\":\"nY0OYP10QvS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":550,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        the\",\"obfuscation\":\"dZo095jIY1Fn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":551,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        final\",\"obfuscation\":\"gW4g3e55OB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":552,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        answer\",\"obfuscation\":\"cJXRIjawD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":553,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        is\",\"obfuscation\":\"Uh6EH7ABhm6jc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":554,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        indeed\",\"obfuscation\":\"vYqQpOHYu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":555,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        just\",\"obfuscation\":\"H1lORyxxiOX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":556,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        3\",\"obfuscation\":\"n3WeeNGCROgAMu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":557,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"!\",\"obfuscation\":\"p1ep9pMhOv5m8b2\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":558,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        It\",\"obfuscation\":\"jvIkpI1DIh5vb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":559,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"\u2019s\",\"obfuscation\":\"WfnJ3Tv0oMiGKC\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":560,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        good\",\"obfuscation\":\"flFoGBQu3G3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":561,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        to\",\"obfuscation\":\"zThfSD1UalifK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":562,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        be\",\"obfuscation\":\"7dlrIwQ18260u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":563,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"
+        thorough\",\"obfuscation\":\"KAyrvbe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":564,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"delta\":\"!\",\"obfuscation\":\"wmHiJCK138CigtX\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":565,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"text\":\"**Confirming
+        substring criteria**\\n\\nI realize that \\\"substring\\\" means I\u2019m
+        only looking for consecutive digits. So, that confirms my answer is just 3.
+        \\n\\nStill, I want to double-check any other potential candidates like 179,
+        197, 279, 297, 379, and 397. However, they don't have the consecutive \\\"79\\\"
+        pairs. \\n\\nTherefore, I'm confident in concluding that the final answer
+        is indeed just 3! It\u2019s good to be thorough!\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":566,\"item_id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"output_index\":0,\"summary_index\":4,\"part\":{\"type\":\"summary_text\",\"text\":\"**Confirming
+        substring criteria**\\n\\nI realize that \\\"substring\\\" means I\u2019m
+        only looking for consecutive digits. So, that confirms my answer is just 3.
+        \\n\\nStill, I want to double-check any other potential candidates like 179,
+        197, 279, 297, 379, and 397. However, they don't have the consecutive \\\"79\\\"
+        pairs. \\n\\nTherefore, I'm confident in concluding that the final answer
+        is indeed just 3! It\u2019s good to be thorough!\"}}\n\nevent: response.output_item.done\ndata:
+        {\"type\":\"response.output_item.done\",\"sequence_number\":567,\"output_index\":0,\"item\":{\"id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to count prime numbers less
+        than 400 that contain \\\"79\\\" as a substring. I\u2019ll start by considering
+        two-digit and three-digit numbers. The two-digit number is 79 itself. For
+        three-digit numbers, anything in the form of 79x (like 790-799) exceeds 400,
+        so those don\u2019t count. However, the format x79 yields 179, 279, and 379\u2014all
+        less than 400. I have to keep in mind that I need to check which of these
+        are prime!\"},{\"type\":\"summary_text\",\"text\":\"**Identifying primes with
+        \\\"79\\\"**\\n\\nNext, I\u2019m looking for numbers where the hundreds and
+        tens digits are 7 and 9. For two digits, it's just 79, and for three-digit
+        numbers, I've already covered 79x and x79. \\n\\nNow, checking 297, it contains
+        \\\"97,\\\" but not \\\"79.\\\" So, I only want the exact \\\"79\\\" in order.
+        \\n\\nThe candidates less than 400 with \\\"79\\\" are 79, 179, 279, and 379.
+        Additionally, I have ruled out others like 709, since it doesn\u2019t contain
+        \\\"79\\\" consecutively.\"},{\"type\":\"summary_text\",\"text\":\"**Testing
+        primality of candidates**\\n\\nI can rule out any four-digit numbers since
+        they exceed 400. So, I just need to test the primality of 79, 179, 279, and
+        379. \\n\\nFirst, 79 is prime\u2014no doubt there. For 179, I check divisibility
+        using primes up to around \u221A179, confirming it's also prime. \\n\\nNow,
+        279 is divisible by 3 because the sum of its digits is 18, so it's not prime.
+        Finally, I check 379 against several primes, and it turns out to be prime
+        as well! \\n\\nThis gives me three primes: 79, 179, and 379.\"},{\"type\":\"summary_text\",\"text\":\"**Final
+        checks on candidates with \\\"79\\\"**\\n\\nI\u2019m going over the numbers
+        less than 400 again for any that contain \\\"79.\\\" \\n\\nChecking 297 and
+        197, neither fit since 197 has \\\"19\\\" and not \\\"79.\\\" I already ruled
+        out 279 as composite, and 379 is prime. For other combinations like \\\"x79\\\"
+        and patterns with \\\"79\\\" in the middle, only 179, 279, and 379 qualify.
+        I also remember checking 397, but it has \\\"97,\\\" not \\\"79.\\\"\\n\\nAfter
+        thorough checks, the only primes are 79, 179, and 379, totaling three.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
+        substring criteria**\\n\\nI realize that \\\"substring\\\" means I\u2019m
+        only looking for consecutive digits. So, that confirms my answer is just 3.
+        \\n\\nStill, I want to double-check any other potential candidates like 179,
+        197, 279, 297, 379, and 397. However, they don't have the consecutive \\\"79\\\"
+        pairs. \\n\\nTherefore, I'm confident in concluding that the final answer
+        is indeed just 3! It\u2019s good to be thorough!\"}]}}\n\nevent: response.output_item.added\ndata:
+        {\"type\":\"response.output_item.added\",\"sequence_number\":568,\"output_index\":1,\"item\":{\"id\":\"msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":569,\"item_id\":\"msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":570,\"item_id\":\"msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"8htDtPB6RxZBdrc\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":571,\"item_id\":\"msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
+        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":572,\"item_id\":\"msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":573,\"output_index\":1,\"item\":{\"id\":\"msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":574,\"response\":{\"id\":\"resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862\",\"object\":\"response\",\"created_at\":1762271435,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        primes with substring \\\"79\\\"**\\n\\nI need to count prime numbers less
+        than 400 that contain \\\"79\\\" as a substring. I\u2019ll start by considering
+        two-digit and three-digit numbers. The two-digit number is 79 itself. For
+        three-digit numbers, anything in the form of 79x (like 790-799) exceeds 400,
+        so those don\u2019t count. However, the format x79 yields 179, 279, and 379\u2014all
+        less than 400. I have to keep in mind that I need to check which of these
+        are prime!\"},{\"type\":\"summary_text\",\"text\":\"**Identifying primes with
+        \\\"79\\\"**\\n\\nNext, I\u2019m looking for numbers where the hundreds and
+        tens digits are 7 and 9. For two digits, it's just 79, and for three-digit
+        numbers, I've already covered 79x and x79. \\n\\nNow, checking 297, it contains
+        \\\"97,\\\" but not \\\"79.\\\" So, I only want the exact \\\"79\\\" in order.
+        \\n\\nThe candidates less than 400 with \\\"79\\\" are 79, 179, 279, and 379.
+        Additionally, I have ruled out others like 709, since it doesn\u2019t contain
+        \\\"79\\\" consecutively.\"},{\"type\":\"summary_text\",\"text\":\"**Testing
+        primality of candidates**\\n\\nI can rule out any four-digit numbers since
+        they exceed 400. So, I just need to test the primality of 79, 179, 279, and
+        379. \\n\\nFirst, 79 is prime\u2014no doubt there. For 179, I check divisibility
+        using primes up to around \u221A179, confirming it's also prime. \\n\\nNow,
+        279 is divisible by 3 because the sum of its digits is 18, so it's not prime.
+        Finally, I check 379 against several primes, and it turns out to be prime
+        as well! \\n\\nThis gives me three primes: 79, 179, and 379.\"},{\"type\":\"summary_text\",\"text\":\"**Final
+        checks on candidates with \\\"79\\\"**\\n\\nI\u2019m going over the numbers
+        less than 400 again for any that contain \\\"79.\\\" \\n\\nChecking 297 and
+        197, neither fit since 197 has \\\"19\\\" and not \\\"79.\\\" I already ruled
+        out 279 as composite, and 379 is prime. For other combinations like \\\"x79\\\"
+        and patterns with \\\"79\\\" in the middle, only 179, 279, and 379 qualify.
+        I also remember checking 397, but it has \\\"97,\\\" not \\\"79.\\\"\\n\\nAfter
+        thorough checks, the only primes are 79, 179, and 379, totaling three.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
+        substring criteria**\\n\\nI realize that \\\"substring\\\" means I\u2019m
+        only looking for consecutive digits. So, that confirms my answer is just 3.
+        \\n\\nStill, I want to double-check any other potential candidates like 179,
+        197, 279, 297, 379, and 397. However, they don't have the consecutive \\\"79\\\"
+        pairs. \\n\\nTherefore, I'm confident in concluding that the final answer
+        is indeed just 3! It\u2019s good to be thorough!\"}]},{\"id\":\"msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":1095,\"output_tokens_details\":{\"reasoning_tokens\":1088},\"total_tokens\":1127},\"user\":null,\"metadata\":{}}}\n\n"
     headers:
       CF-RAY:
-      - 992cbfc43f3c2840-SEA
+      - 99954495fb670f1b-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:24:36 GMT
+      - Tue, 04 Nov 2025 15:50:35 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1140,66 +1168,36 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '189'
+      - '145'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '222'
+      - '161'
       x-request-id:
-      - req_38a36450c04a41309178f718c0629163
+      - req_d4f3e80e30544cd48645117fd676fb10
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"input\":[{\"content\":\"How many primes below 400 contain 79 as a substring?
-      Answer ONLY with the number, not sharing which primes they are.\",\"role\":\"user\"},{\"id\":\"rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8\",\"summary\":[{\"text\":\"**Counting
-      substring primes**\\n\\nI need to count the prime numbers less than 400 that
-      contain \\\"79\\\" as a substring, which means the digits should include \\\"79\\\"
-      together. \\n\\nOkay, so I start with 79, which is prime. Next is 179; that
-      also works since it has \\\"79\\\" at the end. For 197, it doesn\u2019t count
-      because the digits are 1-9-7. I check others too, like 279, 379\u2014actually,
-      379 works\u2014now for others up to 399. \\n\\nBut 793 is over my limit, so
-      I\u2019ll focus only on numbers below 400.\",\"type\":\"summary_text\"},{\"text\":\"**Analyzing
-      prime candidates**\\n\\nI\u2019m looking into numbers with \\\"79\\\" in them.
-      For three-digit numbers below 400, I see patterns: those ending in 79 (like
-      179, 279, 379) and starting with 79 don\u2019t count since they exceed 400.
-      \\n\\nThe only two-digit option is 79 itself. I already checked the endings;
-      now I realize 279 isn't prime because it's divisible by 3. So, I need to verify
-      if 379 is prime next. \\n\\nThat narrows down my candidates for primes containing
-      \\\"79\\\"!\",\"type\":\"summary_text\"},{\"text\":\"**Verifying prime numbers**\\n\\nI\u2019m
-      testing if 379 is prime. The square root is around 19.4, so I\u2019ll check
-      primality against smaller primes like 3, 5, 7, 11, 13, 17, and 19. It\u2019s
-      not divisible by any of those. \\n\\nNext, I check 179, and it\u2019s prime
-      too. So far, I have 79, 179, and 379 as primes. I wonder if there are others
-      below 400. \\n\\nBut 297 doesn\u2019t count, since it doesn't have \\\"79\\\"
-      together, and 790 is over my limit. So, I\u2019m stuck with those three!\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing
-      prime count**\\n\\nI realize that since \\\"substring\\\" refers to something
-      contiguous, 97 can't count as \\\"79\\\" reversed. So, I still think there are
-      3 valid primes: 79, 179, and 379. I double-check other three-digit possibilities
-      starting with \\\"79,\\\" but none qualify since they\u2019d exceed 400. \\n\\nI
-      confirmed each candidate: 79, 179, and 379 are primes, while 279 isn\u2019t.
-      Thus, the total count remains three. I\u2019ll summarize the answer as \u201C3\u201D
-      and make sure everything is accurate.\",\"type\":\"summary_text\"},{\"text\":\"**Delivering
-      the answer**\\n\\nThe user wants a straightforward response, just the number
-      without explanations. I need to stick to that and confirm again: the count is
-      indeed \\\"3.\\\" \\n\\nI\u2019ll double-check for any primes like 197, but
-      it doesn't have \\\"79.\\\" And 297 isn\u2019t prime, nor does it contain the
-      substring. So I\u2019m all set to deliver the answer without any additional
-      text. The final output is \\\"3.\\\"\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\",\"role\":\"user\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"},\"stream\":true}"
+    body: '{"input":[{"content":"If you remember what the primes were, then share
+      them, or say ''I don''t remember.''","role":"user"}],"model":"gpt-5","previous_response_id":"resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862","reasoning":{"effort":"minimal"},"stream":true}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '3136'
+      - '265'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -1221,97 +1219,40 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: 'event: response.created
-
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_00b850169f72b9300068f967cb5ac4819497eaf348580cb67f","object":"response","created_at":1761175499,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
-
-
-        event: response.in_progress
-
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_00b850169f72b9300068f967cb5ac4819497eaf348580cb67f","object":"response","created_at":1761175499,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
-
-
-        event: response.output_item.added
-
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_00b850169f72b9300068f967cc559c8194a05a106b3f51420e","type":"reasoning","summary":[]}}
-
-
-        event: response.output_item.done
-
-        data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"rs_00b850169f72b9300068f967cc559c8194a05a106b3f51420e","type":"reasoning","summary":[]}}
-
-
-        event: response.output_item.added
-
-        data: {"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","type":"message","status":"in_progress","content":[],"role":"assistant"}}
-
-
-        event: response.content_part.added
-
-        data: {"type":"response.content_part.added","sequence_number":5,"item_id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","output_index":1,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"71OQt3y4b3a6bV4"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","output_index":1,"content_index":0,"delta":"
-        don''t","logprobs":[],"obfuscation":"3cbh7Rq6rB"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","output_index":1,"content_index":0,"delta":"
-        remember","logprobs":[],"obfuscation":"ZfnMs3Q"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","output_index":1,"content_index":0,"delta":".","logprobs":[],"obfuscation":"veEcEbM0HiAjHGV"}
-
-
-        event: response.output_text.done
-
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","output_index":1,"content_index":0,"text":"I
-        don''t remember.","logprobs":[]}
-
-
-        event: response.content_part.done
-
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
-        don''t remember."}}
-
-
-        event: response.output_item.done
-
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":1,"item":{"id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
-        don''t remember."}],"role":"assistant"}}
-
-
-        event: response.completed
-
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_00b850169f72b9300068f967cb5ac4819497eaf348580cb67f","object":"response","created_at":1761175499,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[{"id":"rs_00b850169f72b9300068f967cc559c8194a05a106b3f51420e","type":"reasoning","summary":[]},{"id":"msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
-        don''t remember."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":62,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}}}
-
-
-        '
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0c1021cd9b668f0300690a20e6560c8195a98850f36195d7fb\",\"object\":\"response\",\"created_at\":1762271462,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":\"resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862\",\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"minimal\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0c1021cd9b668f0300690a20e6560c8195a98850f36195d7fb\",\"object\":\"response\",\"created_at\":1762271462,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":\"resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862\",\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"minimal\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_0c1021cd9b668f0300690a20e6c55081959b805f2d010cc49a\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":3,\"output_index\":0,\"item\":{\"id\":\"rs_0c1021cd9b668f0300690a20e6c55081959b805f2d010cc49a\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":4,\"output_index\":1,\"item\":{\"id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":5,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":6,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"delta\":\"I\",\"logprobs\":[],\"obfuscation\":\"KcGn4DAeHaLhiNG\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":7,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"delta\":\"
+        don\",\"logprobs\":[],\"obfuscation\":\"phFe0F7g9brn\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":8,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"delta\":\"\u2019t\",\"logprobs\":[],\"obfuscation\":\"aiiJVrlgawQCpy\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":9,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"delta\":\"
+        remember\",\"logprobs\":[],\"obfuscation\":\"2fidHF2\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":10,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"qaokQH2aSxgCpX5\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":11,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"text\":\"I
+        don\u2019t remember.\",\"logprobs\":[]}\n\nevent: response.content_part.done\ndata:
+        {\"type\":\"response.content_part.done\",\"sequence_number\":12,\"item_id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        don\u2019t remember.\"}}\n\nevent: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":13,\"output_index\":1,\"item\":{\"id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        don\u2019t remember.\"}],\"role\":\"assistant\"}}\n\nevent: response.completed\ndata:
+        {\"type\":\"response.completed\",\"sequence_number\":14,\"response\":{\"id\":\"resp_0c1021cd9b668f0300690a20e6560c8195a98850f36195d7fb\",\"object\":\"response\",\"created_at\":1762271462,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_0c1021cd9b668f0300690a20e6c55081959b805f2d010cc49a\",\"type\":\"reasoning\",\"summary\":[]},{\"id\":\"msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        don\u2019t remember.\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":\"resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862\",\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"minimal\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":62,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":11,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":73},\"user\":null,\"metadata\":{}}}\n\n"
     headers:
       CF-RAY:
-      - 992cc05679362840-SEA
+      - 9995453efd230f1b-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:24:59 GMT
+      - Tue, 04 Nov 2025 15:51:02 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1327,15 +1268,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '268'
+      - '185'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '308'
+      - '190'
       x-request-id:
-      - req_52be36b7bd94460e8dd2a820f25b1760
+      - req_e5464db8ece7402ab850bcbf64bef745
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/stream.yaml
@@ -7,12 +7,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '235'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -34,946 +38,665 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0322c5b1ca9ff7880068f96782f25c81979cb63e73b61190bb\",\"object\":\"response\",\"created_at\":1761175427,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0322c5b1ca9ff7880068f96782f25c81979cb63e73b61190bb\",\"object\":\"response\",\"created_at\":1761175427,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
-        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Counting\",\"obfuscation\":\"enqAxr\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        primes\",\"obfuscation\":\"MCNDfKAur\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        with\",\"obfuscation\":\"ZR0uJtvTAfB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        substring\",\"obfuscation\":\"cZpEoH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        '\",\"obfuscation\":\"0KXtNJXreAihZr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"Uq8o0tzrmqIVwk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"'\",\"obfuscation\":\"V3nHuLcL3UqxCbi\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"Fw6kdnV5iTO\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        need\",\"obfuscation\":\"wVfrjhef3xs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        to\",\"obfuscation\":\"N19tXp1tqv7wd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        count\",\"obfuscation\":\"tLtd8ohRqg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        prime\",\"obfuscation\":\"GxS2l97rjJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"A29eBaMG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        less\",\"obfuscation\":\"IMAD4fvtZbi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        than\",\"obfuscation\":\"QgzCcXqYHx0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"N1jtqVIU0IP1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        that\",\"obfuscation\":\"xt5UwJET8Nx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        contain\",\"obfuscation\":\"iHXAFBff\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        '\",\"obfuscation\":\"ljlfN0DzHTG5OQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"VlVEP3BH8YPKQK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"'\",\"obfuscation\":\"3YLibK8Keg6wwpV\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        as\",\"obfuscation\":\"a6n07gzGRBFRa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        a\",\"obfuscation\":\"pZJsXtNjtVZ7mw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        substring\",\"obfuscation\":\"say5u6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"HqUBTZDbOTUdemH\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        This\",\"obfuscation\":\"O6uKznB52eR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        means\",\"obfuscation\":\"xYQeKCyLz8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"fGKkHf70PY8S64\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019m\",\"obfuscation\":\"hqkmKSLrmL05XK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        looking\",\"obfuscation\":\"9ze96DL3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        for\",\"obfuscation\":\"cwbkmZ3WCZg9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"NjEITLYO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        like\",\"obfuscation\":\"6tOgGHZFzeD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"oLiChUSr8u2Oi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"KJwDxz2xz2Sfnt3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        179\",\"obfuscation\":\"a3DajTchbPnX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"B48DPsbfqr9v2cF\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        and\",\"obfuscation\":\"yuachriFpKid\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        279\",\"obfuscation\":\"kK6aNsVrdFyY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"1ohM7yKybMoHVpI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        but\",\"obfuscation\":\"kE0m1b9WHqTg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        I\",\"obfuscation\":\"8eRXMaD3nhDOmP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        realized\",\"obfuscation\":\"pb1ZBTS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        that\",\"obfuscation\":\"oB2qczCrxQy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        197\",\"obfuscation\":\"tm7OQIwbHKNR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        doesn't\",\"obfuscation\":\"4CgoJ2sK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        fit\",\"obfuscation\":\"uYrghbO8oOiK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        because\",\"obfuscation\":\"oA4tFCwU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        it\",\"obfuscation\":\"8KZTwpECd08Du\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        contains\",\"obfuscation\":\"3LuMsMv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        97\",\"obfuscation\":\"sOk7hpg9Rdg1t\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        instead\",\"obfuscation\":\"iaTq6WaH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"s5otx2RUhLTh87T\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        So\",\"obfuscation\":\"yGQLXSoaAPdCb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"AykILfShjgJt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        valid\",\"obfuscation\":\"M9t5UhxE4w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"SsKRpORs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        are\",\"obfuscation\":\"yTKxJW83F7rn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"AzuB3XUZKzfwC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"FxnN7TgHNU2jV7Y\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        179\",\"obfuscation\":\"pcphs0CXyqrq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"HWocxqS5meeFqrW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        279\",\"obfuscation\":\"oVsK87ZfhaEy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"OvlK3vcwQ5uKhIP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        and\",\"obfuscation\":\"PzgTdv1yGqtS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        379\",\"obfuscation\":\"yX8qb380usO0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"8vdjDbvpccBtJx1\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        For\",\"obfuscation\":\"Hj8QVVQYYne7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        three\",\"obfuscation\":\"XVDDyoWjqQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"q4AhfJ3oOt\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        numbers\",\"obfuscation\":\"wxyA0SQq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        starting\",\"obfuscation\":\"tjMeAJi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        with\",\"obfuscation\":\"CTkjIyr9BSc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        '\",\"obfuscation\":\"4y6gmiPFUNjjbp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"tNkIlpH8Nsvzux\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"',\",\"obfuscation\":\"Qea3h0EwznWmFq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        the\",\"obfuscation\":\"97LGnvZXLjcz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        range\",\"obfuscation\":\"r09IiAs0QS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        is\",\"obfuscation\":\"8hAGILeuW22Eq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        790\",\"obfuscation\":\"J09szebmrhB2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-\",\"obfuscation\":\"1Ky4E8cJccdEbmL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"799\",\"obfuscation\":\"33qvU5ZWc30K5\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"XH1LbimX0npiRgb\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        which\",\"obfuscation\":\"1zU5nHXo9P\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        exceeds\",\"obfuscation\":\"kPNVprmK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        400\",\"obfuscation\":\"2lZ8ufyrgHGD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"waLBZViv8pizdT2\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        so\",\"obfuscation\":\"CsVe8udsiBcFW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        they\",\"obfuscation\":\"DJMtkcKyY0C\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019re\",\"obfuscation\":\"Bq5rbFUNdlHpq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        not\",\"obfuscation\":\"lp07fRXC0YrI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        applicable\",\"obfuscation\":\"DcmK7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"geZHxgLHwQaYmVZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":97,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        My\",\"obfuscation\":\"Z60PXNSqLSOXm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":98,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        focus\",\"obfuscation\":\"SEcj1EwnC8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":99,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        remains\",\"obfuscation\":\"QchPRt3H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        on\",\"obfuscation\":\"QD4d49gZ6VTqL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        79\",\"obfuscation\":\"7b2hHTxJ5ERYM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"4DSpLDc3dpfK8Xb\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        179\",\"obfuscation\":\"HuxWR4fJgLgk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":104,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"SCakF3Z6uLNgNP8\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":105,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        279\",\"obfuscation\":\"GFYaDaKPyKNw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":106,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"fxl0xu6POBN8dZl\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":107,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        and\",\"obfuscation\":\"1MyTKbJFStVs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        379\",\"obfuscation\":\"I5BF6UAD9OIT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
-        only\",\"obfuscation\":\"ZqgYBpBFhvw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":110,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"YKE5qtno5L5s9Wa\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":111,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Counting
-        primes with substring '79'**\\n\\nI need to count prime numbers less than
-        400 that contain '79' as a substring. This means I\u2019m looking for numbers
-        like 79, 179, and 279, but I realized that 197 doesn't fit because it contains
-        97 instead. So the valid numbers are 79, 179, 279, and 379. For three-digit
-        numbers starting with '79', the range is 790-799, which exceeds 400, so they\u2019re
-        not applicable. My focus remains on 79, 179, 279, and 379 only.\"}\n\nevent:
-        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":112,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
-        primes with substring '79'**\\n\\nI need to count prime numbers less than
-        400 that contain '79' as a substring. This means I\u2019m looking for numbers
-        like 79, 179, and 279, but I realized that 197 doesn't fit because it contains
-        97 instead. So the valid numbers are 79, 179, 279, and 379. For three-digit
-        numbers starting with '79', the range is 790-799, which exceeds 400, so they\u2019re
-        not applicable. My focus remains on 79, 179, 279, and 379 only.\"}}\n\nevent:
-        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":113,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Evalu\",\"obfuscation\":\"74yhMfa5s\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ating\",\"obfuscation\":\"XCdhGnkHt9D\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primes\",\"obfuscation\":\"LFocwlJbF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        with\",\"obfuscation\":\"E9lG0MVtizJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        '\",\"obfuscation\":\"zI47fe1RYF5ESc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"L9ZS2n04DZDc6M\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"'\",\"obfuscation\":\"971B6FxHFTnJjKK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"eWS16fcSulb\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":122,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019ve\",\"obfuscation\":\"xJSeoaf5svoLL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":123,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        got\",\"obfuscation\":\"Xoy8G9znMY9V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":124,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        three\",\"obfuscation\":\"Lcq3IyCRKT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"-digit\",\"obfuscation\":\"K9ISAVAv5S\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":126,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        numbers\",\"obfuscation\":\"8fbXm7x3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":127,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        like\",\"obfuscation\":\"aaur6K0Xl3E\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":128,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"Xq34gUgrKwVp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"pK2Ktqm9elfZBjj\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"PsTZQEv9rpBD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"AEzKZOpB5CTkyHU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"nalYH2XceRC6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"mx8OLVtEtPAV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        that\",\"obfuscation\":\"kCc7iVko8yU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        have\",\"obfuscation\":\"HnkrNxCfERs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        '\",\"obfuscation\":\"JrzmWlD3RGgjR8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"h2ja2NkGq5t7GC\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".'\",\"obfuscation\":\"F0NniATJjfAKWn\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        For\",\"obfuscation\":\"aEkx85awcowO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        two\",\"obfuscation\":\"wpwG7chsUnyC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"-digit\",\"obfuscation\":\"iJehMp5uhN\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"SiSYEl0m6KNj3Nc\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        there's\",\"obfuscation\":\"5F1YZN4I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        79\",\"obfuscation\":\"CtFomq5kn9vTv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        itself\",\"obfuscation\":\"34PljOLaJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"OP8abAnDnjyLiow\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        Now\",\"obfuscation\":\"YWMLL2UOpgf8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"5qNoRkgS5YF7pya\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"wh5fheZDAzcDEs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        need\",\"obfuscation\":\"iNZ6sH7Y6sh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"ubJnKbD7UdNvQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        check\",\"obfuscation\":\"eq1Dct6qYr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        which\",\"obfuscation\":\"qk2A1Pf83k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        of\",\"obfuscation\":\"aB9Oqp9izEMmQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        these\",\"obfuscation\":\"TBCefuTuue\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        are\",\"obfuscation\":\"SaYkLJBJWoaC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"tNfYuQi8c4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"9fzjjw6wMyQEiqP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        We\",\"obfuscation\":\"2DaIujW0IOVTw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        know\",\"obfuscation\":\"PlQ2pDsKJLJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        79\",\"obfuscation\":\"4Wu6Qho4S0gp3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"hbHqW8ZEyUnO0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"xKnRnYTcUD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"t2QHY5Gvd17Npr3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"mZGwUsIrAXhaqg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        think\",\"obfuscation\":\"WfYnV9OmIh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"BmO6GIhYfcze\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"n92gi2t1JcUZu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        also\",\"obfuscation\":\"l8iZ3RRiJZD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"VsgFgCGXzE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"2xa2HT7paSJ3ZDT\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        but\",\"obfuscation\":\"YFkzp4NQCmzY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        279\",\"obfuscation\":\"MvhZyijRZO2V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        is\",\"obfuscation\":\"hgGVgEplXVbga\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        not\",\"obfuscation\":\"N7jCC9fi7Ik2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        since\",\"obfuscation\":\"YTTmrxmhS5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"xBQXp7DsdbXI2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"jSJb5WgEHba9DK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        divisible\",\"obfuscation\":\"AbUXaT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        by\",\"obfuscation\":\"JVhaByozNhszd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        3\",\"obfuscation\":\"QevNgy9mQRpsDl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"OTNKKPsDSGWX8sw\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        For\",\"obfuscation\":\"g36oXUk8h1i6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"nDbXNui1Lwoa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"pmwEY2DnG1wQkuZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"buYojLdyv8Dkh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        appears\",\"obfuscation\":\"4yBR2gVk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        to\",\"obfuscation\":\"gZzWW6vf7Gy5y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        be\",\"obfuscation\":\"Qh4aaLnfheCEB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        prime\",\"obfuscation\":\"9hpr9RA0jN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\";\",\"obfuscation\":\"qatM7eEISLBCnug\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"x80D98yzsjwwI5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        checked\",\"obfuscation\":\"Gfa1IRXm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"z3nktoJR02bu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        '\",\"obfuscation\":\"kYLcUHLFWYfSHx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"6ch3D5qdUFRgQ1\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"'\",\"obfuscation\":\"T4Wv0FaYYJtd1wg\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        indeed\",\"obfuscation\":\"x8sQI9lyD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        appears\",\"obfuscation\":\"8JJreqNv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        consecut\",\"obfuscation\":\"UHrNuFp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ively\",\"obfuscation\":\"43EkCH9Ctk8\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        within\",\"obfuscation\":\"fqNtlNGIa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        it\",\"obfuscation\":\"29OffRhetgNqq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"trpikdbIP3FPqGl\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":205,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        However\",\"obfuscation\":\"Rw2iysPj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":206,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"Sq6ZX42JmcM3Q9W\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":207,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        797\",\"obfuscation\":\"jR0zj7ZHL1PH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        exceeds\",\"obfuscation\":\"ar1hhK0s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        400\",\"obfuscation\":\"ek32huGmj1NG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"eswNaXLp1UC5vnm\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        so\",\"obfuscation\":\"qH8QybrokWV1f\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I\",\"obfuscation\":\"CwC3BmXvQtGRHb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        won't\",\"obfuscation\":\"bhIaO3DQxh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        count\",\"obfuscation\":\"IJljckW7Cg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":215,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        that\",\"obfuscation\":\"7EkyP4WxlwO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":216,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"xEyzOH7gG7AU1GP\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":217,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        So\",\"obfuscation\":\"HiyjcssAEKL3l\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"iUaO6YzFpn6NbS7\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        the\",\"obfuscation\":\"YT0RHIIy9v8l\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        primes\",\"obfuscation\":\"5w7mAt00D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        I'm\",\"obfuscation\":\"tLQUxgfVZ67T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        left\",\"obfuscation\":\"wY3UcJGpwhk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":223,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        with\",\"obfuscation\":\"bs4MHmAAxpp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":224,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        are\",\"obfuscation\":\"7R6hxP9CX7Ws\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":225,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        79\",\"obfuscation\":\"BpntdFO5Eppxh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":226,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"zdY0bfQrkd0vs3I\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":227,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        179\",\"obfuscation\":\"AbuQrNLYhjIC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":228,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"3hpeIu1jrC4X1wF\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":229,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        and\",\"obfuscation\":\"vX34rrGr2CSD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":230,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
-        379\",\"obfuscation\":\"2ZuSLbgbLKhB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":231,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"8XVSyoVICsU6Uhq\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":232,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Evaluating
-        primes with '79'**\\n\\nI\u2019ve got three-digit numbers like 179, 279, and
-        379 that have '79.' For two-digit, there's 79 itself. Now, I need to check
-        which of these are prime. We know 79 is prime. I think 179 is also prime,
-        but 279 is not since it\u2019s divisible by 3. For 379, it appears to be prime;
-        I checked and '79' indeed appears consecutively within it. However, 797 exceeds
-        400, so I won't count that. So, the primes I'm left with are 79, 179, and
-        379.\"}\n\nevent: response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":233,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Evaluating
-        primes with '79'**\\n\\nI\u2019ve got three-digit numbers like 179, 279, and
-        379 that have '79.' For two-digit, there's 79 itself. Now, I need to check
-        which of these are prime. We know 79 is prime. I think 179 is also prime,
-        but 279 is not since it\u2019s divisible by 3. For 379, it appears to be prime;
-        I checked and '79' indeed appears consecutively within it. However, 797 exceeds
-        400, so I won't count that. So, the primes I'm left with are 79, 179, and
-        379.\"}}\n\nevent: response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":234,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Ident\",\"obfuscation\":\"rgedWakfK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ifying\",\"obfuscation\":\"tOTIP6DypT\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"PycJ9NuG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        with\",\"obfuscation\":\"hwh2wpFCvsp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        '\",\"obfuscation\":\"yoOmm55upfSQtW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"Mtf9qSttCOzs62\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"'\",\"obfuscation\":\"foQZJv2pn8wlvrN\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nLet\",\"obfuscation\":\"ZehDlBR0P\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019s\",\"obfuscation\":\"pIy9F4vrGGu6cY\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        find\",\"obfuscation\":\"G0jfbGjHxN2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        all\",\"obfuscation\":\"pNXOOuhlDE46\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"a6k7WBd1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        under\",\"obfuscation\":\"NJ44aiGyPm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"0lefJgeE1igI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        that\",\"obfuscation\":\"d5i2IZNI2uN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        contain\",\"obfuscation\":\"dW32lEnL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        '\",\"obfuscation\":\"CiStULQ1yaDqlu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"gwmxNaU65bJZKU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".'\",\"obfuscation\":\"lwAVfSFKyZfhKc\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        The\",\"obfuscation\":\"eOueFP2jby8I\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        two\",\"obfuscation\":\"RViOYDzYmvXM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"A2EznUi5Sr\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        number\",\"obfuscation\":\"obcEWQ0TR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"XtLZnUpxd8YWn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"a4Y0qsgclmd2B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"n4PTrkKTXiJkcEq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        For\",\"obfuscation\":\"9OOMq9Fssi5V\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        three\",\"obfuscation\":\"kMmDqHxxev\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-digit\",\"obfuscation\":\"ZQHl1WQaJI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"kCB350Sx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":265,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"ZDPhiEEdq7FXq1k\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":266,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        the\",\"obfuscation\":\"c2nGPMHt48hN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":267,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        possible\",\"obfuscation\":\"wtyuYZB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        patterns\",\"obfuscation\":\"bdJO58n\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"MX6xGelywaeQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"gZdKu1ar57kY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"eXH5qYLbU0hxOfK\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        279\",\"obfuscation\":\"Ft5gHW4xCu3u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"w88qjjU8lTcJh78\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"ZvBS7mcRL13f\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"vXnhTB4eJ1vo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        while\",\"obfuscation\":\"VgzPRZHJdT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        anything\",\"obfuscation\":\"gSWnNYj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        starting\",\"obfuscation\":\"VO1AxAb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        with\",\"obfuscation\":\"2Q032eT3xTJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        '\",\"obfuscation\":\"JPUvftgcepM0cb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"rPe0ioiXVgAMaJ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"'\",\"obfuscation\":\"jFR6di5PXE83ips\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        (\",\"obfuscation\":\"Ow4GHxRg5UHrr1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"like\",\"obfuscation\":\"irNnjfqJVbkq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        790\",\"obfuscation\":\"bjAbTJSVp8oE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"-\",\"obfuscation\":\"ChGhnmtorNvr3ic\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"799\",\"obfuscation\":\"dM165xDbbfzwA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\")\",\"obfuscation\":\"U1x53qmJAmMp3tZ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"E09ZgnR7FwtqG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        out\",\"obfuscation\":\"bHOUCqmx2bDv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        since\",\"obfuscation\":\"KPAFk0sAYs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        they're\",\"obfuscation\":\"bYoBezii\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        above\",\"obfuscation\":\"EtpaqT6h5c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        400\",\"obfuscation\":\"TEJ7vYOzE2P4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"25nepIiOFQwSGv6\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        So\",\"obfuscation\":\"Zcm2DBk2qMJck\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"8GuNH4hwdAvPPPJ\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        the\",\"obfuscation\":\"18w8MlQA8nKU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        valid\",\"obfuscation\":\"eXYyCHAm6D\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        numbers\",\"obfuscation\":\"UOpzeCLF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        are\",\"obfuscation\":\"70atNOCtZ11A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        just\",\"obfuscation\":\"wYhKeLEPY2X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"08V9RASWT7m1y\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"H1KCjtFQLac6ALL\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"dAtx8gi0a39A\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"LmyrPxlbh8VcUTk\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        279\",\"obfuscation\":\"QIst3paFdFyW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"2XRQeTys16LSZ9G\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        and\",\"obfuscation\":\"Sdz5zeXCNTsG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        379\",\"obfuscation\":\"vO2gM523fP2X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"DxNMgrI3hlIdXAr\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        \\n\\nNow\",\"obfuscation\":\"POGPOmbH4s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"EHpE2Tffqgjv3wb\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"1s75McQeOc0kyT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        need\",\"obfuscation\":\"zYh5whGZNz0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        to\",\"obfuscation\":\"h53z0qsiQNXPZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        check\",\"obfuscation\":\"kvnf5FKflR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        for\",\"obfuscation\":\"wm8fv4IoL8gM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        primes\",\"obfuscation\":\"SmWt3KyiV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        among\",\"obfuscation\":\"tn5ZVY35pe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        them\",\"obfuscation\":\"2FrWc3f6STX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"2ybthHO4jxOYRdr\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"5sajEY6dTziP3m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":324,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        know\",\"obfuscation\":\"huLTcpiwMbV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":325,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        that\",\"obfuscation\":\"DTGNjDZud7l\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":326,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        79\",\"obfuscation\":\"kr0hG1w8htJJz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":327,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        is\",\"obfuscation\":\"zcjd1xCG8vwuQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":328,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"XXYhYKfqfa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":329,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"OlSiOF67xdUWN6J\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":330,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        For\",\"obfuscation\":\"0uYa2c0xdXP4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":331,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        179\",\"obfuscation\":\"5Gdj8Ckm0Agc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":332,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"jiCMFNeLl9mz2iU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":333,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        I\",\"obfuscation\":\"JAbCoyHg0Erf1T\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":334,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        confirmed\",\"obfuscation\":\"ypOzGa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":335,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        it\",\"obfuscation\":\"idZPlQKYNpNtI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":336,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019s\",\"obfuscation\":\"UF3GhjL8naMELv\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":337,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        not\",\"obfuscation\":\"3e630o6KvaQC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":338,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        divisible\",\"obfuscation\":\"sBSR6L\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":339,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        by\",\"obfuscation\":\"0wXSRmactiRVc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":340,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        3\",\"obfuscation\":\"P4F9OryAtazB4h\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":341,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"SesWoTSjcImLNK7\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":342,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        5\",\"obfuscation\":\"blkQI7gbYh78u2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":343,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"q4Qy1w6TnZkrnYI\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":344,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        7\",\"obfuscation\":\"PyhogVUGRxQYKo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":345,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"51UQt6iXpZ81g4G\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":346,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        11\",\"obfuscation\":\"haS544zwOjrmn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":347,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"O9nVQxGPMsErDUg\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":348,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        or\",\"obfuscation\":\"vas1ehAH5O9Fd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":349,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        13\",\"obfuscation\":\"RLse3D0QWXX1s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":350,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"217ujUpEcBraNNb\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":351,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        so\",\"obfuscation\":\"W4Ybbrzwul14G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":352,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        it\",\"obfuscation\":\"4LrQiODrU5H29\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":353,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        should\",\"obfuscation\":\"7luJ1cJ5x\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":354,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        be\",\"obfuscation\":\"oLC1X6ntDigt0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":355,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        prime\",\"obfuscation\":\"wIBKbDvHGj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":356,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
-        too\",\"obfuscation\":\"KVlDS77nnTHu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":357,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"delta\":\"!\",\"obfuscation\":\"55awSbiCvU9g2o3\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":358,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Identifying
-        numbers with '79'**\\n\\nLet\u2019s find all numbers under 400 that contain
-        '79.' The two-digit number is 79. For three-digit numbers, the possible patterns
-        are 179, 279, and 379 while anything starting with '79' (like 790-799) is
-        out since they're above 400. So, the valid numbers are just 79, 179, 279,
-        and 379. \\n\\nNow, I need to check for primes among them. I know that 79
-        is prime. For 179, I confirmed it\u2019s not divisible by 3, 5, 7, 11, or
-        13, so it should be prime too!\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":359,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Identifying
-        numbers with '79'**\\n\\nLet\u2019s find all numbers under 400 that contain
-        '79.' The two-digit number is 79. For three-digit numbers, the possible patterns
-        are 179, 279, and 379 while anything starting with '79' (like 790-799) is
-        out since they're above 400. So, the valid numbers are just 79, 179, 279,
-        and 379. \\n\\nNow, I need to check for primes among them. I know that 79
-        is prime. For 179, I confirmed it\u2019s not divisible by 3, 5, 7, 11, or
-        13, so it should be prime too!\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
-        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":360,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":361,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**Ver\",\"obfuscation\":\"ofe7WSO9Wzz\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":362,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"ifying\",\"obfuscation\":\"bQnp34b6Ak\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":363,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"Lvlu3EMbY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":364,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"YcgzfGrF5fFk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":365,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        counts\",\"obfuscation\":\"xK0PmB8As\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":366,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"**\\n\\nFor\",\"obfuscation\":\"cXyFth7Qq\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":367,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        179\",\"obfuscation\":\"5KfJ14C6RWyZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":368,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"Gw9rRPPRxf8tUa3\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":369,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"DkkwFPOvYuC927\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":370,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        checked\",\"obfuscation\":\"ufLL9ETn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":371,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"v3wGvCh5QQcXP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":372,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        against\",\"obfuscation\":\"YH8pT1TD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":373,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        several\",\"obfuscation\":\"Y1wkuLhT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":374,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"eraiCqhYo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":375,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"kBqcI6Gj2oRp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":376,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        confirmed\",\"obfuscation\":\"eEy0iv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":377,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"3ZwMExxDI8z\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":378,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"NfLil36wfI1gF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":379,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019s\",\"obfuscation\":\"XKz5QEQsNRw5am\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":380,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        indeed\",\"obfuscation\":\"4kNSawmrI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":381,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"JffhFUliYK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":382,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"UjDkuyOcUNiCw2A\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":383,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        As\",\"obfuscation\":\"dLLLF6tK7z7uV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":384,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        for\",\"obfuscation\":\"ZO3dvKRZ84NV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":385,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        279\",\"obfuscation\":\"rCU7VBxBKTKM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":386,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"jGXcy4OCU4qiX87\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":387,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"ygT92St4YG7dO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":388,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019s\",\"obfuscation\":\"3CkQRMjq2azs5g\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":389,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        divisible\",\"obfuscation\":\"oLNFjk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":390,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        by\",\"obfuscation\":\"mq3xONDC7tqZi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":391,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        3\",\"obfuscation\":\"E1bc0Rs66MnMCo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":392,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"Y5xI4OdvAJbK98G\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":393,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        so\",\"obfuscation\":\"hfZqT8PrP51Ao\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":394,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"oCs5sFuGuW2hC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":395,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"\u2019s\",\"obfuscation\":\"WQ2iTwwOAKA4u0\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":396,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        not\",\"obfuscation\":\"lHUDKiscRqo3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":397,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"TMe4J4KU6c\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":398,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"2tIBW3Le4tQAXsY\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":399,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\n\\nThen\",\"obfuscation\":\"AU0hKDyiK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":400,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"BDMAs3C1vvUSAd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":401,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        turned\",\"obfuscation\":\"nqXtpN2hP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":402,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        to\",\"obfuscation\":\"5k4acWGne0Ugq\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":403,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"zX5Oa7SuVlyf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":404,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"IDs8NFOpFAGSrBl\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":405,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        The\",\"obfuscation\":\"hSaV7Plz6DRO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":406,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        square\",\"obfuscation\":\"SJogPIaUW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":407,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        root\",\"obfuscation\":\"9TKINPRELOY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":408,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"YJaS0CKvGMqxF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":409,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        about\",\"obfuscation\":\"WouBhDGia3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":410,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        19\",\"obfuscation\":\"iJEEQXTBhDkHY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":411,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"bhWCEHioYMtetiv\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":412,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"467\",\"obfuscation\":\"31vuoGcuIQ76M\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":413,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"rUfyl7tmW0EJLYs\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":414,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        so\",\"obfuscation\":\"i7ZdCutTLfkQ2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":415,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"PVqSg9jOHhWHoV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":416,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        checked\",\"obfuscation\":\"owbfD2P9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":417,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        against\",\"obfuscation\":\"fQ57uWiY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":418,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        all\",\"obfuscation\":\"9qT9mZQ7Io4C\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":419,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"TcsWQH8ZCj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":420,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        numbers\",\"obfuscation\":\"9qSGxQ24\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":421,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        up\",\"obfuscation\":\"xpX6e84fslhcS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":422,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        to\",\"obfuscation\":\"z1b9QubZrOZTa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":423,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        19\",\"obfuscation\":\"mj7q2nHwAG5YH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":424,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"swERZTZzTdFv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":425,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        found\",\"obfuscation\":\"tL0QYfEq30\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":426,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"MJf2tFqK8Xn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":427,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        none\",\"obfuscation\":\"IezDVngnBv3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":428,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        divide\",\"obfuscation\":\"COI0W5UJJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":429,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        it\",\"obfuscation\":\"etCvSn2tAcmG4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":430,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        evenly\",\"obfuscation\":\"XSYAcTAJw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":431,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"KtEMmmoPSNINTUA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":432,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        Thus\",\"obfuscation\":\"miMzTDMuRia\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":433,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"7p7gPDHlDutfbKA\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":434,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"dMjL5cnqc0W0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":435,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"fNcwypH36Txik\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":436,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        also\",\"obfuscation\":\"AgmW4PaOpBD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":437,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        prime\",\"obfuscation\":\"ueNJMg3vo9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":438,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"8WPNEFvHU8I33sW\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":439,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        \\n\\nSo\",\"obfuscation\":\"rYtnpJdRx3l\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":440,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"aWMdosJrJBFP78s\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":441,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"4Ry0Eu1KNW0sly\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":442,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        have\",\"obfuscation\":\"EJ152qSwOOX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":443,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        three\",\"obfuscation\":\"JlEFsUvFbo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":444,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"JAJVwvm3t\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":445,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\":\",\"obfuscation\":\"N9nmth375rxDAbN\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":446,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        79\",\"obfuscation\":\"YfWvSzEfDmgaE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":447,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"SHiNGFAeGE6ESR4\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":448,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        179\",\"obfuscation\":\"PJEvag01XfAc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":449,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\",\",\"obfuscation\":\"ZNpbm9NpS9shxvg\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":450,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"9O7VJt1Lu77u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":451,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        379\",\"obfuscation\":\"szs8o7mLeMpm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":452,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"H3nAjaOnbrMujQU\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":453,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        I\",\"obfuscation\":\"XElkj8z7lZ7XE3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":454,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        made\",\"obfuscation\":\"UEQ3Y8YxLqW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":455,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        sure\",\"obfuscation\":\"CcW4w828f6G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":456,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        to\",\"obfuscation\":\"3rMVHyD17nDcw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":457,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        rule\",\"obfuscation\":\"fGBbo1KWuPQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":458,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        out\",\"obfuscation\":\"r9lzkFDQbMex\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":459,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        other\",\"obfuscation\":\"de9KyvtaX3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":460,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        numbers\",\"obfuscation\":\"NrjkHUj4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":461,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        containing\",\"obfuscation\":\"H4MZt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":462,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        '\",\"obfuscation\":\"eu79vrThxBBmJn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":463,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"79\",\"obfuscation\":\"sf8oElll3m9F24\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":464,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"'\",\"obfuscation\":\"LKBM4sIStVoqKRE\"}\n\nevent:
-        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":465,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        and\",\"obfuscation\":\"xnowoICx9lOF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":466,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        concluded\",\"obfuscation\":\"5zVDNf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":467,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        that\",\"obfuscation\":\"xctTbPl79JI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":468,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        the\",\"obfuscation\":\"GtKO2H0I8jhj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":469,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        answer\",\"obfuscation\":\"4ZerMO4Dl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":470,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        is\",\"obfuscation\":\"YGuiN1LHoWXP5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":471,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        3\",\"obfuscation\":\"O6CaBYzpruLXo8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":472,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        primes\",\"obfuscation\":\"M6tF0zPEo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":473,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\"
-        altogether\",\"obfuscation\":\"fV0ET\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
-        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":474,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"delta\":\".\",\"obfuscation\":\"vweKVDxB9ByB6jM\"}\n\nevent:
-        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":475,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"text\":\"**Verifying
-        primes and counts**\\n\\nFor 179, I checked it against several primes and
-        confirmed that it\u2019s indeed prime. As for 279, it\u2019s divisible by
-        3, so it\u2019s not prime. \\n\\nThen I turned to 379. The square root is
-        about 19.467, so I checked against all prime numbers up to 19 and found that
-        none divide it evenly. Thus, 379 is also prime. \\n\\nSo, I have three primes:
-        79, 179, and 379. I made sure to rule out other numbers containing '79' and
-        concluded that the answer is 3 primes altogether.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
-        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":476,\"item_id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"output_index\":0,\"summary_index\":3,\"part\":{\"type\":\"summary_text\",\"text\":\"**Verifying
-        primes and counts**\\n\\nFor 179, I checked it against several primes and
-        confirmed that it\u2019s indeed prime. As for 279, it\u2019s divisible by
-        3, so it\u2019s not prime. \\n\\nThen I turned to 379. The square root is
-        about 19.467, so I checked against all prime numbers up to 19 and found that
-        none divide it evenly. Thus, 379 is also prime. \\n\\nSo, I have three primes:
-        79, 179, and 379. I made sure to rule out other numbers containing '79' and
-        concluded that the answer is 3 primes altogether.\"}}\n\nevent: response.output_item.done\ndata:
-        {\"type\":\"response.output_item.done\",\"sequence_number\":477,\"output_index\":0,\"item\":{\"id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
-        primes with substring '79'**\\n\\nI need to count prime numbers less than
-        400 that contain '79' as a substring. This means I\u2019m looking for numbers
-        like 79, 179, and 279, but I realized that 197 doesn't fit because it contains
-        97 instead. So the valid numbers are 79, 179, 279, and 379. For three-digit
-        numbers starting with '79', the range is 790-799, which exceeds 400, so they\u2019re
-        not applicable. My focus remains on 79, 179, 279, and 379 only.\"},{\"type\":\"summary_text\",\"text\":\"**Evaluating
-        primes with '79'**\\n\\nI\u2019ve got three-digit numbers like 179, 279, and
-        379 that have '79.' For two-digit, there's 79 itself. Now, I need to check
-        which of these are prime. We know 79 is prime. I think 179 is also prime,
-        but 279 is not since it\u2019s divisible by 3. For 379, it appears to be prime;
-        I checked and '79' indeed appears consecutively within it. However, 797 exceeds
-        400, so I won't count that. So, the primes I'm left with are 79, 179, and
-        379.\"},{\"type\":\"summary_text\",\"text\":\"**Identifying numbers with '79'**\\n\\nLet\u2019s
-        find all numbers under 400 that contain '79.' The two-digit number is 79.
-        For three-digit numbers, the possible patterns are 179, 279, and 379 while
-        anything starting with '79' (like 790-799) is out since they're above 400.
-        So, the valid numbers are just 79, 179, 279, and 379. \\n\\nNow, I need to
-        check for primes among them. I know that 79 is prime. For 179, I confirmed
-        it\u2019s not divisible by 3, 5, 7, 11, or 13, so it should be prime too!\"},{\"type\":\"summary_text\",\"text\":\"**Verifying
-        primes and counts**\\n\\nFor 179, I checked it against several primes and
-        confirmed that it\u2019s indeed prime. As for 279, it\u2019s divisible by
-        3, so it\u2019s not prime. \\n\\nThen I turned to 379. The square root is
-        about 19.467, so I checked against all prime numbers up to 19 and found that
-        none divide it evenly. Thus, 379 is also prime. \\n\\nSo, I have three primes:
-        79, 179, and 379. I made sure to rule out other numbers containing '79' and
-        concluded that the answer is 3 primes altogether.\"}]}}\n\nevent: response.output_item.added\ndata:
-        {\"type\":\"response.output_item.added\",\"sequence_number\":478,\"output_index\":1,\"item\":{\"id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
-        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":479,\"item_id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
-        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":480,\"item_id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"qI8Rb4OefOBZXc7\"}\n\nevent:
-        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":481,\"item_id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
-        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":482,\"item_id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
-        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":483,\"output_index\":1,\"item\":{\"id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
-        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":484,\"response\":{\"id\":\"resp_0322c5b1ca9ff7880068f96782f25c81979cb63e73b61190bb\",\"object\":\"response\",\"created_at\":1761175427,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
-        primes with substring '79'**\\n\\nI need to count prime numbers less than
-        400 that contain '79' as a substring. This means I\u2019m looking for numbers
-        like 79, 179, and 279, but I realized that 197 doesn't fit because it contains
-        97 instead. So the valid numbers are 79, 179, 279, and 379. For three-digit
-        numbers starting with '79', the range is 790-799, which exceeds 400, so they\u2019re
-        not applicable. My focus remains on 79, 179, 279, and 379 only.\"},{\"type\":\"summary_text\",\"text\":\"**Evaluating
-        primes with '79'**\\n\\nI\u2019ve got three-digit numbers like 179, 279, and
-        379 that have '79.' For two-digit, there's 79 itself. Now, I need to check
-        which of these are prime. We know 79 is prime. I think 179 is also prime,
-        but 279 is not since it\u2019s divisible by 3. For 379, it appears to be prime;
-        I checked and '79' indeed appears consecutively within it. However, 797 exceeds
-        400, so I won't count that. So, the primes I'm left with are 79, 179, and
-        379.\"},{\"type\":\"summary_text\",\"text\":\"**Identifying numbers with '79'**\\n\\nLet\u2019s
-        find all numbers under 400 that contain '79.' The two-digit number is 79.
-        For three-digit numbers, the possible patterns are 179, 279, and 379 while
-        anything starting with '79' (like 790-799) is out since they're above 400.
-        So, the valid numbers are just 79, 179, 279, and 379. \\n\\nNow, I need to
-        check for primes among them. I know that 79 is prime. For 179, I confirmed
-        it\u2019s not divisible by 3, 5, 7, 11, or 13, so it should be prime too!\"},{\"type\":\"summary_text\",\"text\":\"**Verifying
-        primes and counts**\\n\\nFor 179, I checked it against several primes and
-        confirmed that it\u2019s indeed prime. As for 279, it\u2019s divisible by
-        3, so it\u2019s not prime. \\n\\nThen I turned to 379. The square root is
-        about 19.467, so I checked against all prime numbers up to 19 and found that
-        none divide it evenly. Thus, 379 is also prime. \\n\\nSo, I have three primes:
-        79, 179, and 379. I made sure to rule out other numbers containing '79' and
-        concluded that the answer is 3 primes altogether.\"}]},{\"id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":1095,\"output_tokens_details\":{\"reasoning_tokens\":1088},\"total_tokens\":1127},\"user\":null,\"metadata\":{}}}\n\n"
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13\",\"object\":\"response\",\"created_at\":1762271376,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13\",\"object\":\"response\",\"created_at\":1762271376,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"type\":\"reasoning\",\"summary\":[]}}\n\nevent:
+        response.reasoning_summary_part.added\ndata: {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":3,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":4,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**Counting\",\"obfuscation\":\"PQBcUI\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":5,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        prime\",\"obfuscation\":\"o8z6TV2SlL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":6,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"CrFvzmqv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":7,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        with\",\"obfuscation\":\"4v0LboCwNtz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":8,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        '\",\"obfuscation\":\"UyRvpAS0JAPbBj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":9,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"GcpU7P2klUhMny\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":10,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"'\",\"obfuscation\":\"fLpVFnqbTSIClcF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":11,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"**\\n\\nI'm\",\"obfuscation\":\"Wtynvkr3Q\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":12,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        looking\",\"obfuscation\":\"VjuwfoF8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":13,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        for\",\"obfuscation\":\"M5roxtMm8aUQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":14,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        prime\",\"obfuscation\":\"uwlW7qDrKg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":15,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"ageyqUd7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":16,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        less\",\"obfuscation\":\"5b6F8Y2H1zu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":17,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        than\",\"obfuscation\":\"KxTFbyv0s18\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":18,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"d2JVcH0ulrXz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":19,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"FSXZtjhPvOf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":20,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        have\",\"obfuscation\":\"Hr1Bts9JLoQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":21,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"WrukMCIDSUmo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":22,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        substring\",\"obfuscation\":\"SBYJy2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":23,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"K19b14yApv6S3H\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":24,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"cvUIryKd8otY6i\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":25,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\\\"\",\"obfuscation\":\"J6uIVM6MC0bVN7\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":26,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        First\",\"obfuscation\":\"FZqz7xVean\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":27,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"KH6zPDXupi30T7I\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":28,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"twU2b23tzM0435\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":29,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019ll\",\"obfuscation\":\"eB0xJ39yeU6EK\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":30,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        identify\",\"obfuscation\":\"5XVZpUS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":31,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        all\",\"obfuscation\":\"WHxuub8AHQ3u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":32,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        primes\",\"obfuscation\":\"ZPMz7Oxpv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":33,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        below\",\"obfuscation\":\"0TvNSPShd3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":34,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"iDgpknYcSwnF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":35,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"nz88PI6jzlE2YIP\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":36,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        Then\",\"obfuscation\":\"4ePU5Lg9UCu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":37,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"qvmrSXOwn1ncduw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":38,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        I\",\"obfuscation\":\"ZqILDtxKwXm6F4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":39,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019ll\",\"obfuscation\":\"S06qWw3sSEypc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":40,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        check\",\"obfuscation\":\"5M5oDy03Ie\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":41,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        two\",\"obfuscation\":\"rWWlqTpojuxH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":42,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"PHCHuv1YX0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":43,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"R87nlp3R2Dvn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":44,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        three\",\"obfuscation\":\"MQZHBc0ZoB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":45,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"Fw6Pb2fT6f\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":46,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"105Z5WT3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":47,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        that\",\"obfuscation\":\"7OCoG5ZPCUp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":48,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        contain\",\"obfuscation\":\"92MBExPQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":49,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\\"\",\"obfuscation\":\"1S9y8b4lRVJDqj\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":50,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"79\",\"obfuscation\":\"EnjsicKzNq4buT\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":51,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\\\"\",\"obfuscation\":\"rAAnk7UWwdEpTu\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":52,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        \\n\\nIn\",\"obfuscation\":\"45WLO01XRgD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":53,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"1L3aAdS7cs9a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":54,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        two\",\"obfuscation\":\"NT5JEsqvDzv5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":55,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"dSu6PAA0VR\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":56,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        range\",\"obfuscation\":\"5rCMK8yYre\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":57,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"SRubVN4U3TlyFxx\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":58,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        we\",\"obfuscation\":\"DhzJ6FMktvb9w\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":59,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        only\",\"obfuscation\":\"ShfZxnt60lG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":60,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        have\",\"obfuscation\":\"fwWz1ox7HpN\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":61,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        79\",\"obfuscation\":\"13WUNDFpvTayK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":62,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        itself\",\"obfuscation\":\"eahPPm27a\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":63,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"SDbFQNOXxHO2teb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":64,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        For\",\"obfuscation\":\"Jw6JRAuuMt5B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":65,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        three\",\"obfuscation\":\"ASJDPUxwf1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":66,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"-digit\",\"obfuscation\":\"qtRdCllWmd\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":67,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"kzW8y4G3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":68,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"Pk3ybUpuQldjQKS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":69,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"3SUhqU1jYAqD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":70,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        relevant\",\"obfuscation\":\"GNdXWv5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":71,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        candidates\",\"obfuscation\":\"gTZn6\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":72,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        are\",\"obfuscation\":\"on6FMClpPue7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":73,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        179\",\"obfuscation\":\"m2LqRB8QbvRK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":74,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"n7NY1BArqOPhoNP\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":75,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        279\",\"obfuscation\":\"xUyMrD2yL6EM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":76,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"LUzFTLNQ5C1XMpF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":77,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"hESVzvj9DTL4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":78,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        379\",\"obfuscation\":\"HT0xqm0dnUQf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":79,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"vdsaMdlrHrhfOB2\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":80,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        However\",\"obfuscation\":\"5EVpwrv3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":81,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"7WYLn0fam2MtE1q\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":82,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        numbers\",\"obfuscation\":\"2SreLj0m\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":83,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        like\",\"obfuscation\":\"Aji8yR8qKNY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":84,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        790\",\"obfuscation\":\"NW39PSr05FJP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":85,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        or\",\"obfuscation\":\"ZSgx0O62VVxgO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":86,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        above\",\"obfuscation\":\"ArtCJKVuus\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":87,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        don\",\"obfuscation\":\"Sw67qhJSYXkP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":88,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"\u2019t\",\"obfuscation\":\"NZZ7CfjXlrKJYk\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":89,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        count\",\"obfuscation\":\"R2MklQ1LXH\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":90,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        since\",\"obfuscation\":\"hmQn8AHrNP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":91,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        they\",\"obfuscation\":\"nUS6P1SIOWK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":92,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        exceed\",\"obfuscation\":\"Mn0Qpno57\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":93,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        400\",\"obfuscation\":\"u0mWQTK6OTdT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":94,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"dtEfyoYdQqlWLOD\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":95,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        So\",\"obfuscation\":\"2F7SqbdwvNmnS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":96,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"ZA9o79aKZDZDLNA\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":97,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        the\",\"obfuscation\":\"PZd3jMsVrZwL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":98,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        confirmed\",\"obfuscation\":\"E2zYBE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":99,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        candidates\",\"obfuscation\":\"h32pZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":100,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        are\",\"obfuscation\":\"yTQ9ZpLry42q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":101,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        79\",\"obfuscation\":\"OQzieFVCAm7V2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":102,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"lp5bS0cfNeciKel\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":103,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        179\",\"obfuscation\":\"WAZ3XXosC6KY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":104,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"0A75IUTCaUsaCQn\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":105,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        279\",\"obfuscation\":\"DBrwxYfMrrEP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":106,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\",\",\"obfuscation\":\"XV0FlkPhD1V6OBV\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":107,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        and\",\"obfuscation\":\"zlocgr7MD7GP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":108,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\"
+        379\",\"obfuscation\":\"0568KnFgojVn\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":109,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"delta\":\".\",\"obfuscation\":\"jlacMjh1TYDC5Ts\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":110,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"text\":\"**Counting
+        prime numbers with '79'**\\n\\nI'm looking for prime numbers less than 400
+        that have the substring \\\"79.\\\" First, I\u2019ll identify all primes below
+        400. Then, I\u2019ll check two-digit and three-digit numbers that contain
+        \\\"79.\\\" \\n\\nIn the two-digit range, we only have 79 itself. For three-digit
+        numbers, the relevant candidates are 179, 279, and 379. However, numbers like
+        790 or above don\u2019t count since they exceed 400. So, the confirmed candidates
+        are 79, 179, 279, and 379.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":111,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":0,\"part\":{\"type\":\"summary_text\",\"text\":\"**Counting
+        prime numbers with '79'**\\n\\nI'm looking for prime numbers less than 400
+        that have the substring \\\"79.\\\" First, I\u2019ll identify all primes below
+        400. Then, I\u2019ll check two-digit and three-digit numbers that contain
+        \\\"79.\\\" \\n\\nIn the two-digit range, we only have 79 itself. For three-digit
+        numbers, the relevant candidates are 179, 279, and 379. However, numbers like
+        790 or above don\u2019t count since they exceed 400. So, the confirmed candidates
+        are 79, 179, 279, and 379.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
+        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":112,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":113,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**Ver\",\"obfuscation\":\"RIOvRHquFfi\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":114,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ifying\",\"obfuscation\":\"6GR1kK8M1M\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":115,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        prime\",\"obfuscation\":\"xWIzUMJxJC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":116,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        status\",\"obfuscation\":\"Noa8T7quS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":117,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        of\",\"obfuscation\":\"slcPGdU27u3pA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":118,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        candidates\",\"obfuscation\":\"Lkz13\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":119,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"j83ozY0IMMO\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":120,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        need\",\"obfuscation\":\"DKDOutFldq0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":121,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        to\",\"obfuscation\":\"zWqkHx6voUaQF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":122,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        ensure\",\"obfuscation\":\"ep5GIwhO0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":123,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        that\",\"obfuscation\":\"kpPvLUw8K30\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":124,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\\"\",\"obfuscation\":\"c0VSAXinNmEuGB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":125,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"79\",\"obfuscation\":\"1yKsNCXM2iepSn\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":126,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\\\"\",\"obfuscation\":\"rPdlPtx5gb7pvY0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":127,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        is\",\"obfuscation\":\"t1qxV7lC9Iz51\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":128,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        specifically\",\"obfuscation\":\"XL8\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":129,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        in\",\"obfuscation\":\"6bPx78Hm0GzO9\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":130,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        that\",\"obfuscation\":\"2M6KqdUwS6W\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":131,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        order\",\"obfuscation\":\"b7wWJ7oEaD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":132,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"MVaFEYJGzptRLZ0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":133,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        which\",\"obfuscation\":\"QbwB2WKVOi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":134,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        means\",\"obfuscation\":\"hZwC6lB4Yz\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":135,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"9Imn2fhZjkPgbE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":136,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019m\",\"obfuscation\":\"QbzvU08En8Hp4x\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":137,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        working\",\"obfuscation\":\"scTYzmSD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":138,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        with\",\"obfuscation\":\"c1PvKooEakP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":139,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        four\",\"obfuscation\":\"GsOxXkjn3BJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":140,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        candidates\",\"obfuscation\":\"Qgozp\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":141,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\":\",\"obfuscation\":\"1zMpEerOwXzoRTw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":142,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"XA49aK62iLDcY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":143,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"Tme4Z8m4DvG8HhG\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":144,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        179\",\"obfuscation\":\"cCgxmaNFf1AG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":145,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"MQu70LAHpN6zDio\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":146,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        279\",\"obfuscation\":\"vtVW4OFTmxFO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":147,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"pSso1fFQnjwzjU5\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":148,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"g1iRMwkyntfI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":149,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        379\",\"obfuscation\":\"aVSLcA1Eyi23\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":150,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"lDGNdDgg7zieIQB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":151,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\n\\nFirst\",\"obfuscation\":\"dJlYA0ks\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":152,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"L7I7sON9f3yZYk1\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":153,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"wgGXEwyZXEEEtC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":154,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        know\",\"obfuscation\":\"8EPjeDe1aFk\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":155,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        79\",\"obfuscation\":\"owkzFGZ8tNnXs\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":156,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        is\",\"obfuscation\":\"p8aO2YQGTwy85\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":157,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        prime\",\"obfuscation\":\"f7RhX3DJX3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":158,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"gAfGRE7v25PhoLg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":159,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        For\",\"obfuscation\":\"KaxaMEuEu8sK\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":160,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        179\",\"obfuscation\":\"Fw1jQbrw8dUO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":161,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"36v7ur3CfQt4rUF\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":162,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"X5p8RecsD8oBom\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":163,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019ll\",\"obfuscation\":\"uyFvqhQPbeMyL\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":164,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        check\",\"obfuscation\":\"8BdPTmfmMb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":165,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        primal\",\"obfuscation\":\"DdrSgZAll\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":166,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ity\",\"obfuscation\":\"e91HUbQjRQorL\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":167,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        by\",\"obfuscation\":\"ulYWwmMa8EAFa\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":168,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        testing\",\"obfuscation\":\"rHXmJOy1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":169,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        divis\",\"obfuscation\":\"pRNIW8eHLX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":170,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ibility\",\"obfuscation\":\"bPH0OLIfB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":171,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        against\",\"obfuscation\":\"aMifPncZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":172,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        primes\",\"obfuscation\":\"ttLkLPSxo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":173,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        up\",\"obfuscation\":\"tXjKnGaaYu2oL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":174,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        to\",\"obfuscation\":\"sxcgOnHKN0uY3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":175,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        its\",\"obfuscation\":\"0l94lBfSZBQ1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":176,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        square\",\"obfuscation\":\"WHXGPp8uU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":177,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        root\",\"obfuscation\":\"C3AMNwnsW0k\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":178,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"TdWHbj6GfLaQQxJ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":179,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        It\",\"obfuscation\":\"Xu1UuZMk5pMMt\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":180,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        passes\",\"obfuscation\":\"pGwDZ9lh4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":181,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        all\",\"obfuscation\":\"sjDuDYCJrOfm\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":182,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        the\",\"obfuscation\":\"QvTwxhw8RVJA\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":183,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        tests\",\"obfuscation\":\"TXmaatj4yL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":184,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"fDRXllFLZtioSfg\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":185,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        so\",\"obfuscation\":\"0sk1nKWznQbKf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":186,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it\",\"obfuscation\":\"uVwRlaVvCqug7\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":187,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"GmZV1jvidoyQxd\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":188,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        prime\",\"obfuscation\":\"7A2n6veKu2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":189,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"VL4AQQEUhdoA6oT\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":190,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        \\n\\nNext\",\"obfuscation\":\"X1PssvaDb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":191,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"HLluXnPMxp6H87F\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":192,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"0qNYFN4Woy2MaY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":193,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        check\",\"obfuscation\":\"KdlN96Bupr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":194,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        279\",\"obfuscation\":\"Mq06dHb0YK3G\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":195,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\";\",\"obfuscation\":\"nQuUabVftzoa03y\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":196,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it\",\"obfuscation\":\"27f8sFew6ockh\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":197,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"\u2019s\",\"obfuscation\":\"ohmX35nEi9W8hc\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":198,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        divisible\",\"obfuscation\":\"b8O51B\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":199,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        by\",\"obfuscation\":\"K9pakr2TBvBLl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":200,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        3\",\"obfuscation\":\"2qhyhaUZBJxmy5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":201,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"Z14uAurXSe7eLUB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":202,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        so\",\"obfuscation\":\"Ms9YaF2cHvQBf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":203,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it's\",\"obfuscation\":\"T5g9XNAVlyC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":204,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        not\",\"obfuscation\":\"hzFRYFYpVS8e\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":205,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        prime\",\"obfuscation\":\"BIarzlrpYW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":206,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"K86FJASQHzFLQh5\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":207,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        Lastly\",\"obfuscation\":\"VCfXoEkgf\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":208,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"WkbOzNZ6dfjO6rh\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":209,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        I\",\"obfuscation\":\"mDvEdpG1ktQiiv\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":210,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        test\",\"obfuscation\":\"BElin146JJZ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":211,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        379\",\"obfuscation\":\"xLBWHq4rTyUS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":212,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\",\",\"obfuscation\":\"4J56lOgDwdKcmtN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":213,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        and\",\"obfuscation\":\"MqvITX5QYpvW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":214,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        it\",\"obfuscation\":\"KyxnkuXqIE5eT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":215,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        also\",\"obfuscation\":\"HcKS2xrTPV4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":216,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        checks\",\"obfuscation\":\"bCYD8eiNW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":217,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        out\",\"obfuscation\":\"6m7xsC8K1WES\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":218,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        as\",\"obfuscation\":\"Sy66wpGvaXs4R\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":219,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        prime\",\"obfuscation\":\"qWNPcprY2X\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":220,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        after\",\"obfuscation\":\"hDDj809UxY\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":221,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        verifying\",\"obfuscation\":\"JYtXbu\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":222,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"
+        divis\",\"obfuscation\":\"3McG6dJLv1\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":223,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\"ibility\",\"obfuscation\":\"9ZuKy4yBn\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":224,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"delta\":\".\",\"obfuscation\":\"8a1pwkpIQH4Awm9\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":225,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"text\":\"**Verifying
+        prime status of candidates**\\n\\nI need to ensure that \\\"79\\\" is specifically
+        in that order, which means I\u2019m working with four candidates: 79, 179,
+        279, and 379. \\n\\nFirst, I know 79 is prime. For 179, I\u2019ll check primality
+        by testing divisibility against primes up to its square root. It passes all
+        the tests, so it\u2019s prime. \\n\\nNext, I check 279; it\u2019s divisible
+        by 3, so it's not prime. Lastly, I test 379, and it also checks out as prime
+        after verifying divisibility.\"}\n\nevent: response.reasoning_summary_part.done\ndata:
+        {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":226,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":1,\"part\":{\"type\":\"summary_text\",\"text\":\"**Verifying
+        prime status of candidates**\\n\\nI need to ensure that \\\"79\\\" is specifically
+        in that order, which means I\u2019m working with four candidates: 79, 179,
+        279, and 379. \\n\\nFirst, I know 79 is prime. For 179, I\u2019ll check primality
+        by testing divisibility against primes up to its square root. It passes all
+        the tests, so it\u2019s prime. \\n\\nNext, I check 279; it\u2019s divisible
+        by 3, so it's not prime. Lastly, I test 379, and it also checks out as prime
+        after verifying divisibility.\"}}\n\nevent: response.reasoning_summary_part.added\ndata:
+        {\"type\":\"response.reasoning_summary_part.added\",\"sequence_number\":227,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"\"}}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":228,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**Confirm\",\"obfuscation\":\"Gir4woB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":229,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"ing\",\"obfuscation\":\"DbZmy9bor8oYo\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":230,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"5Xl1kPqC0u\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":231,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        count\",\"obfuscation\":\"q8yTWCWYxd\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":232,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"**\\n\\nI\",\"obfuscation\":\"tuPDR9EeX8J\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":233,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019ve\",\"obfuscation\":\"VsYkkXl8myn9M\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":234,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        identified\",\"obfuscation\":\"AeAsO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":235,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        the\",\"obfuscation\":\"oGQXjtIajsib\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":236,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"qpkXczvMQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":237,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        below\",\"obfuscation\":\"N0G01jhB29\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":238,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        400\",\"obfuscation\":\"DKAELscKlw0P\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":239,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"EQaAHQpYIAQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":240,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        contain\",\"obfuscation\":\"1F6KrZh3\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":241,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\\"\",\"obfuscation\":\"mOeJXEbrnpbUGT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":242,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"hUhz0wfmQ1oo7J\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":243,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\":\",\"obfuscation\":\"CgMhfQNz41dxUt\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":244,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        they\",\"obfuscation\":\"lsI6BnsGJug\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":245,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        are\",\"obfuscation\":\"ZhhN9hV92DDC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":246,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        79\",\"obfuscation\":\"LFRQhTEgsXdqe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":247,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"yJH72fCr3ohSeKs\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":248,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        179\",\"obfuscation\":\"PNx88TmTL7zT\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":249,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"7ZJLoD0Zp1l3mzv\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":250,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"ONNMWWcXxOjS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":251,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        379\",\"obfuscation\":\"u402mrYgLVzL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":252,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"7rEGfltv4TVgy8K\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":253,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        totaling\",\"obfuscation\":\"gtUn3Bw\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":254,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        three\",\"obfuscation\":\"T3kEPe5g7s\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":255,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        primes\",\"obfuscation\":\"5M1eD91YS\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":256,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"epCxsls9BPMXar3\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":257,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I've\",\"obfuscation\":\"Nv5vJz3yz8M\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":258,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        confirmed\",\"obfuscation\":\"mrqfqE\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":259,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"JysdnIfcGPP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":260,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        279\",\"obfuscation\":\"LaeHjuW29qVr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":261,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"SoDpTRyngGRyc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":262,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        not\",\"obfuscation\":\"GWp6HoCupxx5\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":263,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"Yg3rHGaTC4\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":264,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"4wJoSHbDieJg\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":265,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"qFPLu7Z71fJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":266,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        197\",\"obfuscation\":\"Xi17v9iIpUWM\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":267,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"9\",\"obfuscation\":\"k66862vKbQ1amMN\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":268,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        exceeds\",\"obfuscation\":\"rGGSWvQb\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":269,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        400\",\"obfuscation\":\"V8WVkegGGilC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":270,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"YNCVEdLXwx2n7qb\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":271,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Additionally\",\"obfuscation\":\"JU2\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":272,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"xV1jCA6K7uI28EB\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":273,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        97\",\"obfuscation\":\"8qHJ46aWA5W0q\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":274,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        doesn't\",\"obfuscation\":\"XlOVuGdP\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":275,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        count\",\"obfuscation\":\"5NmsaGzVXW\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":276,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        since\",\"obfuscation\":\"rIZTWZDVdU\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":277,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it\",\"obfuscation\":\"4hMzLKjDsYvNB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":278,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        doesn't\",\"obfuscation\":\"SbyiPViF\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":279,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        have\",\"obfuscation\":\"OyFABHV5bnl\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":280,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\\"\",\"obfuscation\":\"102Nrd7J8QBOuV\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":281,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"wU9hZKpKmPwEEJ\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":282,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\\\"\",\"obfuscation\":\"KdVx9y86PLlIgt\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":283,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"GHuUcLSC5Dx0RX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":284,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        checked\",\"obfuscation\":\"PcikL0q0\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":285,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        297\",\"obfuscation\":\"1AocEo62pxve\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":286,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        for\",\"obfuscation\":\"yAhpiykD7DgX\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":287,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        containment\",\"obfuscation\":\"td7R\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":288,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"v6YV9s70oLTMtTw\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":289,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        and\",\"obfuscation\":\"qMpezZJx08vD\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":290,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it\",\"obfuscation\":\"2g0VNbM0KRpuI\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":291,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        doesn't\",\"obfuscation\":\"THYyuIAB\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":292,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        apply\",\"obfuscation\":\"6x7RhK9yhR\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":293,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        either\",\"obfuscation\":\"WCFIfIjLJ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":294,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"l8Q4wHx55RWgJI9\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":295,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        Just\",\"obfuscation\":\"au9yoi63v2g\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":296,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        to\",\"obfuscation\":\"VFXfS0K7a6gyC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":297,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        be\",\"obfuscation\":\"fpiy5FE0aLXLC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":298,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        thorough\",\"obfuscation\":\"2mfeO2J\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":299,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"5c0ICy84aWwVyCe\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":300,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        I\",\"obfuscation\":\"HBNHqR4W62I82h\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":301,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        noted\",\"obfuscation\":\"83SdnFTNuc\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":302,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        that\",\"obfuscation\":\"06Siccnggea\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":303,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\\"\",\"obfuscation\":\"7FqwPFOrtYuINr\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":304,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"79\",\"obfuscation\":\"3yjRPTv0Q7bzl8\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":305,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\\\"\",\"obfuscation\":\"1VmxO4ehVbdkCyS\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":306,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        occurs\",\"obfuscation\":\"gJTC8WgTx\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":307,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        in\",\"obfuscation\":\"5efGqwJQgRlRQ\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":308,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        \\\"\",\"obfuscation\":\"0UKOwppuzqSsSo\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":309,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"279\",\"obfuscation\":\"FKRjuZ4TcZCZh\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":310,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\\\"\",\"obfuscation\":\"U0DNYje2fbERyz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":311,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        but\",\"obfuscation\":\"WdaZF1d62nDy\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":312,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        it\",\"obfuscation\":\"ZXYl5T9bF4SPO\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":313,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"\u2019s\",\"obfuscation\":\"bgQcjPUFQFNSyP\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":314,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        not\",\"obfuscation\":\"OtH8BFmCzbiL\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":315,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        prime\",\"obfuscation\":\"NvR6QdHKzC\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":316,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"ExmEtm0eyx6yPx0\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":317,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        So\",\"obfuscation\":\"IHR84DnzOoxVi\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":318,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\",\",\"obfuscation\":\"rrZ095KWUvmvv7N\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":319,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        my\",\"obfuscation\":\"R278KhhS541En\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":320,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        final\",\"obfuscation\":\"sVNR8XSnBe\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":321,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        answer\",\"obfuscation\":\"UryDMd9vG\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":322,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        is\",\"obfuscation\":\"Ko7ZBBkMcnD46\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":323,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        simply\",\"obfuscation\":\"Er7FDEi60\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":324,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\":\",\"obfuscation\":\"Zunm2ab9bm8i0Tz\"}\n\nevent:
+        response.reasoning_summary_text.delta\ndata: {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":325,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\"
+        3\",\"obfuscation\":\"O27XE3v5COfFao\"}\n\nevent: response.reasoning_summary_text.delta\ndata:
+        {\"type\":\"response.reasoning_summary_text.delta\",\"sequence_number\":326,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"delta\":\".\",\"obfuscation\":\"vpSUAU9ouaRusGX\"}\n\nevent:
+        response.reasoning_summary_text.done\ndata: {\"type\":\"response.reasoning_summary_text.done\",\"sequence_number\":327,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"text\":\"**Confirming
+        prime count**\\n\\nI\u2019ve identified the primes below 400 that contain
+        \\\"79\\\": they are 79, 179, and 379, totaling three primes. I've confirmed
+        that 279 is not prime and that 1979 exceeds 400. Additionally, 97 doesn't
+        count since it doesn't have \\\"79.\\\" I checked 297 for containment, and
+        it doesn't apply either. Just to be thorough, I noted that \\\"79\\\" occurs
+        in \\\"279,\\\" but it\u2019s not prime. So, my final answer is simply: 3.\"}\n\nevent:
+        response.reasoning_summary_part.done\ndata: {\"type\":\"response.reasoning_summary_part.done\",\"sequence_number\":328,\"item_id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"output_index\":0,\"summary_index\":2,\"part\":{\"type\":\"summary_text\",\"text\":\"**Confirming
+        prime count**\\n\\nI\u2019ve identified the primes below 400 that contain
+        \\\"79\\\": they are 79, 179, and 379, totaling three primes. I've confirmed
+        that 279 is not prime and that 1979 exceeds 400. Additionally, 97 doesn't
+        count since it doesn't have \\\"79.\\\" I checked 297 for containment, and
+        it doesn't apply either. Just to be thorough, I noted that \\\"79\\\" occurs
+        in \\\"279,\\\" but it\u2019s not prime. So, my final answer is simply: 3.\"}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":329,\"output_index\":0,\"item\":{\"id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        prime numbers with '79'**\\n\\nI'm looking for prime numbers less than 400
+        that have the substring \\\"79.\\\" First, I\u2019ll identify all primes below
+        400. Then, I\u2019ll check two-digit and three-digit numbers that contain
+        \\\"79.\\\" \\n\\nIn the two-digit range, we only have 79 itself. For three-digit
+        numbers, the relevant candidates are 179, 279, and 379. However, numbers like
+        790 or above don\u2019t count since they exceed 400. So, the confirmed candidates
+        are 79, 179, 279, and 379.\"},{\"type\":\"summary_text\",\"text\":\"**Verifying
+        prime status of candidates**\\n\\nI need to ensure that \\\"79\\\" is specifically
+        in that order, which means I\u2019m working with four candidates: 79, 179,
+        279, and 379. \\n\\nFirst, I know 79 is prime. For 179, I\u2019ll check primality
+        by testing divisibility against primes up to its square root. It passes all
+        the tests, so it\u2019s prime. \\n\\nNext, I check 279; it\u2019s divisible
+        by 3, so it's not prime. Lastly, I test 379, and it also checks out as prime
+        after verifying divisibility.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
+        prime count**\\n\\nI\u2019ve identified the primes below 400 that contain
+        \\\"79\\\": they are 79, 179, and 379, totaling three primes. I've confirmed
+        that 279 is not prime and that 1979 exceeds 400. Additionally, 97 doesn't
+        count since it doesn't have \\\"79.\\\" I checked 297 for containment, and
+        it doesn't apply either. Just to be thorough, I noted that \\\"79\\\" occurs
+        in \\\"279,\\\" but it\u2019s not prime. So, my final answer is simply: 3.\"}]}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":330,\"output_index\":1,\"item\":{\"id\":\"msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":331,\"item_id\":\"msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":332,\"item_id\":\"msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f\",\"output_index\":1,\"content_index\":0,\"delta\":\"3\",\"logprobs\":[],\"obfuscation\":\"RSJxVfocIwJl9zo\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":333,\"item_id\":\"msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f\",\"output_index\":1,\"content_index\":0,\"text\":\"3\",\"logprobs\":[]}\n\nevent:
+        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":334,\"item_id\":\"msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f\",\"output_index\":1,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":335,\"output_index\":1,\"item\":{\"id\":\"msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":336,\"response\":{\"id\":\"resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13\",\"object\":\"response\",\"created_at\":1762271376,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5-2025-08-07\",\"output\":[{\"id\":\"rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879\",\"type\":\"reasoning\",\"summary\":[{\"type\":\"summary_text\",\"text\":\"**Counting
+        prime numbers with '79'**\\n\\nI'm looking for prime numbers less than 400
+        that have the substring \\\"79.\\\" First, I\u2019ll identify all primes below
+        400. Then, I\u2019ll check two-digit and three-digit numbers that contain
+        \\\"79.\\\" \\n\\nIn the two-digit range, we only have 79 itself. For three-digit
+        numbers, the relevant candidates are 179, 279, and 379. However, numbers like
+        790 or above don\u2019t count since they exceed 400. So, the confirmed candidates
+        are 79, 179, 279, and 379.\"},{\"type\":\"summary_text\",\"text\":\"**Verifying
+        prime status of candidates**\\n\\nI need to ensure that \\\"79\\\" is specifically
+        in that order, which means I\u2019m working with four candidates: 79, 179,
+        279, and 379. \\n\\nFirst, I know 79 is prime. For 179, I\u2019ll check primality
+        by testing divisibility against primes up to its square root. It passes all
+        the tests, so it\u2019s prime. \\n\\nNext, I check 279; it\u2019s divisible
+        by 3, so it's not prime. Lastly, I test 379, and it also checks out as prime
+        after verifying divisibility.\"},{\"type\":\"summary_text\",\"text\":\"**Confirming
+        prime count**\\n\\nI\u2019ve identified the primes below 400 that contain
+        \\\"79\\\": they are 79, 179, and 379, totaling three primes. I've confirmed
+        that 279 is not prime and that 1979 exceeds 400. Additionally, 97 doesn't
+        count since it doesn't have \\\"79.\\\" I checked 297 for containment, and
+        it doesn't apply either. Just to be thorough, I noted that \\\"79\\\" occurs
+        in \\\"279,\\\" but it\u2019s not prime. So, my final answer is simply: 3.\"}]},{\"id\":\"msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"3\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":\"medium\",\"summary\":\"detailed\"},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":32,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":711,\"output_tokens_details\":{\"reasoning_tokens\":704},\"total_tokens\":743},\"user\":null,\"metadata\":{}}}\n\n"
     headers:
       CF-RAY:
-      - 992cbe921e5675e6-SEA
+      - 999543243c5ceb76-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:23:47 GMT
+      - Tue, 04 Nov 2025 15:49:36 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -989,59 +712,36 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '155'
+      - '170'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '183'
+      - '188'
       x-request-id:
-      - req_87ac445e7cf54dae9ca331eb72b17e96
+      - req_e2f68f82f5994a048248451428db901b
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"input\":[{\"content\":\"How many primes below 400 contain 79 as a substring?
-      Answer ONLY with the number, not sharing which primes they are.\",\"role\":\"user\"},{\"id\":\"rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e\",\"summary\":[{\"text\":\"**Counting
-      primes with substring '79'**\\n\\nI need to count prime numbers less than 400
-      that contain '79' as a substring. This means I\u2019m looking for numbers like
-      79, 179, and 279, but I realized that 197 doesn't fit because it contains 97
-      instead. So the valid numbers are 79, 179, 279, and 379. For three-digit numbers
-      starting with '79', the range is 790-799, which exceeds 400, so they\u2019re
-      not applicable. My focus remains on 79, 179, 279, and 379 only.\",\"type\":\"summary_text\"},{\"text\":\"**Evaluating
-      primes with '79'**\\n\\nI\u2019ve got three-digit numbers like 179, 279, and
-      379 that have '79.' For two-digit, there's 79 itself. Now, I need to check which
-      of these are prime. We know 79 is prime. I think 179 is also prime, but 279
-      is not since it\u2019s divisible by 3. For 379, it appears to be prime; I checked
-      and '79' indeed appears consecutively within it. However, 797 exceeds 400, so
-      I won't count that. So, the primes I'm left with are 79, 179, and 379.\",\"type\":\"summary_text\"},{\"text\":\"**Identifying
-      numbers with '79'**\\n\\nLet\u2019s find all numbers under 400 that contain
-      '79.' The two-digit number is 79. For three-digit numbers, the possible patterns
-      are 179, 279, and 379 while anything starting with '79' (like 790-799) is out
-      since they're above 400. So, the valid numbers are just 79, 179, 279, and 379.
-      \\n\\nNow, I need to check for primes among them. I know that 79 is prime. For
-      179, I confirmed it\u2019s not divisible by 3, 5, 7, 11, or 13, so it should
-      be prime too!\",\"type\":\"summary_text\"},{\"text\":\"**Verifying primes and
-      counts**\\n\\nFor 179, I checked it against several primes and confirmed that
-      it\u2019s indeed prime. As for 279, it\u2019s divisible by 3, so it\u2019s not
-      prime. \\n\\nThen I turned to 379. The square root is about 19.467, so I checked
-      against all prime numbers up to 19 and found that none divide it evenly. Thus,
-      379 is also prime. \\n\\nSo, I have three primes: 79, 179, and 379. I made sure
-      to rule out other numbers containing '79' and concluded that the answer is 3
-      primes altogether.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\",\"role\":\"user\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"},\"stream\":true}"
+    body: '{"input":[{"content":"If you remember what the primes were, then share
+      them, or say ''I don''t remember.''","role":"user"}],"model":"gpt-5","previous_response_id":"resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13","reasoning":{"effort":"minimal"},"stream":true}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '2671'
+      - '265'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -1063,97 +763,97 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0322c5b1ca9ff7880068f96797ee088197aa6c5f6bfdb0945d","object":"response","created_at":1761175447,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_049d8e19d65d9d4d00690a20a92a64819799ec460e235c6a49","object":"response","created_at":1762271401,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0322c5b1ca9ff7880068f96797ee088197aa6c5f6bfdb0945d","object":"response","created_at":1761175447,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_049d8e19d65d9d4d00690a20a92a64819799ec460e235c6a49","object":"response","created_at":1762271401,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_0322c5b1ca9ff7880068f9679857988197b0db6ead99086fd3","type":"reasoning","summary":[]}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"rs_049d8e19d65d9d4d00690a20aa0f6c8197a18f7003fe24148f","type":"reasoning","summary":[]}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"rs_0322c5b1ca9ff7880068f9679857988197b0db6ead99086fd3","type":"reasoning","summary":[]}}
+        data: {"type":"response.output_item.done","sequence_number":3,"output_index":0,"item":{"id":"rs_049d8e19d65d9d4d00690a20aa0f6c8197a18f7003fe24148f","type":"reasoning","summary":[]}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":4,"output_index":1,"item":{"id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":5,"item_id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":5,"item_id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","output_index":1,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"BESXAmpauASH2Mx"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","output_index":1,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"oj725MMakGDJ8Oy"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","output_index":1,"content_index":0,"delta":"
-        don''t","logprobs":[],"obfuscation":"A1dt4f1D4J"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","output_index":1,"content_index":0,"delta":"
+        don''t","logprobs":[],"obfuscation":"koc25z1DPa"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","output_index":1,"content_index":0,"delta":"
-        remember","logprobs":[],"obfuscation":"e8qbtu2"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","output_index":1,"content_index":0,"delta":"
+        remember","logprobs":[],"obfuscation":"MUgYPNi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","output_index":1,"content_index":0,"delta":".","logprobs":[],"obfuscation":"TNU5Y9gqFulGGOc"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","output_index":1,"content_index":0,"delta":".","logprobs":[],"obfuscation":"Ks7AfV8AlPLNIWH"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","output_index":1,"content_index":0,"text":"I
+        data: {"type":"response.output_text.done","sequence_number":10,"item_id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","output_index":1,"content_index":0,"text":"I
         don''t remember.","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        data: {"type":"response.content_part.done","sequence_number":11,"item_id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
         don''t remember."}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":12,"output_index":1,"item":{"id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        data: {"type":"response.output_item.done","sequence_number":12,"output_index":1,"item":{"id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
         don''t remember."}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_0322c5b1ca9ff7880068f96797ee088197aa6c5f6bfdb0945d","object":"response","created_at":1761175447,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[{"id":"rs_0322c5b1ca9ff7880068f9679857988197b0db6ead99086fd3","type":"reasoning","summary":[]},{"id":"msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
-        don''t remember."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":62,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","sequence_number":13,"response":{"id":"resp_049d8e19d65d9d4d00690a20a92a64819799ec460e235c6a49","object":"response","created_at":1762271401,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-5-2025-08-07","output":[{"id":"rs_049d8e19d65d9d4d00690a20aa0f6c8197a18f7003fe24148f","type":"reasoning","summary":[]},{"id":"msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        don''t remember."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":"minimal","summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":62,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":72},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbf13bfb975e6-SEA
+      - 999543c07a65eb76-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:24:08 GMT
+      - Tue, 04 Nov 2025 15:50:01 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1169,15 +869,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '124'
+      - '475'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '155'
+      - '485'
       x-request-id:
-      - req_7ff117f1a8934ae38b77ccff34816ad9
+      - req_acb316e7de994e7db844c2c5d55f1ead
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking_true/openai_responses_gpt_5/sync.yaml
@@ -7,12 +7,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '221'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -34,45 +38,39 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7RXy47jthLd91cUtMnNwG3IdtuyehsguA3cZJPJKh0YZalk8zZFKmTJ3Uow/x4U
-        KcnStGeyCGbjBx/FqjqnXn/dASSqTB4hceSbQ1puN4irzf5hR+kGd2m621f5LtuV27RM96t8i4jF
-        7mG1r/LqodhmWbIQEfb4fyp4EGONp7heOEKm8oCyt8p2q1W2fUi3Yc8zcuvlTmHrRhNTGS8dsXg5
-        Odsa0atC7SkuK62VOSWP8NcdAEDSYEdO7pd0IW0bcskdwKdwmJyzsmdarcOCMsMrh5IYlfbzXc+u
-        LVhZM1uv8e1gW25aPrB9ofebbK0+FKjn4mpbkhbNTg3fb+/X6Xp7n+7v08FbQWLyCL8FQ6I5VyD8
-        V2DAqtoLDHmZVetdvkpXR9zt9nkQHIRw11AEAr014rBxy7d1ja4bH54+PrvbHzwwvfF4PZ6QlUdI
-        Pnz4wbaGlTlB41RNHl4Vn+E5yfLnBHx79OyUOX348GyezRMYohLYQqVMOVzQ5D3wGQ08pKn8YCis
-        YVRmEIMe8CprCR/PBI31Xh01QYGmVCUyeUBHkOWg2JOuFoCmBD47ovtSnRSDaesjOQ9avRCssnwB
-        a/mQY5ssX8J/7StdyC0gy9Owikd7ISiteW7X6SoXvVrD4JUpCPhMHdBbIRY9pOkSnjge86DqxjpG
-        w2Kqo5rk3WhZb1HdeoYjBUPVqbWtX4C3cw3zDKyDCzqFgY+AhbPew1EiAp0iP1Xtjxa1qrol/KpZ
-        1ciku4XoCBfUavR19NDihvXJiO6nxb8nxY/KoFZ/jrQArTxPqdETImpfg2/dhTo5Prgg8gDNjAvL
-        5ySAb43uesP41fbw2kbcBMpfObCEH627yYEjafsquC3gleCMl5uM+LWxBoozFS/KnILXwp58uQBe
-        pVxNpRA0OngBr2elScSIIqW6qMjSYwebnpDkqLKOwFgGjPeW8AR8tu3pzEK6lgX8Y8ugGEpLfkLA
-        qzMWEhmmXABdyPTXYZVncEYv91HePyn2i3dierIAKVFnzpm6mxh2izbfhjE/xDevjIllAWw1ifAZ
-        ay5TBAJdhO5f0TiAU5zhpC7kofWRGLMAWcJHCxdyquoeIWLoGSXcSt2Bo8KejPpzgvgSfqY3XsBT
-        pAmVgSTHDph8yIo9BZRW3MUA6DVsTUlOeAr+j1bUddYy/CfCv9osN/vvg+JXG9WYYKKH+OwC5pIi
-        bOujBn4J4qNIwBHw3qUhcSn+7nNmLuF/6FnQv9qxGTyHFUv26u1RDHhCqZODITGUvmRIvnz4PhCQ
-        W2c8yBpbSX29DdYu4RcbU1UlWaNPso5qeSVitAjBkGcL4XfUap1nt9Lft01jfghAWbmZyIZkARtR
-        tA9hLLhFrbvhtofnJM9iYYshCuv7zSJkhCHN/dTNM7e3UKH7Kq/ZMureY5JRhmIrdQYdVa0GST5w
-        pAJbT/AEr32NIuNbRzE3yROjW9F0YGV5ztqxUCtT6LakoawpAwjGmvtrXYNX7KIjwoVZGsKm0d0S
-        fp7V5TmukQwxTy3EX4rBN6R19KHkwKnXbjHJVrdak3lPIYFOb1iw7nr/fQMiRXKANTf0+ZxG12yo
-        qisuAY/bSIQSdrWtB8FT0bKSJibQTJqUaSDewjukwKOQwYb0Ms0JY9PVIDOJmIDZW+SgCHsDh+ZE
-        Hipna0iFXBvhYiVNyzvmTgunUKQvm9KhW6+Y+lYvPgZZ/gaasPQiNcvT+ywXUVoLxDEEpv3Yx7N0
-        VU/gCCtx5rVGTNqHL4V18HZgwuNXK1//6/e7CVM+6+Nrf/piI79Py4ddIY38/qHKd+s1ZnleFrtt
-        +r6Rr8l7PNGkjf/C4BQ2xSIy/M89/jDWvGMvGmMZh1Hot99nm9qeGmePN3YG0m9ueGnUzlkdHkfv
-        lRRYjoflYDiUNOhQa9LzwYpdG2fAxtFFat5hGDMPwdfj4NU4Wzd8KLA40+GFuunedSAaJ0iqKus4
-        OrlUbd07YjIoJXFYpPI6WnqsiLuDKsmwqhTNxkxP7qIKOrAaRtMKWx09nHi2jqbmMNUNOeQ2LK+W
-        ab8aPNnrWFlX4/X/BMFwbkrA5ELuKAHUTUwa9Y4ePVtVRAhatsm4cQU0YdscJjCn42Iz1dG1pggk
-        CVYqj0c9zO9toOtogDKz8XmzXrxfn8zko5kBxPJ6MZ2Z+vlUvlqvN7e2bkkemTC9vtrN5IeiOt3f
-        bkdPtn4Oek2MJTLKG5/uPv0NAAD//wMAaZ724VURAAA=
+        H4sIAAAAAAAAA6xWS28jNwy+51ewc1kgcIIZO37l1hYokHvRy6YwOBLH1kYjzUqUE3eR/15QY4/H
+        ebSH9uIHSfHx8aPEH1cAhdHFPRSBYrcp1Vrf0WKmUS2q6QLLcrEucVou69XdYrWq1nNUZVXfVVhp
+        pPm0mRYTceHrb6T45Ma7SL1cBUImvUHRVcvFdLqsZvN51kVGTlHOKN92lph0f6hG9bQNPjnJq0Eb
+        qRcba43bFvfw4woAoOjwQEHOa9qT9R2F4grgNRtTCF50LlmbBcadomw0MRobL7WRQ1JsvLuQt/iy
+        8Ym7xBv2T/Reyd7bjUJ76a71mqxktu34Zn4zLafzm3J1Uy6PaGWPxT18zYX05ZwbEf+hDY2q7qQN
+        9UwtmrvVYqV1iWU1y46zEz501DcCo3cC2KCKqW0xHIbA4+AXZ4+GG6YXHo73FiK5h+L6+lefHBu3
+        hS6YliI8G95BTHXkINLHYrl+LK6vH92jewBHpIE9NMZp4B2BktPgm/40uNTWFCIkpynAXVkC75Bh
+        h3s6egKMgGf/t/D7jiCQpT06BoVOG41METAQLNcTqORjKh/oNMyWa4jGKQLe+UjZCq2Fmqx/loC3
+        8ABoowe1I/VEGpbr5QTqxDmTLxGw9nvKuVvTGhb7ZwnNHsjFFAgewDt7AOVdNFLGHq3RJ3iUd4xG
+        +pF9vAUKnnfGEtCLskmLGN2hx0B795imZbVmaIm4Ry8YpmCwR0F515jQ0hDrUwhui6GXr5P/ToE/
+        KJjmMHBg3IXMhksOnNPMdUlHTATjjphGgbSvtAUO2W1mzFaw9YnBNGIajs1zh4E1OdgyF7kWnjjv
+        blB/Q0WOQZut4di38sQAgu+Jokw7xI6UaQxFyLHVJc0mWajBMFjvnyJY8zQ0OrNTnDU+hVHx95+A
+        Dw9f9jTwi1DtwDs5HTJ+aA0f5Gw+UMl3oB7ZyZEe0x4zbfYmmtoS1AeYZXPnuTe9hd+MQ2sPE3iA
+        vTTIvEH86DH6nDt7RvtmHC/YeuSnicC7QPQ/Uygna/6SQG9y6Gkj/EYXnylIBrOf4JfE8C3FPHd1
+        nubg03Yn1Wqfaks3J4BzzdWJZZpO8yGgsXTfbcHwgKYR+AG3KG/BCYfUSZw8sN+TtCN4LzyVC0Eg
+        v+jEdAKzCcwnsJxAVU3AB6hmGWjDfduj8FhujvhsGu7vivFM9Mnma+jYzJ8t76Q+uW28XI6k5SZK
+        DF5mAZRva+MwP1yTYSAyS9fLnqEI2jQNBRkGH+RiEsKMrpUM/JGdIVnScPbf+NDGPjl6UYLhXVnm
+        moZZzTVo8W4cBOp84NMtFygmyzKSj8VMLjkj1XAeXtTaSNpooUtOccpFjOl1/PXn1Yhsb97KNm4/
+        fSxXel1NVd5ZltOl0uViNq/nJa6r949lSzHilkZP5SfLSVbKdJDjf39HT6vDuwFA5zzjad34+ueF
+        0vptF3z9geY0N7MPUBqyC97m4BijiYyOe2MxzEZFhwGtJXu5vHBI/Z7VBdobn+LmtMptMtbDctMF
+        33a8Uah2tHmiw6e6QIKS8W5scV5Lhj2OmsYH7tugTWqPUI3WlaJf2UifF7yIDfFhk4knd9zFshcp
+        7I2iDZvTgthgsn0Pisg+0LhgprajgJyyuLotj9KM9TFHmQM8/x/1ONuNKVrsKdQ+Gj6MShry7jHf
+        eaP6JiX2xaA4t7xg321GRCgHYTfOMSSn8AhxoU3E2p626JQJPRRg3MUSO5tO3stHm/FQZm6lPh8s
+        L0p9uxuvZuuPNB85HogwPj298J7fppF6WQ0wpnjZ8ZYYNTJKhNer178BAAD//wMADChq6tgMAAA=
     headers:
       CF-RAY:
-      - 992cbe0ade9675e6-SEA
+      - 999542a34962eb76-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -80,7 +78,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:23:45 GMT
+      - Tue, 04 Nov 2025 15:49:34 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -96,13 +94,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '19872'
+      - '18488'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '19875'
+      - '18496'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -110,65 +108,34 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '1998994'
+      - '1999378'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 30ms
+      - 18ms
       x-request-id:
-      - req_aa2c1f3ffd80480cb4bd95bb3a5beedd
+      - req_b3a4fcd818e041a58f32b4041581dc02
     status:
       code: 200
       message: OK
 - request:
-    body: "{\"input\":[{\"content\":\"How many primes below 400 contain 79 as a substring?
-      Answer ONLY with the number, not sharing which primes they are.\",\"role\":\"user\"},{\"id\":\"rs_0d53aa13846e03a60068f9676daff881959d7f269101ba6689\",\"summary\":[{\"text\":\"**Counting
-      primes with \\\"79\\\" substring**\\n\\nI need to find primes less than 400
-      that contain \\\"79\\\" as a substring. The possible candidates are 79 itself,
-      and three-digit numbers like 179, 279, and 379. However, 790 and above don\u2019t
-      count since they exceed 400. It\u2019s important to remember that \\\"79\\\"
-      must be contiguous, so numbers like 97 or variations across boundaries don\u2019t
-      qualify. Ultimately, the valid primes are 79, 179, 279, and 379.\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing
-      prime list with \\\"79\\\"**\\n\\nI\u2019m surveying numbers that can contain
-      \\\"79.\\\" The only valid two-digit option is 79 itself. For three-digit numbers
-      below 400, we have 179, 279, and 379. Upon checking, 179 and 79 are confirmed
-      as primes, while 279 is divisible by 3 and therefore not a prime. I thought
-      about 97 but it doesn\u2019t contain \\\"79,\\\" and, even though 197 has 97
-      as digits, it doesn\u2019t qualify either. Ultimately, my confirmed primes are
-      79, 179, and 379.\",\"type\":\"summary_text\"},{\"text\":\"**Confirming prime
-      status of candidates**\\n\\nI\u2019ve confirmed that the primes are 79, 179,
-      and 379, which gives us three valid primes. To verify: 79 is standardly recognized
-      as prime. Next, I checked 179 by testing divisibility with primes under its
-      square root (about 13.38) and confirmed it\u2019s prime through various checks.
-      \\n\\n279 isn\u2019t prime since it's divisible by 3. Lastly, I checked 379,
-      and after testing it against primes below its square root (about 19.4), it turns
-      out to be prime too. So, the final count remains three, but 97, 197, and 297
-      don\u2019t qualify.\",\"type\":\"summary_text\"},{\"text\":\"**Finalizing primes
-      containing \\\"79\\\"**\\n\\nI\u2019m checking 397, but it actually contains
-      \\\"97\\\" as digits 2-3, not \\\"79.\\\" My valid primes so far are 79, 179,
-      and 379, which totals three. I need to be careful here because I want to ensure
-      there aren\u2019t any other primes under 400 that include \\\"79\\\" in a non-contiguous
-      way, but that doesn\u2019t apply. Numbers like 197 don\u2019t count either,
-      as it spells \\\"97,\\\" not \\\"79.\\\" So, the final count of primes with
-      \\\"79\\\" as a substring is exactly three.\",\"type\":\"summary_text\"},{\"text\":\"**Final
-      check on primes with \\\"79\\\"**\\n\\nI\u2019m confirming if there are any
-      primes under 400 that have \\\"79\\\" as non-consecutive digits. It turns out
-      there aren\u2019t any. To be thorough, I checked possible patterns like x79,
-      where x ranges from 0 to 3. I found 79, 179, and 379 as primes, but 279 is composite.
-      The pattern 79x leads to 790-799, all of which exceed 400. Thus, I reaffirm
-      that the only valid primes containing \\\"79\\\" are three: 79, 179, and 379.\",\"type\":\"summary_text\"}],\"type\":\"reasoning\"},{\"id\":\"msg_0d53aa13846e03a60068f96780d46c819584f9622a799dc650\",\"content\":[{\"annotations\":[],\"text\":\"3\",\"type\":\"output_text\",\"logprobs\":[]}],\"role\":\"assistant\",\"status\":\"completed\",\"type\":\"message\"},{\"content\":\"If
-      you remember what the primes were, then share them, or say 'I don't remember.'\",\"role\":\"user\"}],\"model\":\"gpt-5\",\"reasoning\":{\"effort\":\"minimal\"}}"
+    body: '{"input":[{"content":"If you remember what the primes were, then share
+      them, or say ''I don''t remember.''","role":"user"}],"model":"gpt-5","previous_response_id":"resp_0c9d4e63dac6126a00690a207b84688195ac01b41a1dae52f2","reasoning":{"effort":"minimal"}}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '3230'
+      - '251'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -190,27 +157,27 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3xUy27jMAy85ysMXfbSFLbjR5I/2G8oCoOW6VQbvSBRQYMi/76wnPixTfeWcMjx
-        kEPqa5MkTHTsmDCH3jZpV+4Ast2+qDDdQZWm1b4/VPU+K/s+3WeH8lDsEEus8g77rKyRvQwUpv2D
-        nB40Rvt7nDsEwq6BAcvqKsvqssjLiHkCCn6o4UZZiYTdWNQCP5+cCXrQ1YP0OIaFlEKf2DH52iRJ
-        kjALV3RDfYcXlMaiY5skucVkdM4MmA5SxoDQj680HRII6deoJxc4CaNXcQWfjQlkAzVkzvgdJGNk
-        w0Gu6ZTpUA7KTpa25TZP83Kb7rdpfZ9WZGTH5C02MrYzG+F/tiHPspRHG0rMi11ZHniRFztsI3Ek
-        oavF0QjwRg8DmyAflAJ3HT78HmO3l2cClD/9R8HuUEcFe8z4HuqqwDTvsMq+K1DoPZxw8f0fHI8g
-        N5pQz1NZClvRPvzAT5qqYwJobQgeHr69r0BpTtaZ9gkSiY4J+510Rv+ixKFC1aJ7ZVPW7f5rKmTO
-        yCgGvBeeQNOYPCTGJGbBgZQo1xtCLozLbB1ehAm+edxLE2c/bZB1RllqOPAPbM54XWKzs9MpYN8b
-        F7tQQgsF8j6ZheVD+XQeHnqkayM61CR6gatT8egugmND4nFePQQ5Dpt5Mg6XnRAqiw4oxHD2mt6j
-        cah3eb1xCub/CzNj3nIX2QVda7yg67hCnQhqPutxmB9G8HH6gQybgNlbRsY2C8fTKWiXGl3QPO5L
-        7FJ4aOXjDQpxc6cGhF49AVX+8j2+eFemNqN/3VyYrlr992XJ0mfAM95pBX6iJkMgZ7DOpxEGv3Zb
-        IUEHBAP9bXP7CwAA//8DAL3FtMMSBgAA
+        H4sIAAAAAAAAA4xUy27jMAy85ysMXfbSFLLj2En+YL+hKAxaolNt9TAkKmhQ5N8XlhPH3qbFIheH
+        Q44ozlCfqyxjSrJDxjyGvuFiL0usNhJElRcVcF7tORR8h5ttVe7y/baV3fBrc9gLrHfAngYK1/5B
+        QTcaZwOOceERCGUDA5bXVVHU+aYuExYIKIahRjjTaySUY1EL4v3oXbRDXx3ogGNYaa3skR2yz1WW
+        ZRnr4Yx+qJd4Qu169GyVZZeUjN67AbNR6xRQ9nZKI5FA6bBEA/koSDm7iBv4aFykPlJD7h2/guSc
+        bgToJZ1xEvXQ2bGn9XZd8GK75rs1r6/TSozskL2ki4zXuQsRfpBhLzs+yAAV55tyV2AnN4Xc80Sc
+        SOjc4ygEBGeHgU1QiMaAPw8Hv6bY5elRAyYcf+hAIi/HDkRRtfsSod7WdSm+dmAwBDji7PxvFE+g
+        cJbQ3qcyb2xBe9MDP2iqTglgrSO4afjyugC1O/betQ+QRHTI2O9MOvuLMo8GTYv+mU1Zl+vXVMi8
+        06kZCEEFAktj8pCYklgPHrRGvXQI+Tiaufd4Ui6G5rYvzX9sYd3uymqXhi943pY55BJwW3QFu5I6
+        01MjQLxh847nuSUXmMdh1MrZecbdMNOGYdc5n4ZjlFUG9HXgMycN5dPWBeiQzo2SA3uncLGBAf1J
+        CWxI3ba2g6hHDVkg53E+IELToweKKZw/82s0aXVtr3PewP3/zCMpb25xdkLfuqDoPDpTqmjur8Wo
+        0ZtTYhQ1kmMTcLcMI9c3MyPxKdjPe/TRCrhOl0kVoNW3py2mhZguoOziZamKp6/x2XM1XTOpKO+F
+        fHHVfx+snD8CHvFOFviOmhyBvoN1MY0whqXaBgkkEAz0l9XlLwAAAP//AwCOo3A0aQYAAA==
     headers:
       CF-RAY:
-      - 992cbe881c9f75e6-SEA
+      - 999543182835eb76-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -218,7 +185,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:23:46 GMT
+      - Tue, 04 Nov 2025 15:49:35 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -234,13 +201,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1259'
+      - '1725'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1264'
+      - '1733'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -254,7 +221,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 0s
       x-request-id:
-      - req_ddbe2375572f4113abca56f8feba3752
+      - req_5a25ae648fcc4858a75a71330d64bebd
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async.yaml
@@ -8,6 +8,8 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
@@ -31,34 +33,34 @@ interactions:
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xVS2/cOAy+z68QdE4Ke/yYx63A7vbSFi32tNgUBi3REyWy5UjUtJNg/vvC8vg1
-        aRbby95sfiRNfvxovqwY40ryPeMWXVtE8W693ZXbBOJ1HguIonxb7fK8TMRmI7bxLoN4k5SYJek6
-        k/EaMn7TpTDlAwoa0pjGYW8XFoFQFtBh8SaP4022jncBcwTkXRcjTN1qJJR9UAni8WCNb7q6KtAO
-        e7PSWjUHvmcvK8YY4y2c0HbxEo+oTYuWrxg7B2e01nRY47UOBtUMXykkEijtlqgj6wUp0yzsNfwo
-        jKfWU0HmEV+DZIwuBOhlutpI1F1lh5ZuU3O7jtbpbbS9jfILXSEl37O/Qyd9P+MkKvH2HLIy3aZh
-        DuskjtJdFpdys4lET11IQqcWQxrfhIZCeRP8Fu0BBHvwNTYU8Jc73oJz342Vd3x/x2vU2jR3/Dz5
-        d6mLvurw+OnpKD5/jY/icyzxwx8Pv5V/PUD83EwRDdShOofCIhUWySo8gg5M8uB1vvlVVnIB5bZj
-        ZVvFmCaZzGMpSpkn/wMrFqSCRuC/8vL705/PIj2V70VSVfXx+/PH1Fr5ePg1XlaMfQv6acGC1qiX
-        8iPr+01pLR6V8a4YlrEvZZRna03dUiFA3GPxiKc5ZhGcaRZ7hlVlLM2cOr58XYMdIse1c1AhnQol
-        sSFVKVysoEN7VAILUsPaVuA18cvfwFicN0FYt2iBfDDH76KL9QdNlVXG1jC9z8Yc/OZq4ke0pXGK
-        upp5jVL5evpd9DzeGyVCNHgyfATc60W9VtM0R4lOWNUG457x96zLwOgeiFl88sqiY8AGBTEy7DJq
-        ZMD64b/7r6oY3To91Eho3YyLftAtWlK4tIeIvoAre9eaIh2++WVwublyuPTuyHYymYHn8fk8xfBL
-        23Jk8bqE0fhtFgVSqo5E0F/mTYzn4KqYywFaXX0+FBkOUwi8WiMybaHNobWm7HJHo7GdK876RsAw
-        T6kclHq4VN7BASc5qmZxKJL85rV9dn1epr+FuEc5BUYL4V7fnyz9GfCzvOMuv5WaDAUtXcBdNC6E
-        d8vdrZFAAkGX/rw6/wMAAP//AwDaYZvdOAgAAA==
+        H4sIAAAAAAAAAwAAAP//vFVLj9s2EL77VxA87waSn9LegiDNpSjSQw9tNxBG5MhmlhJlcuisu/B/
+        L0jJenizRXPJTZrHx5mP33BeFoxxJfkD4xZdWySrvNrmq6RcbardbiuSZJsnkFYyk2UmsjRfletN
+        lVai2u2yXApc8rsAYcqvKOgKYxqHnV1YBEJZQPClu+1yuUvTfBl9joC8CznC1K1GQtkllSCe9tb4
+        JtRVgXbYmZXWqtnzB/ayYIwx3sIZbciXeEJtWrR8wdglBqO1Jvgar3U0qOZ6SiGRQGk39zqyXpAy
+        zcxew3NhPLWeCjJP+NpJxuhCgJ7D1UaiDpXtW7pfm/tlslzfJ9l9su3pipD8gf0dO+n6GW6iEm/f
+        Q7nJqngPsC43uUy2QuZlli6rCBxB6NxihPFNbCiWN7rfoj06we59jQ1F/8sjb8G5b8bKR/7wyGvU
+        2jSP/DLGB+iiqzp+0ofnoz7X6rfDH/Zo8/NB/vLPn8ejGzMaqGN1DoVFKiySVXgCHZnkMepy98Os
+        ZPkuC6zkuEnLzXKdpFki15j9BFYsSAWNwP/mJXlfrw8fTt8+LXefjh/T5OuvO0G///VjvCwY+xL1
+        04IFrVHP5UfWd5PSWjwp411xHcaulEGerTV1S4UAccDiCc9v+iwSNoGtaYRFcKaZTSJWlbE0CQqM
+        +roGe8UeBtNBhXQulAzAlcLZkDq0JyWwIHUd7Aq8Jt6/F8bitE3CukUL5KM5fZf01mcaK6uMrWH8
+        nwghxk31xk9oS+MUhZp5jVL5enxQOqYPRomYDZ4MHxzu9Sjf6m28aYlOWNX2tPL3LCAwOgAxi0ev
+        LDoG7KoxRob1YkAGrJPHu/+rmyEsKKZGQusmXHTX3aIlhXN7zOgKuLGH1hTpeObna8jdTUDfuyMb
+        ZDJxXobvy5jD+7blwOJtCYPxyyQLpFSBRNCfp00MC+OmmH5FLW6Oj0XG1RUTbwaNTFtos2+tKQN2
+        MhjbqeKsbwRc71MqB6W+7jLvYI+jHFUzWyWr7d1r+2Q/vYzviTigHBOTmXBvN9Rm/T3H93CHWX4L
+        mgxFLfXOPBkGwrv57NZIIIEgwF8Wl38BAAD//wMAFebv3FoIAAA=
     headers:
       CF-RAY:
-      - 992cb9833e8a23f8-SEA
+      - 99953eaa8c8ae090-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -66,9 +68,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:20:23 GMT
+      - Tue, 04 Nov 2025 15:46:36 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=gnjWBsoLo40_YJwYb_y9II3QEnI8YYfosA62uf0whnA-1762271196-1.0.1.1-Q5BrWPgz6Om5vEk7TdBBlZ4JroeEOX3UZsSZdK0JHYOLKkmcsmBzLrGMqee0F9GKj0BHLs7yO_763lLv5aWikKeLSkemxC.dinMBwDFdlBI;
+        path=/; expires=Tue, 04-Nov-25 16:16:36 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=hO.kviNFGuB84wyzUMZyEkB3vDTRwygA2_EJIftTPYs-1762271196052-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -82,13 +90,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '3393'
+      - '3147'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '3400'
+      - '3154'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -102,27 +110,30 @@ interactions:
       x-ratelimit-reset-tokens:
       - 21ms
       x-request-id:
-      - req_fd88983e186d46cda47bda05e8607a06
+      - req_04573bc117f541d68be03718577a6f5d
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance","role":"user"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_MqvcNQ1vcN1deGFjDbYja1zn","name":"secret_retrieval_tool","type":"function_call","id":"fc_019289b83a1261ca0068f966b5b4848195a23104951bd770cd","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_EqSzc4ybAc3ffmvwzL4rrdkg","name":"secret_retrieval_tool","type":"function_call","id":"fc_019289b83a1261ca0068f966b6cab881958f1e435d61dcbd63","status":"completed"},{"call_id":"call_MqvcNQ1vcN1deGFjDbYja1zn","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_EqSzc4ybAc3ffmvwzL4rrdkg","output":"Life
-      before Death","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"call_id":"call_tCxqlymiNhUrqr9yhdFzYqqs","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_t0Am4hCvwG27GqE10jL7ctQZ","output":"Life
+      before Death","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_039f6930b35f776c00690a1fd8db8c8193b45f1fcf7789dce2","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1142'
+      - '608'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -144,30 +155,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RVTY/bOAy951dodZ4UtpNxnNwW6LEFeijQQ2dh0DKdaEeWXIrONijy3xeWvzMz
-        t4SPfOLHI/1nI4TUpTwJSeibPIqPSXYssh3ESRoriKI0q45pWhyeq2ifxcdn2EOyP6iiSKtsB1Es
-        nzoKV/yLikcaZz32dkUIjGUOHRYf0jg+PCfJLmCegVvfxShXNwYZyz6oAPV6JtfaLq8KjMferI3R
-        9ixP4s9GCCFkAzekLr7EKxrXIMmNEPfgjESuw2xrTDBoO76Sl8igjV+jnqlVrJ1d2Wv4nbuWm5Zz
-        dq/4FmTnTK7ArOlqV6LpMjs3vN27bRIl+22UbaN0aFeglCfxM1TS1zNNovbnjweRHSrIukEcsxSS
-        PRYZ7o5qf6gCc2DhW4OBB72HM87ARx0PoHKW0c5JLRNb0Y79wN88RQcHsNYxjD38+c8KNO7ckCve
-        QQLRScjvFxQeFSF7UTkSfEHRgPf/OSq9AMLTi32xW/EiazTG2Rd5Ej/QKFejYCe+OtLwV+9AUGqw
-        CjuXL7pCUWDlCMVnBL7I6fH78GvKR5IzoUbwXnsGy71z5xicZAMExqBZD56p7TXaEF61a30+rkEe
-        RjoJoyFXN5wrUBfMX/G2xAjBO7tSOFaVI144dUNs6xpojJwE76FCvuW6RMu60rgSv0e6aoU563Fh
-        KmhNPz7p2REui2CsGyTgNpjjT9FgDWMaMqsc1TD/X8gj+PVdGzK+IhXOa771oix1W8+L2vfx4rTq
-        G9+ykxPg367I+EzV2rCus4BL9Ip0E4wnIf8WHYPgC7Ag/NVqQi9gUlQnGUImjVcUMAjv08xmoQ7v
-        9EA+uEI/+Nmt00ONjOQXvegH3SCxxrU9RPQJPNi70jT36vs2ujw9OAy1e6ZOJgvwPmt6jpFD2eVq
-        p5cpTMbFRkooS901Ecy3ZRHTIX48B/3p3zw8H5IMn4QQ+LBG7Jp8cRGiydgsFUetVTDOs9QeCjN+
-        I9pw2SY5ars60fEufXoLLA7/JKewieUcGa2U+3j6k+w94D3eaZk/ombHQUxjxul+WonWr7e3RoYS
-        GDr+++b+PwAAAP//AwA0GI8otAcAAA==
+        H4sIAAAAAAAAAwAAAP//jFVNj+M2DL3Pr1B1niycj3Gc3Ar00EML7K2HncKgJTpRR5Zcis5usMh/
+        LyR/xM7MAL0lfOQzRb4n/XwSQhotj0IShrbMtoc6P2yzavtS7/e5yrL8kMG61mq3We+K9WFbFXm2
+        3eTwgllRQIbyOVL46h9UPNJ4F4a4IgRGXULE1vt8s9mv14c8YYGBuxBrlG9ai4y6L6pAvZ3Idy72
+        VYMN2IeNtcad5FH8fBJCCNnCFSnWa7yg9S2SfBLilpKRyEfMddamgHHjV0qNDMaGJRqYOsXGu0W8
+        gR+l77jtuGT/hu9B9t6WCuySrvEabezs1PJq51ebbLNbZcUqy4dxJUp5FN/SSfrzTJtowunzRWg4
+        1Couoqh3VZYXugCNSucqMScWvraYeDAEOOEd+GziCVTeMbp7U/PGFrTjPPAHT9UpAZzzDOMMv/29
+        AK0/teSrD5BEdBTydyQUQCj4jCKgIuQgIASvTNSQ+G74nLAWQvjuSYfjq3t1K/EqG7TWu1d5FH+h
+        Vb5BwV786cnAL30CgTbgFMaUP0yNosLaE4rfEPgsp25uw6+pQUnepkNDCCYwOO6TY2JKki0QWIt2
+        qQSmrhdtS3gxvgvl6Ivy/7it0FWRllztXup1rer9vjhohRs5kPqm5VKBOmP5hte59BYYYVyp8W6e
+        QQjBu4WTsK498SwpiqVrGqCRezJWgBr5WhodiWuDC5MFpItRWLIZjVlDZ3uZyMCecD4bxqZFAu5S
+        eP0lG6JJDkNntacG7v9nMkx5/TKGji9IlQ+Gr734tema+4XQr+fsjer32bGXExDeW3H8TN25dC3c
+        jaIxKDLtMFb5q4gMgs/AgvDfzhAGAZNIoxIJmQxeUMCg6y93NgdN+k4PlEMq9Hq6p0WZNchIYTaL
+        ft0tEhtcxlNF38BDPB7NcC/qr2PK80PCcPbAFGUyA293q9xr5HBsvbg75i1MwZnzJWht4hDBfp0f
+        YrrwH6+d/ol5evh8ajI9PanwwZ3s23J282RTsJ0rjjqnYNynNgEqO75FXbpBJzkat3gK1tv8+T0w
+        e2AmOSU/6ntltlDu4xOzzT4CPuKdzPwZNXtOYho7zvPJEl1YurdBBg0Mkf/2dPsPAAD//wMAjGn2
+        rRwIAAA=
     headers:
       CF-RAY:
-      - 992cb9995c5b23f8-SEA
+      - 99953ebfdb3ae090-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -175,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:20:25 GMT
+      - Tue, 04 Nov 2025 15:46:40 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -191,13 +203,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2086'
+      - '4169'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2099'
+      - '4174'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -211,7 +223,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_c323c8628a2d4c29a940eca06f1bcbcc
+      - req_afb61a1766c44627bcd458a1a2099af6
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/async_stream.yaml
@@ -8,12 +8,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '508'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -35,134 +39,134 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_03573e2d83248b7c0068f966bd516481949f9edc17d44d51ed","object":"response","created_at":1761175229,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6","object":"response","created_at":1762271201,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_03573e2d83248b7c0068f966bd516481949f9edc17d44d51ed","object":"response","created_at":1761175229,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6","object":"response","created_at":1762271201,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","type":"function_call","status":"in_progress","arguments":"","call_id":"call_4l0LYGshWqEvG3DEq9hY8PKo","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","type":"function_call","status":"in_progress","arguments":"","call_id":"call_BnBrJ4EwrnrNrOAgYK5QJtZk","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"delta":"{","obfuscation":"PSNkZJ3BzQ3PD4U"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"delta":"{","obfuscation":"3zVsA85JMJHwFMy"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"delta":"\"password","obfuscation":"jCVlVDR"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"delta":"\"password","obfuscation":"F3ZdUNt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"delta":"\":","obfuscation":"213quAm7DGYwOy"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"delta":"\":","obfuscation":"1IGR2LcljDnPz4"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"delta":"\"m","obfuscation":"dI1xEqywcpD9I3"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"delta":"\"m","obfuscation":"Zj7kGysvBrMM16"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"delta":"ell","obfuscation":"CuRtayV5tOpdG"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"delta":"ell","obfuscation":"vnFh7dIe8dh7q"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"delta":"on","obfuscation":"iyuiG89xy247xu"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"delta":"on","obfuscation":"RMx97iWSV9efgt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"delta":"\"}","obfuscation":"SLrGf6tb8NsCwR"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"delta":"\"}","obfuscation":"uZHZyqrwO8PswV"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_4l0LYGshWqEvG3DEq9hY8PKo","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_BnBrJ4EwrnrNrOAgYK5QJtZk","name":"secret_retrieval_tool"}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","type":"function_call","status":"in_progress","arguments":"","call_id":"call_hG4DmWUygGVSGrsCV3zwCiZU","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","type":"function_call","status":"in_progress","arguments":"","call_id":"call_3rPVUHZLIu5xyoiazpL8PRII","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","output_index":1,"delta":"{","obfuscation":"oWZs6Vy2FAJytBR"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","output_index":1,"delta":"{","obfuscation":"h5dbJqtyu13P7Dh"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","output_index":1,"delta":"\"password","obfuscation":"QQhC3mJ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","output_index":1,"delta":"\"password","obfuscation":"W7vRP87"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","output_index":1,"delta":"\":","obfuscation":"o1AxECjUkRrNfc"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","output_index":1,"delta":"\":","obfuscation":"Pn8aL1vMOJGCUe"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","output_index":1,"delta":"\"radi","obfuscation":"lyv1S0skOym"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","output_index":1,"delta":"\"radi","obfuscation":"mv2qJ95Uc9P"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","output_index":1,"delta":"ance","obfuscation":"JntQSD8lxfh9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","output_index":1,"delta":"ance","obfuscation":"I3TGuHq9YW2e"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","output_index":1,"delta":"\"}","obfuscation":"v3toBiq8GMBqyq"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","output_index":1,"delta":"\"}","obfuscation":"HA9HafDBRxVWZD"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_hG4DmWUygGVSGrsCV3zwCiZU","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_3rPVUHZLIu5xyoiazpL8PRII","name":"secret_retrieval_tool"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_03573e2d83248b7c0068f966bd516481949f9edc17d44d51ed","object":"response","created_at":1761175229,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_4l0LYGshWqEvG3DEq9hY8PKo","name":"secret_retrieval_tool"},{"id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_hG4DmWUygGVSGrsCV3zwCiZU","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6","object":"response","created_at":1762271201,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_BnBrJ4EwrnrNrOAgYK5QJtZk","name":"secret_retrieval_tool"},{"id":"fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_3rPVUHZLIu5xyoiazpL8PRII","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":36,"input_tokens_details":{"cached_tokens":0},"output_tokens":54,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":90},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cb9becf0b769a-SEA
+      - 99953ede49e0e398-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:20:29 GMT
+      - Tue, 04 Nov 2025 15:46:41 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -178,35 +182,38 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '190'
+      - '38'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '202'
+      - '45'
       x-request-id:
-      - req_e6472c5c17ab4d25ab7fcdababe7a255
+      - req_cda05646e2e141d28cb69f35b4a7cb82
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance","role":"user"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_4l0LYGshWqEvG3DEq9hY8PKo","name":"secret_retrieval_tool","type":"function_call","id":"fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_hG4DmWUygGVSGrsCV3zwCiZU","name":"secret_retrieval_tool","type":"function_call","id":"fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec","status":"completed"},{"call_id":"call_4l0LYGshWqEvG3DEq9hY8PKo","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_hG4DmWUygGVSGrsCV3zwCiZU","output":"Life
-      before Death","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"call_id":"call_BnBrJ4EwrnrNrOAgYK5QJtZk","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_3rPVUHZLIu5xyoiazpL8PRII","output":"Life
+      before Death","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1156'
+      - '622'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -228,215 +235,237 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_03573e2d83248b7c0068f966bed85c81949f664a46b938e4ba","object":"response","created_at":1761175230,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_06995068fdb81d8900690a1fe244c08195a96bae2221a1e526","object":"response","created_at":1762271202,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_03573e2d83248b7c0068f966bed85c81949f664a46b938e4ba","object":"response","created_at":1761175230,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_06995068fdb81d8900690a1fe244c08195a96bae2221a1e526","object":"response","created_at":1762271202,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"Here","logprobs":[],"obfuscation":"JzovhaFKeLRK"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"Here","logprobs":[],"obfuscation":"J9ZGGGLmWy9f"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        are","logprobs":[],"obfuscation":"LLI7l4fzCr5p"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        are","logprobs":[],"obfuscation":"fb6S1s53bbje"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"qiU3QpSjkIB6"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"c7RvViLwXzWP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        secrets","logprobs":[],"obfuscation":"50NMnd4D"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        secrets","logprobs":[],"obfuscation":"k5cg9jIV"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"eFfa2BpiVgx0q"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        associated","logprobs":[],"obfuscation":"3gNJm"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"2SmDZoB9w2SvYRB"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        with","logprobs":[],"obfuscation":"yzRHF1CxymI"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        Password","logprobs":[],"obfuscation":"NMdlRN8"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        each","logprobs":[],"obfuscation":"p3aUUlLAmf5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"8NHMOc1eHSOtTG"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        password","logprobs":[],"obfuscation":"4ZOUDXS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"H6A6pdNP40G7yXn"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"Zw1GFHhrwG4hd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"3JstzbgDf87ra"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"mlleUDXHzczoLJv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"0HnfOkQXj7UmYE"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"WNr0s3tnX5Rhx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"Z9qlDMaw2bhYDP"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"vLrQblz4SAr9MNf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        Welcome","logprobs":[],"obfuscation":"f1R4ijT9"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"eugiocVfXtccb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        to","logprobs":[],"obfuscation":"6A4F0y6V9Hr0g"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"7zk0jNLegHAfiz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        M","logprobs":[],"obfuscation":"3jEgGSB4yUFA1I"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"yfAgCJCJu9F3ue"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"ePix3FHr68r0"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"zW3SIFQy95D7UEu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"3ZNCGmNYFv5xkg"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        Welcome","logprobs":[],"obfuscation":"si32d1DL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"Wlbu303Ld1uf6rw"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        to","logprobs":[],"obfuscation":"NtUSjemixIpMd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        Password","logprobs":[],"obfuscation":"vkHo5ZQ"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        M","logprobs":[],"obfuscation":"YQWi0thHftTdIu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"XmnfpkGy56kLev"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"556LX0XZSVq5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"1LudDP0Csd6Y"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"XZ9ucDJPtx8dP6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"oxUXx1qDFacT"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"69l9bNXBEvf0fHz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"RAz3AaZ8Drz7aR"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"TzNtJEsLINljg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        Life","logprobs":[],"obfuscation":"OSpbgBNsWoI"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"e1EQQubXPITu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        before","logprobs":[],"obfuscation":"GBJeTni5z"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"wbWM9SqD0EmI"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"delta":"
-        Death","logprobs":[],"obfuscation":"nCoakfqoYQ"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"fQP15osq3dZbFg"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"J0sEfIoKVQaSIj7"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        Life","logprobs":[],"obfuscation":"uj6XANloD0k"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        before","logprobs":[],"obfuscation":"2sPdWzKgO"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"delta":"
+        Death","logprobs":[],"obfuscation":"33tOqDwKYZ"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":30,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"text":"Here
-        are the secrets:\n\n- Password \"mellon\": Welcome to Moria!\n- Password \"radiance\":
-        Life before Death","logprobs":[]}
+        data: {"type":"response.output_text.done","sequence_number":34,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"text":"Here
+        are the secrets associated with each password:\n\n- **mellon**: Welcome to
+        Moria!\n- **radiance**: Life before Death","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":31,"item_id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets:\n\n- Password \"mellon\": Welcome to Moria!\n- Password \"radiance\":
-        Life before Death"}}
+        data: {"type":"response.content_part.done","sequence_number":35,"item_id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the secrets associated with each password:\n\n- **mellon**: Welcome to
+        Moria!\n- **radiance**: Life before Death"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":32,"output_index":0,"item":{"id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets:\n\n- Password \"mellon\": Welcome to Moria!\n- Password \"radiance\":
-        Life before Death"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","sequence_number":36,"output_index":0,"item":{"id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the secrets associated with each password:\n\n- **mellon**: Welcome to
+        Moria!\n- **radiance**: Life before Death"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":33,"response":{"id":"resp_03573e2d83248b7c0068f966bed85c81949f664a46b938e4ba","object":"response","created_at":1761175230,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets:\n\n- Password \"mellon\": Welcome to Moria!\n- Password \"radiance\":
-        Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
-        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":136,"input_tokens_details":{"cached_tokens":0},"output_tokens":28,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":164},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","sequence_number":37,"response":{"id":"resp_06995068fdb81d8900690a1fe244c08195a96bae2221a1e526","object":"response","created_at":1762271202,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the secrets associated with each password:\n\n- **mellon**: Welcome to
+        Moria!\n- **radiance**: Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":136,"input_tokens_details":{"cached_tokens":0},"output_tokens":32,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":168},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cb9c83983769a-SEA
+      - 99953ee58f58e398-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:20:31 GMT
+      - Tue, 04 Nov 2025 15:46:42 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -452,15 +481,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '206'
+      - '237'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '222'
+      - '243'
       x-request-id:
-      - req_4076522e9c40406bb93eb6e2c0d28d98
+      - req_1405b7c0350c4981afb834a6eb0d8a90
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/stream.yaml
@@ -8,12 +8,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '508'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -35,134 +39,134 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c3b09d20eedf2d30068f966b9b7048190b7501a24a1447ec0","object":"response","created_at":1761175225,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c","object":"response","created_at":1762271155,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c3b09d20eedf2d30068f966b9b7048190b7501a24a1447ec0","object":"response","created_at":1761175225,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c","object":"response","created_at":1762271155,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","type":"function_call","status":"in_progress","arguments":"","call_id":"call_sKC7OABqf2A2PTLCm0CLeRWV","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","type":"function_call","status":"in_progress","arguments":"","call_id":"call_97ayj0C3bp5IcprjGmdcP3YD","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"delta":"{","obfuscation":"eMWlO7RB6LZnWas"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"delta":"{","obfuscation":"JuBrTvusaBWgcOr"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"delta":"\"password","obfuscation":"E0RUrpZ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"delta":"\"password","obfuscation":"Mu1jB2I"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"delta":"\":","obfuscation":"ALuOgGt1Y30bCY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"delta":"\":","obfuscation":"9Qjd5hWBz0R5ar"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"delta":"\"m","obfuscation":"03xquugxYTgA76"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"delta":"\"m","obfuscation":"pLHEJuuHlFVtIu"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"delta":"ell","obfuscation":"uxljapQp8smY4"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"delta":"ell","obfuscation":"NsfjGS7XYszGk"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"delta":"on","obfuscation":"PnXJZA3EmBlfGP"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"delta":"on","obfuscation":"nmcmHQa5hKzuVG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"delta":"\"}","obfuscation":"rNvPCarSjzXIFY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"delta":"\"}","obfuscation":"5HbVPGzHDDzhb0"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_sKC7OABqf2A2PTLCm0CLeRWV","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_97ayj0C3bp5IcprjGmdcP3YD","name":"secret_retrieval_tool"}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","type":"function_call","status":"in_progress","arguments":"","call_id":"call_OdR3s3xop0vtgkDyWRMLafuH","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","type":"function_call","status":"in_progress","arguments":"","call_id":"call_SOHDB5HyLUg7QvE7pUWlXUMQ","name":"secret_retrieval_tool"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","output_index":1,"delta":"{","obfuscation":"YY4K5T22skTwGcg"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","output_index":1,"delta":"{","obfuscation":"KoYnKpdtrxuuZuO"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","output_index":1,"delta":"\"password","obfuscation":"gPYhRob"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","output_index":1,"delta":"\"password","obfuscation":"dEhSsEO"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","output_index":1,"delta":"\":","obfuscation":"jFTSVrb5LI9vWs"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","output_index":1,"delta":"\":","obfuscation":"8aUuudiTeTNz2s"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","output_index":1,"delta":"\"radi","obfuscation":"BViLoKscpWK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","output_index":1,"delta":"\"radi","obfuscation":"NCDJ8uwnwqY"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","output_index":1,"delta":"ance","obfuscation":"QDi01uuVV59N"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","output_index":1,"delta":"ance","obfuscation":"SymbxXjbLkNR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","output_index":1,"delta":"\"}","obfuscation":"YWugD8slk0pQwI"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","output_index":1,"delta":"\"}","obfuscation":"p1uYUmgcQHlArz"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_OdR3s3xop0vtgkDyWRMLafuH","name":"secret_retrieval_tool"}}
+        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_SOHDB5HyLUg7QvE7pUWlXUMQ","name":"secret_retrieval_tool"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_0c3b09d20eedf2d30068f966b9b7048190b7501a24a1447ec0","object":"response","created_at":1761175225,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_sKC7OABqf2A2PTLCm0CLeRWV","name":"secret_retrieval_tool"},{"id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_OdR3s3xop0vtgkDyWRMLafuH","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c","object":"response","created_at":1762271155,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_97ayj0C3bp5IcprjGmdcP3YD","name":"secret_retrieval_tool"},{"id":"fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_SOHDB5HyLUg7QvE7pUWlXUMQ","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":36,"input_tokens_details":{"cached_tokens":0},"output_tokens":54,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":90},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cb9a838427537-SEA
+      - 99953dc3ac92faf6-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:20:25 GMT
+      - Tue, 04 Nov 2025 15:45:56 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -178,35 +182,38 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '179'
+      - '83'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '193'
+      - '97'
       x-request-id:
-      - req_8d6d8f1c29d6405e959403d5f0e2384c
+      - req_3b9631ff1dde4753a7062b5af46faabe
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance","role":"user"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_sKC7OABqf2A2PTLCm0CLeRWV","name":"secret_retrieval_tool","type":"function_call","id":"fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_OdR3s3xop0vtgkDyWRMLafuH","name":"secret_retrieval_tool","type":"function_call","id":"fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5","status":"completed"},{"call_id":"call_sKC7OABqf2A2PTLCm0CLeRWV","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_OdR3s3xop0vtgkDyWRMLafuH","output":"Life
-      before Death","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"call_id":"call_97ayj0C3bp5IcprjGmdcP3YD","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_SOHDB5HyLUg7QvE7pUWlXUMQ","output":"Life
+      before Death","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1156'
+      - '622'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -228,237 +235,251 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c3b09d20eedf2d30068f966bb69a481909f316f030c175460","object":"response","created_at":1761175227,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0512b776faee5b9e00690a1fb547dc81938da9d903d4a58194","object":"response","created_at":1762271157,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c3b09d20eedf2d30068f966bb69a481909f316f030c175460","object":"response","created_at":1761175227,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0512b776faee5b9e00690a1fb547dc81938da9d903d4a58194","object":"response","created_at":1762271157,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
         tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"Here","logprobs":[],"obfuscation":"YAF4xBluYWF7"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"Here","logprobs":[],"obfuscation":"yUnfenFYMQ8K"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        are","logprobs":[],"obfuscation":"5uE5bQTrEAma"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        are","logprobs":[],"obfuscation":"X2nZNyuHnaWg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        the","logprobs":[],"obfuscation":"OHDWD29968Tx"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"hnmHvsOnCMwa"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        secrets","logprobs":[],"obfuscation":"HOxcwIRx"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        retrieved","logprobs":[],"obfuscation":"HHipsc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        associated","logprobs":[],"obfuscation":"zCKhZ"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        secrets","logprobs":[],"obfuscation":"UnE4eFvw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        with","logprobs":[],"obfuscation":"MaiZ4bN2LNt"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"TLR0O9yeask3P"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        each","logprobs":[],"obfuscation":"gh3CxA09iCD"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"uv7A6N1pz1Vb19H"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        password","logprobs":[],"obfuscation":"tmYSwEX"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"TuUw9Uw3GgQFFn4"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":":\n\n","logprobs":[],"obfuscation":"Y1raZC5zx4hgn"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"lHzufqRqtdic6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"NKI657vFjWzCICE"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"Password","logprobs":[],"obfuscation":"op49m4tZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        **","logprobs":[],"obfuscation":"PjGuncupneet2"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"HsL0wLT0udoNEH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"gWyGzdESixlFEjm"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"m","logprobs":[],"obfuscation":"O7DsmElgQFwlqn8"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"VV7H1yVlB6MVO"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"ell","logprobs":[],"obfuscation":"hYuhBMAjXJT4Q"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"hUGr3Hj26Q1Azt"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"on","logprobs":[],"obfuscation":"EJM7d2GzszZaOx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"l8SQh3GWvbqREk"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"280UzLKCZCGSIo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"EW7VsSbL41isJxe"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"kMXvvnS8mRAUcw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        Welcome","logprobs":[],"obfuscation":"PSirV8JP"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        Welcome","logprobs":[],"obfuscation":"s9VOMVxG"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        to","logprobs":[],"obfuscation":"Ys7kM0C0fhOSq"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        to","logprobs":[],"obfuscation":"VgDMZdFOpQm2a"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        M","logprobs":[],"obfuscation":"zYtcUuy3TSqGQi"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        M","logprobs":[],"obfuscation":"1e4KNOtfG4GnLZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"gnQxe7NoKFOE"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"oria","logprobs":[],"obfuscation":"YnL4wbZVPYFq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"ivX8iL8Pc2bTAS"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"!\n","logprobs":[],"obfuscation":"WtGKFVVnC09Q5N"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"-","logprobs":[],"obfuscation":"qcqSeWWijyeIIzV"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"UvykXTWGTevBMly"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        **","logprobs":[],"obfuscation":"KjH1Cj2LwrUuT"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"4B5FHvXNof0kSzE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"wKBugwCokhGe"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"ZVOB9CgR7O4nN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"5qx7ahUVUxRw"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"Password","logprobs":[],"obfuscation":"bwQl4sNu"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"Dgq3vQcuMMtJqW"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"G0kGnFYxNiSNpZ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"gl9aWuwiirkGTJX"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"radi","logprobs":[],"obfuscation":"rsBwVVmiEM0N"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        Life","logprobs":[],"obfuscation":"77ZuauLRUOx"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"ance","logprobs":[],"obfuscation":"ZEH6QVJiwGvg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        before","logprobs":[],"obfuscation":"JB2KkMbrM"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"6PrO0SlfyPgOsP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"delta":"
-        Death","logprobs":[],"obfuscation":"YBFompK4sS"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"1lxBH33LuLeowg"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        Life","logprobs":[],"obfuscation":"SarfEcKbolC"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        before","logprobs":[],"obfuscation":"D4QY4atoB"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"delta":"
+        Death","logprobs":[],"obfuscation":"FW9D71p7tC"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":34,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"text":"Here
-        are the secrets associated with each password:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death","logprobs":[]}
+        data: {"type":"response.output_text.done","sequence_number":37,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"text":"Here
+        are the retrieved secrets:\n\n1. **Password \"mellon\":** Welcome to Moria!\n2.
+        **Password \"radiance\":** Life before Death","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":35,"item_id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets associated with each password:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death"}}
+        data: {"type":"response.content_part.done","sequence_number":38,"item_id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the retrieved secrets:\n\n1. **Password \"mellon\":** Welcome to Moria!\n2.
+        **Password \"radiance\":** Life before Death"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":36,"output_index":0,"item":{"id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets associated with each password:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death"}],"role":"assistant"}}
+        data: {"type":"response.output_item.done","sequence_number":39,"output_index":0,"item":{"id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the retrieved secrets:\n\n1. **Password \"mellon\":** Welcome to Moria!\n2.
+        **Password \"radiance\":** Life before Death"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":37,"response":{"id":"resp_0c3b09d20eedf2d30068f966bb69a481909f316f030c175460","object":"response","created_at":1761175227,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
-        are the secrets associated with each password:\n\n- **mellon**: Welcome to
-        Moria!\n- **radiance**: Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
-        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":136,"input_tokens_details":{"cached_tokens":0},"output_tokens":32,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":168},"user":null,"metadata":{}}}
+        data: {"type":"response.completed","sequence_number":40,"response":{"id":"resp_0512b776faee5b9e00690a1fb547dc81938da9d903d4a58194","object":"response","created_at":1762271157,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Here
+        are the retrieved secrets:\n\n1. **Password \"mellon\":** Welcome to Moria!\n2.
+        **Password \"radiance\":** Life before Death"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":136,"input_tokens_details":{"cached_tokens":0},"output_tokens":35,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":171},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cb9b2dd1c7537-SEA
+      - 99953dcc59cafaf6-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:20:27 GMT
+      - Tue, 04 Nov 2025 15:45:57 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -474,15 +495,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '239'
+      - '222'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '258'
+      - '229'
       x-request-id:
-      - req_fc04d1f2c5884e53ab79dd358cbf146a
+      - req_2adf06d7f70044fea511f0674b9e2101
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/openai_responses_gpt_4o/sync.yaml
@@ -8,6 +8,8 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
@@ -35,30 +37,30 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xVTW/bOBC9+1cQPCeF5Miy7Fu7xaJosUGxlxZoCmFEjhxuKJElh27cwP+9EGXr
-        w2kW28vepHkzT/PxRvO0YIwrybeMO/S2TFbJMoFNukkFyDWIJMmLepPngKJYJUW6SaoqT7PlKqtv
-        IBMbmfGrjsJU/6CgM41pPfZ24RAIZQkdlq7zNF2vlmkeMU9AwXcxwjRWI6HsgyoQDztnQtvlVYP2
-        2JuV1qrd8S17WjDGGLdwQNfFS9yjNhYdXzB2jM7onOmwNmgdDao9f6WUSKC0n6OeXBCkTDuzN/BY
-        mkA2UEnmAZ+DZIwuBeg5XWMk6i6znaXrzFwvk2V2nRTXSX5qV6TkW/YlVtLXM0yiFi/OoUqzLBdx
-        DjdZtS5kXq+LAhFFJI4kdLAYaUIbC4rpjfBLbY8guF1osKWIP91xC95/N07e8e0db1Br097x4+jf
-        UZd91vGx+vEZ3qTv3n7ynw7rNq/+co/vf9zewhjRQhOz8ygcUumQnMI96NhJHr2OV7/dlbwuojqL
-        os4lVLlIc5Hlq5v/oSsOpIJW4L/25a3Mvu8PD3+4/Jbo84fHvz8kb/58t8l/ry8Lxr5G/VhwoDXq
-        ufzIhX5TrMO9MsGX52XsUxnkaZ1pLJUCxD2WD3iYYg7Bm3a2Z1jXxtHEqetXaBpw58hh7TzUSIdS
-        SWxJ1QpnK+jR7ZXAktR5bWsImvjpb2AcTosgbCw6oBDN6avkZH2kMbPauAbG98mYo99UTXyPrjJe
-        UZczb1Cq0Iy/i76P90aJGA2BDB8A/3xRL9U0zlGiF07ZaNwy/pp1DIzugZjDb0E59AzYWUGMDDuN
-        Ghmwfviv/qsqBrdODw0SOj/pRT9oi44Uzu0xok/gwt6VpkjHb348u1xdOJxq9+Q6mUzA4/B8HGP4
-        qWw5dPEyhcH4dRIFUqquiaA/TosYzsFFMqcDtLj4fEwyHqYYeLFGZGypzc46U3XcyWC0U8W50Ao4
-        z1MqD5U+X6rgYYejHFU7OxQ3+dVz++T6PI1/C3GPcgxMZsK9vD+r7FfAr3iHXX6JmgxFLZ3ATTIs
-        RPDz3W2QQAJBR39cHH8CAAD//wMA//qR9DgIAAA=
+        H4sIAAAAAAAAAwAAAP//vFVNj9s2EL37VxA87waSLcvy3rJBkCLtIUiAokA3EEbkyGZMiSo5dLJZ
+        +L8XpGx9eLNFc8lNmo/Hmcc3nKcFY1xJfse4RdeVyXIp8norVlIi5FuZJPk2gbQuVllRiCLdJsW2
+        XmFeb4q0XuXrQvCbAGGqLyjoAmNah71dWARCWULwpZt8udykabKJPkdA3oUcYZpOI6HskyoQh501
+        vg111aAd9maltWp3/I49LRhjjHfwiDbkSzyiNh1avmDsFIPRWhN8rdc6GlR7OaWUSKC0m3sdWS9I
+        mXZmb+BbaTx1nkoyB3zuJGN0KUDP4RojUYfKdh3dZuZ2mSyz26S4TfIzXRGS37G/Yyd9P8NN1OLl
+        e8i26zreAyT5qiiKPEtTsU1FEoEjCD12GGF8GxuK5Y3ul2iPTrA732BL0f/0wDtw7qux8oHfPfAG
+        tTbtAz+N8QG67KuOn38Ve7j/PUuyt3jY/fnuu/zid/s3+eSEFppYnUNhkUqLZBUeQUcmeYw63fw0
+        K9W2ygIrVV4ViEku0s26EtnyF7BiQSpoBf4nL+7eGXGf4m/m/fr9Rzxs9PLjH6+/f/o5XhaMfY76
+        6cCC1qjn8iPr+0npLB6V8a68DGNfyiDPzpqmo1KA2GN5wMcXfRYJ28DWNMIiONPOJhHr2liaBAVG
+        fdOAvWAPg+mgRnoslQzAtcLZkDq0RyWwJHUZ7Bq8Jn5+L4zFaZuETYcWyEdz+io5W7/RWFltbAPj
+        /0QIMW6qN35EWxmnKNTMG5TKN+OD0jO9N0rEbPBk+OBwz0f5Wm/jTUt0wqruTCt/zQICoz0Qs/iP
+        VxYdA3bRGCPDzmJABqyXx6v/q5shLCimQULrJlz0192hJYVze8zoC7iyh9YU6Xjmh0vIzVXAuXdH
+        Nshk4jwN36cxh5/blgOL1yUMxs+TLJBSBRJBf5g2MSyMq2LOK2pxdXwsMq6umHg1aGS6UptdZ00V
+        sJPB2E0VZ30r4HKfUjmo9GWXeQc7HOWo2tkqWeU3z+2T/fQ0vidij3JMTGbCvd5Q6+xHjh/hDrP8
+        EjQZilo6O7fJMBDezWe3QQIJBAH+tDj9CwAA//8DAMveCTFaCAAA
     headers:
       CF-RAY:
-      - 992cb963bde9b9b2-SEA
+      - 99953c93ce1de385-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -66,9 +68,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:20:17 GMT
+      - Tue, 04 Nov 2025 15:45:09 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=TY_GAwVBGC3fWvIorZWxaJKQzbMEF9gCzjQSDQlbxZc-1762271109-1.0.1.1-F_nlRYJPSkXXvGKxgaTmfbGfYH7HQIVC900TNkww_jWFqnPjV87CIuxPxUV1Dwa8M_xOnGZq.qfoYF3jB5v2pDs8p4URSL4_E6HVdzr.tt8;
+        path=/; expires=Tue, 04-Nov-25 16:15:09 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=R6L5D5KmzXiaD3Np8ql0crfmfxh9JMyC_k02kdtZ_ag-1762271109115-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -82,13 +90,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2873'
+      - '1786'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2895'
+      - '1792'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -102,27 +110,30 @@ interactions:
       x-ratelimit-reset-tokens:
       - 21ms
       x-request-id:
-      - req_be19fccd385a403aba2477c35162adf8
+      - req_6ac9ddcb87e940ec989d8f5a682efdb2
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":"Please
-      retrieve the secrets associated with each of these passwords: mellon,radiance","role":"user"},{"arguments":"{\"password\":\"mellon\"}","call_id":"call_bzXaB1HDWsWy7n6bMrxJzNNa","name":"secret_retrieval_tool","type":"function_call","id":"fc_05020a9191cad7ac0068f966b1446c8190b34b78d6f788eeec","status":"completed"},{"arguments":"{\"password\":\"radiance\"}","call_id":"call_Dd4wvykCr6NttXKxRK0BFH96","name":"secret_retrieval_tool","type":"function_call","id":"fc_05020a9191cad7ac0068f966b16f80819088f6dab6c16c4653","status":"completed"},{"call_id":"call_bzXaB1HDWsWy7n6bMrxJzNNa","output":"Welcome
-      to Moria!","type":"function_call_output"},{"call_id":"call_Dd4wvykCr6NttXKxRK0BFH96","output":"Life
-      before Death","type":"function_call_output"}],"model":"gpt-4o","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+    body: '{"input":[{"call_id":"call_X8haBK404EekgVGzdjughC6d","output":"Welcome
+      to Moria!","type":"function_call_output"},{"call_id":"call_sBsocB1eHoJ5JRek7l2RLAzS","output":"Life
+      before Death","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_022c6f9c3ddea69d00690a1f83488c819089f3e6f781f3658c","tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1142'
+      - '608'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -144,30 +155,30 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA3RVS4/jNgy+51eoOk8WdjLjPG4LFEUPLbC3HnYKg5boRB1ZUik63WCR/15Yjl+Z
-        mZvNj/zEx0fp50oIabQ8CkkYQ5m9ZJsMDvkhV6B3oLKs2NeHoqhynT3v9/khqzJV5C+7zSHf4lbp
-        vXzqKHz1DyoeaLyL2NsVITDqEjos3xV5vnvZ5LuERQZuYxejfBMsMuo+qAL1diLfui6vGmzE3mys
-        Ne4kj+LnSgghZIArUhev8YLWByS5EuKWnJHId5hrrU0G44ZTSo0MxsYlGplaxca7hb2BH6VvObRc
-        sn/D9yB7b0sFdknXeI22y+wUeP3s15ts87zO9uusuLcrUcqj+J4q6esZJ9HE0+eD2BzqjUqDyHeY
-        466o8gKrba4Sc2Lha8DEgzHCCSfgs44nUHnH6Kak5oktaId+4A8eo5MDOOcZhh5+/3sBWn8K5KsP
-        kER0FPJ3JBRAKPiMIqIi5Hh8da9uLX7zJALE+J8nLV5lg9Z69yqP4i+0yjco2Is/PRn45QNvAm3A
-        Kez8/zA1igprTyh+ReCzHDO53b/G5CR5mwqGGE1kcNw7d47JSQYgsBbtUgVMbS/YQHgxvo3lsBNl
-        mu+okkC+CVwqUGcs3/A6xwghereQO9a1J545dRNtmwZoiBzVH6FGvpZGo2NTG1xsQkS6GIUlm2F7
-        amhtP0sZ2RPOi2BsAhJwm8z5l+xuTTO7Z1Z7amD6n2kl+fVdu2d8Qap8NHztFapN20xb2/fx7I3q
-        G9+ylyMQ3+/LcEzdurS7k5o1RkUmJONRyK+iYxB8BhaE/7aGMAqYVMJeEDIZvKCAu/i+TGwOmnRO
-        D5R3V+gHP7l1emiQkeKsF/2gAxIbXNpTRJ/Ag70rzXCvvm+Dy9ODw732yNTJZAbeJk1PMfJetl4s
-        +DyF0ThbTwlam66JYL/Nixhv5ce7oX8HVg/HpyTT+5ACH9aIfShn10M2GsNccdQ6BcM8tYlQ2eHB
-        aNM1N8rRuMV9nW+Lp/fA7BUY5ZQ2UU+R2UK5j+/ANvsI+Ih3XObPqNlzEtOQcVGMK9HG5fY2yKCB
-        oeO/rW7/AwAA//8DAJMNshjBBwAA
+        H4sIAAAAAAAAA4xVTY/jNgy951eoPg4mC9tJPE5uC/TQQwvsrYfdwmAkOtGOLLkUnW6wyH8vJMdf
+        mRlgbwkf+UyR70k/V0IkWiUHkRD6tkrzXBb1Xm6UQij2Kk2LfQpZXe62MpNltk+PGyiVhB0We9iW
+        WZE8Bwp3/I6SBxpnPfZxSQiMqoKAZS9Fnr9kWbqPmGfgzoca6ZrWIKPqi44gX0/kOhv6qsF47MPa
+        GG1PyUH8XAkhRNLCFSnUK7ygcS1SshLiFpORyAXMdsbEgLbDVyqFDNr4JeqZOsna2UW8gR+V67jt
+        uGL3im9Bds5UEsySrnEKTejs1PJ669Z5mm/XablOh3FFyuQgvsaT9OcZN9H408eLKPIS07CIfSFV
+        gbtc7jb5PivSyBxZ+Npi5EHv4YQT8NHEIyidZbRTU/PGFrTDPPAHj9UxAax1DMMMv/6zAI07teSO
+        7yCR6CCSP5BQAKHgMwqPkpC9qB3F/yd9QSta8P4/R8ofvtlvdi2enho0xtmnp4P4G410DQp24i9H
+        Gn7rEwiUBisxpPypaxRHrB2h+B2Bz8nYx+3+a2wtIWficcF77Rks98khMSYlLRAYg2apAaaul2tL
+        eNGu89XgiOpXfLbZlmX0WbmvN1jUL2VWb4pdKZM7qWtariTIM1aveJ2LboERhmVqZ+cZhOCdXXgI
+        69oRz5KCTLqmARq4R0t5qJGvlVaBuNa4sJdHumiJFevBkjV0phdI4tkRzmfD2LRIwF0MZ5/SezQK
+        4d5Z7aiB6f9MgDGvX8a94wvS0XnN1172SnfNdBX06zk7Lft9duySEfBvTTh8pu5svBAmiyj0knR7
+        H2vyWQQGwWdgQfhvpwm9gFGkQYmETBovKOCu6E8Tm4UmfqcHqnsq9Hqa0oLMGmQkP5tFv+4WiTUu
+        47Gib+AhHo6muRf1lyHl+SHhfnbPFGQyA2+TVaaa5H5stbg15i2MwZnnE1BKhyGC+TI/xHjVP144
+        /eOyevh8bDI+OrHwwZ3s2mp256RjsJ0rjjorYdin0h6OZniFunh3jnLUdvEIZJvi+S0we1pGOUU/
+        qqkyXSj38XHZ5O8B7/GOZv6Imh1HMQ0dF+Voic4v3dsggwKGwH9b3f4HAAD//wMAFYhAMhYIAAA=
     headers:
       CF-RAY:
-      - 992cb976d8a7b9b2-SEA
+      - 99953ca04d7ee385-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -175,7 +186,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:20:19 GMT
+      - Tue, 04 Nov 2025 15:45:10 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -191,13 +202,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1297'
+      - '1628'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1304'
+      - '1636'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -211,7 +222,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_bdeebaa55f544370beb1b08fba53c21c
+      - req_c15503d91ec743dabcdbb1b806cc02fb
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async.yaml
@@ -16,12 +16,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1090'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -43,29 +47,29 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA4RUy47jOAy85ysEnTsDOXGcx3FvjX1ggTnMAtsDQ5botCaypJaoYIJG/n0hOfEj
-        PY29JSyzVCSLfF8QQpWkB0I9BFczVmzXJW/WzYY1ZVEyVu3afbVl+6rYlbtiX+7Wm41cN2UhVmVR
-        tQV9ShS2+QEC7zTWBOjjwgNHkDVPWLGtimK7WbNNxgJyjCHlCNs5DQiyT2q4OB29jSbparkO0IeV
-        1soc6YG8LwghhDp+AZ/yJZxBWweeLgi55o/Be5swE7XOAWXur9QSkCsd5mhAHwUqa2bxjv+sbUQX
-        sUZ7go8gWqtrwfWcrrMSdFJ2dLgs7XLFVuWS7ZasurUrU9ID+TdX0tczTKIVn8+Br4qK5TnsQK5Z
-        JVi757DbtJk4k+DFQaaJJheU5Y3wZ23PIPfH2IHBjL+/UBUa80IPL5Qtt9VmvSyK7W75zwu9jimJ
-        ve6F55/Hsyjevv1u2N4/b93qzSss/vz2daLA8C4LPALWjbWnWpnW0oxeF4R8zy1y3HOtQc87jD72
-        ZnAezsrGUN/91ksYJuC87RzWgotXqE9wmWIeeLBmZiVoW+tx8lFqVOw67u+Zg7MCbwEvtZJgULUK
-        Zi4L4M9KQI3q7syWR430ZnjrYVoEQufAc4w5XHxht+hPHJW11nd8/D+Z749gTX1bvL55N+Fn8I0N
-        CpN02oFUsRsXo2/nq1Uik/CIlg5A+GjJRzeNY5QQhFcuBw+E/mHtiURH0kRJmmjSrawhzYU8f/3t
-        ry//Z4ABTqPvAMGHSdn9TB14VDCPp70JjXmIJekKdX7nOcFPD+CtroA+OWECXoff1zGHeniLyoMc
-        OjR9egh8n2RwKVVqANd/T4UPB+1ByHSSk6ezwHxac+LDlqB1tbZH522TuNkQdFND+WgEv89JqsAb
-        fb+1MfAjjG5TZnbqVkX19BGYHND38QqIV5BjJps58vGErta/An7FO+zqZ9Rokesp836wegzz5ewA
-        ueTIE/91cf0PAAD//wMAaI+BWfwGAAA=
+        H4sIAAAAAAAAA4RUy27bOhDd+ysIruNCkh0/sms39xa4KArcTYGmEEbkyGFMkSw5DGoE/veClK2H
+        06A7aQ7n8HDmzLwuGONK8gfGPQZXF+t91a6q1T1UbSWwKYrNvoCqQNw3G7Er9/dQVhLkqq3KndiK
+        RvK7RGGbZxR0pbEmYB8XHoFQ1pCwcrupqm253hYZCwQUQ8oRtnMaCS9kDYjjwdtokq4WdMA+rLRW
+        5sAf2OuCMca4gxP6lC/xBbV16PmCsXM+jN7bhJmodQ4oc72llkigdJijgXwUpKyZxTv4VdtILlJN
+        9ohvQbJW1wL0nK6zEnVSdnC0XNtlVVTrZbFbFptLuTIlf2Df80v69wydaMX7fWjLZrXLfYDtqmyk
+        WIm2XBX3+0ycSejkMNNEkx+U5Y3we2XPIPhD7NBQxl8fuQqNeeQPj7xYbjf3q2VZbnfLb4/8PKYk
+        9roXnj+ftQ76tI3fvhYf//3nZ2yr+MX7aj1mGOiywANS3Vh7rJVpLc/oecHYj1wiBx60Rj2vMPnY
+        m8F5fFE2hvrqt17C0AHnbeeoFiCesD7i6V3MI6FJZZqe8AjBmpnZsG2tp8mhVMrYdeCv3IP3ArRI
+        p1rJRNwqnPkwoH9RAmtSV++2EDXxy0hYj9NnEnYOPVDM4fJDcYn+olFZa30H4//EAc/Bmvoymn15
+        L8Jf0Dc2KErSeYdSxW4cnb7gT1aJTAKRLB+A8Na0t34bGy0xCK/cpbr8P2uPLDqWes5Sz5NuZQ1r
+        Tuzz/5++fPibRQY4maNDQh8mz+4769CTwnk8TVZozE0sSVek8z2fE3x3A17eFcgnJ0zA8/B9HnO4
+        x59ReZRDhaZXD4EfkwyQUqUCgP46FT6svBsh005Ors4C8/LNiTdzRNbV2h6ct03iLoagmxrKRyPg
+        2iepAjT6uo1jgAOOblNmtgyrcnP3Fpis2NdxT4gnlGNmMXPk7ZKtVn8C/sQ7zOp71GQJ9JR5P1g9
+        hvlwdkgggSDxnxfn3wAAAP//AwBUONxkHgcAAA==
     headers:
       CF-RAY:
-      - 992cbb99e844a347-SEA
+      - 99954572883eca1f-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,7 +77,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:46 GMT
+      - Tue, 04 Nov 2025 15:51:11 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -89,13 +93,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1128'
+      - '832'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1134'
+      - '837'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -109,35 +113,29 @@ interactions:
       x-ratelimit-reset-tokens:
       - 32ms
       x-request-id:
-      - req_1f220d7f85d54d81ab2fd043e2796fee
+      - req_83ce178eb8de4decaab0afc047d08de8
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
-      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
-      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
-      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":"Please look up the
-      book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_gvc1qWKn09rI7p2qrit1MWSl","name":"get_book_info","type":"function_call","id":"fc_001734ab3b50b4140068f9670a2160819488ed306c0f9ae85f","status":"completed"},{"call_id":"call_gvc1qWKn09rI7p2qrit1MWSl","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_jllsly7uXP0AHGquf2uNrr24","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0492f3235a2f2ceb00690a20ee9b6c8195a12dad3f218c7cbd","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1486'
+      - '584'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -159,30 +157,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFVNb9s4EL3nVxA8JwXlyJ/HAi1QYHexQPdWF8JIHDlsKJJLDoMagf97
-        Qcr6cpKT7Xkzj8OZ9+jXO8a4kvzAuMfgKiGK7WMJ9WO9FnVZlEJsdu1+sxWwb8tyV+xLWG92otxI
-        XO/XO9HU/D5R2PoXNjTQWBOwjzcegVBWkLBiuymK7fpRbDIWCCiGVNPYzmkklH1RDc3zydtoUl8t
-        6IB9WGmtzIkf2OsdY4xxB2f0qV7iC2rr0PM7xi45Gb23CTNR6xxQZjilkkigdFiigXxsSFmziHfw
-        u7KRXKSK7DO+BclaXTWgl3SdlahTZydHD6V9WIlV+SB2D2JzHVem5Af2I9+kv8+4iS6cPl5EvV7j
-        Li9CoCh2rdzuV7tSrkVmzix0dph5MAQ44QR8NPEMNtYQmqmpeWML2mEe+JvG6pwAxliCYYY/fi5A
-        bU/O2/odJBMdGH89GsaOnBRpPPIDO/K/VaDaenNg/z0h+6oMaPalc8rjkd/32RDpyfo+/bMHI61h
-        38FI9MGaMcvBCUNKWpflEIq1Vk3utjojZIqVEJujufCxu8v129gw91bnIUAIKhAY6pNTYk7iDjxo
-        jXqpDPKxF7Hz+KJsDNXgkyrvfFSO87ZzVDXQPGH1jOc55hGCNQsLYNtaT7OktOXYdeCHytERAVqk
-        c6UkGlKtwoU7AvoX1WBFanBUC1H3++WBrMf5JQg7hx4o5nDxSVyjeY/XzlrrO5h+z/TzK1hTXR+M
-        fnjXxl/Q1zYoOvfilSp2k6H7cT5Z1fTzj2T5CIS3VhpOa6PJtp6ELjE0XrkcPDD+l7XPLDpWp09l
-        +r6VNaw+s2/fP//zaao00GXOE1KV0quUPsFp9R0S+jC7dr9Th54ULuPJ76E2N7HUenJAOudbgu9v
-        wOu9AvmkhBl4mWQ71XCP/0flUS58PRw9BmaO5CClSgMA/e+88fEhvn0OZpucHZ0bzH8JufDGJWRd
-        NXsRxBh0c0H5aHqHZkmqALUe/iNiftlGtSmzeKJX2+39W2D28I8yyUaTU6VYKPL26S9X7wHv8Y5e
-        /YiaLIGewMdiP0o9hqU5OySQQJD4L3eXPwAAAP//AwAKzzMKtAcAAA==
+        H4sIAAAAAAAAA4xVy27cOBC8+ysInu1AI2mexwC7QIBksUD2llkILao1ZkyRXLJpZGDMvy9Ivf0A
+        cvK4q1lsdVc1X+4Y47LhJ8Ydeltl5TFvi7zYQt7mAuss2x0zyDNsISuzw+a4PRzEtigObV027bbY
+        Nfw+Upj6JwoaaYz22MeFQyBsKojYZr/L8/2m3G8S5gko+HhGmM4qJBzIahBPF2eCjnW1oDz2YamU
+        1Bd+Yi93jDHGLVzRxfMNPqMyFh2/Y+yWktE5EzEdlEoBqcdbqgYJpPJr1JMLgqTRq3gHvyoTyAaq
+        yDzhW5CMUZUAtabrTIMqVnax9FCahzzLy4fs8JDthnYlSn5iP9KX9N8zTaLzlw8H0WYZbMs4iGNR
+        HOGQ7QqR78pt2ybmxEJXi4kHvYcLzsBHHU+gMJpQz0UtC1vRjv3AXzSdTgmgtSEYe/jj3xWozMU6
+        U7+DJKIT4y9nzdiZkySFZ35iZ/5NeqqN0yf2zyOyP6UGxf7orHR45vd9NgR6NK5P/+xAN0az76Ab
+        dN7oKcvCBX1M2pblGAq1kiJVW10REkWeZbuzvvGputvwayqYO6NSE8B76Qk09ckxMSVxCw6UQrVW
+        BrnQi9g6fJYm+Gr0SfU77sNjvRNx6LDJG2iKNt8cxF7Ug2GsM52lSoB4xOoJr0sprjCHccTS6GWG
+        Q/BGr5yFbWscLZKieELXgRu5J6N5aJGulWwicStxZTqP7lkKrEiORm0hqF423JNxuOwNYWfRAYUU
+        3nzKhmiSx1BZa1wH8/8LWf70RlfDHupnMhT+jK42XtK190QjQzfviX5Kj0aKfqyBDJ8A/9ah421t
+        0GlbzP5p0Asn7dBd/tWYJxYsq+Nfqfu6pdGsvrIv3z//9Wk+qaFLnBekKqZXMX2Go6I6JHR+8dn9
+        ZC06kriOxzXia/0qFkuPxor3fInw/Stw+C5PLiphAd5mN8xnuMP/gnTYrNbFePUUWBidQ9PI2ABQ
+        fy8Ln/b76y2zmOTi6lRgemnSwVfmI2OrxaLJpqBdCsoF3Rs/SVJ6qNX49IS0MCe1Sb3a/Pl+f/8W
+        WLwnk0yS3Zr5ZLZS5OsXpczfA97jnbz6ETUZAjWDxeY4ST34tTk7JGiAIPLf7m7/AwAA//8DAOUz
+        KsoLCAAA
     headers:
       CF-RAY:
-      - 992cbba1ee57a347-SEA
+      - 99954578ee23ca1f-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:48 GMT
+      - Tue, 04 Nov 2025 15:51:12 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -206,13 +205,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1420'
+      - '788'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1492'
+      - '796'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -226,7 +225,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 37ms
       x-request-id:
-      - req_aa8a3d845a094a93b6ff3629f2316d9b
+      - req_c3cd0895a73746d592ec0ba58a859e9d
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/async_stream.yaml
@@ -16,12 +16,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1104'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -43,114 +47,114 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0075d4e9136cabd30068f96729c4908193b30a50fb724e887c","object":"response","created_at":1761175337,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089","object":"response","created_at":1762271495,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0075d4e9136cabd30068f96729c4908193b30a50fb724e887c","object":"response","created_at":1761175337,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089","object":"response","created_at":1762271495,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","type":"function_call","status":"in_progress","arguments":"","call_id":"call_WeASSdshXbzOg7UDwf1RHvre","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","type":"function_call","status":"in_progress","arguments":"","call_id":"call_EvbQN4bviS5tMkqeccx4QAqK","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"{\"","obfuscation":"lrbt6jRBQm5EYJ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"{\"","obfuscation":"xEhYQjBq3Wp1BY"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"isbn","obfuscation":"MGkxfbaqq3Y4"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"isbn","obfuscation":"vsyi0gZrV70L"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"\":\"","obfuscation":"Cs1tUanS37UBk"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"\":\"","obfuscation":"bqIjj244JNevN"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"0","obfuscation":"6gXxHagu1DWxHVt"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"0","obfuscation":"9BYzQkipkfezsIW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"-","obfuscation":"8HTrYIvmlptvUe1"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"-","obfuscation":"vqhL7LtXFteon3x"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"765","obfuscation":"Cuh8PrIbFx34K"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"765","obfuscation":"W8dAnZ2Fl39Xu"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"3","obfuscation":"4EgQaO3zvorauDf"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"3","obfuscation":"if5WjG8sprU9ks2"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"-","obfuscation":"zwdY64ZZbOG3DCG"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"-","obfuscation":"He1MJAaYxPk2p4F"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"117","obfuscation":"oKaHLE4cfklCD"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"117","obfuscation":"oGZwla44TUdgM"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"8","obfuscation":"qxxPyIZ5TG1caLY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"8","obfuscation":"Vy48tl0HmvOetCu"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"-X","obfuscation":"RdUKkOgkTCZBj2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"-X","obfuscation":"jnCwVQpRtIIC4J"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"delta":"\"}","obfuscation":"ElfubVQ6nMALtu"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"delta":"\"}","obfuscation":"8yoRf0mndZArAa"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WeASSdshXbzOg7UDwf1RHvre","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EvbQN4bviS5tMkqeccx4QAqK","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0075d4e9136cabd30068f96729c4908193b30a50fb724e887c","object":"response","created_at":1761175337,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WeASSdshXbzOg7UDwf1RHvre","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089","object":"response","created_at":1762271495,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_EvbQN4bviS5tMkqeccx4QAqK","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":216,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":239},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc644c33709c-SEA
+      - 999546105fd24e57-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:18 GMT
+      - Tue, 04 Nov 2025 15:51:35 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -166,43 +170,37 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '334'
+      - '69'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '378'
+      - '79'
       x-request-id:
-      - req_a48eba32316746119574fb5d30795688
+      - req_7b95ea4331194303b80f70a9a14f0617
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
-      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
-      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
-      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":"Please look up the
-      book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WeASSdshXbzOg7UDwf1RHvre","name":"get_book_info","type":"function_call","id":"fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec","status":"completed"},{"call_id":"call_WeASSdshXbzOg7UDwf1RHvre","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_EvbQN4bviS5tMkqeccx4QAqK","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1500'
+      - '598'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -224,288 +222,288 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0075d4e9136cabd30068f9672b5f5881938cc03d5f06096a0c","object":"response","created_at":1761175339,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_02f36303af99bf2d00690a210932048197a680b67d9debbae0","object":"response","created_at":1762271497,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0075d4e9136cabd30068f9672b5f5881938cc03d5f06096a0c","object":"response","created_at":1761175339,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_02f36303af99bf2d00690a210932048197a680b67d9debbae0","object":"response","created_at":1762271497,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"QJfLd1jDC90ATn"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"3C86uT1WJVrMDo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"pYZKtZApiaaGkj1"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"RtvTrvwuJEoTcNl"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"rUlfqgdL0rQF1T"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"xGesTL93kMbLbS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"V4hLZNeUjwH"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"tEFmHp5FNjN"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"CZxnKwqqywoda3"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"jz9RXzv84wyrt6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"FSRNIitEat6oEb"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"Sb1u8OQF6ybtPa"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"QC3ICYpj3V9Z"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"ozANvKOfeOAT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"R3FcoJbRIOuf"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"n0LmVDR3TN88"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"kFTzZLO9oaS3xa2"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"lZm1Gk4iEUN2BgR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"EqhXh2gcfWIq"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"xENhJaJjSb2S"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"gLecilBurk"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"rmVAeawJnx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"f6KhMC4N9"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"AKPaeyu2Y"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"9I3rbaICDVGD4"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"7kK8Hd1rPT2as"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"nEJSnY9u88p8gNC"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"eAQqhM0aIIrNG1H"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"fMvy5sth19SAlh"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"CLODxV97uipMFs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"CMZMTd04em"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"wKB4UY3ZNy"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"zrQFW0mbSMFwxm"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"tLWDeyF2znmZ2f"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"8iJkLOuvizShbw"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"1y5qg6Z55LAopJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"uu5XqDwJtS0iHW"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"naS5w9eBOq1F4i"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"tte7CDzro66"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"gZxHElVAqEi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"LeajQGwqvLe"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"aZy5tS7NPey"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"mwJOaZPyCp8"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"Mp6kzE6qabc"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"8jvtIGvP3eDfD"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"R02RAC9xIIM10"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"oU562XmV9m7yUtx"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"7uYUTYVzPrt5sH5"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"sCdpLZvvXKPMLJ"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"soEhtdoTDxlCjr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"BV60Nyibv0B"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"rUndc3vw1ir"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"QibdCjgIxPcaXk"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"IxkLuSZNgq3jC2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"Zwx3x8WwWFTVYxQ"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"TYRxaEVZfklwokB"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"cWxF9i1OWgFnE"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"8mpBJMKZ7ikgk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"BAzlCrHdgzuiPE"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"MIeZtPe96vj0ts"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"uYo6zcxUplGoZJm"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"8oaSWkPNVtmk3gF"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"Yv5NQMuzRZidAp"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"24AQnWCvWhCapz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"jBb0K"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"WuxxW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"Zcue38oPl6m"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"eCRhGTXpOje"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"0srC1tJ9pZJ9Nd"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"JCkQoxguCH7Dsh"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"S2BZQnfCIWnuzwV"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"EQdwbXK5mThmWRR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"ek4MLyieqnTk3"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"8vpnNKIZu3ewb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"rMEGlkFdIpy7oFm"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"BmI4oGL35SfJcKs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"PZCXwwo9iRuTIHv"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"MGwQ1ImQrfN6HfL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"aFL94Nma5ZZXl0N"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"ip9WU6OAgrRCmsg"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"text":"{\n  \"title\":
+        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_0075d4e9136cabd30068f9672b5f5881938cc03d5f06096a0c","object":"response","created_at":1761175339,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_02f36303af99bf2d00690a210932048197a680b67d9debbae0","object":"response","created_at":1762271497,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
-        544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":277,"input_tokens_details":{"cached_tokens":0},"output_tokens":42,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":319},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc6e8aef709c-SEA
+      - 99954618cf134e57-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:19 GMT
+      - Tue, 04 Nov 2025 15:51:37 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -521,15 +519,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '329'
+      - '177'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '349'
+      - '182'
       x-request-id:
-      - req_b95c7d84dc5b418d89681e34fe37f9c9
+      - req_1c6d8078822447fc9549ad3c14599033
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/stream.yaml
@@ -16,12 +16,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1104'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -43,114 +47,114 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f1f1f1012662e2a0068f9671b86c48194bbf31b828ae7208a","object":"response","created_at":1761175323,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648","object":"response","created_at":1762271481,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f1f1f1012662e2a0068f9671b86c48194bbf31b828ae7208a","object":"response","created_at":1761175323,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648","object":"response","created_at":1762271481,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","type":"function_call","status":"in_progress","arguments":"","call_id":"call_V1BAu6CPIaeWyMim4iiKLay2","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","type":"function_call","status":"in_progress","arguments":"","call_id":"call_3dRVRGLC0ZOgqqAqqwxLP1oA","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"{\"","obfuscation":"FWfjcZUOT7DXrN"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"{\"","obfuscation":"uvXwBedZklm9cc"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"isbn","obfuscation":"zNcC1sl3nP70"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"isbn","obfuscation":"GPmeswj7Wp5c"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"\":\"","obfuscation":"G3ACwnx4dm32i"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"\":\"","obfuscation":"tB2V2eA0uqDmo"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"0","obfuscation":"8WXpCaVEAN5AhYz"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"0","obfuscation":"N8a3PdMmdpF8k5B"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"-","obfuscation":"eX7h17RpyJ6sHxE"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"-","obfuscation":"XXwX5cFCneUYYYi"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"765","obfuscation":"uScT8e0ipDXUb"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"765","obfuscation":"daqUYQ3Sy0O9R"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"3","obfuscation":"yZZtmk0OMNXNXAu"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"3","obfuscation":"4GPSl92eiKzbGxk"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"-","obfuscation":"PXJK7BmIru4F3s9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"-","obfuscation":"cpD2lzQgdGPpcjH"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"117","obfuscation":"d4o4WAMOPkykW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"117","obfuscation":"lrL7B3vykxKAa"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"8","obfuscation":"kZahOdfIRSqex2v"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"8","obfuscation":"uMy3WAT7bGu0LYD"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"-X","obfuscation":"KSEJxid9CSuLGe"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"-X","obfuscation":"nRbt2ZkAICIuqw"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"delta":"\"}","obfuscation":"breb7gGta1HyD2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"delta":"\"}","obfuscation":"S3eDWHHnnExZQY"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_V1BAu6CPIaeWyMim4iiKLay2","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_3dRVRGLC0ZOgqqAqqwxLP1oA","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0f1f1f1012662e2a0068f9671b86c48194bbf31b828ae7208a","object":"response","created_at":1761175323,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_V1BAu6CPIaeWyMim4iiKLay2","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648","object":"response","created_at":1762271481,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_3dRVRGLC0ZOgqqAqqwxLP1oA","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":216,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":239},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc0b6c93b98d-SEA
+      - 999545b87dab8eb8-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:03 GMT
+      - Tue, 04 Nov 2025 15:51:21 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -166,43 +170,37 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '233'
+      - '133'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '263'
+      - '153'
       x-request-id:
-      - req_d1d6592efb644be8838ef29728faf96b
+      - req_05d3b57c26b14bda8296aeb8baff8d3e
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
-      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
-      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
-      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":"Please look up the
-      book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_V1BAu6CPIaeWyMim4iiKLay2","name":"get_book_info","type":"function_call","id":"fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8","status":"completed"},{"call_id":"call_V1BAu6CPIaeWyMim4iiKLay2","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_3dRVRGLC0ZOgqqAqqwxLP1oA","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648","stream":true,"text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1500'
+      - '598'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -224,288 +222,288 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f1f1f1012662e2a0068f9671cd474819496a8b53a23715fd2","object":"response","created_at":1761175325,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0ba0218446ccdbff00690a20fbb9248194a1737b7ca1166ecc","object":"response","created_at":1762271483,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f1f1f1012662e2a0068f9671cd474819496a8b53a23715fd2","object":"response","created_at":1761175325,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0ba0218446ccdbff00690a20fbb9248194a1737b7ca1166ecc","object":"response","created_at":1762271483,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"fjQKor6k2rX9fZ"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"{\n","logprobs":[],"obfuscation":"novWVeNYVDfKkq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"745J9UlrcW83vrJ"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"avXT818EHP8vMH7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"5gOV62LvAYOr7V"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"iOkU84PrHuxy69"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"l42PXvFU1Nt"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"CjZlXkVO0wT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"nUf2RxvXPqKtJP"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"6HbVGP8UGpeoqn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"45bW4A903n1Xii"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"fcTFIj0u28VxMi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"YGXEgNmy9vTo"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"SfK7cZNR4vIf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"n3q7WFVIyL7V"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"sKVJJLjA40le"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"g0p43phaFbQlJXy"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"kgUObHQ6mWG8x8P"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"Lf0E36uSAtF1"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"fcqHtpjdzcXK"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"L0XlUpUqau"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"wkk26krEn8"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"EzdP3fbHo"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"OdcpL6pwJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"EqgYaso2FCzN4"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"5Mt41Rap7wj2G"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"gYRnvLLx0vlDMBm"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"0ydVDJFSO2R3oxQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"YLdxpYyoQ5SrLv"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"ZxRRft0Tkgg0ri"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"gBi2G6Cnkt"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"PAbvasaeHT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"MN8nkVDuVoMq5c"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"3SasUPp51Wb84j"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"tpMG0g1meZ1xYk"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"aF8TtMkBrDArNW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"0wz1icI2GqwEBX"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"ulwkor5MLrwL7x"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"KxqNvW0ttot"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"yJsCmkrmeYJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"fMHyjkuSrDI"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"hTY859A4PFi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"FjP2tGt9k38"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"hwgKN5ee63t"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"jz9DNWZuBBZU3"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"\",\n","logprobs":[],"obfuscation":"0D4yzwPDyhuVQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"64PkCPTzHQH1nzG"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"s2dMgKWGRcsNJ24"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"uVuA2WJoZ4uxqw"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"IrzcPHjPEQXyud"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"XC25hs9rSGB"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"9LVX1DPANIS"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"A04ppROq1vT8Yy"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"YVwMh4G0pJHmOA"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"vuBw58UQJ7T1jsq"}
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"WcgFwLBhJp7pMmz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"KvkJec8hN3Y3j"}
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"8q6TMJipfZ6Yh"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"N8G6ynZSqlEgFz"}
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":",\n","logprobs":[],"obfuscation":"n3w8nZBlQ4gI7a"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"il1b7exkMPZVgei"}
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"f7mqdab9QiwmrVs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        \"","logprobs":[],"obfuscation":"F3fCC895wh22Py"}
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        \"","logprobs":[],"obfuscation":"sop5GhLxKcygse"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"lkozd"}
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"MqLb1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"3XAzpiEJOwg"}
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"u1fTlBbnueE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"WV1iFEQMTDgmfe"}
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"238BlbsToh2c4A"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"
-        ","logprobs":[],"obfuscation":"lyrFweoeQkAKf9c"}
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"VlEkvReFnJyxeRr"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"dWfIJc20TTRtA"}
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"1uDFwYpUYlIDq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"PrT9imyN2j8iAia"}
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"B11OUQxEnMCoxr8"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"yvuA4mzLyIIdb5I"}
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"\n","logprobs":[],"obfuscation":"h2hkaG8e6iztzC1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"vQj3hVspIdnFU1L"}
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"JSr5t4ZLrDjdLKI"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"text":"{\n  \"title\":
+        data: {"type":"response.output_text.done","sequence_number":44,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.content_part.done","sequence_number":45,"item_id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.output_item.done","sequence_number":46,"output_index":0,"item":{"id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
         544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_0f1f1f1012662e2a0068f9671cd474819496a8b53a23715fd2","object":"response","created_at":1761175325,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
+        data: {"type":"response.completed","sequence_number":47,"response":{"id":"resp_0ba0218446ccdbff00690a20fbb9248194a1737b7ca1166ecc","object":"response","created_at":1762271483,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\n  \"title\":
         \"Mistborn: The Final Empire\",\n  \"author\": \"Brandon Sanderson\",\n  \"pages\":
-        544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
+        544,\n  \"publication_year\": 2006\n}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_object"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":277,"input_tokens_details":{"cached_tokens":0},"output_tokens":42,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":319},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc13ac7db98d-SEA
+      - 999545c49d9b8eb8-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:05 GMT
+      - Tue, 04 Nov 2025 15:51:23 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -521,15 +519,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '516'
+      - '181'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '531'
+      - '186'
       x-request-id:
-      - req_3b9972b99c674cb5ab518b7c6a1c4f9b
+      - req_3831e991348b4f82b243e3cbb71f7e53
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/openai_responses_gpt_4o/sync.yaml
@@ -16,12 +16,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1090'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -43,29 +47,29 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//hFTbjts4DH3PVwh6nhS24ziXx8UCi2IXbRdFgQKdwqBtOqOJLKkSlW0w
-        yL8XkhNfMh3sW8JjHh2Sh3xZMMZFw/eMW3SmTHa7Kks2ebbbpKsUMUmKbbsrinaTV6t8m+7WuzzP
-        sII6S5MmabfIHwKFrp6xphuNVu4ary0CYVNCwNJNkaabdbbdRMwRkHchp9adkUjY9EkV1MeD1V4F
-        XS1Ih31YSCnUge/Zy4IxxriBM9qQ3+AJpTZo+YKxS/wYrdUBU17KGBDq9krZIIGQbo46sr4modUs
-        3sHPUnsynkrSR3wNktayrEHO6TrdoAzKDoaWuV5mSZYvk+0yKa7tipR8z77FSvp6hkm09dtz2Cbr
-        9TbMAaoEVllRwCrfrrHKInEkobPBSONVLCjKG+G32h5BsAffoaKIvzxy4Sr1yPePPFluivVqmaab
-        7fLrI7+MKYG97IXHn6e//pRp/p//cnj+u6u+rv49ff708cvHiQIFXRR4QCorrY+lUK3mEb0sGPse
-        W2TAgpQo5x0m63szGIsnob0rb37rJQwTMFZ3hsoa6icsj3ieYhbBaTWzErattjT5KDTKdx3YW+bg
-        LAct0rkUDSoSrcCZyxzak6ixJHFzZgteEr8aXlucFkHYGbRAPobTd8k1+pNGZa22HYz/J/N9dlqV
-        18Xrm3cVfkJbaScoSOcdNsJ342L07XzSoo4k4EnzAXCvLXnvpnGMDbraChODe8b/0frIvGFhoixM
-        NOgWWrHqzN5//uPDu/8zwACH0XdIaN2k7H6mBi0JnMfD3rhK3cWCdEEyvvM+wA934LUuRzY4YQJe
-        ht+XMYdb/OGFxWbo0PTpIfB9kgFNI0IDQH6aCh8O2p2Q6SQnT0eB8bTGxLstIW1KqQ/G6ipwJ0PQ
-        TA1lvarhNqdGOKjk7dZ6Bwcc3SbU7NRlafHwGpgc0JfxCtRP2IyZycyR9yc0W/0O+B3vsKtvUZMm
-        kFPm3WB17+bL2SFBAwSB/7K4/AIAAP//AwC2o7at/AYAAA==
+        H4sIAAAAAAAAA4RUTW/bOBC9+1cQPMeFJMeSlWOwPRQoigI97AJNIVDkyGFMkSw5NGIE/u8FKVsf
+        ToO9SfM4j48zb+ZtRQiVgj4Q6sDbJtuWvN5WmzzfVV3G6ywr64zlXSeg7fgur8u63VSlqDfVdpPd
+        892W3kUK074AxyuN0R6GOHfAEETDIpZXZVFUeVHUCfPIMPiYw01vFSCIIall/LB3Juioq2PKwxCW
+        Skm9pw/kbUUIIdSyE7iYL+AIylhwdEXIOR0G50zEdFAqBaS+3tIIQCaVX6IeXeAojV7Ee/bamIA2
+        YIPmAO9BNEY1nKklXW8EqKhsb3F9b9ZFVtyvs906Ky/lSpT0gfxMLxneM3ai4x/3Aeqy3cU+tLy8
+        31Z5tt21G8FFnYgTCZ4sJJqg04OSvAn+qOwJZG4fetCY8LcnKn2rn+jDE83WVbndrPO82q3/e6Ln
+        KSWyN4Pw9HncH7+/CsRs+/gb/1Gfq5fd4795cZwyNOuTwD1g0xpzaKTuDE3oeUXIr1QiyxxTCtSy
+        wujCYAbr4ChN8M3Vb4OEsQPWmd5iwxl/huYApw8xBwg6lml+wgHzRi/MBl1nHM4OxVKGvmfuyj16
+        z7MO8NRIEYk7CQsfenBHyaFBefVux4JCehkJ42D+TITegmMYUjj/lF2irzgp64zr2fQ/c8CLN7q5
+        jOZQ3ovwI7jWeIlROu1ByNBPozMU/NlInkhYQENHwL837a3fpkYL8NxJe6ku/WrMgQRLYs9J7HnU
+        LY0m7Yl8+fH47dP/WWSEozl6QHB+9uyhsxYcSljG42T5Vt/EonSJKt3zJcJ3N+DlXR5ddMIMPI/f
+        5ymHOvgdpAMxVmh+9Rj4NctgQshYAKa+z4WPK+9GyLyTs6uTwLR8U+LNHKGxjTJ760wbubMxaOeG
+        ckFzdu2TkJ616rqNg2d7mNwm9WIZFnl59x6Yrdi3aU/wZxBTZrZw5O2SLTZ/A/7GO87qR9RokKk5
+        cz1aPfjlcPaATDBkkf+8Ov8BAAD//wMADmGnFx4HAAA=
     headers:
       CF-RAY:
-      - 992cbb291aadb9a4-SEA
+      - 99953f925872d5c8-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,7 +77,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:28 GMT
+      - Tue, 04 Nov 2025 15:47:11 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -89,13 +93,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1183'
+      - '1072'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1189'
+      - '1077'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -109,35 +113,29 @@ interactions:
       x-ratelimit-reset-tokens:
       - 32ms
       x-request-id:
-      - req_7a8af39bac4b4a22910ceadef7b4c2fa
+      - req_400b24189cd644ce8c80fbf32bde9275
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Respond only with valid JSON that
-      matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
-      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
-      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
-      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
-      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
-      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
-      \"BookSummary\",\n  \"type\": \"object\"\n}"},{"content":"Please look up the
-      book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_vGDl14wuUgjKmbX3QvSPOUOl","name":"get_book_info","type":"function_call","id":"fc_099b2074297131ee0068f966f805588195ab0a3266a3485eb2","status":"completed"},{"call_id":"call_vGDl14wuUgjKmbX3QvSPOUOl","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_vgvPxdtt05BqtDlE7j8BW12v","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_056c95731187f0c900690a1ffdebfc81969b376d9375304c85","text":{"format":{"type":"json_object"}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
       accept:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1486'
+      - '584'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -159,30 +157,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//dFVNb9s4EL3nVxA8J4Wk2LLlY4EWKLC7WKB7qwthJI4cNhTJJYdBjcD/
-        vSBlfTnJyfa8mcfhzHv06x1jXAp+YNyht3VWVU2R7TZFtcsfc8QsK/ddVZbdHkS32efVtgEsuqbb
-        l9tdle9Ezu8jhWl+YUsjjdEeh3jrEAhFDRHLd2We77bFfp8wT0DBx5rW9FYhoRiKGmifT84EHfvq
-        QHkcwlIpqU/8wF7vGGOMWziji/UCX1AZi47fMXZJyeiciZgOSqWA1OMptUACqfwa9eRCS9LoVbyH
-        37UJZAPVZJ7xLUjGqLoFtabrjUAVOztZetiYhyIrNg/Z/iErr+NKlPzAfqSbDPeZNtH708eLqMoc
-        92kR26JpH6tWFG352EKXmBMLnS0mHvQeTjgDH008ga3RhHpuatnYinacB/6mqTolgNaGYJzhj58r
-        UJmTdaZ5B0lEB8Zfj5qxIydJCo/8wI78b+mpMU4f2H9PyL5KDYp96a10eOT3QzYEejJuSP/sQAuj
-        2XfQAp03esqycEIfk7abzRgKjZJt6rY+IySKIsvKo77wqbvL9dvUMHdGpSGA99ITaBqSY2JK4hYc
-        KIVqrQxyYRCxdfgiTfD16JM67XxSjnWmt1S30D5h/YznJeYQvNErC2DXGUeLpLjl0PfgxsrJER46
-        pHMtBWqSncSVOzy6F9liTXJ0VAdBDfvlnozD5SUIe4sOKKRw/im7RtMer511xvUw/17o55c3ur4+
-        GMPwro2/oGuMl3QexCtk6GdDD+N8MrId5h/I8Anwb600ntYFnWw9C12gb520KXhg/C9jnlmwrImf
-        Ug99S6NZc2bfvn/+59NcqaFPnCekOqbXMX2G4+p7JHR+ce1hpxYdSVzHo999o29isfXogHjOtwjf
-        34DXe3lyUQkL8DLLdq7hDv8P0qFY+Xo8egosHMlBCBkHAOrfZePTQ3z7HCw2uTg6NZj+ElLhjUvI
-        2HrxImRT0C4F5YIeHJokKT00avyPCOllm9Qm9eqJLna7+7fA4uGfZJKMJubKbKXI26d/U7wHvMc7
-        efUjajIEagYf82qSevBrc/ZIIIAg8l/uLn8AAAD//wMATX+SorQHAAA=
+        H4sIAAAAAAAAA4xVTY/jNgy9z68QdJ5Z2M6HnRwXaIEF2qLA9rYpDNqiM9qRJVWiBhsM8t8LyfFX
+        ZrboKQ4f+USRfNTbA2NcCn5k3KG3dbbbt4dducnzquyy9pBl+0MGedd1RdtUVX7Ywwaxq0QnNpnI
+        q7Lgj5HCNN+xpZHGaI+DvXUIhKKGiOXlvijKvNjkCfMEFHyMaU1vFRKKIaiB9uXsTNAxrw6Ux8Es
+        lZL6zI/s7YExxriFC7oYL/AVlbHo+ANj1+SMzpmI6aBUMkg9nlILJJDKr1FPLrQkjV7Ze/hRm0A2
+        UE3mBd+DZIyqW1Brut4IVDGzs6WnrXkqsmL7lFVP2f5WrkTJj+xbuslwn6kTvT//RyPwsE2NqA5Q
+        7ap9Xm67fduJoRGJhS4WEw96D2ecgZ9VPIGt0YR6TmqZ2Ip2rAf+oCk6OYDWhmCs4be/V6AyZ+tM
+        8wGSiI6Mv500YydOkhSe+JGd+O/SU2OcPrK/npH9KjUo9ktvpcMTfxy8IdCzcYP7ZwdaGM2+ghbo
+        vNGTl4Uz+ui0225HU2iUbFO29QUhURRZtj/pK5+yu96+poS5MyoVAbyXnkDT4BwdkxO34EApVOvJ
+        IBeGIbYOX6UJvh51Uv8f9QlsujY2/dBsyr04bMrdJtu21Y7fSE1vqW6hfcb6BS/LUVxhDmOLpdFL
+        D4fgjV4pC7vOOFo4xeEJfQ9u5J6E5qFDutRSROJO4kp0Ht2rbLEmOQq1g6CGseGejMNlbQh7iw4o
+        JHP+KbtZ03jcMuuM62H+vxjL797o+raHhp7cEn9F1xgv6TJoQsjQz3ti6NKzke3Q1kCGT4B/r9Dx
+        tC7otC1m/Qj0rZP2Vl3+mzEvLFjWxF+ph7yl0ay5sC9fP//xaY7U0CfOM1Id3evoPsNxonokdH5x
+        7aGzFh1JXNvjGvGNvrPF1KOw4jlfIvx4B97u5cnFSViA11kNcwx3+E+QDsVqXYxHT4aF0DkIIWMB
+        QP25THza7/dbZtHJxdEpwfTSpMA78ZGx9WLRZJPRLgfKBT0IP42k9NCo8ekJaWFO0yb1avMXZfn4
+        Hli8J9OYJLmJOTJbTeT9i7ItPgI+4p20+jNqMgRqBjf5YRr14Nfi7JFAAEHkvz5c/wUAAP//AwC9
+        +4cACwgAAA==
     headers:
       CF-RAY:
-      - 992cbb31bb58b9a4-SEA
+      - 99953f9a2d95d5c8-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -190,7 +189,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:30 GMT
+      - Tue, 04 Nov 2025 15:47:12 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -206,13 +205,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1316'
+      - '1371'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1324'
+      - '1379'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -226,7 +225,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 37ms
       x-request-id:
-      - req_cccbcd03b24842658342a26866a5bdfc
+      - req_d5ab67b2ba9d444690f4767ce3907812
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async.yaml
@@ -9,123 +9,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '830'
       content-type:
       - application/json
-      host:
-      - api.openai.com
-      user-agent:
-      - AsyncOpenAI/Python 1.100.2
-      x-stainless-arch:
-      - arm64
-      x-stainless-async:
-      - async:asyncio
-      x-stainless-lang:
-      - python
-      x-stainless-os:
-      - MacOS
-      x-stainless-package-version:
-      - 1.100.2
-      x-stainless-read-timeout:
-      - '600'
-      x-stainless-retry-count:
-      - '1'
-      x-stainless-runtime:
-      - CPython
-      x-stainless-runtime-version:
-      - 3.10.16
-    method: POST
-    uri: https://api.openai.com/v1/responses
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFbbjts2EH33VxB8Xge6WJJ335JFgAYtggVSFC26gUBJI5kxJbLkcBtj
-        4X8PSNm6eK3N5c2eQx7O5cyMnleEUF7RO0I1GJUHEcRJkm024TaqgqwOgnRb36ZZGEVZXG7D24Bl
-        CUDAogCSaMuyLb1xFLL4AiWeaWRnoLeXGhhClTOHhVkahlkShxuPGWRojbtTylYJQKj6SwUr942W
-        tnN+1UwY6M1cCN419I48rwghhCp2AO3uV/AEQirQdEXI0R8GraXDOiuEN/Du/EpeATIuzBw1qG2J
-        XHYze8u+5tKispij3MNLEKUUecnEnK6VFQjnWaNwvZHrKIg262C7DtJTujwlvSP/+kj6eIZK1OVy
-        HeIo2m5cHW6TIijSKg3TTRInceCJPQkeFHga2/mAvHsjvJR2DzLd2BY69PjzI+Wm6B7p3SMN1lma
-        xOswzLbrvx/pcbzi2PPecf9ThOr9ffybStL7vwCT+4ffE/wI/9+PNzrWegcbwLyQcp/zrpbUo8cV
-        IZ99ihTTTAgQ8wyjtr0YlIYnLq3Jz3rrXRgqoLRsFeYlK3eQ7+EwxTQwI7uZlKCupcbJIZco27ZM
-        n28OyjKsBjzkvIIOec1hpjID+omXkCM/K7NmViA9CV5qmAaB0CrQDK03h2+Ck/Urjp7VUrds/D+p
-        7xcju9yUO2jZmNsKTKm5cnWfRTNJ+zsp959OsY2q6HnGZ/ocKtDIwczszgWOAi6MEzP90/+4uUBP
-        fhvULvcT8Dg9SZnFne/dJfa3/YFfpFeseRHQlP3B4wvkvENo+jmzwG4LwUvm++4A7LUwHsaj5B93
-        9CfeXF15nWr4z3IN1TBXZi9ey/GVxLwezQB+nrw7RHRNWZNATktigrCq4o6ciYep1vzMX10E6Avr
-        d4zrn9UEo0+gC2k4ul6lLVTctuMm6OfHTvLSO8EsSjoA5uUMvhyfS71F/5ByT6wiboQRN8Jco7pi
-        Fgfy4dO7j2++N/EG2M26FhC0+dEGdHP5FWl9cPCP98dPqck/fVUHr1VzWQ7LdR5lMK4FlCoXslFa
-        Fo47GIxqOkG17XrV+hnMDSvE+ePCGtaMo4vybrbbw3hz8xKYfDE8j2uv3EE13gxmirz8Zojia8A1
-        3mE5LVGjRCYmHifZIHVr5tuoBWQVQz/Wj6vjNwAAAP//AwCdckEf7QkAAA==
-    headers:
-      CF-RAY:
-      - 992cbbcc3acaec88-SEA
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 22 Oct 2025 23:21:55 GMT
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      X-Content-Type-Options:
-      - nosniff
-      alt-svc:
-      - h3=":443"; ma=86400
-      cf-cache-status:
-      - DYNAMIC
-      openai-organization:
-      - sotai-i3ryiz
-      openai-processing-ms:
-      - '1569'
-      openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
-      openai-version:
-      - '2020-10-01'
-      x-envoy-upstream-service-time:
-      - '2289'
-      x-ratelimit-limit-requests:
-      - '5000'
-      x-ratelimit-limit-tokens:
-      - '800000'
-      x-ratelimit-remaining-requests:
-      - '4999'
-      x-ratelimit-remaining-tokens:
-      - '799649'
-      x-ratelimit-reset-requests:
-      - 12ms
-      x-ratelimit-reset-tokens:
-      - 26ms
-      x-request-id:
-      - req_e5f81d25accd4dc6aac40c80faf224d8
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_l1pEC3Hp56CVet5CPK5tNewC","name":"get_book_info","type":"function_call","id":"fc_02e355744182d07f0068f967132284819095b0b6d616453530","status":"completed"},{"call_id":"call_l1pEC3Hp56CVet5CPK5tNewC","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
-      up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
-    headers:
-      accept:
-      - application/json
-      accept-encoding:
-      - gzip, deflate
-      connection:
-      - keep-alive
-      content-length:
-      - '1226'
-      content-type:
-      - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -147,32 +40,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xWy47bOgzd5ysErWcKO+9k1wFaoEB7UWC6uWgKg7bpRI0s6UrUoMEg/34hOfEj
-        kwRtV3F4KIqPQ1KvI8a4KPmacYvOZMkYJ7PZYjpNl+MyWVRJMl9Wq/kinRTldLlMV8lqucA54DJN
-        V8lsMR/zh2BC5z+xoLMZrRw28sIiEJYZBCxdzNN0MZuk84g5AvIunCl0bSQSls2hHIr91mqvgl8V
-        SIeNWEgp1Jav2euIMca4gQPacL7EF5TaoOUjxo5RGa3VAVNeyigQ6nxLViKBkG6IOrK+IKHVQF7D
-        r0x7Mp4y0nt8C5LWMitADs3VukQZPNsaepzqx3Eynj4my8dkfkpXNMnX7HuMpImnrUTttrcLMSuq
-        fBoKkaertJrDbDzNk+UKmoRHK3QwGO2gc7DtAbcyHsFCK0LVOdV3bGD2nA/8Re3pqABKaYJzDr//
-        GIBSb43V+RUkGloz/rrhJEjihq83/ItwlGur1uzbDtlHoUCyD7URFjf8YcPB007bqPlkQZVasWdQ
-        JVqnVVQwsEW34evZdBr++VyKIrqWHRDCwXGSzI+89eN4+mpd41bLGC44JxyBokY5KEYlbsCClCiH
-        HCDrG7oaiy9Ce5edOyKL1W05YqyuDWUFFDvM9njoYxbBaTUgO1aVttRTCvX0dQ32fLLlvoMK6ZCJ
-        EhWJSuCgDxzaF1FgRuLcOxV42VSSO9IW+0EQ1gYtkI/i9F1yksaKnTyrtK2h+99jyk+nVeaKHdbQ
-        8axEV1hhQi0G0TDGFdTx3JPW++dTbB15GzvrHilDDg1aEugG8uBCYNKFsCfm3+LHwwV68tuRDbnv
-        gcch0SP77lh/3yj8pfnI3TvWv0b8hnGhCLfNJLxh/aIX7l3UqbJ/g+of3Dm6cju3+J8XFsvBkGlv
-        vJbjK4m5H00L9oZMF9E1ZvVHW7PGegiUpQjGQX7tcy1updFFgLGwcQuG/hn1MP6CNtdO0KGZy6Xw
-        dbermvmx06JoBo4nzVvAvd0SZ28rr+LGutVb/LPWe+YNy8OvUE2jhmLmB/bp+emfd/xN622RsqCe
-        BfUODrOuRkLrfrcBhcvVHWp9CvDv98cfsSlefZUH96p5mw6369zRoFsLpE3WW3ZJKzT9CWq9algb
-        Z7BwkMvz88fHpd2OV6EGr490NXt4C/TeNC1N4mYpu5PJgJGXr5rJ5BpwzW67nG6ZJk0gO3A8XrZU
-        9264jWokKIHiWD+Ojv8DAAD//wMAX3/5YY8KAAA=
+        H4sIAAAAAAAAA5xWyY7bOBC9+ysEntuB5E1236bn1EAQNJBBkKUDoUSVbMaUyCGLRoyG/z0gZWtx
+        Wz3J3Ox65GMtr6r0MokiJgp2HzGDVmcxLOeQxLDazMpZnEIcrzYxzJLlmq/yxTrZrPJNulwt0gUs
+        OJYbTNmdp1D5D+R0oVG1xcbODQJhkYHHknQ1m6XJMl0FzBKQs/4OV5WWSFg0l3Lg+61RrvZ+lSAt
+        NmYhpai37D56mURRFDENRzT+foEHlEqjYZMoOoXDaIzyWO2kDAZRX17JCiQQ0g5RS8ZxEqoe2Cv4
+        mSlH2lFGao+vQVJKZhzkkK5SBUrv2VbTdKGms3i2mMbrabw6pytQsvvoW4ikiaetRMnH6wAxT9a+
+        DuvFrOA5rvl8Xm4Kvg7EgYSOGgONq0NAwb0OHkt7AMFsXYU1BfzlmQmb18/s/pnF03S1nE+TJF1P
+        Pz+zU3fFs2eN4+HnJ/E3JYdi/1mZesO/PPLi4at+0tDdqKEKDm6RslypfSbqUrGAniZR9D2kSIMB
+        KVEOM0zGNWLQBg9COZtd9Na40FZAG1VpyjjwHWZ7PI5iBglrn6b+CYNgVT0QG5alMtQ75FPpqgrM
+        hbvVnoUS6ZiJwhOXAgc6tGgOgmNG4qLdEpwkdm4JZbAfJmGl0QC5YE7exWfrT+o8K5WpoPvfU8AP
+        q+rM8h1WvewXaLkR+irkQWEelNp/PMfW6abh6Z5pMqnRkEA7sHsXBEm8MvbM7J/w4+4KPfttyfjc
+        98BT/yQDR7vQ3WPsfzUH/ie9hu2rgPrsTwEfIRc14baZRCPsLpeCQ+jMI8JbYTx1R6Mv/ugfvDm5
+        8Toz+K8TBot28gxevJXjG4l5O5oW/N57t43olrJ6gZzXSA+BohCeHORTX2thK0yuAgyFDVvI98+k
+        h7EDmlxZQb5XWYWFcFW3K5oJs1OCByfAkWItYF9P6esBO9Zb7L1S+8jpyA+5yA8536i+mPkxevz4
+        8OHdf83EFvbTsEJCY3+3Af3kfkNajx7+/f74IzWFp2/q4K1qjsthvM6dDLrFQUpnUm21Ubnnjluj
+        7k9Q4+pGtWEGCwu5vHx+OAvbbnQxUQ+2fzJf3L0Get8UL91i5DssupvxQJHXXxWz+S3gFm+7nMao
+        SRHInsfLtJW6s8NtVCFBARTG+mly+gUAAP//AwAk1moCDwoAAA==
     headers:
       CF-RAY:
-      - 992cbbdb3dddec88-SEA
+      - 999548095dbaf6f6-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -180,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:58 GMT
+      - Tue, 04 Nov 2025 15:52:58 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -196,13 +88,128 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2710'
+      - '1782'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2718'
+      - '1792'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '800000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '799649'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 26ms
+      x-request-id:
+      - req_c4f3badb12834cd08b885b3affac4b8e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"input":[{"call_id":"call_ViCt1vdkXorn9cYIcdBZpPpa","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0a53a10a692f207a00690a2158c6b48196b9756474a4cef9e7","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
+      up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      authorization:
+      - <filtered>
+      connection:
+      - keep-alive
+      content-length:
+      - '963'
+      content-type:
+      - application/json
+      cookie:
+      - <filtered>
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 1.100.2
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.100.2
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//nFZNj+M2DL3nVxg6zywcj504uXWAFligLRaYvRSbhUHLdKKNLLkSNdhg
+        kP9eSE78kUmC2Z7i8FFPFPVI6m0WRUxUbB0xg7YtYsieYB7DYpXUSbyEOF6sYkjmGUDyxPP5alHW
+        UC+TeJ6teJbzeM4ePIUufyCnM41WFjs7NwiEVQEemy8XSbKcZ8s8YJaAnPVruG5aiYRVt6gEvt8a
+        7ZSPqwZpsTMLKYXasnX0NouiKGItHND49RW+otQtGjaLomNwRmO0x5STMhiEOu9SVEggpJ2ilozj
+        JLSa2Bv4WWhHraOC9B7fg6S1LDjIKV2jK5Q+sm1Lj6l+TOIkfYzzx3hxSlegZOvoWzhJd57+Jhq7
+        vX0RPEkg9xcBeZ6u0uUqSxHyLOkSHljo0GLgQWthOwJuZTyAXCtCNQQ1DmxCe84H/qR+dXAApTTB
+        OYffvk9Aqbet0eUVJBCtI/a2YSRI4oatN+wvYanURq2jrzuM/hAKZPR70wqDG/awYeBop03wfDag
+        Kq2iF1AVGqtVcGhhi3bD1lma+n+ulIKH0IoDgl+YxPHiyPo4jqevPjRmtAzHBWuFJVDUOXvH4MRa
+        MCAlyqkGyLhOrq3BV6GdLc4VUXykznK+KNNQZ6tltkiXKaQc6xUu2YlUNy0VHPgOiz0exqKbYAb9
+        ZQqtxh4GwWo1qSGsa21o5ORl4poGzJm7LykLNdKhEJUnrgVOysuieRUcCxLnkqzByU4gzJI2OM4N
+        YdOiAXLBPP8Un6xBCKfIam0aGP6PBPjDalVYvsMGBvlWaLkR7cWRA6SgCeuetd6/nM421ETHsx5p
+        3WeyRUMC7cTuQ/ACvTCOzOxr+Hi4QE9xWzI+9yPwOK2fIOo77L91Dv+TPpTEHfYvAb9BLhThtmuw
+        N9gvSuzeRoNr9I93/YU9Z1d2Zwb/dcJgNeld/Y7XcnwlMfdP04Oj3jWc6Jqyxh2zm44jBKpKeHKQ
+        X8ZaC8NudnHAcLFhuPr6mY0w9oqm1FbQoWv3lXDNMAK7trTTgnd9zJFmPWDfD59ztLVTYRDeqi32
+        p9b7yLVR6X+F6grVX2Z5iD6/PP/9ib0rvS1S4d0L7z7AvoU2SGjsRwtQ2FLdkdZnD3+8Pn5JTWHr
+        qzq4d5u35XD7ngcZDNOGdFuMZmjcG9txBzVOdaoNPVhYKOX5VeXCW6Bvr0JNHjXzVfbwHhg9lXqZ
+        hPlSDSvjiSIvH0tPT9eAa7z9cLpFTZpADmCS5L3UnZ1OowYJKqDQ1o+z438AAAD//wMA2nWnLuYK
+        AAA=
+    headers:
+      CF-RAY:
+      - 99954815ac80f6f6-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 04 Nov 2025 15:53:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '1962'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '1969'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -216,7 +223,7 @@ interactions:
       x-ratelimit-reset-tokens:
       - 30ms
       x-request-id:
-      - req_b7e52335480b401aa23a119bbb66785e
+      - req_bd33b0ed936946f8b98b5fbad1a2d67a
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/async_stream.yaml
@@ -9,12 +9,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '844'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -36,103 +40,103 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_08be1f3e41d5b6620068f96733f6fc8193843e86eb5afff668","object":"response","created_at":1761175347,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217","object":"response","created_at":1762271584,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_08be1f3e41d5b6620068f96733f6fc8193843e86eb5afff668","object":"response","created_at":1761175347,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217","object":"response","created_at":1762271584,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","type":"function_call","status":"in_progress","arguments":"","call_id":"call_GS0nL2200gVPzwISOcNTBALX","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","type":"function_call","status":"in_progress","arguments":"","call_id":"call_4fq8qlDGU2rabJ7ZLxVwc2dd","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"{\"","obfuscation":"wc2ohRTvLVjJ5r"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"{\"","obfuscation":"HiVENMQyjevvEN"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"isbn","obfuscation":"FBkXbWBSR4RU"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"isbn","obfuscation":"57giSvKMIGzc"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"\":\"","obfuscation":"UKSoq2jhnlUYR"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"\":\"","obfuscation":"rSWnfrxBMCBMt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"0","obfuscation":"mPg8kkpiuWYo4Q7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"0","obfuscation":"oUtBZoz70TE2mJe"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"-","obfuscation":"OgAzXeyJaYvzQTm"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"-","obfuscation":"PF2I2QTlTivpEhC"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"765","obfuscation":"R0ZKAArliYz6z"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"765","obfuscation":"q0xPVy3FTNVL5"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"3","obfuscation":"019S9kxF0m7Qm0e"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"3","obfuscation":"WPJCbrs33PgWLtx"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"-","obfuscation":"traf2iNaY10OXWO"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"-","obfuscation":"QLna7wDat8buTPG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"117","obfuscation":"31aS9oMvgilR7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"117","obfuscation":"ZnXXDtlojbsHN"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"8","obfuscation":"q3BSwQRcQimld7r"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"8","obfuscation":"F8BsvvcYYXlA1Il"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"-X","obfuscation":"8uQKglOa0HmDxB"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"-X","obfuscation":"TX22JwpP9SlvtG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"delta":"\"}","obfuscation":"xmGVXDzelAu7qq"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"delta":"\"}","obfuscation":"fp2UOrwrNPeJnD"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_GS0nL2200gVPzwISOcNTBALX","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_4fq8qlDGU2rabJ7ZLxVwc2dd","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_08be1f3e41d5b6620068f96733f6fc8193843e86eb5afff668","object":"response","created_at":1761175347,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_GS0nL2200gVPzwISOcNTBALX","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217","object":"response","created_at":1762271584,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_4fq8qlDGU2rabJ7ZLxVwc2dd","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
 
@@ -140,13 +144,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 992cbca45da4df01-SEA
+      - 99954837ed480b25-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:28 GMT
+      - Tue, 04 Nov 2025 15:53:04 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -162,23 +166,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '66'
+      - '96'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '80'
+      - '103'
       x-request-id:
-      - req_683a5ef7958e45769d032812185066e5
+      - req_6dcb2dfb05fc465fa9529bc7d89c1e5f
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_GS0nL2200gVPzwISOcNTBALX","name":"get_book_info","type":"function_call","id":"fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea","status":"completed"},{"call_id":"call_GS0nL2200gVPzwISOcNTBALX","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"call_id":"call_4fq8qlDGU2rabJ7ZLxVwc2dd","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -186,12 +188,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '977'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -213,210 +219,378 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_08be1f3e41d5b6620068f96734fb308193a1f1b9ab9b70cc24","object":"response","created_at":1761175349,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0918a05a3af60ce100690a2161763881949873e93ccae9aace","object":"response","created_at":1762271585,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_08be1f3e41d5b6620068f96734fb308193a1f1b9ab9b70cc24","object":"response","created_at":1761175349,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0918a05a3af60ce100690a2161763881949873e93ccae9aace","object":"response","created_at":1762271585,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"KJBzaDpnhDVQzt"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"0X36iIh3exwUjj"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"xZm4aqBTszb"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"yLloQ10hPlw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"iCrWVDue8PpNX"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"NnzbBZidEPK12"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"Nwy6oak7uvkY"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"cyUYsDx4qWgx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"V4voxpIuIywW"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"Tc8DQJ2PSckW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"f1oLhBrivKxo5e6"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"BwlEo9rEO9IRed1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"UxPgWvSbS05C"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"TYLV4CVeMJrT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"0d8W7yaTvJ"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"LXi8Ewbkzb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"2TEOdug4b"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"1Yfgc0Tx6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"bMRRNDSKUXZwu"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"q9tIGNrBNCeF3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"flojJyoYlg"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"BxaDdiLbaT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"uO7RJcy8xjHET"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"euzW9e0d69UIt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"wYoaWej9KCSHAO"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"YsnBUNDCUJIWl9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"S09FQDHg2kN"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"pZBQZzhD6G1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"qGUIV0ZNAaZ"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"s7GeL3lZhU9"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"oc2JawOsPJr"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"aO0y7lx9Nuo"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"DTUOr2xB6wdoA"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"cCzFQvOyjC8tC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"dutcQIlKbyM"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"aQvMKtYpEmP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"uedbkRqrKdE6ri"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"TTDR6OVkSgCOLb"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"qBYMvZ6gvAbDd"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"dLuXeFKsfs7hJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"ptUFB1PdIqfOTE"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"EEFovMHxjgpL0H"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"vHKRL"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"NJUZ6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"sqhxu39C7sN"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"EjL8sAPGnRD"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"0GZBNPY7mWZxrV"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"KR7bWUxlHzln0G"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"CRuOY39G4IEvJ"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"cvdMcw4hEqqcB"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"1EfwwoM2s0cfc5K"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"gq4DyaU1LyHygUe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"Y74a6lKUy0sF6in"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"tfzIrmw7Umph27Q"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":34,"output_index":1,"item":{"id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":35,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"VSoThOR82I9c8e"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"PExn36dgisK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"Aw3UjbikIRADA"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"PDShr3xoSXo0"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"bC5E7ehtHsEs"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":":","logprobs":[],"obfuscation":"l6PQ4VnoER6uUfi"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"q59T99Tt7nBK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"iEBfV9KAu4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"iSzmNTQgB"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"UGqaXci7s1nVt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"rcbftPmubK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"uOzr5r5jZO5HF"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"UK158lzfJDwcYN"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"EWsYKmwXNBA"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"jV2VFA9Fu95"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"8tMuLZbSq29"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"rBSCQIS4sC2Xk"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"1MrZBqJkHvp"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"eXGJmsd7jUi4Ym"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"9VffN6s4gMcFj"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"tdEX0tRcTEcVVe"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"xh99i"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"2kZUpfnpd0w"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"UU9b7rQj3A2Jis"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"nnM1RAUyqmKQ4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"BAjx95WVCs4eEET"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"khN2X7ARKWyZRmF"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":63,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":64,"item_id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":65,"output_index":1,"item":{"id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_08be1f3e41d5b6620068f96734fb308193a1f1b9ab9b70cc24","object":"response","created_at":1761175349,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":66,"response":{"id":"resp_0918a05a3af60ce100690a2161763881949873e93ccae9aace","object":"response","created_at":1762271585,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0918a05a3af60ce100690a21624a788194a388dff99c783902","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"},{"id":"msg_0918a05a3af60ce100690a216357108194893f899395309b5e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":197,"input_tokens_details":{"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":263},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbcaa8c37df01-SEA
+      - 999548406bba0b25-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:29 GMT
+      - Tue, 04 Nov 2025 15:53:05 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -432,15 +606,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '271'
+      - '160'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '304'
+      - '170'
       x-request-id:
-      - req_a3ac1ba321e94fe681ae56c1964be290
+      - req_84af78882f0d40f5ae82e3462dc8dd77
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/stream.yaml
@@ -9,6 +9,8 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
@@ -36,103 +38,103 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d7f412d0c19301b0068f967225ee08196a5855317522a69d0","object":"response","created_at":1761175330,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f","object":"response","created_at":1762271579,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d7f412d0c19301b0068f967225ee08196a5855317522a69d0","object":"response","created_at":1761175330,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f","object":"response","created_at":1762271579,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","type":"function_call","status":"in_progress","arguments":"","call_id":"call_Wg2va0blJgvoHylhrTA6FZN9","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","type":"function_call","status":"in_progress","arguments":"","call_id":"call_sluavrUJS6H6lgKYY4nwdO5u","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"{\"","obfuscation":"mklC6ABFc11mDC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"{\"","obfuscation":"fiVFnvFhvfCEgC"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"isbn","obfuscation":"4YoCOiA6ezvt"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"isbn","obfuscation":"QpxAYAb3fkTP"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"\":\"","obfuscation":"AqjQSQu3aimQg"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"\":\"","obfuscation":"tVdL7ARAgOU8L"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"0","obfuscation":"AplYhPaRzttou1K"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"0","obfuscation":"kM87R9kRqOBE72E"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"-","obfuscation":"I2ks7GvZSyeDmUk"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"-","obfuscation":"q95aNf3nXsL2v1T"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"765","obfuscation":"K1JjSDoFMDd5i"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"765","obfuscation":"Mi27I2Qo1S5Fn"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"3","obfuscation":"FkaCyYtB0vXKjbx"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"3","obfuscation":"xWgJKoT9t3ujep2"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"-","obfuscation":"pHdBHK1XhfzEUJ7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"-","obfuscation":"1zWl09EwlQpyRcT"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"117","obfuscation":"jf1wXGfMXUVkY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"117","obfuscation":"qETkat5lUTopz"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"8","obfuscation":"jBrMhsQMSC1HKVE"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"8","obfuscation":"H3LpP5dvqzBLBXi"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"-X","obfuscation":"75lBrQHrfxHTdt"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"-X","obfuscation":"zhljRbJEqGXFf6"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"delta":"\"}","obfuscation":"9y9G6Qtbah9kn7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"delta":"\"}","obfuscation":"nlHmc2VJmDerIh"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_Wg2va0blJgvoHylhrTA6FZN9","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_sluavrUJS6H6lgKYY4nwdO5u","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0d7f412d0c19301b0068f967225ee08196a5855317522a69d0","object":"response","created_at":1761175330,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_Wg2va0blJgvoHylhrTA6FZN9","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f","object":"response","created_at":1762271579,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_07813cfec04bdc3200690a215be5f88196833a36241574585e","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_sluavrUJS6H6lgKYY4nwdO5u","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
 
@@ -140,15 +142,21 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 992cbc363880b98d-SEA
+      - 99954819bf10ca53-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:10 GMT
+      - Tue, 04 Nov 2025 15:52:59 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=AEahNAf7hlbd_TYnvQqr9w8cYCxdvzN.YsGFd0qoRRw-1762271579-1.0.1.1-AGFPWSCfK3C.CcsaCnmibIuwWTR5NrEne.LZRHtD1hlimlcH_dMY6STxS_tCDY52xF3LInWmOsOL6xU0Q4Go2Oemkhyd6dh.dTBlcivCU54;
+        path=/; expires=Tue, 04-Nov-25 16:22:59 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=sA07ENDcg7jrCy3fm6Dsm9ex4d.lWKy4IAT4mmSBIgg-1762271579394-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -162,23 +170,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '361'
+      - '73'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '450'
+      - '78'
       x-request-id:
-      - req_2dadd0c0ea2c4c49b438bed2dcea22dc
+      - req_33e554fb79974052a3838324df361a62
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_Wg2va0blJgvoHylhrTA6FZN9","name":"get_book_info","type":"function_call","id":"fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3","status":"completed"},{"call_id":"call_Wg2va0blJgvoHylhrTA6FZN9","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"call_id":"call_sluavrUJS6H6lgKYY4nwdO5u","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -186,12 +192,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '977'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -213,210 +223,378 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d7f412d0c19301b0068f96723e4048196807ee1c9b51fccd7","object":"response","created_at":1761175331,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07813cfec04bdc3200690a215c7ea081969c24d07d0ac2e008","object":"response","created_at":1762271580,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d7f412d0c19301b0068f96723e4048196807ee1c9b51fccd7","object":"response","created_at":1761175331,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07813cfec04bdc3200690a215c7ea081969c24d07d0ac2e008","object":"response","created_at":1762271580,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"m3B9jUYEJ9Mdha"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"kVQJod4Pn4oB2f"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"kOFFr9AC29M"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"UNQMl4D00DR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"PY6J5XlXORtoR"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"deB71k3iDq2CJ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"DSZE0j8mc2dE"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"vyTzvkDZ7YOg"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"XFsPYxW1g5Kc"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"aeeOvCKDuivd"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"xzNNuky5OQYQQal"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"PwVPunFezbP60Tw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"es0CM1e1gmyE"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"0ejDv2pQLFdk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"HtyaSQ9HJX"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"x7rJTS2mcY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"YDEUcrOqm"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"HBbYrf59U"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"WDMxEkyU2Tx63"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"rCUJxkl1uBgoq"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"btiwemgN3i"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"zsId5C0ytC"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"iLQkIeH1kyKR8"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"RpjxcKwvgt32J"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"y47lQERvsxdljz"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"YDQBLewFxwULs1"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"2wRcEOf8poZ"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"V9V7AWgMTEU"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"lCn4Ge02c33"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"ei3owZQ8Nsy"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"OnMxaceWBWl"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"Oj5SGN5gaTv"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"xPhTCW66FulKz"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"FDKul9saVwzdk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"wOFKNaXwxbh"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"trSr6k1ddMx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"EFVPYoqKX9Nm6N"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"TqLAeJI5UQfRQx"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"csy2s3ur7dpjw"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"Fedfj5w3HmgR3"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"T7ODUCs0jXHHVo"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"HidsISMZ6kRsZs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"iYqcx"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"VFU9l"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"W0WiC2Nl85V"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"1gH18WaoXFi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"MKCiQA2jEkiDNT"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"bIs9FnaJWvoCM0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"ERw5yjH08G2ut"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"FP3Ps0MZK1WuQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"EGHJY4tCHQdRb5F"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"XlBK8q1KF79FFp7"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"KgEw9prnztlFCu1"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"XuSd2YvfCwgXdD5"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":34,"output_index":1,"item":{"id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":35,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"NNoX9AWik91d8P"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"Z7Fr65QlV5X"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"l24ijzVTLrdib"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"ja92qPcvrh3K"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"xHyDQR6YcCC4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":":","logprobs":[],"obfuscation":"QrSyp5H6A5kFFLG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"fs5S4ppeXTC8"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"6PaGu3rv6r"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"2RPDbgQZZ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"KqsksaJgFv5N4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"kHAWVOA67R"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"pFuAOEFO6nMqX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"XZDSsClBWZkm2A"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"spg0TLjLOJn"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"PWM2ONCW98p"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"OXmIIyXYyjH"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"P2CnGufZZmwkv"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"n7LD1Kn7Yl8"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"kSaK3x39W07U6G"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"HMmpueyM31PFe"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"Aa7Mvt0W2Dj9b4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"38xp0"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"1pQzacfDO9K"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"lA22jwOW2U14UK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"IcIF1NXhXeAcj"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"jj507LGgWrpaE7h"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"LjQ2qyMPJi9xrwg"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":63,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":64,"item_id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":65,"output_index":1,"item":{"id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_0d7f412d0c19301b0068f96723e4048196807ee1c9b51fccd7","object":"response","created_at":1761175331,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":66,"response":{"id":"resp_07813cfec04bdc3200690a215c7ea081969c24d07d0ac2e008","object":"response","created_at":1762271580,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"},{"id":"msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":197,"input_tokens_details":{"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":263},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc3fe8e2b98d-SEA
+      - 999548216a8fca53-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:12 GMT
+      - Tue, 04 Nov 2025 15:53:00 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -432,15 +610,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '129'
+      - '211'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '133'
+      - '219'
       x-request-id:
-      - req_8f965f73a4884aeda912829ba93f03e4
+      - req_615877732c914214a8d136bb1d79f727
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/openai_responses_gpt_4o/sync.yaml
@@ -9,12 +9,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '830'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -36,31 +40,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xWy27bOhDd+ysEruNC8lPKLt0VuCgCJEVb3BTCSBrJrCmRJYdujcD/fkHK1sOx
-        3fbu7Dnk4TzOzOh1EgSMF+w+YBqNSsN4HYXhHCDBxSyBJAxXcZmsViXOiyiOo2SZJMlyFcG6jPMs
-        gwLYnaOQ2XfM6UQjG4OtPdcIhEUKDovWqyhaL2fJwmOGgKxxd3JZK4GERXspg3xbaWkb51cJwmBr
-        5kLwpmL3weskCIKAKdijdvcL3KGQCjWbBMHBH0atpcMaK4Q38Ob0SlogARdmjBrSNicum5G9hl+p
-        tKQspSS3+BYkKUWagxjT1bJA4TyrFE0XcjoLZ4tpGE/D1TFdnpLdB//6SNp4ukqU+Y06FHGU+zqE
-        EcawmEEeLWezaOGJPQntFXoa2/iAvHs9fC3tHgRd2Rob8vjrC+Mma17Y/QsLp+vVcj6NonU8/fLC
-        Dv0Vx562jvufT/XHz6uILP3cPT6EXz89P8Onh83Pz/2NBmrvYIWUZlJuU96Uknn0MAmCbz5FCjQI
-        gWKcYdK2FYPSuOPSmvSkt9aFrgJKy1pRmkO+wXSL+yGmEYxsRlLCspSaBodcomxdgz7d7JRloETa
-        p7zAhnjJcaQyg3rHc0yJn5RZghXEjoKXGodBENYKNZD15uhdeLT+ot6zUuoa+v+D+n43sklNvsEa
-        +twWaHLNlav7KJpB2t9LuX06xtarouXpn2lzqFATRzOyOxc4CTwzDszs2f+4O0OPfhvSLvcD8DA8
-        ycDSxvfuNfaH9sD/pFdQvQloyP7o8SvkvCGs2jlzhd1mgufg+26PcCuMx/5o8NUd/Ys3JxdeZxp/
-        WK6x6ObK6MVLOb6QmNvRdOC3wbtdRJeUNQjkuCQGCBQFd+QgHoda8zN/chagL6zfMa5/JgOM7VBn
-        0nByvcpqLLit+03Qzo+N5Ll3AixJ1gHm7Qw+H5/Xeov9I+U2sCpwIyxwI8w1qitmtg8+PL3/+O53
-        E6+D3ayrkVCbP21AN5dvSOuDg/+8P/5KTf7pizq4Vc3rcrhe514G/VogqVIhK6Vl5rjDzqiGE1Tb
-        plWtn8HcQCZOHxfWQNWPLsab0W6P5ou7t8Dgi+G1X3v5Bov+ZjhS5Pk3w2x+CbjE2y2na9QkCcTA
-        4+W6k7o1421UI0EB5Mf6YXL4DwAA//8DANpLsWXtCQAA
+        H4sIAAAAAAAAA5xW247bNhB991cIfF4Huq0v+5YgQLpFUGyQAm3RDYQRNbK5pkSVHDoxFv73gpSt
+        i9faXN7sOeThXM7M6HkWBEwU7C5gGk2ThYt1gWmyLOJVkcZJFIaLdQhxmOAi4eEqWqdrLLGE1SKG
+        db6+BWA3jkLlT8jpTKNqg62dawTCIgOHRctFHC+jeJ16zBCQNe4OV1UjkbBoL+XAdxutbO38KkEa
+        bM1CSlFv2F3wPAuCIGANHFC7+wXuUaoGNZsFwdEfRq2Vw2orpTeI+vxKViCBkGaMGtKWk1D1yF7B
+        t0xZaixlpHb4EiSlZMZBjukqVaB0nm0amqdqHodxOg9X83BxSpenZHfBvz6SNp6uEiWfrkOZRiV3
+        dYBVWiZ8nUfLMkxyXHliT0KHBj2NrX1A3r0enkq7B0FvbIU1efz5kQmT14/s7pGF8+XiNplH0XI1
+        //uRHfsrjj1rHfc/f/8tT/ZPn77eVxK2f33Q/GPyPt2/Xfc3aqi8gxukLFdql4m6VMyjx1kQfPEp
+        akCDlCjHGSZtWzE0GvdCWZOd9da60FWg0apqKOPAt5jt8DCJaSSsXZqGJzSCUfVIbFiWStPgkEul
+        rSrQZ+5OewZKpEMmCkdcChzp0KDeC44ZibN2S7CS2KkllMZhmIRVgxrIenP0JjxZv1HvWal0Bf3/
+        gQKejKozw7dYQZ/9Ag3XorkIeVSYd0rtPp9i63XT8vTPtJlsUJNAM7I7FwRJvDAOzOxP/+PmAj35
+        bUi73A/A4/AkA0tb391T7G/bA79I38DmRUBD9gePT5CLmnDTTqIJdptLwcF35gHhtTAe+qPBP+7o
+        T7w5u/I60/ifFRqLbvKMXryW4yuJeT2aDvwyeLeL6JqyBoGc1sgAgaIQjhzkw1BrfivMLgL0hfVb
+        yPXPbICxPepcGUGuV1mFhbBVvyvaCbNVgnsnwJJiHWBeTunLATvVW+yjUrvANoEbcoEbcq5RXTHz
+        Q3D/+d0fb743EzvYTcMKCbX50QZ0k/sVad07+Mf746fU5J++qoPXqjkth+k69zLoFwepJpNq02iV
+        O+6wMzbDCapt3arWz2BhIJfnzw9rYNOPLibq0faPkvTmJTD4pnjuFyPfYtHfDEeKvPyqiJNrwDXe
+        bjlNUZMikAOPb5ed1K0Zb6MKCQogP9aPs+P/AAAA//8DAIDWvbEPCgAA
     headers:
       CF-RAY:
-      - 992cbb549b46b9a4-SEA
+      - 999541252cbcec14-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:35 GMT
+      - Tue, 04 Nov 2025 15:48:15 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -84,13 +88,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '965'
+      - '1208'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '968'
+      - '1213'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -104,15 +108,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_2dc71b958f084f20bc0d7ea9801a63a8
+      - req_3ab19bc9cdfc4f21b0faf5a15b067571
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_SmNW61tutwvPA0YUTTaUAhwW","name":"get_book_info","type":"function_call","id":"fc_0871003aa9e429a90068f966fed81c8195901e8a42ac152214","status":"completed"},{"call_id":"call_SmNW61tutwvPA0YUTTaUAhwW","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"call_id":"call_JHb3vjQwImlahWGrcL3D4vA9","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_069de437d28d423100690a203e63c081949efefa862a9b95aa","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -120,12 +122,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1226'
+      - '963'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -147,32 +153,33 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA5xWTY/bOAy951cIOs8UtvNhJ7cdoAUK7C4KTC+LpjBom07UkSWvRA0aDPLfF5IT
-        f2SSoN1THD7qiRIfSb3NGOOi4hvGDdo2j7I0jqI5wBoXyRrWUbTK6vVqVddpWiyyeL0slssojtN1
-        mSVpXKwq/uApdPEDSzrTaGWxs5cGgbDKwWNxuorjdJms04BZAnLWryl100okPJEVUL7sjHbKx1WD
-        tNiZhZRC7fiGvc0YY4y3cEDj11f4ilK3aPiMsWNwRmO0x5STMhiEOu+SV0ggpJ2ilowrSWg1sTfw
-        M9eOWkc56Rd8D5LWMi9BTukaXaH0ke1aelzoxyRKFo9R9hitTtcVKPmGfQsn6c7TZ6Kxu1uJSKMk
-        jdPIJyLLsgKirMQyS4p0Pg/MgYUOLQYetBZ2OAC3bjyApVaEaghqHNiE9nwf+JP61cEBlNIE5zv8
-        9n0CSr1rjS6uIIFow/jblpMgiVu+2fK/hKVCG7VhX/fIPgkFkn1sWmFwyx+2HBzttQmeTwZUpRV7
-        BlWhsVoFhxZ2aLd8s1ws/D9XSFGG0PIDgl+YRNHqyPs4jqevPjRutAzHBWuFJVDUOXvH4MRbMCAl
-        yqkGyLhOrq3BV6Gdzc8VkYfs9hppjW5aykso95i/4GGMGQSr1UTsWNfa0MjJ59M1DZjzyl77Fmqk
-        Qy4qVCRqgZM6sGheRYk5iXPt1OBkl0luSRscH4KwadEAuWCOP0Qna8jYKbJamwaG/yOl/LBa5bbc
-        YwODziq0pRGtz8XkNIxxBU1Y96T1y/PpbIN4O57NSJT+Dls0JNBO7D4Er6QL48jMv4aPhwv0FLcl
-        4+9+BB6nQg/qu8P+R+fwP+mDdu+wfwn4DXKhCHddJ7zBflEL9zYaXNk/3vU39pxd2Z0b/NcJg9Wk
-        yfQ7XrvjKxdz/zQ9OGoyw4muKWvc2roxNkKgqoQnB/llrLUwlWYXBwyJDVPQ189shPFXNIW2gg5d
-        X66Ea4ZZ1fWPvRZl13Acad4D9v2UOEdbOxUm1q3a4n9q/cJcywr/K1RXqD6ZxYF9fn76+wN/V3o7
-        pNy75959gH2va5DQ2F8tQGELdUdanz386/XxW2oKW1/Vwb1s3pbD7TwPMhjGAuk2Hw27qDe24w5q
-        nOpUG3qwsFDI8/PHhaHdt1ehJq+PeL18eA+M3jS9TMJkqYaV0USRl6+a+fwacI23H063qEkTyAFM
-        kqyXurPTadQgQQUU2vpxdvwPAAD//wMAwfU4RY8KAAA=
+        H4sIAAAAAAAAAwAAAP//7FZNj+M2DL3nVxg6Zxa2k3E+bh2gBRZoiwVmL8VmYdAWnWgjS65EDTYY
+        5L8XkhN/ZJJgpoeeeorDRz1RIvnE10kUMcHZOmIGbZPH2YrjfLbg6ZLP01kSx9kqhjSex0kB8TJZ
+        zZdJES9WMMfHsnp8RGRTT6GLH1jSmUYre7KXBoGQ5+CxZJGl6SJJV1nALAE569eUum4kEvJ2UQHl
+        fmu0Uz6uCqTF1iykFGrL1tHrJIqiiDVwQOPXc3xBqRs0bBJFx+CMxmiPKSdlMAh13iXnSCCkHaOW
+        jCtJaDWy1/Az144aRznpPb4FSWuZlyDHdLXmKH1k24Ye5vohjdP5Q7x8iLPTdQVKto6+hZO05+ky
+        Udvt7UQk86RNxCrhPJkVi5in1WxZJIE5sNChwcCD1sIWe+DWjQew1IpQ9UENAxvRnu8Df1K3OjiA
+        UprgfIffvo9AqbeN0cUVJBCtI/a6YSRI4oatN+wPYanQRq2jrzuMfhMKZPRr3QiDGzbdMHC00yZ4
+        PhlQXKvoGRRHY7UKDg1s0W7Y+nE+9/9cIUUZQssPCH5hGsfZkXVxHE9fXWjMaBmOC9YKS6CodT5O
+        P5yyWbyMQ8qggtlyUVVpGuMyWy3/T9l/k7LJyYk1YEBKlOO2JeNahWkMvgjtbH4Wsfwd0jjDbFa2
+        HYkVVrDMUlgVq0cAdiLVdUN5CeUO8z0ehjoxwgz6ZAqthh4GwWo1kj2sKm1o4OTLxNU1mDN3p4IW
+        KqRDLrgnrgSOFNGieREl5iTOKlqBk22BMEva4PBuCOsGDZAL5uRTfLKGQjhFVmlTQ/9/UIA/rFa5
+        LXdYQ1++HG1pRHNx5AApqMO6J633z6ez9T3R8qwHte5vskFDAu3I7kPwBXphHJjZ1/AxvUBPcVsy
+        /u4H4HHcP6Go77D/0jr8S/rQEnfYvwT8BrlQhNv2TbzBftFi9zbqXaO/vOsH9pxc2Z0Z/NsJg3yk
+        Xd2O1+74ysXcP00HDrSrP9G1yhoqZjvQDBDgXHhykF+GtRbmk8nFAUNiwzzk+2f4brAXNIW2gg6t
+        3HPh6n5qaWVpp0XZ6pgjzTrAvp0XztFWToXZ5VZvsd+13keuiQr/K1TbqD6ZxSH6/Pz05yf2pvW2
+        SLl3z717D3sJrZHQ2Pc2oLCFulNanz38/v74UDWFra/Wwb1s3i6H23nuy6B/bUg3+eANjTtjM1RQ
+        41RbtUGDhYVCngdhF2aBTl6FGs2hyWoxfQsMptuuTML7wvuV8agiL+fbLLsGXOPtHqdb1KQJZA+m
+        2awrdWfHr1GNBBwoyPpxcvwHAAD//wMALPkSS5kMAAA=
     headers:
       CF-RAY:
-      - 992cbb5be9bdb9a4-SEA
+      - 9995412dfc2fec14-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -180,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:39 GMT
+      - Tue, 04 Nov 2025 15:48:19 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -196,13 +203,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '4304'
+      - '3730'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '4316'
+      - '3849'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -210,13 +217,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799588'
+      - '799552'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 30ms
+      - 33ms
       x-request-id:
-      - req_ff52db9379fc4bf2b68917e799eb4f97
+      - req_2fbf8a7655854fcd950f00792fdedf85
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async.yaml
@@ -9,12 +9,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '830'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -36,31 +40,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFbbjts2EH33VxB8XgeSb7L3rUFekhTtAmmBBt1AGEkjmTElsuRwscbC
-        /16QsnXxWtukb/Yc8nAuZ2b0MmOMi4LfM27Q6jQqF5ttEq1wtSt3GEdRtNmWu00SrXZQbrfxbrNb
-        Jbk3rVdJtlvjgt95CpV9x5wuNKqx2Npzg0BYpOCxONnEcbJeRlHALAE56+/kqtYSCYv2Ugb5oTLK
-        Nd6vEqTF1iykFE3F79nLjDHGuIYjGn+/wCeUSqPhM8ZO4TAaozzWOCmDQTSXV9ICCYS0Y9SScTkJ
-        1YzsNTynypF2lJI64GuQlJJpDnJMV6sCpfes0jRfqfkiWqzm0XYebc7pCpT8nv0dImnj6SpR5tN1
-        WCdLyH0dYItZAklclJsElnEciAMJHTUGGteEgIJ7PTyV9gCCqVyNDQX85ZELmzWP/P6RR/Nks17O
-        4zjZzv965Kf+imdPW8fDzzjBr3bxEH0u3Yei/nPdfHqOdr9/Xvc3GqiDgxVSmil1SEVTKh7Q04yx
-        byFFGgxIiXKcYTKuFYM2+CSUs+lFb60LXQW0UbWmNId8j+kBj0PMIFjVjKSEZakMDQ75RLm6BnO5
-        2SnLQol0TEWBDYlS4EhlFs2TyDElcVFmCU4SPwteGRwGQVhrNEAumON30dn6TL1npTI19P8H9f1u
-        VZPafI819Lkt0OZGaF/3UTSDtL9X6vDlHFuvipanf6bNoUZDAu3I7l0QJPHKODDzP8KPuyv07Lcl
-        43M/AE/Dkxwc7UPvTrH/0h74n/QaqlcBDdkfAj5BLhrCqp0zE+wukyKH0HdHhLfCeOiPsq/+6E+8
-        ObvxOjf4jxMGi26ujF68leMbiXk7mg78Nni3i+iWsgaBnJfEAIGiEJ4c5MNQa2Hmz64CDIUNO8b3
-        z2yA8Sc0mbKCfK/yGgvh6n4TtPNjr0QenABHineAfT2Dr8fnVG/xX5U6MKeZH2HMjzDfqL6Y2ZF9
-        /PL+t3f/NfE62M+6GgmN/dEG9HP5DWl99PCP98dPqSk8fVMHb1VzWg7Tde5l0K8FUjqVqtJGZZ47
-        6ox6OEGNa1rVhhksLGTy8nHhLFT96OKiGe32eLm6ew0Mvhhe+rWX77Hob0YjRV5/MyyWt4BbvN1y
-        mqImRSAHHq+TTurOjrdRjQQFUBjrp9npXwAAAP//AwB83rsy7QkAAA==
+        H4sIAAAAAAAAAwAAAP//nFbbjts2EH33Vwh8XgeUL7J335qHFgGSYtEEbYJuIIykkcw1JbLkcBF3
+        4X8PSNm6eK1t0jd7Dnk4lzMzep5FERMFu4uYQatTXiDP1sUagWfZOss4T245LDgCJMt8G9+ub1ew
+        hW0RxzwHgE3CbjyFyh4xpzONaiy29twgEBYpeCzeJIvFJl4lScAsATnr7+Sq1hIJi/ZSBvm+Mso1
+        3q8SpMXWLKQUTcXuoudZFEUR03BA4+8X+IRSaTRsFkXHcBiNUR5rnJTBIJrzK2mBBELaMWrJuJyE
+        akb2Gr6lypF2lJLa40uQlJJpDnJMV6sCpfes0jRfqfmCL1Zzvp3zc7oCJbuL/g6RtPF0lSjz6Tpk
+        yYavfB0ynizW2xVu8jKL+aLNdyChg8ZA45oQUHCvh6fSHkAwlauxoYA/PzBhs+aB3T0wPt8k6+U8
+        jjfb+ecHduyvePa0dTz8tEu+a/blv+Uff623Wf3p/s/iw+Ovj7/1Nxqog4MVUpoptU9FUyoW0OMs
+        ir6GFGkwICXKcYbJuFYM2uCTUM6mZ721LnQV0EbVmtIc8h2mezxMYgYJG5+m4QmDYFUzEhuWpTI0
+        OORT6eoazJm7056FEumQisITlwJHOrRonkSOKYmzdktwktipJZTBYZiEtUYD5II5fsNP1m/Ue1Yq
+        U0P/f6CAR6ua1OY7rKHPfoE2N0JfhDwqzFul9h9PsfW6aXn6Z9pMajQk0I7s3gVBEi+MAzP7FH7c
+        XKAnvy0Zn/sBeByeZOBoF7p7iv2X9sD/pNdQvQhoyH4f8Aly0RBW7SSaYHeZFDmEzjwgvBbGfX80
+        +uKP/sSbsyuvM4P/OGGw6CbP6MVrOb6SmNej6cCvg3e7iK4paxDIaY0MECgK4clB3g+1FrbC7CLA
+        UNiwhXz/zAYYe0KTKSvI9yqrsRCu7ndFO2F2SuTBCXCkWAfYl1P6csBO9RZ7r9Q+cjryQy7yQ843
+        qi9mdojefXz7+5v/mokd7KdhjYTG/mgD+sn9irTeefjH++On1BSevqqD16o5LYfpOvcy6BcHKZ1K
+        VWmjMs/NO6MeTlDjmla1YQYLC5k8f344C1U/uphoRts/Xq5uXgKDb4rnfjHmOyz6m3ykyMuvisXy
+        GnCNt1tOU9SkCOTA4/Wmk7qz421UI0EBFMb6cXb8DgAA//8DAHDHNc0PCgAA
     headers:
       CF-RAY:
-      - 992cbb7c18e3ed00-SEA
+      - 99954558fda1fcc4-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,7 +72,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:41 GMT
+      - Tue, 04 Nov 2025 15:51:07 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -84,13 +88,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1263'
+      - '1108'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1269'
+      - '1137'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -104,15 +108,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_45dae5b7075e446ea62f31ade817a30c
+      - req_94652a4bb13a437f91d8526e615fbb0b
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_17eYs2P0KfuDdmU5nJx09OK5","name":"get_book_info","type":"function_call","id":"fc_0f268704e49f9e100068f9670573ac8196a8eb7a71df67a311","status":"completed"},{"call_id":"call_17eYs2P0KfuDdmU5nJx09OK5","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"call_id":"call_s30hnkfzfRW58bmTPVdMjFjG","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0de0b5d5ea0bb5bb00690a20eaa63c819594a8a8d110caaa76","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -120,12 +122,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1226'
+      - '963'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -147,32 +153,33 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFZNjxo5EL3zKyyfZyLDNAxw25ESKdLuKtLksgpRq7q7Gpxx2167PAoa
-        8d9XdkN/MICSPdHUKz+XXa+q/DZhjMuKrxl36G0u6tli+SgyzFb1CqdCiMWyXi0exbzGYrmcrhYg
-        ZvNiXsOqzmD+AEt+FylM8QNLOtEY7bG1lw6BsMohYtPHxXT6OH8Qs4R5Ago+rilNYxUSVu2iAsqX
-        rTNBx7hqUB5bs1RK6i1fs7cJY4xxC3t0cX2Fr6iMRccnjB2SMzpnIqaDUskg9WmXvEICqfwY9eRC
-        SdLokb2Bn7kJZAPlZF7wPUjGqLwENaZrTIUqRra1dJ+Z+5mYZfdieS8Wx+tKlHzNvqWTtOfpMtH4
-        7fVELKpFVcZEFGUGmRBzXGZiWs+KxJxYaG8x8aD3sMUeuHbjCSyNJtR9UMPARrSn+8Cf1K1ODqC1
-        ITjd4bfvI1CZrXWmuIAkojXjbxtOkhRu+HrD/5KeCuP0mn3dIfskNSj2sbHS4YbfbTgE2hmXPJ8c
-        6Mpo9gy6QueNTg4Wtug3fD3PsvgvFEqWKbR8jxAXzoRYHHgXx+H41YXGnVHpuOC99ASaWufomJy4
-        BQdKoRprgFxo5WodvkoTfH6qiDxlt9OIdaaxlJdQ7jB/wf0Qcwje6JHYsa6No4FTzGdoGnCnlZ32
-        PdRI+1xWqEnWEkd14NG9yhJzkqfaqSGoNpPck3E4PARhY9EBhWSefhBHa8rYMbLauAb6/wOl/PBG
-        577cYQO9zir0pZM25mJ0Gsa4hiatezLm5fl4tl68Lc96IMp4hxYdSfQjewwhKunMODDzr+nj7gw9
-        xu3JxbsfgIex0JP6brD/0Tr8T/qk3RvsXxJ+hVxqwm3bCa+wn9XCrY16V/ZPdP2NPScXducO/w3S
-        YTVqMt2Ol+74wsXcPk0HDppMf6JLyhq2tnaMDRCoKhnJQX0Zai1NpcnZAVNi0xSM9TMZYPwVXWG8
-        pH3blysZmn5Wtf1jZ2TZNpxAhneAfz8lTtHWQaeJda22+J/GvLBgWRF/pW4LNSaz2LPPz09/f+Dv
-        Sm+LlEf3PLr3cOx1DRI6/6sFKH2hb0jrc4R/vT5+S01p64s6uJXN63K4nudeBv1YIGPzwbATndEO
-        O6gLulVt6sHSQ6FOz5+QhnbXXqUevT6mq/nde2DwpulkkiZL1a8UI0Wev2oeHi4Bl3i74XSNmgyB
-        6sHZbNlJPfjxNGqQoAJKbf0wOfwHAAD//wMAnb3HMI8KAAA=
+        H4sIAAAAAAAAA+xWTW/jNhC9+1cIPDsLybHlj1sDtMACbbFA9lKsF8KIHDncUKRKDoM1Av/3gpSt
+        D8c2kh566snyvOHjkDPzOK+TJGFSsE3CLLqmSAWm5UIsENKyXJRlmubrFGYplhz5apWtF+tMLPhS
+        rJcLPs8WmLFpoDDlD+R0ojHaYWvnFoFQFBCwbJnPZstsni8j5gjIu7CGm7pRSCjaRSXw5501Xoe4
+        KlAOW7NUSuod2ySvkyRJEtbAHm1YL/AFlWnQskmSHKIzWmsCpr1S0SD1aZdCIIFUbow6sp6TNHpk
+        r+FnYTw1ngoyz/gWJGNUwUGN6WojUIXIdg3dzc3dLJ3N79LVXZofrytSsk3yLZ6kPU+XidrtrieC
+        L4HzkIjyPsOFEBUu5zmUszQyRxbaNxh50DnYYQ9cu/EIcqMJdR/UMLAR7ek+8Cd1q6MDaG0ITnf4
+        7fsIVGbXWFNeQCLRJmGvW0aSFG7ZZsv+kI5KY/Um+fqEyW9Sg0p+rRtpccumWwaenoyNng8WtDA6
+        eQQt0Dqjo0MDO3RbtlnM5+GfL5XkMbRijxAWztI0P7AujsPxqwuNWaPiccE56Qg0tc6H6YdTJnKA
+        NKQMqmValQg4zxBW9/+n7D9K2eToxBqwoBSqcduS9a3CNBZfpPGuOIlY8R5pBMjvY0eu57CClciy
+        lAPA8tjrjTV1QwUH/oTFM+6HOjHCLIZkSqOHHhbBGT2SPawqY2ngFMrE1zXYE3engg4qpH0hRSCu
+        JI4U0aF9kRwLkicVrcCrtkCYI2NxeDeEdYMWyEdz9ik9WmMhHCOrjK2h/z8owB/O6MLxJ6yhL1+B
+        jlvZnB05QhrquO7BmOfH49n6nmh5NoNaDzfZoCWJbmQPIYQCPTMOzOxr/Jieoce4Hdlw9wPwMO6f
+        WNQ32H9pHf4lfWyJG+xfIn6FXGrCXfsmXmE/a7FbG/WuyV/B9QN7Ti7sziz+7aVFMdKubsdLd3zh
+        Ym6fpgMH2tWf6FJlDRWzHWgGCAghAzmoL8Nai/PJ5OyAMbFxHgr9M3w32Ava0jhJ+1buhfR1P7W0
+        svRkJG91zJNhHeDezgunaCuv4+xyrbfY78Y8J75JyvArdduoIZnlPvn8+PDnJ/am9XZIRXAvgnsP
+        BwmtkdC69zagdKW+UVqfA/z+/vhQNcWtL9bBrWxeL4free7LoH9tyDTF4A1NO2MzVFDrdVu1UYOl
+        g1KdBmEfZ4FOXqUezaHZejl9Cwym265M4vsi+pXpqCLP59s8vwRc4u0ep2vUZAhUD87y+67UvRu/
+        RjUSCKAo64fJ4R8AAAD//wMAI5RHs5kMAAA=
     headers:
       CF-RAY:
-      - 992cbb84ef9fed00-SEA
+      - 99954561184dfcc4-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -180,7 +187,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:44 GMT
+      - Tue, 04 Nov 2025 15:51:09 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -196,13 +203,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2586'
+      - '2071'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2600'
+      - '2076'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -210,13 +217,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799588'
+      - '799553'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 30ms
+      - 33ms
       x-request-id:
-      - req_5f1fdf8ec757436781023e14fad429e4
+      - req_d970bf07a16148e9961062645cc4b21b
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/async_stream.yaml
@@ -9,12 +9,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '844'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -36,103 +40,103 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0568f6e6bd681de70068f967260b448194ae53ece1789c8ec5","object":"response","created_at":1761175334,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7","object":"response","created_at":1762271491,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0568f6e6bd681de70068f967260b448194ae53ece1789c8ec5","object":"response","created_at":1761175334,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7","object":"response","created_at":1762271491,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","type":"function_call","status":"in_progress","arguments":"","call_id":"call_KP5QYSrxpHlZcPeYYd3ixkWE","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","type":"function_call","status":"in_progress","arguments":"","call_id":"call_WvUTcxwhMmj1z37Za716EaPu","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"{\"","obfuscation":"vQ0bIkaos5Kz6o"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"{\"","obfuscation":"0QKFTqkicl3wZE"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"isbn","obfuscation":"hKnvSU3Mq7On"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"isbn","obfuscation":"XoDz30t9QbZq"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"\":\"","obfuscation":"3TQAXEE3HN6gj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"\":\"","obfuscation":"7a14mexVApMuv"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"0","obfuscation":"HRQHq4QBd1E3ar0"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"0","obfuscation":"HIPXyQbsH2pNUAT"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"-","obfuscation":"dc87shs2ih9oe4o"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"-","obfuscation":"Dix5SHLXcS01fFb"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"765","obfuscation":"i3tprBsvGeNbx"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"765","obfuscation":"CsGytDdbSqcXw"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"3","obfuscation":"iclHvI6iFlFx1Ql"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"3","obfuscation":"BsH5qSClNhSq03G"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"-","obfuscation":"yI4LshpRkfHVZyP"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"-","obfuscation":"s6htxkh3zWP8pSP"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"117","obfuscation":"JJMLMx40aRpJa"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"117","obfuscation":"zbyCEPSfjWaWF"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"8","obfuscation":"ykLDxPEzbafEjAO"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"8","obfuscation":"Kg0eVHiBum50iFK"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"-X","obfuscation":"1VUi5Gj7e11lrU"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"-X","obfuscation":"WAtqZmAAFRhcyW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"delta":"\"}","obfuscation":"d1DI6S45QER55a"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"delta":"\"}","obfuscation":"R60Z5D6pQknAMF"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_KP5QYSrxpHlZcPeYYd3ixkWE","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WvUTcxwhMmj1z37Za716EaPu","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0568f6e6bd681de70068f967260b448194ae53ece1789c8ec5","object":"response","created_at":1761175334,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_KP5QYSrxpHlZcPeYYd3ixkWE","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7","object":"response","created_at":1762271491,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_WvUTcxwhMmj1z37Za716EaPu","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
 
@@ -140,13 +144,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 992cbc4d2c00ddb8-SEA
+      - 999545f49c3ed55f-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:14 GMT
+      - Tue, 04 Nov 2025 15:51:31 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -162,23 +166,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '236'
+      - '53'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '242'
+      - '59'
       x-request-id:
-      - req_186b4bad4d7f44c7abf4a891da907857
+      - req_f76d814d95b24eb4ade3bbefbe06beff
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_KP5QYSrxpHlZcPeYYd3ixkWE","name":"get_book_info","type":"function_call","id":"fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca","status":"completed"},{"call_id":"call_KP5QYSrxpHlZcPeYYd3ixkWE","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"call_id":"call_WvUTcxwhMmj1z37Za716EaPu","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -186,12 +188,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '977'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -213,210 +219,378 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0568f6e6bd681de70068f9672778288194b698a6bdab31ad42","object":"response","created_at":1761175335,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_06e779162f023f0000690a2104b1308196be43ce550a1af79f","object":"response","created_at":1762271492,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0568f6e6bd681de70068f9672778288194b698a6bdab31ad42","object":"response","created_at":1761175335,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_06e779162f023f0000690a2104b1308196be43ce550a1af79f","object":"response","created_at":1762271492,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"jHFdFmdghKmx8F"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"6hUZedNyjHWLLf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"SQfo1QKbrm2"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"ud6iIOhjwPI"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"n9IBQACW6IZ3K"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"X57qEWx1r5GVW"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"dfL34d2BQweZ"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"tHFDYEpf2h1w"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"sV9gBp0273Ox"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"IkvR0to7a8WE"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"oQYUgrUCapAx6uE"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"rlt6XnRQUMbkfjk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"7IhniDhCeBgS"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"iTslE2H9iq0n"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"LQUD4ZpuNx"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"L7wbJhFpJ0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"y1ittNTVo"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"BKXP5x3O0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"b12XQVsusnpe9"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"mw7WkIN2P9u0W"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"gGms4SGiIW"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"38mayIrltR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"ne7Hrth4v7XiW"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"KxleWYzUGszVp"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"pLd12bc0sKe2Eo"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"qLbednl7DhQ1Bz"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"FiVSaKhzoGS"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"JbVwIPsPT6j"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"JjSoZo9n0El"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"Qe6hTyjt2mQ"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"pAMAunk2WVu"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"97vKvuJccvP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"M19ZZbGYr9hTE"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"KsSB9KaaTnb8M"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"nyEzZ4S05Jx"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"2QGfZAYZQ6N"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"pCpwPVF5IQt2Ks"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"cvvMfthYRSJBKT"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"UlkGBdT0KoVGb"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"Ia4mc7nRhqYPY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"33XGxD1nI4ROfr"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"Hk6Bt1Pezkp4tX"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"zvFFP"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"EdS6P"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"J0KTmsHcdMc"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"t0CXg8ZI1l6"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"xu69iJ3m1A6QVs"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"2QDdpnvJhHEZmn"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"laolaP6WshfhV"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"Ldt4wNMZqaPrs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"4vF2EDmGlrQbmkC"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"L1b4G7C2mNXroYe"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"QudcUyR7biDPCER"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"kG1404hHn2Q0PD4"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":34,"output_index":1,"item":{"id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":35,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"3voa89MWvOb8Nl"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"oPSIxsFtws8"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"a54gYGrqiW1wS"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"AGUTvvjvPGQ0"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"9Misi0UYgrZG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":":","logprobs":[],"obfuscation":"QSRbkA6HOWCKYzx"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"lkxh0JEpx2gi"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"4XZiwmMj11"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"Uw3cuejTO"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"0AMeOdAhMjfFW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"C38nVr6NmM"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"lset2ydwOekdY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"mAfS8wQVAyRIq5"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"Xsmu9HOESTL"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"5OKLyaRie3o"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"bh5dA8pWT1w"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"2aZbDOWBTbseC"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"UxRaN1capeN"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"QzapKzkQ6D8iCr"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"BzXnB7T59p7iK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"NCl7t8YaLQCQIR"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"TfWFR"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"UBiexKC0Syh"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"9AIVpDF6WZkqMV"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"YwMpboitlH96o"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"PTdjYLcrcO1JSOn"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"rS8zQWiLq9sxpbE"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":63,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":64,"item_id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":65,"output_index":1,"item":{"id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_0568f6e6bd681de70068f9672778288194b698a6bdab31ad42","object":"response","created_at":1761175335,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":66,"response":{"id":"resp_06e779162f023f0000690a2104b1308196be43ce550a1af79f","object":"response","created_at":1762271492,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"},{"id":"msg_06e779162f023f0000690a2106943c81968f113b2de635c96f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":197,"input_tokens_details":{"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":263},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc562c7cddb8-SEA
+      - 999545fc8a24d55f-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:15 GMT
+      - Tue, 04 Nov 2025 15:51:32 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -432,15 +606,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '272'
+      - '225'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '287'
+      - '236'
       x-request-id:
-      - req_e8b712ad9f5d4b97bdab2820e2706403
+      - req_88f18f999ca64ad8b0b11e9f05de2e05
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/stream.yaml
@@ -9,12 +9,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '844'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -36,103 +40,103 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0b0d1528ca873fd80068f96716e0a881959ce78c2741741b42","object":"response","created_at":1761175319,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206","object":"response","created_at":1762271478,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0b0d1528ca873fd80068f96716e0a881959ce78c2741741b42","object":"response","created_at":1761175319,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206","object":"response","created_at":1762271478,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","type":"function_call","status":"in_progress","arguments":"","call_id":"call_DKUnanrHFNzdv0dwE1kN17XB","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","type":"function_call","status":"in_progress","arguments":"","call_id":"call_BN7teDnGzxfSWoRXGsgqX1F0","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"{\"","obfuscation":"mI4SuC4xB4EOPi"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"{\"","obfuscation":"qS2JpDt9OOvGgt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"isbn","obfuscation":"EJv9a4wtu5OS"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"isbn","obfuscation":"jaUTXmquGasF"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"\":\"","obfuscation":"ND43JMTtOflPl"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"\":\"","obfuscation":"NlY4qHNUn5953"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"0","obfuscation":"BI8LW76NwOuf7H3"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"0","obfuscation":"auet79CcT6aK8wv"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"-","obfuscation":"Cgs5VogbNuynWNI"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"-","obfuscation":"iAtxpYAZda9NmTh"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"765","obfuscation":"T5OckBc7bVUgT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"765","obfuscation":"V9SxCwDD4otLL"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"3","obfuscation":"tppuYnDM9NFMEcZ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"3","obfuscation":"VEksxG0Ip4T2gtR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"-","obfuscation":"wVRfGfavlMgPt5p"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"-","obfuscation":"b5OVKOmjt7daPhd"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"117","obfuscation":"iDMGcG6QHUaSW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"117","obfuscation":"iShE9d5ngEiUM"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"8","obfuscation":"LjcwsSKd0jTurGj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"8","obfuscation":"B8uupjbd4fqkfT5"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"-X","obfuscation":"XFE45Y4d2PzZQo"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"-X","obfuscation":"5iTgVvrJUHBlMD"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"delta":"\"}","obfuscation":"Yo3HlCTWaqRsuf"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"delta":"\"}","obfuscation":"LTpnpAU5Xg52Vp"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_DKUnanrHFNzdv0dwE1kN17XB","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_BN7teDnGzxfSWoRXGsgqX1F0","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0b0d1528ca873fd80068f96716e0a881959ce78c2741741b42","object":"response","created_at":1761175319,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_DKUnanrHFNzdv0dwE1kN17XB","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206","object":"response","created_at":1762271478,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_BN7teDnGzxfSWoRXGsgqX1F0","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":134,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":157},"user":null,"metadata":{}}}
 
@@ -140,13 +144,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 992cbbee6a13b98d-SEA
+      - 999545a689938eb8-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:21:59 GMT
+      - Tue, 04 Nov 2025 15:51:19 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -162,23 +166,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '365'
+      - '65'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '418'
+      - '71'
       x-request-id:
-      - req_8a52acb19ee545d9b349271b63f90922
+      - req_e55bb6f31a2d4d6880d3c8b494253efb
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_DKUnanrHFNzdv0dwE1kN17XB","name":"get_book_info","type":"function_call","id":"fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8","status":"completed"},{"call_id":"call_DKUnanrHFNzdv0dwE1kN17XB","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"call_id":"call_BN7teDnGzxfSWoRXGsgqX1F0","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206","stream":true,"text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -186,12 +188,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1240'
+      - '977'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -213,378 +219,210 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0b0d1528ca873fd80068f967186c688195adf23339fde81706","object":"response","created_at":1761175320,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_001c8b1138c31f9e00690a20f83cc8819785df31b537a55a06","object":"response","created_at":1762271480,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0b0d1528ca873fd80068f967186c688195adf23339fde81706","object":"response","created_at":1761175320,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_001c8b1138c31f9e00690a20f83cc8819785df31b537a55a06","object":"response","created_at":1762271480,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
 
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","type":"message","status":"in_progress","content":[],"role":"assistant"}}
 
 
         event: response.content_part.added
 
-        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"xhwArbgdX7wI5T"}
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"SOSYvmIBSILkim"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"4BTXhK5VPWV"}
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"ixwv3OiNiRi"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"wLJOlRrxeUgZ9"}
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"PCv9NIlBx5kME"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"PXvMMSdR6ePr"}
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"HAegORURAbHk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"V8ILIItv3g4J"}
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"L8gkUDZOhaZw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"k3tDcBFskzsxZvV"}
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":":","logprobs":[],"obfuscation":"fgMhi2F58w3O2J2"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"cVyD7nIcLAfu"}
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"
+        The","logprobs":[],"obfuscation":"exXTg40dhX0u"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"kajHUSrkcs"}
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"
+        Final","logprobs":[],"obfuscation":"pLD7IFFQO0"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"6Mt0WPp8I"}
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"
+        Empire","logprobs":[],"obfuscation":"xX1hgKokY"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"y9pSH6adjFhJJ"}
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"l240I4ccEhTlP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"U0Peher2sN"}
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"BfpunlrnHR"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"DgIfl28rogxnn"}
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"zk3KgEdSnDv05"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"P05JIg82F25b9U"}
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"TuWkHtsVUX9I56"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"1Miz7w9ky2v"}
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"bd3U68QWQFw"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"0DCg6PH7CpM"}
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"
+        Sand","logprobs":[],"obfuscation":"XKL9bmeMfVf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"izzurVwz2HR"}
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"TvvOsSfjXsf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"qJNWuqaEbJ9XB"}
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"jFYDfmbd6FgQt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"a2rvHiT3tK1"}
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"QIf3UvKN3qP"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"3DJEgpYfqDhkvc"}
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"ntlwFHzQJT4ZWH"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"UbUvC5H5bNh8f"}
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"snLBLyZzjbFFL"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"OcSN2sY0DwvvGW"}
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"KqHoFvfmNKxLPs"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"FdoZF"}
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"lvTki"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"fhQeAXp5OO4"}
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"hDtbGoL7u3X"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"uefRTW6axjM3Qa"}
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"XM35Rrc2AhBhLt"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"yhSox7Rb1dpaP"}
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"JBEpTYicKNNZk"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"LxeQuRAJnXw2zjQ"}
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"R1UnYW4wtDRKeOf"}
 
 
         event: response.output_text.delta
 
-        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"UyGxzZfK40L8gPz"}
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"e5ro7eQHn7xFNBf"}
 
 
         event: response.output_text.done
 
-        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_text.done","sequence_number":31,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
 
 
         event: response.content_part.done
 
-        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.content_part.done","sequence_number":32,"item_id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
-
-
-        event: response.output_item.added
-
-        data: {"type":"response.output_item.added","sequence_number":34,"output_index":1,"item":{"id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","type":"message","status":"in_progress","content":[],"role":"assistant"}}
-
-
-        event: response.content_part.added
-
-        data: {"type":"response.content_part.added","sequence_number":35,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"{\"","logprobs":[],"obfuscation":"iQMQzrwGS89mCw"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"title","logprobs":[],"obfuscation":"v3ei811NZmg"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"2Q0nj4tExa3b1"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"Mist","logprobs":[],"obfuscation":"ANb3Pfnjn7RP"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"born","logprobs":[],"obfuscation":"KUFW3roto4o2"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":":","logprobs":[],"obfuscation":"mjEJ64hqiER9dTE"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"
-        The","logprobs":[],"obfuscation":"MZQsYGY2rl8A"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"
-        Final","logprobs":[],"obfuscation":"y3grMvf8cJ"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"
-        Empire","logprobs":[],"obfuscation":"g1LAMuOR1"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"h9DGROMbtus01"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"author","logprobs":[],"obfuscation":"tdqpMqjlg1"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"\":\"","logprobs":[],"obfuscation":"GQvsk83YBK9A2"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"Br","logprobs":[],"obfuscation":"tWo7RE1YUXyjCa"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"andon","logprobs":[],"obfuscation":"AoanxIQI3aT"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"
-        Sand","logprobs":[],"obfuscation":"xN5bMKyHsFf"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"erson","logprobs":[],"obfuscation":"xiQqLXHGOXa"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"\",\"","logprobs":[],"obfuscation":"u7QVt9emRATwy"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"pages","logprobs":[],"obfuscation":"VUM4nV8DXvG"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"WfBYYZ3crjh632"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"544","logprobs":[],"obfuscation":"eavsULcjZw3eX"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":",\"","logprobs":[],"obfuscation":"HNlEazATXcIOpN"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"publication","logprobs":[],"obfuscation":"aIuNO"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"_year","logprobs":[],"obfuscation":"BCRBjsmnng1"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"\":","logprobs":[],"obfuscation":"ndFWJfWKmN9v00"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"200","logprobs":[],"obfuscation":"YTXccolWI1sPB"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"6","logprobs":[],"obfuscation":"MRuOWrXBTVugth4"}
-
-
-        event: response.output_text.delta
-
-        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"delta":"}","logprobs":[],"obfuscation":"YMwQ4u8QVQiFyZi"}
-
-
-        event: response.output_text.done
-
-        data: {"type":"response.output_text.done","sequence_number":63,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","logprobs":[]}
-
-
-        event: response.content_part.done
-
-        data: {"type":"response.content_part.done","sequence_number":64,"item_id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","output_index":1,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}}
-
-
-        event: response.output_item.done
-
-        data: {"type":"response.output_item.done","sequence_number":65,"output_index":1,"item":{"id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":66,"response":{"id":"resp_0b0d1528ca873fd80068f967186c688195adf23339fde81706","object":"response","created_at":1761175320,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"},{"id":"msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_001c8b1138c31f9e00690a20f83cc8819785df31b537a55a06","object":"response","created_at":1762271480,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":"resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"json_schema","description":null,"name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"Look
-        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":197,"input_tokens_details":{"cached_tokens":0},"output_tokens":66,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":263},"user":null,"metadata":{}}}
+        up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":195,"input_tokens_details":{"cached_tokens":0},"output_tokens":33,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":228},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbbf81ae3b98d-SEA
+      - 999545aead5d8eb8-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:00 GMT
+      - Tue, 04 Nov 2025 15:51:20 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -600,15 +438,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '264'
+      - '243'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '297'
+      - '259'
       x-request-id:
-      - req_afe11894d2db4358b0e0e2c2d32bb0fa
+      - req_d399b7ee22ce4797b6c5eaa4d32414f3
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/openai_responses_gpt_4o/sync.yaml
@@ -9,6 +9,8 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
@@ -36,31 +38,31 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//nFbJbuM4EL37Kwie44YWL0puk1sDjUFmMpg1DYGiSjLblMghi0Ybgf99
-        QMrW4liZ7r7Z9cjHWl5V6XVBCBUlfSDUgNV5xOO04Nk2iXmZZVEaRZusut9sqriChGfx/ZplSbxJ
-        0tWWr7N7vq3onadQxRfgeKFRrYXOzg0whDJnHou3mzjerpMsCZhFhs76O1w1WgJC2V0qGN/XRrnW
-        +1UxaaEzCylFW9MH8roghBCq2RGMv1/CAaTSYOiCkFM4DMYoj7VOymAQ7eWVvARkQtopatE4jkK1
-        E3vDvubKoXaYo9rDWxCVkjlnckrXqBKk96zWuFypZRIlq2WULaPNOV2Bkj6Qf0IkXTx9JSo+X4e0
-        WKWZr0ORQAJpyhkvqjKOeSAOJHjUEGhcGwIK7g3wXNoDyEztGmgx4K8vVNiifaEPLzRabjfrdBnH
-        22z55ws9DVc8e945Hn4eH6sylesn+PX3X/7Y2ftDU/69e8aRBy1rgoM1YF4otc9FWyka0NOCkM8h
-        RZoZJiXIaYbRuE4M2sBBKGfzi946F/oKaKMajTlnfAf5Ho5jzACzqp1ICapKGRwd8olyTcPM5Wav
-        LMsqwGMuSmhRVAImKrNgDoJDjuKizIo5ifQseGVgHARCo8EwdMEcf4jO1q84eFYp07Dh/6i+X6xq
-        c8t30LAhtyVYboT2dZ9EM0r7o1L753Nsgyo6nuGZLocaDAqwE7t3QaCEK+PITH8LP+6u0LPfFo3P
-        /Qg8jU9S5nAXeneO/afuwA/Sa1a/CWjM/hTwGXLRItTdnJlhd4UUnIW+OwJ7L4yn4Sj5yx/9jjcX
-        N16nBv51wkDZz5XJi7dyfCMx70fTg59H7/YR3VLWKJDzkhghrCyFJ2fyaay1MPMXVwGGwoYd4/tn
-        McLoAUyhrEDfq7SBUrhm2ATd/NgpwYMTzKGiPWDfzuDr8TnXW/STUnviNPEjjPgR5hvVF7M4ko/P
-        jz9/+L+J18N+1jWAYOy3NqCfy+9I66OHv70/vktN4embOnivmvNymK/zIINhLaDSuVS1Nqrw3FFv
-        1OMJalzbqTbMYGFZIS8fF86yehhdVLST3R6nq7u3wOiL4XVYe3wH5XAzmijy+pshSW8Bt3j75TRH
-        jQqZHHm83vZSd3a6jRpAVjIMY/20OP0HAAD//wMAm+cUxe0JAAA=
+        H4sIAAAAAAAAAwAAAP//nFZLb+M2EL77Vwg8xwtJtmU7t6btIWjRBN0eumgWwogayVxTokoOg7iB
+        /3tBytbDsbKPmz0f+XEe38zodRYETOTsNmAaTZOGOYbJMkvCeMPzTbINw2QbQlQUsIo3m020XW05
+        AkC44KvVhkeLiN04CpV9QU5nGlUbbO1cIxDmKTgsWidxvI7iOPGYISBr3B2uqkYiYd5eyoDvS61s
+        7fwqQBpszUJKUZfsNnidBUEQsAYOqN39HJ9RqgY1mwXB0R9GrZXDaiulN4j6/EqaI4GQZowa0paT
+        UPXIXsFLqiw1llJSe3wLklIy5SDHdJXKUTrPyobmSzWPw3g5DzfzMDmly1Oy2+AfH0kbT1eJgk/X
+        IdsWydLVYbOCVZKst1G2WC74KvbEnoQODXoaW/uAvHs9PJV2D4IubYU1efz1iQmT1U/s9omF83Wy
+        WsyjaL2Z//3Ejv0Vx562jvuf/72Un6Jffr3/7ecHfnjQukL5cLj7c+BBDZV3sERKM6X2qagLxTx6
+        nAXBZ5+iBjRIiXKcYdK2FUOj8Vkoa9Kz3loXugo0WlUNpRz4DtM9HiYxjYS1S9PwhEYwqh6JDYtC
+        aRoccqm0VQX6zN1pz0CBdEhF7ogLgSMdGtTPgmNK4qzdAqwkdmoJpXEYJmHVoAay3hx9CE/WF+o9
+        K5SuoP8/UMAXo+rU8B1W0Gc/R8O1aC5CHhXmTqn9x1NsvW5anv6ZNpMNahJoRnbngiCJF8aBmf3l
+        f9xcoCe/DWmX+wF4HJ5kYGnnu3uK/af2wA/SN1C+CWjI/ujxCXJRE5btJJpgt5kUHHxnHhDeC+Ox
+        Pxp8cke/483ZldeZxn+t0Jh3k2f04rUcX0nM+9F04OfBu11E15Q1COS0RgYI5Llw5CAfh1rzW2F2
+        EaAvrN9Crn9mA4w9o86UEeR6lVWYC1v1u6KdMDsluHcCLCnWAebtlL4csFO9xX5Xah/YJnBDLnBD
+        zjWqK2Z2CO4/3v3x4WszsYPdNKyQUJtvbUA3ud+R1r2Dv70/vktN/umrOnivmtNymK5zL4N+cZBq
+        UqnKRqvMcYedsRlOUG3rVrV+BgsDmTx/flgDZT+6mKhH2z9aLG/eAoNvitd+MfId5v3NcKTIy6+K
+        eHENuMbbLacpalIEcuDxat1J3ZrxNqqQIAfyY/04O/4PAAD//wMACls3sA8KAAA=
     headers:
       CF-RAY:
-      - 992cbb07cf84b9a4-SEA
+      - 99953f7a2873d5c8-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -68,9 +70,15 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:24 GMT
+      - Tue, 04 Nov 2025 15:47:08 GMT
       Server:
       - cloudflare
+      Set-Cookie:
+      - __cf_bm=gAaoQmTpI16wkP72rXpmcHBtKltMn5XIKEsoVfKVLSo-1762271228-1.0.1.1-HRu8hITQLGkg8fOGYzB80fyNUTvU5cZJGGFt6GSwdHigC4yd13SyxRo8IGC0ZuHfRQen3nf2oSnlVjvxYOhXJSJ2JapnOEblxCwU2r5Szao;
+        path=/; expires=Tue, 04-Nov-25 16:17:08 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=Fb8oD_PI.LQFRWm9qE_kuzSFUnRy5hLLQJ6MAxlV0GM-1762271228333-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
@@ -84,13 +92,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2109'
+      - '2145'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2119'
+      - '2221'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -104,15 +112,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 26ms
       x-request-id:
-      - req_d06efb4da137416ba23b157889a9b8e4
+      - req_55d36895c30143c5aad626260666e061
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"content":"Please look up the book with ISBN 0-7653-1178-X and
-      provide detailed info and a recommendation score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_yBfd3l5PeRVQWhs9vmdZhStl","name":"get_book_info","type":"function_call","id":"fc_0c13bc8721cd88030068f966f3b4388195b2e2e33cacbfd11c","status":"completed"},{"call_id":"call_yBfd3l5PeRVQWhs9vmdZhStl","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+    body: '{"input":[{"call_id":"call_zxgY1DEIKCOcyOrrmelOyBRl","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0de064b6028cd86900690a1ffa528881959ceaaa03c558c131","text":{"format":{"type":"json_schema","name":"BookSummary","schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"title":"BookSummary","type":"object","additionalProperties":false},"strict":true}},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false}]}'
     headers:
@@ -120,12 +126,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1226'
+      - '963'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -147,33 +157,33 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA+xWTY/bNhC9+1cQPO8G8pcs+9YFWiBAWwTYXIo4EEbiyMssRarkcBFj4f9ekLL1
-        4bWNbA855WR53vBxhvM4nNcJY1wKvmHcomvypJzOizJbzaalyLJkniRpVq3TtFos59Msm66XkGWz
-        dZkJnFeZmGHF7wKFKb5hSScaox229tIiEIocAjZdpdPpajnLFhFzBORdWFOaulFIKNpFBZTPO2u8
-        DnFVoBy2ZqmU1Du+Ya8TxhjjDezRhvUCX1CZBi2fMHaIzmitCZj2SkWD1KddcoEEUrkx6sj6kqTR
-        I3sN33PjqfGUk3nGtyAZo/IS1JiuNgJViGzX0P3C3M+S2eI+ye6T9HhckZJv2JeYSZtPV4na7a4X
-        YrmcJ7EQhRBila6wWKznAiCLzJGF9g1GHnQOdtgD1048gqXRhLoPahjYiPZ0HvidutXRAbQ2BKcz
-        /PJ1BCqza6wpLiCRaMP465aTJIVbvtnyv6Sjwli9YZ+fkP0hNSj2e91Ii1t+t+Xg6cnY6PlgQQuj
-        2SNogdYZHR0a2KHb8s1ysQj/fKFkGUPL9whh4SxJ0gPv4jgcv7rQuDUqpgvOSUegqXU+3L27ZOly
-        OY8ly1aL9SoryvkCi3IF618l+zklmxydeAMWlEI1vrZkfdthGosv0niXn5pYHqvbXevGmrqhvITy
-        CfNn3A8xi+CMHvUnrCpjaeAU6unrGuxpZdeuHFRI+1wK1CQriaPW5dC+yBJzkqd2V4FXbSW5I2Nx
-        mARh3aAF8tE8/ZAcrbFix8gqY2vo/w+U8s0ZnbvyCWvodSbQlVY2oRajbBjjGuq47sGY58djbr14
-        W57NQJThDBu0JNGN7CGEoKQz48DMP8ePuzP0GLcjG85+AB7GQo/qu8H+W+vwP+mjdm+wf4r4FXKp
-        CXft43WF/ewu3Nqod2X/BNd37Dm5sDu3+K+XFsWoyXQ7XjrjCwdzO5sOHDSZPqNLyhq2tnbyGCAg
-        hAzkoD4NtRYHiclZgrGwcXAJ92fY4PkL2sI4Sfu2Lwvp6368aPvHk5Fl23A8Gd4B7u3Dfoq28joO
-        GdfuFv/TmGfmG1aEX6nbixqKWezZx8eHvz/wN1dvh5QH9zy493DodTUSWvejF1C6Qt+Q1scA//j9
-        eJea4tYXdXCrmtflcL3OvQz6Z4FMkw8eu6QzNsMOar1uVRt7sHRQqNPE6uOj3bVXqUcD43S9unsL
-        DMbQTibxZRH9ymSkyPNBNE0vAZd4u8fpGjUZAtWDs3TeSd278WtUI4EAim39MDn8BwAA//8DAJlT
-        BzlCDAAA
+        H4sIAAAAAAAAAwAAAP//nFZNb+M2EL37Vwg8JwtJlhzFtwZogQXaYoHspVgvhBE1crimSJUcBmsE
+        /u8FKVsfjm1ke7I8b/g4HL6Z4dsiipio2TpiBm1XxjXGq6xaxWnB62L1GMerxxiSpuFFWvAiecwr
+        3gDUq5xnD2mSNRm78xS6+oGcTjRaWezt3CAQ1iV4LHlYpelDkqZFwCwBOevXcN12EgnrflEFfLc1
+        2ikfVwPSYm8WUgq1ZevobRFFUcQ62KPx62t8Rak7NGwRRYfgjMZojyknZTAIddqlrJFASDtHLRnH
+        SWg1s7fws9SOOkcl6R2+B0lrWXKQc7pW1yh9ZNuO7jN9n8Zpdh8X9/HqmK5AydbRt3CS/jzDTbR2
+        e/0i6ixZFf4iICvyrEqWDSZ5nhdFYA4stO8w8KC1sMURuJbxAHKtCNUY1DSwGe0pH/iThtXBAZTS
+        BKccfvs+A6XedkZXF5BAtI7Y24aRIIkbtt6wv4SlShu1jr6+YPSHUCCj39tOGNywuw0DRy/aBM8n
+        A6rWKnoGVaOxWgWHDrZoN2ydZ5n/5yopeAit3CP4hWkcrw5siONw/BpCY0bLcFywVlgCRb2zdwxO
+        rAMDUqKca4CM6+XaGXwV2tnyVBHlR+oM8rQI1/vIEQDiJc/zgifLhB1JddtRyYG/YLnD/VR0M8yg
+        v0yh1dTDIFitZjWETaMNTZy8TFzbgjlxDyVloUHal6L2xI3AWXlZNK+CY0niVJINONkLhFnSBqe5
+        IWw7NEAumJNP8dEahHCMrNGmhfH/RIA/rFal5S/YwijfGi03ojs7coAUtGHdk9a75+PZxproedYT
+        rftMdmhIoJ3ZfQheoGfGiZl9DR93Z+gxbkvG534CHub1E0R9g/233uF/0oeSuMH+JeBXyIUi3PYN
+        9gr7WYnd2mh0jf7xrr+w5+LC7szgv04YrGe9a9jxUo4vJOb2aQZw0rvGE11S1rRj9tNxgkBdC08O
+        8stUa2HYLc4OGC42DFdfP4sJxl7RVNoK2vftvhauHUdg35ZetOB9H3Ok2QDY98PnFG3jVBiE12qL
+        /an1LnJdVPlfofpC9ZdZ7aPPz09/f2LvSm+LVHr30ruPsG+hLRIa+9ECFLZSN6T12cMfr49fUlPY
+        +qIObt3mdTlcv+dRBuO0Id2VkxkaD8Zu2kGNU71qQw8WFip5elW58BYY2qtQs0dN8pjfvQcmT6VB
+        JmG+1OPKeKbI88fScnkJuMQ7DKdr1KQJ5AimaTFI3dn5NGqRoAYKbf2wOPwHAAD//wMApaumz+YK
+        AAA=
     headers:
       CF-RAY:
-      - 992cbb162878b9a4-SEA
+      - 99953f898fced5c8-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -181,7 +191,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:26 GMT
+      - Tue, 04 Nov 2025 15:47:09 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -197,13 +207,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '2425'
+      - '1196'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '2494'
+      - '1201'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -211,13 +221,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799553'
+      - '799588'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 33ms
+      - 30ms
       x-request-id:
-      - req_e1cfe019565548a59dfc7ad997b03536
+      - req_15749d60dc5e4f6baea72629885f1d8b
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async.yaml
@@ -12,12 +12,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1222'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -39,33 +43,33 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//vFZNb+M2EL3nVxA6xwvJdmzJt24vXbQoEmwXaNEEBCWNZNYUyZLDNEbg
-        /16Qsr78kd10gZ4sz3AeZ+Y9cvh6Q0jEy2hDIgNW03idr1hasqxcldU6SeJ4lVbZah0X1bJK0ySL
-        0ypbQlwtV3G1WGVZHN16CJX/BQV2MEpaaO2FAYZQUuZ9yXqVJOu7RZwFn0WGzvqYQjVaAELZBuWs
-        2NVGOenzqpiw0Jq5EFzW0Ya83hBCSKTZHoyPL+EZhNJgohtCDmExGKO8TzohgoHLbhdaAjIu7NRr
-        0bgCuZITe8NeqHKoHVJUOzh3olKCFkxM4RpVgvCZ1RpnSzWbx/PlLE5n8erYrgAZbcifoZK2np6J
-        qrjOAyRrWHoesjRfQhGni7SMc7acB+AAgnsNAcbJUFBIb3Bfa3twMlO7BiQG/+tjxG0uH6PNYxTP
-        1qu7xSxJ1uns98foMIR4dNomHj5/jG3z5SHJX35e183DT/Jhnu51meyHCMmakGANSHOldpTLSkXB
-        e7gh5Cm0SDPDhAAx7TAa14pBG3jmylna6a1NoWdAG9VopAUrtkB3sB/7DDCr5ERKUFXK4GiRb5Rr
-        Gma6yF5ZllWAe8pLkMgrDhOVWTDPvACKvFNmxZzA6Ch4ZWBcBEKjwTB0wZx8iI/WFxwyq5Rp2PB/
-        xG9Y13btmPEzmFxZjj7nqIGSu2Y4EW0ft4oXMKB3WEwI9Q+Uodn2yFRQcXuk/3bc9DKJ2kWdeAf5
-        XtBeT/rbtPclvBuM0oYbZgulgbat8tdNf2SVoLTfIvw+TRpiz8/g1V2jEmxhuA7GDYl+UWpHnCa+
-        FuJr8btzJUm+J58+f/z1w9cU37u91htAMHbEcytiDQY5TO3+orC5PLH51DmKsM8n7749cR7rsmi8
-        9EfOQ/99GHW4Z30geti6NzyNIlhZct8AJu7Hifc3+Ekix5lxKoCQYJglIXAs8Pdz9MUCwS23xJNN
-        UBF4QcMKJCVDRrgkH5XafW4POmkZ9D+EkYpLJkh3u1zg8luU9x0Md1xeo/i38PHtHI9XRszhNozH
-        a+g/tAv+I7xm9VlBY/T74L8CziVC3Y7yK+guF7wIR43ugb1Vxv2wlPzhl75jz3cdCjxjo+vxhca8
-        Xc3/crT8CDoZuKg0FarWRuUeOu6NejybjJNtsmG6ccty0T3bnGX1aLRwOXk1JXfz23PH6C32Ojwo
-        im0YRcfIeDLjTl9ji+yS4xJuP/avQaNCJkYZZ0k/K5ydzvkGkPkrxOMfbg7/AgAA//8DAEWe9P9H
-        CwAA
+        H4sIAAAAAAAAA7xWTW/jNhC951cQOscLSbZjO7cG6CHboht0u8AWTUCMpJHNmhIZcpjGDfzfF6Ss
+        LztONy3Qk+UZ8nFm3hsOXy4Yi0QRXbPIoNU8LjLIppDNZ9NlkqzmcXy1iiGNyySBxWyZrGZQlKvZ
+        Ik/TYr5YFNMiuvQQKvsTc2phVG2xsecGgbDg4H3J4ipNF8lsMQ0+S0DO+j25qrREwgNYBvl2bZSr
+        fVwlSIuNWUgp6nV0zV4uGGMs0rBD4/cX+IRSaTTRBWP7sBiNUd5XOymDQdTtKbxAAiHt2GvJuJyE
+        qkf2Cp65cqQdcVJbPHWSUpLnIMdwlSpQ+sjWmiYzNUnjdDaJl5P46lCuABldsz9CJk0+HRNl/gYP
+        EBex5yErZqsU4nI1S65KWKYBOIDQTmOAcXVIKITXu8+VPTjBrF2FNQX/y30kbFbfR9f3UTxZXM2n
+        kyRZLCdf76N9v8Wj8ybw8Kk/3VY3P5qPjx/jLz9lv37aPIL4+2u17HfUUIUA10g8U2rLRV2qKHj3
+        F4w9hBJpMCAlynGFybhGDNrgk1DO8lZvTQgdA9qoShPPId8g3+LurM8gYe3LNFxhEKyqR2LDslSG
+        Bot8KV1VgWmxO+1ZKJF2XBQeuBQ40qFF8yRy5CRa7ZbgJEWHllAGh2kSVhoNkAvm5EN8sD5TH1mp
+        TAX9/4ECwrqmroeIn9BkygryMUcVFsJVfc80ld4okWOP3mKBlOovLAId9sBl0HnT9I9OmE5IUbOo
+        lXcv8FfU2cnibWF0KbwbjPNKGLC50sibUvkLqWtqJTnvjgi/D6OC2NMuPXtqVKDNjdAHOUU/K7Vl
+        TjOfC/O5+NOFqlm2Y7efb3758E890bl9N1RIaOyA50bKGg0JHNv9VWKz+sjmQxckwzm33n155Dzk
+        Zcl46Q+c++57P6hwx3pPdH90Z3gY7ICiEL4AIO+GgXd3/FEgh6lyLIAQYJg2YeNQ4O/n6ItFRhth
+        mSebkWL4TAZyYgUQMFGzG6W2n5tGZw2D/ocBK0UNkrX3zytcfo/y/gPDLZfnKP4tfHw/x8OVETja
+        hAF6Dv2HZsG/hNewPkloiH4X/GfARU24bob9GXSXSZGHVuM7hLfSuOuXst/90nec+a6moBM22hq/
+        Upi3s/lfWsuPoKORTEpzqdbaqMxDx51RD2eTcXUTbJhuwkIm24eds7AejBZRj95VyTy9PHUMXmsv
+        /ZMj34RRdNgZj2bc8Xstnb7meA23G/vnoEkRyEHEi3k3K5wdz/kKCfwV4vH3F/tvAAAA//8DAL/3
+        iqhpCwAA
     headers:
       CF-RAY:
-      - 992cbbb05c6375e2-SEA
+      - 99954581dab9af58-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -73,7 +77,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:50 GMT
+      - Tue, 04 Nov 2025 15:51:14 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -89,13 +93,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1897'
+      - '885'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1914'
+      - '893'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -109,17 +113,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 27ms
       x-request-id:
-      - req_b18aab80716745ea912fc91b21b199dd
+      - req_792b7602cd964b3981ab664979b215d3
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_C0smUQ1bxK7gmQHnQ28ypd1y","name":"get_book_info","type":"function_call","id":"fc_07b6a8da9d6df7110068f9670e17e4819098b4ec0838d0ba42","status":"completed"},{"call_id":"call_C0smUQ1bxK7gmQHnQ28ypd1y","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_pOImBErJqJ0UKbROhqaizXm8","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0dbab3ab5438119500690a20f11a748194adf947c22d577d3d","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -128,12 +128,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1618'
+      - '1117'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -155,33 +159,33 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWS2/jNhC+51cQPCeBlDiS41sDtNh02yBAdg9FHQgjaWSzpkiVHKYxAv/3gpT1
-        cuJgkwI9WZ7Hx5n5Zjh8OWGMi5IvGDdomyxK8wTmJVyXSVmlcRxFyby6TtKoiuMkmsfX0fwSkryo
-        0uIyyYsI5vzUQ+j8Lyyog9HKYisvDAJhmYHXxWkSx+nVZRwHnSUgZ71PoetGImHZOuVQbFZGO+Xj
-        qkBabMVCSqFWfMFeThhjjDewReP9S3xCqRs0/ISxXTBGY7TXKSdlEAjVnZKVSCCknWotGVeQ0Goi
-        r+E5044aRxnpDb5WktYyK0BO4WpdovSRrRo6m+mzi+hidhbNz6JkX64AyRfsz5BJm0/PRFUc5SGO
-        orycex7y2WVcXqXRdVrOCoQWOIDQtsEA41RIKIQ3qI+VPSjBrFyNioL+ZclJkMQlXyz578JSro1a
-        sG9rZL8IBZL9XDfC4JKfLjk4WmsTLG8MqFIr9gCqRGO1CgYNrNAu+eJqNvP/XC5FASG8LYJ3vIii
-        ZDdE4oPO2nqET/c1fU7T5Pvl7Td5/+X6Np1/+fXu7v7r4KGgDnlnWS0M2EI3mFXa1EC+A3sWtcwy
-        Hnx2J4w9Bj4aMCAlyimdZFzbeY3BJ6GdzbrmbgPr6W6MrhvKCijWmG1wO9YZBKvVpG+xqrShkZFn
-        xdU1mM6zb2MLFdI2EyUqEpXASUtbNE+iwIxENwYVOEl8P13a4DgJwrpBA+SCOD6P9tJnGiJry9X/
-        HzVTsGurto/4CU2urSAfM6+xFK4exq+t41qLAgf0Dguk1P9gGYpt9/yFkWnvj7+dMH1P8taom5Rh
-        Vt5o9L4VRs2wQspyrTeZUJXme/3u9HNgP9xZbW8x9jgpiH098EdP5SXawogmCBeM/6b1hrmG+VyY
-        z8WfLrRi+ZbdPtzcnb+eg2nqvdr3eo2Exo54bpu4QUMCp3J/K9lcHch86P5q8OfcevXpgXKflyXj
-        W3+k3PXfu1GFe9YHooeje8HjyAPKUvgCgLwfB96vi4NA9gvqsAFCgGFxBcdxg3+co+8WGa2FZZ5s
-        RprhMxkoiJVAwIRiN1pvHtpBZy2D/ocBq8J12t0u55+70/4Dwx2Xxyj+Fj5+nOOx5X41vIP+U2vw
-        SfiwWN5Bvw/6I+BCEa7ad8MR9INF9d5Bgyn7w5t+4MwPDQW9YqOr8RuFeT+b/2W0/Ao6WLikm0zq
-        VWN07qGjXtiMd5Nxqg02bDdhIZfdG9FZWI1Wi1CTJ9pFHJ2+Vowefi/DM6NYh1W094wmO+7w6Teb
-        vaV4C7df+8egSRPIUcRXs35XODvd8zUS+CvE4+9Odv8CAAD//wMAG3FonbQLAAA=
+        H4sIAAAAAAAAAwAAAP//vFZLb9s4EL77VxA6J4Eky89bU+x2A3SDFkkPxboQRtLI5oYiteQwGzfw
+        f1+QsvWw46BpgT1ZnsfH4Xzz4POIsYAXwZIFGk2dhkUG2RiySTKeR9FiEobTRQhxWMbxbDyfR4sk
+        y+b5NCnDaRbnGUTj4MJBqOxvzOkAo6TBRp5rBMIiBaeLZtM4nkXJLPE6Q0DWOJ9cVbVAwqJxyiB/
+        WGtlpYurBGGwEXMhuFwHS/Y8YoyxoIYtaudf4CMKVaMORoztvDFqrZxOWiG8gMvDKWmBBFyYodaQ
+        tjlxJQfyCp5SZam2lJJ6wFMlKSXSHMQQrlIFChfZuqbLRF3GYZxchvPLcLpPl4cMluwvf5PmPi0T
+        ZX6eh/FkPM0dD3Moy0URJcl8GoXjSeaBPQhta/QwVvoL+fA69bm0eyXota1Qktc/rwLiJHAVLFfB
+        n9xQprRcsvsNst+5BMF+q2qucRVcrAKwtFHaW15rkIWS7A5kgdoo6Q1qWKNZBctJkrh/NhM8Bx/e
+        FsE5xmE43XWRuKDTJh/+8/Zj+ce/N5/fZ9u7D/cf3n1V35/k5+zLbechofL3TtOKazC5qjEtla6A
+        XAW2LCqRpoH32Y0Y++b5qEGDECiGdJK2TeXVGh+5siY9FHf6Iy0TRTBLHFVQlItklsdxMZnNivG+
+        ymutqprSHPINpg+47dfPQKeRULpM9S00glFy0A5YlkpTz8iRbasK9AG77Q4DJdI25YUDLjkOOsWg
+        fuQ5psQP3VWCFRTsm1Zp7OeGsKpRA1kvjq7CvfSJusgaFtr/vRr1dg0Z+4gfUWfKcHIxBxUW3FZd
+        Vzf0bBTPsUM/rvd9Rby1HroTzGljnjmDueyYXPN6z0/wUakHZmuWuV8um/O4kizbspu769ur03pd
+        I6XOPHXmndrVZIWE2vQS19RGjZo4DuVuephMHslc6K6F3Tk3Tn1xpNzfy5B2tdRT7trvXecTaPzH
+        co1Fm6H+0a3gW88DioK7BID41A+8HetHgewXyejoaB+gXzDesV8xb+foi0FGG26YI5uRYvhEGnJi
+        BRAwLtm1Ug93TeewhkH3w4CVfuwdpsDVz82eX2D4wOU5iu/9x49z3Lfcj/BX0N81Bj8J7xfAK+if
+        vP4MOJeE62a/n0E/WiivHdSZsq/O9A1nvqkp6ISNQ45fSMzrt/lfWsvN9KPFSKpOhVrXWmUOOmyF
+        dX/YayubYP264AYycXjLWQPr3qzmcvCUiuPFxami90B77p4D+QaLzjMcLI3jJ1o8f0nxEm67R89B
+        kyIQPeTJrN0V1gwXZ4UEboQ4/N1o9x8AAAD//wMAYhxUWlwLAAA=
     headers:
       CF-RAY:
-      - 992cbbbd2f7f75e2-SEA
+      - 99954588b8ceaf58-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -189,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:52 GMT
+      - Tue, 04 Nov 2025 15:51:15 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -205,13 +209,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1696'
+      - '1654'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1718'
+      - '1661'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -219,13 +223,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799573'
+      - '799554'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 32ms
+      - 33ms
       x-request-id:
-      - req_efc711e4ec224a50935619bee0521c62
+      - req_0fce30c2455242f09ca38c98f03a962c
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/async_stream.yaml
@@ -12,12 +12,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1236'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -39,14 +43,14 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_01419a96ead129020068f9672e41308190bd28888eb4d2134c","object":"response","created_at":1761175342,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369","object":"response","created_at":1762271498,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -54,7 +58,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_01419a96ead129020068f9672e41308190bd28888eb4d2134c","object":"response","created_at":1761175342,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369","object":"response","created_at":1762271498,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -62,82 +66,82 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","type":"function_call","status":"in_progress","arguments":"","call_id":"call_MFflVGir2tx2To8GUNv7JNr8","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","type":"function_call","status":"in_progress","arguments":"","call_id":"call_Ebrf4w4HjSIKEfrqSWJlQEOP","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"{\"","obfuscation":"tIxwLxZnG9I0MM"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"{\"","obfuscation":"GGLiAtQ9OULYKz"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"isbn","obfuscation":"hSMNe1xeSsWj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"isbn","obfuscation":"lkAMzM7hZ1T9"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"\":\"","obfuscation":"AfKXkPxeGo2ip"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"\":\"","obfuscation":"O8EOcYCJQC84m"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"0","obfuscation":"FIbEJnJyXt72Ehz"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"0","obfuscation":"yJu5yroHSmdyj01"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"-","obfuscation":"B14a2o31MtP4Lzr"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"-","obfuscation":"wmE3b31x7SrTjq0"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"765","obfuscation":"cIvbfbTIb98a2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"765","obfuscation":"iyvUqisV0FimG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"3","obfuscation":"9VAsaSilacRHMj9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"3","obfuscation":"XCHrUzogX6pQj2u"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"-","obfuscation":"phO8JEtX6utTDLr"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"-","obfuscation":"w6h3JEHwbykXTlR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"117","obfuscation":"eQFKO4aPlaHij"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"117","obfuscation":"Gw3eBFUf8lnLe"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"8","obfuscation":"2xNpIdTyv4Dkzjv"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"8","obfuscation":"aCiXdpcuo2oZIv3"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"-X","obfuscation":"7rlh3admHxK6j9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"-X","obfuscation":"fsau1gDdxCRaSG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"delta":"\"}","obfuscation":"LoaMJ7I6SzHDF8"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"delta":"\"}","obfuscation":"ds2CGjO1daXQdw"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_MFflVGir2tx2To8GUNv7JNr8","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_Ebrf4w4HjSIKEfrqSWJlQEOP","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_01419a96ead129020068f9672e41308190bd28888eb4d2134c","object":"response","created_at":1761175342,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_MFflVGir2tx2To8GUNv7JNr8","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369","object":"response","created_at":1762271498,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_Ebrf4w4HjSIKEfrqSWJlQEOP","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":152,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":175},"user":null,"metadata":{}}}
@@ -146,13 +150,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 992cbc802fd8b9ca-SEA
+      - 999546236cfa6833-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:23 GMT
+      - Tue, 04 Nov 2025 15:51:39 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -168,25 +172,21 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '769'
+      - '77'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '818'
+      - '91'
       x-request-id:
-      - req_b3dc881666fe4402951ab023b3af6367
+      - req_5b3d47b1ad5a40309ee97fce5388acb8
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_MFflVGir2tx2To8GUNv7JNr8","name":"get_book_info","type":"function_call","id":"fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface","status":"completed"},{"call_id":"call_MFflVGir2tx2To8GUNv7JNr8","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_Ebrf4w4HjSIKEfrqSWJlQEOP","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369","stream":true,"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -195,12 +195,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1632'
+      - '1131'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -222,14 +226,14 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_01419a96ead129020068f96731cfa081908338251660239fbc","object":"response","created_at":1761175345,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_07d4b736b402fe6b00690a210c43088190b5d10264d5c33aa0","object":"response","created_at":1762271500,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -237,7 +241,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_01419a96ead129020068f96731cfa081908338251660239fbc","object":"response","created_at":1761175345,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_07d4b736b402fe6b00690a210c43088190b5d10264d5c33aa0","object":"response","created_at":1762271500,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -245,179 +249,179 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","type":"function_call","status":"in_progress","arguments":"","call_id":"call_pM0ZrNyD2lmX46nJN8fOi4vG","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","type":"function_call","status":"in_progress","arguments":"","call_id":"call_54XIsBCfIoLdIc2lYjjXWxrQ","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"{\"","obfuscation":"EdYJMiuCFkp4NQ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"{\"","obfuscation":"HTEWcXFDL3UhKQ"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"title","obfuscation":"THnL0tzt3HK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"title","obfuscation":"oEP7CQxPEyW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"\":\"","obfuscation":"MGQqisoBafn7U"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"\":\"","obfuscation":"6SLLYqDUInhwe"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"Mist","obfuscation":"2BYwbqaVibbQ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"Mist","obfuscation":"RD4mqwdZdEz1"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"born","obfuscation":"XvkljvxQZXNy"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"born","obfuscation":"x7X9L3SIO0vO"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":":","obfuscation":"uoRgCNzkaXRmWni"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":":","obfuscation":"DOJWlYFshH3WB6S"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"
-        The","obfuscation":"MRqu2mSzhAEr"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"
+        The","obfuscation":"HEt6EukLfKNG"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"
-        Final","obfuscation":"o63hu6GyqS"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"
+        Final","obfuscation":"7ioHL06LFV"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"
-        Empire","obfuscation":"yuHj7u8gO"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"
+        Empire","obfuscation":"YD3Tkms4j"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"\",\"","obfuscation":"fJJucbp5LVNa2"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"\",\"","obfuscation":"KpSKuB1VlURCS"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"author","obfuscation":"nrgYtKbfyt"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"author","obfuscation":"ow3pqLbzNc"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"\":\"","obfuscation":"jYZ9yhiLnyQjk"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"\":\"","obfuscation":"cUgma1dYG4ikf"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"Br","obfuscation":"nwsaIrw53uKw0c"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"Br","obfuscation":"5yktODOz8SzwiV"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"andon","obfuscation":"uiCpe8cibvP"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"andon","obfuscation":"XGyNbbMvNfn"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"
-        Sand","obfuscation":"u3p3cmIcWqT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"
+        Sand","obfuscation":"SM3ZXHq44gb"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"erson","obfuscation":"jrnuFHHBTk9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"erson","obfuscation":"htFCuFlsVNW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"\",\"","obfuscation":"JLYQhwmdd6fq7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"\",\"","obfuscation":"KUroqoEr7y5S4"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"pages","obfuscation":"NdUJ5yyUKjW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"pages","obfuscation":"NnCadaQjFoS"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"\":","obfuscation":"LxvphXY07FD42y"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"\":","obfuscation":"90LHhU9jW5xrkK"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"544","obfuscation":"2lwwUd6zznceX"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"544","obfuscation":"E68ZM2I1OuPSK"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":",\"","obfuscation":"XW9hSn5f4EUb0W"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":",\"","obfuscation":"lEuQzvqRRleUuy"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"publication","obfuscation":"ZjXff"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"publication","obfuscation":"naVX8"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"_year","obfuscation":"ou8uZV4bprW"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"_year","obfuscation":"XeAq45TZwli"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"\":","obfuscation":"TVRlamnUQYE6dV"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"\":","obfuscation":"ibEGIexoiVjvui"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"200","obfuscation":"sSJKKTjfQAkw4"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"200","obfuscation":"KfCMfS9OS2nKW"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"6","obfuscation":"OOo5qak7GefY9oc"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"6","obfuscation":"iaqJZNjr4gz7wbd"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"delta":"}","obfuscation":"MpcQzOYTM88hgNp"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"delta":"}","obfuscation":"FatuqqguPXU3SGX"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","output_index":0,"arguments":"{\"title\":\"Mistborn:
+        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","output_index":0,"arguments":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_pM0ZrNyD2lmX46nJN8fOi4vG","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_54XIsBCfIoLdIc2lYjjXWxrQ","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_01419a96ead129020068f96731cfa081908338251660239fbc","object":"response","created_at":1761175345,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_pM0ZrNyD2lmX46nJN8fOi4vG","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_07d4b736b402fe6b00690a210c43088190b5d10264d5c33aa0","object":"response","created_at":1762271500,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_54XIsBCfIoLdIc2lYjjXWxrQ","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":"resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-        Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":213,"input_tokens_details":{"cached_tokens":0},"output_tokens":44,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257},"user":null,"metadata":{}}}
+        Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":229,"input_tokens_details":{"cached_tokens":0},"output_tokens":28,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc96dd0db9ca-SEA
+      - 9995462bea496833-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:26 GMT
+      - Tue, 04 Nov 2025 15:51:40 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -433,15 +437,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '263'
+      - '174'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '280'
+      - '178'
       x-request-id:
-      - req_4c61b3a26e9f474a83816e014b1174ff
+      - req_0fd6721b7b8c4a288537a1fc7030a1a8
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/stream.yaml
@@ -12,12 +12,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1236'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -39,14 +43,14 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_080ef7d1f38539e70068f9671f9b288190939b254f26dc197d","object":"response","created_at":1761175327,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61","object":"response","created_at":1762271485,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -54,7 +58,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_080ef7d1f38539e70068f9671f9b288190939b254f26dc197d","object":"response","created_at":1761175327,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61","object":"response","created_at":1762271485,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -62,82 +66,82 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","type":"function_call","status":"in_progress","arguments":"","call_id":"call_0C0lm2bJk0qtb2BrgwgmvKMy","name":"get_book_info"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","type":"function_call","status":"in_progress","arguments":"","call_id":"call_N66aZ6aFsMUMljMdRITvljUZ","name":"get_book_info"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"{\"","obfuscation":"joNK3DMZ7wK6S9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"{\"","obfuscation":"qGRnUjZUkgPL5Y"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"isbn","obfuscation":"Kf3wpdrwTnh7"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"isbn","obfuscation":"5saARoPqE9lD"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"\":\"","obfuscation":"GtkIj86KVjHYU"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"\":\"","obfuscation":"RtkBJPE37dq0O"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"0","obfuscation":"aCwVhGAZuMzJmpj"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"0","obfuscation":"CckM67UtoIeXU6c"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"-","obfuscation":"o58LDY9Dq972hbH"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"-","obfuscation":"cDXTlcsuyXdEK8p"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"765","obfuscation":"wmhUU5bK1jvuG"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"765","obfuscation":"xZcGa7jHWEsHs"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"3","obfuscation":"vovzl8o9TWP4SFB"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"3","obfuscation":"NT2UiLHeuHkpY5a"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"-","obfuscation":"qyx1y9Q1rfHiyem"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"-","obfuscation":"KlxYSQ6RTTTmjKk"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"117","obfuscation":"eW8xHeOFSTpkI"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"117","obfuscation":"UmWab4Qw4iVjm"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"8","obfuscation":"T5bbr0wnhQSQYx9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"8","obfuscation":"WwXoStzHwZKAXk6"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"-X","obfuscation":"5x9KWirdSu92j3"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"-X","obfuscation":"lDlwqxLBgt6Xe4"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"delta":"\"}","obfuscation":"7aAX48lHJoDr8G"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"delta":"\"}","obfuscation":"3n5kmbuLZ2kgmC"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
+        data: {"type":"response.function_call_arguments.done","sequence_number":15,"item_id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","output_index":0,"arguments":"{\"isbn\":\"0-7653-1178-X\"}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_0C0lm2bJk0qtb2BrgwgmvKMy","name":"get_book_info"}}
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_N66aZ6aFsMUMljMdRITvljUZ","name":"get_book_info"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_080ef7d1f38539e70068f9671f9b288190939b254f26dc197d","object":"response","created_at":1761175327,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_0C0lm2bJk0qtb2BrgwgmvKMy","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61","object":"response","created_at":1762271485,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117","type":"function_call","status":"completed","arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_N66aZ6aFsMUMljMdRITvljUZ","name":"get_book_info"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":152,"input_tokens_details":{"cached_tokens":0},"output_tokens":23,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":175},"user":null,"metadata":{}}}
@@ -146,13 +150,13 @@ interactions:
         '
     headers:
       CF-RAY:
-      - 992cbc250ae5b98d-SEA
+      - 999545cdcce08eb8-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:07 GMT
+      - Tue, 04 Nov 2025 15:51:25 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -170,23 +174,19 @@ interactions:
       openai-processing-ms:
       - '184'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '201'
+      - '213'
       x-request-id:
-      - req_60eaedd308da4e048bf904ca85518673
+      - req_460fcb1e136f4900b5d9cbaac46e048c
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_0C0lm2bJk0qtb2BrgwgmvKMy","name":"get_book_info","type":"function_call","id":"fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6","status":"completed"},{"call_id":"call_0C0lm2bJk0qtb2BrgwgmvKMy","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_N66aZ6aFsMUMljMdRITvljUZ","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61","stream":true,"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -195,12 +195,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1632'
+      - '1131'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -222,14 +226,14 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: 'event: response.created
 
-        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_080ef7d1f38539e70068f96720b14481908d9e262c66579510","object":"response","created_at":1761175328,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0d3c00fa56b7a15000690a20fed050819482baf817ee693d47","object":"response","created_at":1762271486,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -237,7 +241,7 @@ interactions:
 
         event: response.in_progress
 
-        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_080ef7d1f38539e70068f96720b14481908d9e262c66579510","object":"response","created_at":1761175328,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0d3c00fa56b7a15000690a20fed050819482baf817ee693d47","object":"response","created_at":1762271486,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":"resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
         Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
@@ -245,179 +249,179 @@ interactions:
 
         event: response.output_item.added
 
-        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","type":"function_call","status":"in_progress","arguments":"","call_id":"call_JGRho7xlgYVKcbpEXdylfeCy","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","type":"function_call","status":"in_progress","arguments":"","call_id":"call_6z4qGHD8LfRVZz9FKPDJGgQm","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"{\"","obfuscation":"2kW6ox3SMR6TgK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"{\"","obfuscation":"ILJtq4Au2M8h4F"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"title","obfuscation":"gV6CwvHu33a"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"title","obfuscation":"jkylrQRwIOm"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"\":\"","obfuscation":"ZhDgrs1uTmrjC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"\":\"","obfuscation":"9vZrEHeo1jGM2"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"Mist","obfuscation":"ZoJ1eyi1Osht"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"Mist","obfuscation":"V8uZd8ROpOe2"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"born","obfuscation":"GXLZiAIwhT7u"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"born","obfuscation":"jZMpzmvgUBzR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":":","obfuscation":"rE5lS4Cvg1vzxiI"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":":","obfuscation":"y2cEjs3z9PfkHK9"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"
-        The","obfuscation":"Vm5JjwlGEPYr"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"
+        The","obfuscation":"NC2Q928BGGnd"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"
-        Final","obfuscation":"38GeY4SYNm"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"
+        Final","obfuscation":"ogXSpIJ889"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"
-        Empire","obfuscation":"ECJHv4mUT"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"
+        Empire","obfuscation":"c8fUnrkdM"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"\",\"","obfuscation":"hKur0YOYiMFkw"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"\",\"","obfuscation":"f7fhq9mrGtc6G"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"author","obfuscation":"E9uailTBaS"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"author","obfuscation":"5DRqNR8Bn4"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"\":\"","obfuscation":"U6YcN3Xqfry3G"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"\":\"","obfuscation":"GEGWt8PxjsKPR"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"Br","obfuscation":"VN9JIPKZRhSW5S"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"Br","obfuscation":"UlkWImvDc15k7j"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"andon","obfuscation":"k4IOLs0r97m"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"andon","obfuscation":"OwHN4eIXQGE"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"
-        Sand","obfuscation":"WZPo9EiPEUC"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"
+        Sand","obfuscation":"V1h61U7SXec"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"erson","obfuscation":"GhwoSWPZ1R5"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"erson","obfuscation":"Jen71IJiMpt"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"\",\"","obfuscation":"CXbPkAId8crWb"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"\",\"","obfuscation":"QI5OzzgvcfLNX"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"pages","obfuscation":"l5Jj3OklWFU"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"pages","obfuscation":"mFkbrTGDazC"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"\":","obfuscation":"QITCL4K4VbgtR9"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"\":","obfuscation":"Zef7FpMxpfeFwx"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"544","obfuscation":"U5sJbJGFf8uhK"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"544","obfuscation":"qBTwA2Y9Tm9bP"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":",\"","obfuscation":"VfnblIysnVunYk"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":",\"","obfuscation":"RanJZO6TZrcmwh"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"publication","obfuscation":"VzPn4"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"publication","obfuscation":"KYDdN"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"_year","obfuscation":"WoEYaSOuNDJ"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"_year","obfuscation":"DX20V9G4VlN"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"\":","obfuscation":"EtGNOBMc3tuA5E"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"\":","obfuscation":"2MFQjvm2DCMoO7"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"200","obfuscation":"j4RMtvWSGEt6y"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"200","obfuscation":"Ee2uK0mP1w3V7"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"6","obfuscation":"63NUpaOHX14hvNq"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"6","obfuscation":"bH8zRNDG5vMuTXc"}
 
 
         event: response.function_call_arguments.delta
 
-        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"delta":"}","obfuscation":"bUENfqR7pRuV9bY"}
+        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"delta":"}","obfuscation":"FHxm7g8SoxycsLj"}
 
 
         event: response.function_call_arguments.done
 
-        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","output_index":0,"arguments":"{\"title\":\"Mistborn:
+        data: {"type":"response.function_call_arguments.done","sequence_number":30,"item_id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","output_index":0,"arguments":"{\"title\":\"Mistborn:
         The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}"}
 
 
         event: response.output_item.done
 
-        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_JGRho7xlgYVKcbpEXdylfeCy","name":"__mirascope_formatted_output_tool__"}}
+        data: {"type":"response.output_item.done","sequence_number":31,"output_index":0,"item":{"id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_6z4qGHD8LfRVZz9FKPDJGgQm","name":"__mirascope_formatted_output_tool__"}}
 
 
         event: response.completed
 
-        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_080ef7d1f38539e70068f96720b14481908d9e262c66579510","object":"response","created_at":1761175328,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
-        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_JGRho7xlgYVKcbpEXdylfeCy","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","description":"Look
+        data: {"type":"response.completed","sequence_number":32,"response":{"id":"resp_0d3c00fa56b7a15000690a20fed050819482baf817ee693d47","object":"response","created_at":1762271486,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42","type":"function_call","status":"completed","arguments":"{\"title\":\"Mistborn:
+        The Final Empire\",\"author\":\"Brandon Sanderson\",\"pages\":544,\"publication_year\":2006}","call_id":"call_6z4qGHD8LfRVZz9FKPDJGgQm","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":"resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61","prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Look
         up book information by ISBN.","name":"get_book_info","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","description":"Use
         this tool to extract data in BookSummary format for a final response.","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
-        Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":213,"input_tokens_details":{"cached_tokens":0},"output_tokens":44,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257},"user":null,"metadata":{}}}
+        Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":229,"input_tokens_details":{"cached_tokens":0},"output_tokens":28,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":257},"user":null,"metadata":{}}}
 
 
         '
     headers:
       CF-RAY:
-      - 992cbc2bc81db98d-SEA
+      - 999545d7dedf8eb8-NRT
       Connection:
       - keep-alive
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Wed, 22 Oct 2025 23:22:09 GMT
+      - Tue, 04 Nov 2025 15:51:27 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -433,15 +437,15 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '393'
+      - '205'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '429'
+      - '209'
       x-request-id:
-      - req_9d60151dba8d4aa7b8e1fa7b8508d4fb
+      - req_47c0b973ea274804a23744000e8b4076
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/openai_responses_gpt_4o/sync.yaml
@@ -12,12 +12,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
       - '1222'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -39,32 +43,33 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAA7xWTW/jNhC951cQOscLSZYl27fungK0RYB0gQZNQFDUyGZNiSo5zMYI/N8LUtaX
-        P9LNLtCT5Znh48y8Rw7fbggJRBGsSaDBNDTMkngOjCVJEs2j5SoM02W5StOSLeN5soxW4TKJ0qiM
-        k3AVxVmaxcGtg1D538Cxg1G1gdbONTCEgjLni7I0irJFvAq9zyBDa9warqpGAkLRLsoZ3220srXL
-        q2TSQGsWUop6E6zJ2w0hhAQN24N26wt4Aaka0MENIQcfDFor56utlN4g6m4XWgAyIc3Ua1BbjkLV
-        E3vFXqmy2FikqHZw7kSlJOVMTuEqVYB0mW0anCVqFodxMguXszA9tstDBmvyl6+kradnouTXeciX
-        JXDHA0uAJ4tsnnKehSEkHtiD4L4BD2NrX5BPb3Bfa7t3Mr2xFdTo/W9PgTB5/RSsn4JwlqWL+SyK
-        suXsz6fgMCxx6LRN3H/e2S8F3n1NH78U/Df8VkY8e0gfy1EGNat8ghtAmiu1o6IuVeC9hxtCnn2L
-        GqaZlCCnHUZtWzE0Gl6EsoZ2emtT6BlotKoapJzxLdAd7Mc+DcyoeiIlKEulcRTkGmWriuluZa8s
-        w0rAPRUF1ChKAROVGdAvggNF0SmzZFZicBS80jAuAqFqQDO03hx9Co/WVxwyK5Wu2PB/xK+Pa7t2
-        zPgFdK6MQJdzUEEhbDWciLaPWyU4DOgdFpNSfYPCN9scmfIqbo/0P1boXiZBG9SJd5DvBe31pL9P
-        e1/Ch8EorYRmhqsGaNsqd930R1ZJSvst/O/zpCHm/Axe3TUowHAtGm9ck+BXpXbENsTVQlwtbneh
-        apLvyd3D598//Zfie7fTegUI2ox4bkXcgEYBU7u7KExen9hc6gKl3+fOuW9PnMe6DGon/ZHz0H8f
-        Rh3uWR+IHrbuDc+jFawohGsAk/fjxPsb/CSR48w4FYBP0M8Sv3As8I9z9NUAwa0wxJFNUBF4Rc04
-        koIhI6Imn5XaPbQHnbQMuh/CSClqJkl3u1zg8nuU9xMMd1xeo/gP//H9HI8jA2Zx68fjNfRf2oAf
-        hG/Y5qygMfq9918BFzXCph3lV9BtLgX3R43ugb1Xxv0QSh5d6Af2/NChwDM2uh5faMz71fwvR8uN
-        oJOBi6qhUm0arXIHHfbGZjybtK3bZP10E4blsnu2WcM2o9Ei6smrKVrEt+eO0VvsbXhQ8K0fRceV
-        4WTGnb7G4vklxyXcfuxfg0aFTI4yzhb9rLBmOucrQOauEId/uDn8CwAA//8DAFPNUTJHCwAA
+        H4sIAAAAAAAAAwAAAP//vFbbbuM2EH33VxB6jheSfM9bF22BBYrW6KZFF01AUNTIZkyRWnKY2gj8
+        7wUp6+ZLummBPlmeIQ9n5pzh8HVESCTy6J5EBmxF4ziZ82Q1XRXzfJ4vsjier2KWxnGcZ/F0mawm
+        yxkHBul0ulimCc+W0Z2H0NkzcGxgtLJQ27kBhpBT5n3JYp6miySdpMFnkaGzfg/XZSUBIa83ZYzv
+        NkY75eMqmLRQm4WUQm2ie/I6IoSQqGIHMH5/Di8gdQUmGhFyDIvBGO19ykkZDEI1p9AckAlph16L
+        xnEUWg3sJdtT7bBySFHv4NKJWkvKmRzClToH6SPbVDie6nEap9NxvBzH81O5AmR0T/4MmdT5tEwU
+        /DYPCZ/N48BDOlkkCStWRT7JshUPwAEEDxUEGKdCQiG8zn2r7MHJzMaVoDD4Xx8jYTP1GN0/RvF4
+        MZ9NxkmyWI7/eIyO3RaPTuvAw+f+9/Swe4bi4csPD/t4/ev3v/y4ll+fs26HYmUIcANIM613VKhC
+        R8F7HBHyFEpUMcOkBDmsMBpXi6Ey8CK0s7TRWx1Cy0BldFkh5Yxvge7gcNNnAEH5MvVXGGBWq4HY
+        oCi0wd4iX0pXlsw02K32LCsAD1TkHrgQMNChBfMiOFAUjXYL5iRGp5bQBvppIpQVGIYumJMP8cm6
+        xy6yQpuSdf97Cgjr6rqeIn4Bk2kr0McclZALV3Y9U1d6qwWHDr3BYlLqvyAPdNgTl0HnddN/dcK0
+        QorqRY28O4FfUWcri7eF0abwbjBKS2GY5boCWpfKX0htU2tJaXtE+H0aFMRedunNU6McLDeiOskp
+        +knrHXEV8bkQn4s/XWhFsgP59Pnjzx/+qSdat++GEhCM7fFcS7kCgwKGdn+V2Eyd2XzoAmU455N3
+        3505T3lZNF76Peex/T72Ktyy3hHdHd0anno7WJ4LXwAm1/3A2zv+LJDTVDkXQAgwTJuwsS/w93P0
+        mwWCW2GJJ5ugJrBHwziSnCEjQpGPWu8+141Oagb9D2GkEIpJ0tw/V7j8FuX9B4YbLm9R/BA+vp3j
+        /sqIOdyGAXoL/bt6wb+Er9jmIqE++jr4b4ALhbCph/0NdJdJwUOr0QOwt9JYd0vJF7/0HWe+qynw
+        go2mxlcK83Y2/0tr+RF0NpJRV1TqTWV05qHj1lj1Z5Nxqg42TDdhWSabh52zbNMbLUIN3lXJLL27
+        dPRea6/dk4Nvwyg67YwHM+78vZZOrjmu4bZj/xY0amSyF/Fi1s4KZ4dzvgRk/grx+MfR8W8AAAD/
+        /wMAH8enYmkLAAA=
     headers:
       CF-RAY:
-      - 992cbb3d1ef2b9a4-SEA
+      - 99953fa46fb8d5c8-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -72,7 +77,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:32 GMT
+      - Tue, 04 Nov 2025 15:47:14 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -88,13 +93,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1532'
+      - '1535'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1537'
+      - '1543'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -108,17 +113,13 @@ interactions:
       x-ratelimit-reset-tokens:
       - 27ms
       x-request-id:
-      - req_085e4db53edc481cadb5b4a0073eca73
+      - req_4332ca4faa124b90a74c677d947658d7
     status:
       code: 200
       message: OK
 - request:
-    body: '{"input":[{"role":"developer","content":"Always respond to the user''s
-      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":"Please
-      look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score","role":"user"},{"arguments":"{\"isbn\":\"0-7653-1178-X\"}","call_id":"call_IuCdtIU6YCdcMtwf1c7S6Yfl","name":"get_book_info","type":"function_call","id":"fc_07423eaa444131890068f966fb8fec8190a4ec45736cc700e4","status":"completed"},{"call_id":"call_IuCdtIU6YCdcMtwf1c7S6Yfl","output":"Title:
-      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
-      2006-07-25","type":"function_call_output"}],"model":"gpt-4o","tool_choice":{"type":"allowed_tools","mode":"required","tools":[{"type":"function","name":"get_book_info"},{"type":"function","name":"__mirascope_formatted_output_tool__"}]},"tools":[{"type":"function","name":"get_book_info","description":"Look
+    body: '{"input":[{"call_id":"call_xV2ykjefTYETx0PRDOFPlqjb","output":"Title: Mistborn:
+      The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25","type":"function_call_output"}],"model":"gpt-4o","previous_response_id":"resp_0016c1949f6d6d7b00690a2000db04819385ceae2447821cb8","tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"get_book_info","description":"Look
       up book information by ISBN.","parameters":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"},"strict":false},{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
       this tool to extract data in BookSummary format for a final response.","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
       Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"},"strict":true}]}'
@@ -127,12 +128,16 @@ interactions:
       - application/json
       accept-encoding:
       - gzip, deflate
+      authorization:
+      - <filtered>
       connection:
       - keep-alive
       content-length:
-      - '1618'
+      - '1117'
       content-type:
       - application/json
+      cookie:
+      - <filtered>
       host:
       - api.openai.com
       user-agent:
@@ -154,33 +159,33 @@ interactions:
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
-      - 3.10.16
+      - 3.10.15
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAAAwAAAP//vFZLb+M2EL7nVxA6J4HsKH7dGqAFtui2C2T3sKgDYSSNbK4pkksO3biB
-        //uC1NuJg00K9GR5Hh9n5pvh8OmCsYgX0YpFBq1O43kyvUGAJEkmN5PFMo5ni3I5m5V5kk0Xi8ky
-        hnyCi5sl5rNZuZznRXTpIVT2DXNqYZS0WMtzg0BYpOB1k/lsMpnfTpfToLME5Kz3yVWlBRI2YBnk
-        u41RTvq4ShAWazEXgstNtGJPF4wxFmk4oPH+Be5RKI0mumDsGIzRGOV10gkRBFy2p6QFEnBhx1pL
-        xuXElRzJK3hMlSPtKCW1w+dKUkqkOYgxXKUKFD6yjaarRF1N42lyFS+u4llTrgAZrdjfIZM6n46J
-        Mj/PQ5HMk9jzsMwmEGMRZ7NinmSzJAAHEDpoDDBOhoRCeL36XNmDEszGVSgp6J/WEXESuI5W6+gj
-        t5QpI1fs8xbZb1yCYL9WmhtcR5frCBxtlQmWdwZkoSS7B1mgsUoGAw0btOtodZsk/p/LBM8hhHdA
-        8I7TOJ4d+0h80Gldj/ApH799j/fyd/xiv1JGf32c7/+dLtRN7yGhCnmnacUN2FxpTEtlKiDfgR2L
-        SqRpFHyOF4w9BD40GBACxZhOMq7uPG1wz5WzadvcdWAd3dqoSlOaQ77FdIeHoc4gWCVHfYtlqQwN
-        jDwrrqrAtJ5dG1sokQ4pL1ASLzmOWtqi2fMcU+LtGJTgBEXNdCmDwyQIK40GyAXx5DpupI/UR1aX
-        q/s/aKZgV1etiXiPJlOWk485qrDgrurHr67jVvEce/QWC4RQ/2ARim0b/sLI1PfHd8dN15NRbdRO
-        Sj8rLzR61wqDZtggpZlSu5TLUkWN/nj5PrCf7qy6txh7GBXEPh/4s6dGBdrccB2EKxb9odSOOc18
-        Lszn4k/nSrLswD7c3/15/XwOxql3at/rFRIaO+C5bmKNhjiO5f5Wspk8kfnQ/dXgz/ng1ZcnyiYv
-        S8a3/kB57L6Pgwp3rPdE90d3goeBBxQF9wUA8WkYeLcuTgJpFtRpA4QAw+IKjsMGfztHXywy2nLL
-        PNmMFMNHMpATK4CAccnulNrd14POagb9DwNWhuu0vV2u33en/QeGWy7PUfw5fPw8x0PLZjW8gv5L
-        bfBO+LBYXkH/FPRnwLkk3NTvhjPoJ4vqtYN6U/bVm77hzDcNBT1jo63xC4V5PZv/ZbT8CjpZuKR0
-        KtRGG5V56LgT6uFuMk7WwYbtxi1kon0jOgubwWrhcvREm05uLp8rBg+/p/6ZkW/DKmo849GOO336
-        JclLipdwu7V/DpoUgRhEfDvvdoWz4z1fIYG/Qjz+8eL4AwAA//8DACA5ZwC0CwAA
+        H4sIAAAAAAAAA7xW227jNhB991cQek4CWZEd2W9Nu0UX2C1SJIuiqBfCiBzZrClSJUdBjMD/viBl
+        6+LEwWYL9MnyXA6Hc+bC5wljkRTRkkUWXZ3H8XTOp4t0Uc7FXNwUcTxfxJDEcZJhkmXTxXXGr8tM
+        zBO+KNKCQxZdeAhT/IOcjjBGO2zl3CIQihy8bnozT5KbaXKdBp0joMZ5H26qWiGhaJ0K4Nu1NY32
+        cZWgHLZiqZTU62jJnieMMRbVsEPr/QU+ojI12mjC2D4Yo7XG63SjVBBIfTwlF0gglRtrHdmGkzR6
+        JK/gKTcN1Q3lZLb4UknGqJyDGsNVRqDyka1rukzNZRIn6WWcXcbzQ7oCZLRkf4ebtPfpmCj5eR6u
+        r9My9jwUmchiECAKMZ9O5zwABxDa1RhgGh0uFMLr1efSHpRg102FmoL+eRWRJIWraLmKPktHhbF6
+        yR42yH6VGhT7UNXS4iq6WEXQ0MbYYHlrQQuj2T1ogdYZHQxqWKNbRctZmvp/TaEkhxDeDsE7JnE8
+        3/eR+KDzNh/hs/zt4fbTH3cLPvvz6ecv9PmXuw/V7I6w99BQhXvneSUtOG5qzEtjKyBfgR2LRuV5
+        FHz2E8a+Bj5qsKAUqjGdZJu28mqLj9I0Lj8Wd/49LROLIk5Dy8w4AiZpepMlU14cWqa2pqop58A3
+        mG9xN6yfkc4iofaZGlpYBGf0qB2wLI2lgZEnu6kqsEfsrjsclEi7XAoPXEocdYpD+yg55iSP3VVC
+        oyg6NK2xOMwNYVWjBWqCeHoVH6RP1EfWstD9H9RosGvJOET8iLYwTpKPOapQyKbqu7qlZ2Mkxx79
+        tN4PFfHeeuhPcC8b88wZzGfHcSvrAz/RJ2O2rKlZ4X+lbs+TRrNixz7e3/5+9bJe10i5N8+9ea/2
+        NVkhoXWDxLW1UaMliWO5nx6u0CcyH7pvYX/OR6++OFEe7uXI+loaKPfd9773iSz+20iLosvQ8OhO
+        8HXgAUJInwBQd8PAu7F+EshhkUxOjg4BhgUTHIcV836OvjhktJGOebIZGYZPZIETE0DApGa3xmzv
+        285hLYP+hwErw9g7ToGrH5s9/4HhI5fnKH4IH9/P8dDyMMLfQP+pNfhB+LAA3kC/C/oz4FITrtv9
+        fgb9ZKG8dVBvyv7ypu84811NQS/YOOb4lcS8fZv/pbX8TD9ZjGTqXJl1bU3hoeNOWA+HvW10G2xY
+        F9JBoY5vucbBejCrpR49pZJkcfFSMXigPffPAb5B0XvGo6Vx+kRLstcUr+F2e/QcNBkCNUCe3XS7
+        onHjxVkhgR8hHn8/2X8DAAD//wMAlUBdfFwLAAA=
     headers:
       CF-RAY:
-      - 992cbb481844b9a4-SEA
+      - 99953faf3ae1d5c8-NRT
       Connection:
       - keep-alive
       Content-Encoding:
@@ -188,7 +193,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Wed, 22 Oct 2025 23:21:33 GMT
+      - Tue, 04 Nov 2025 15:47:15 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -204,13 +209,13 @@ interactions:
       openai-organization:
       - sotai-i3ryiz
       openai-processing-ms:
-      - '1427'
+      - '1255'
       openai-project:
-      - proj_2kPLXdwNOjkHt3ifb0aZ4FwU
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
       openai-version:
       - '2020-10-01'
       x-envoy-upstream-service-time:
-      - '1446'
+      - '1261'
       x-ratelimit-limit-requests:
       - '5000'
       x-ratelimit-limit-tokens:
@@ -218,13 +223,13 @@ interactions:
       x-ratelimit-remaining-requests:
       - '4999'
       x-ratelimit-remaining-tokens:
-      - '799570'
+      - '799554'
       x-ratelimit-reset-requests:
       - 12ms
       x-ratelimit-reset-tokens:
-      - 32ms
+      - 33ms
       x-request-id:
-      - req_297468999c434cd9b91238197851ba90
+      - req_c799395ad9bf4cb0b0228f502dbd0169
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/snapshots/test_call/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/openai_responses_gpt_4o_snapshots.py
@@ -33,6 +33,7 @@ sync_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0bee99a5de5b12910068f9669f8f3481958652a29720d87669",
                         }
                     ],
                 ),
@@ -69,6 +70,7 @@ async_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_03b14221ccca5c620068f966a32fa0819580a8ac3e59222bce",
                         }
                     ],
                 ),
@@ -104,6 +106,7 @@ stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0360bd45725b0a010068f966a4c4a881959717ba17b93477ef",
                         }
                     ],
                 ),
@@ -140,6 +143,7 @@ async_stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_05aee6862dd20adc0068f966a7186c8193b56f2a2a8b514dc5",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_responses_gpt_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_responses_gpt_5_snapshots.py
@@ -26,39 +26,23 @@ sync_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Counting primes with "79" substring**
+**Counting primes with substring "79"**
 
-I need to find primes less than 400 that contain "79" as a substring. The possible candidates are 79 itself, and three-digit numbers like 179, 279, and 379. However, 790 and above don’t count since they exceed 400. It’s important to remember that "79" must be contiguous, so numbers like 97 or variations across boundaries don’t qualify. Ultimately, the valid primes are 79, 179, 279, and 379.\
+I need to find the count of prime numbers under 400 that have "79" as a substring. The relevant candidates are 79, 179, 279, and 379 since those are all below 400. I also checked 797, but that's above the limit. I want to ensure I only consider valid primes containing the substring "79" while excluding any that don’t meet the criteria. The confirmed primes are 79, 179, 279, and 379.\
 """
                         ),
                         Thought(
                             thought="""\
-**Finalizing prime list with "79"**
+**Verifying prime candidates with "79"**
 
-I’m surveying numbers that can contain "79." The only valid two-digit option is 79 itself. For three-digit numbers below 400, we have 179, 279, and 379. Upon checking, 179 and 79 are confirmed as primes, while 279 is divisible by 3 and therefore not a prime. I thought about 97 but it doesn’t contain "79," and, even though 197 has 97 as digits, it doesn’t qualify either. Ultimately, my confirmed primes are 79, 179, and 379.\
+I confirmed that 379 is in the list. I’m trying to figure out if there are any numbers with 7 and 9 as non-adjacent digits, but since the question specifies “as a substring,” it looks like I only have the four candidates: 79, 179, 279, and 379. I've checked each one for primality: 79 and 179 are prime, while 279 is divisible by 3 and not prime. Finally, I verified that 379 is prime, so the total count of primes containing "79" is three.\
 """
                         ),
                         Thought(
                             thought="""\
-**Confirming prime status of candidates**
+**Finalizing count of primes**
 
-I’ve confirmed that the primes are 79, 179, and 379, which gives us three valid primes. To verify: 79 is standardly recognized as prime. Next, I checked 179 by testing divisibility with primes under its square root (about 13.38) and confirmed it’s prime through various checks. \n\
-
-279 isn’t prime since it's divisible by 3. Lastly, I checked 379, and after testing it against primes below its square root (about 19.4), it turns out to be prime too. So, the final count remains three, but 97, 197, and 297 don’t qualify.\
-"""
-                        ),
-                        Thought(
-                            thought="""\
-**Finalizing primes containing "79"**
-
-I’m checking 397, but it actually contains "97" as digits 2-3, not "79." My valid primes so far are 79, 179, and 379, which totals three. I need to be careful here because I want to ensure there aren’t any other primes under 400 that include "79" in a non-contiguous way, but that doesn’t apply. Numbers like 197 don’t count either, as it spells "97," not "79." So, the final count of primes with "79" as a substring is exactly three.\
-"""
-                        ),
-                        Thought(
-                            thought="""\
-**Final check on primes with "79"**
-
-I’m confirming if there are any primes under 400 that have "79" as non-consecutive digits. It turns out there aren’t any. To be thorough, I checked possible patterns like x79, where x ranges from 0 to 3. I found 79, 179, and 379 as primes, but 279 is composite. The pattern 79x leads to 790-799, all of which exceed 400. Thus, I reaffirm that the only valid primes containing "79" are three: 79, 179, and 379.\
+The answer is 3! But just to be thorough, I double-checked that 179 is indeed prime by testing its divisibility against primes up to the square root. It's not divisible by 2, 3, 5, 7, 11, or 13, so it checks out. I swiftly confirmed that 79 is also prime. Although I wondered about other combinations, numbers like 97 have a different order and don’t count. I've ruled out other forms that exceed 400, so I’m confident in reporting the result as "3" without any additional punctuation.\
 """
                         ),
                         Text(text="3"),
@@ -67,55 +51,38 @@ I’m confirming if there are any primes under 400 that have "79" as non-consecu
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0d53aa13846e03a60068f9676daff881959d7f269101ba6689",
+                            "id": "rs_0c9d4e63dac6126a00690a207bfc148195b3c6f4868dd0a013",
                             "summary": [
                                 {
                                     "text": """\
-**Counting primes with "79" substring**
+**Counting primes with substring "79"**
 
-I need to find primes less than 400 that contain "79" as a substring. The possible candidates are 79 itself, and three-digit numbers like 179, 279, and 379. However, 790 and above don’t count since they exceed 400. It’s important to remember that "79" must be contiguous, so numbers like 97 or variations across boundaries don’t qualify. Ultimately, the valid primes are 79, 179, 279, and 379.\
+I need to find the count of prime numbers under 400 that have "79" as a substring. The relevant candidates are 79, 179, 279, and 379 since those are all below 400. I also checked 797, but that's above the limit. I want to ensure I only consider valid primes containing the substring "79" while excluding any that don’t meet the criteria. The confirmed primes are 79, 179, 279, and 379.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Finalizing prime list with "79"**
+**Verifying prime candidates with "79"**
 
-I’m surveying numbers that can contain "79." The only valid two-digit option is 79 itself. For three-digit numbers below 400, we have 179, 279, and 379. Upon checking, 179 and 79 are confirmed as primes, while 279 is divisible by 3 and therefore not a prime. I thought about 97 but it doesn’t contain "79," and, even though 197 has 97 as digits, it doesn’t qualify either. Ultimately, my confirmed primes are 79, 179, and 379.\
+I confirmed that 379 is in the list. I’m trying to figure out if there are any numbers with 7 and 9 as non-adjacent digits, but since the question specifies “as a substring,” it looks like I only have the four candidates: 79, 179, 279, and 379. I've checked each one for primality: 79 and 179 are prime, while 279 is divisible by 3 and not prime. Finally, I verified that 379 is prime, so the total count of primes containing "79" is three.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Confirming prime status of candidates**
+**Finalizing count of primes**
 
-I’ve confirmed that the primes are 79, 179, and 379, which gives us three valid primes. To verify: 79 is standardly recognized as prime. Next, I checked 179 by testing divisibility with primes under its square root (about 13.38) and confirmed it’s prime through various checks. \n\
-
-279 isn’t prime since it's divisible by 3. Lastly, I checked 379, and after testing it against primes below its square root (about 19.4), it turns out to be prime too. So, the final count remains three, but 97, 197, and 297 don’t qualify.\
-""",
-                                    "type": "summary_text",
-                                },
-                                {
-                                    "text": """\
-**Finalizing primes containing "79"**
-
-I’m checking 397, but it actually contains "97" as digits 2-3, not "79." My valid primes so far are 79, 179, and 379, which totals three. I need to be careful here because I want to ensure there aren’t any other primes under 400 that include "79" in a non-contiguous way, but that doesn’t apply. Numbers like 197 don’t count either, as it spells "97," not "79." So, the final count of primes with "79" as a substring is exactly three.\
-""",
-                                    "type": "summary_text",
-                                },
-                                {
-                                    "text": """\
-**Final check on primes with "79"**
-
-I’m confirming if there are any primes under 400 that have "79" as non-consecutive digits. It turns out there aren’t any. To be thorough, I checked possible patterns like x79, where x ranges from 0 to 3. I found 79, 179, and 379 as primes, but 279 is composite. The pattern 79x leads to 790-799, all of which exceed 400. Thus, I reaffirm that the only valid primes containing "79" are three: 79, 179, and 379.\
+The answer is 3! But just to be thorough, I double-checked that 179 is indeed prime by testing its divisibility against primes up to the square root. It's not divisible by 2, 3, 5, 7, 11, or 13, so it checks out. I swiftly confirmed that 79 is also prime. Although I wondered about other combinations, numbers like 97 have a different order and don’t count. I've ruled out other forms that exceed 400, so I’m confident in reporting the result as "3" without any additional punctuation.\
 """,
                                     "type": "summary_text",
                                 },
                             ],
                             "type": "reasoning",
+                            "response_id": "resp_0c9d4e63dac6126a00690a207b84688195ac01b41a1dae52f2",
                         },
                         {
-                            "id": "msg_0d53aa13846e03a60068f96780d46c819584f9622a799dc650",
+                            "id": "msg_0c9d4e63dac6126a00690a208d912c8195a727cd0635b50a91",
                             "content": [
                                 {
                                     "annotations": [],
@@ -143,12 +110,13 @@ I’m confirming if there are any primes under 400 that have "79" as non-consecu
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0d53aa13846e03a60068f96782110c819595e243559c4243eb",
+                            "id": "rs_0c9d4e63dac6126a00690a208e9df08195a6003482efd32d90",
                             "summary": [],
                             "type": "reasoning",
+                            "response_id": "resp_0c9d4e63dac6126a00690a208e35648195bdfdfdfb1a9ce78a",
                         },
                         {
-                            "id": "msg_0d53aa13846e03a60068f96782397c81958e1c8a764e02de61",
+                            "id": "msg_0c9d4e63dac6126a00690a208ede048195a6c26b94ea75774c",
                             "content": [
                                 {
                                     "annotations": [],
@@ -188,42 +156,41 @@ async_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Identifying primes with substring "79"**
+**Counting primes with substring**
 
-I need to find prime numbers less than 400 that have the substring "79." That means I should consider numbers like 79, 179, 279, and 379. But now, I realize any numbers like 790 or higher are not applicable since they're over 400. I’ve ruled out any instances where "79" is not in that exact order. So, the valid primes under 400 containing "79" are 79, 179, 279, and 379.\
+I need to count primes below 400 that include the substring "79." That means I should consider both 2-digit and 3-digit primes. The number 79 itself is prime, and I should check if 179, 279, and 379 qualify. 279 isn’t prime, and while I'm wondering about 3-digit numbers, I realize "79" can appear in various positions, but then I remember numbers from 790 to 799 exceed 400. So, let’s focus on valid candidates!\
 """
                         ),
                         Thought(
                             thought="""\
-**Checking primality of numbers with "79"**
+**Determining valid primes**
 
-I’m looking at numbers that contain "79" as a substring and checking if they are prime. The valid numbers are 79, 179, 279, and 379. \n\
-
-For 79, it is indeed prime since it’s not divisible by any small primes. \n\
-
-179 is also prime after checking divisibility against smaller primes. \n\
-
-However, 279 is composite because its digits sum to 18, which is divisible by 3, and thus it’s ruled out. \n\
-
-I still need to check the primality of 379!\
+I realize that numbers 790-799 are irrelevant since they're greater than 400. For the numbers below 400, I can only consider "x79," meaning the last two digits would be 79. That includes 79, 179, 279, and 379. 79 counts as itself, but I have to remember that other combinations like 97 or separated digits don't work since the substring must be consecutive. Now, let’s check the primality of 179, since I need to find all the primes under 400.\
 """
                         ),
                         Thought(
                             thought="""\
-**Confirming prime counts with "79"**
+**Identifying prime candidates**
 
-I’m checking the primality of 379. I verified it against smaller primes: it isn’t divisible by 2, 3, 5, 7, 11, 13, 17, or 19. So, it turns out 379 is prime!
-
-Now, counting the primes: we have 79, 179, and 379, bringing the total to three. I checked for additional numbers under 400 with the substring "79," but only found those three. Numbers like 197 and 97 don’t count, so the final answer is three.\
+I have the candidates to consider: 79 and 179 are primes, but 279 isn’t since it’s divisible by 3. I also look at 379, which seems prime. I think about 97 and 197, but neither contains "79". For 379, I check divisibility: it isn't divisible by primes up to about 19, confirming that it is prime. Then, I check 179: the same method shows it’s not divisible by primes up to 13, meaning 179 is also prime.\
 """
                         ),
                         Thought(
                             thought="""\
-**Finalizing prime count**
+**Confirming prime counts**
 
-I want to double-check the primality of 179. It has a remainder of 4 when divided by 7, 3 when divided by 11, and 10 when divided by 13, confirming that it's prime. So, I can confidently say we have three primes under 400. It’s important to clarify that we're looking for primes strictly less than 400. \n\
+Alright, I've confirmed that 79, 179, and 379 are indeed primes, making a total of three primes. I'm also checking if there are any other forms of numbers under 400 that contain the substring "79." The only 2-digit representation is 79. For 3-digit numbers, "x79" works, while "79x" exceeds 400. \n\
 
-The final answer is simply "3." Great, let's go with that!\
+I ruled out any combinations like "7 9" since the substring needs to be consecutive. Besides 279 being composite, I've checked that 179 and 379 contain "79." That means my count remains three primes, and I also checked if 297 contains "79."\
+"""
+                        ),
+                        Thought(
+                            thought="""\
+**Finalizing the count of primes**
+
+I checked that 297 doesn’t contain the substring "79," so it doesn't count. I also looked at 97, which isn’t "79" either. This confirms that the count is still three. I made sure I didn't overlook anything with 3-digit numbers starting with "79," which would be 790-799, and those exceed 400. \n\
+
+Finally, I’ve verified that both 179 and 379 are indeed primes. So, I’ll return the final count: "3."\
 """
                         ),
                         Text(text="3"),
@@ -232,57 +199,58 @@ The final answer is simply "3." Great, let's go with that!\
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0ab4ebd2bc7242170068f96799c350819580541603dcce2ade",
+                            "id": "rs_03efd3e35645773100690a20aba26c8190b7044f0ebd19ed26",
                             "summary": [
                                 {
                                     "text": """\
-**Identifying primes with substring "79"**
+**Counting primes with substring**
 
-I need to find prime numbers less than 400 that have the substring "79." That means I should consider numbers like 79, 179, 279, and 379. But now, I realize any numbers like 790 or higher are not applicable since they're over 400. I’ve ruled out any instances where "79" is not in that exact order. So, the valid primes under 400 containing "79" are 79, 179, 279, and 379.\
+I need to count primes below 400 that include the substring "79." That means I should consider both 2-digit and 3-digit primes. The number 79 itself is prime, and I should check if 179, 279, and 379 qualify. 279 isn’t prime, and while I'm wondering about 3-digit numbers, I realize "79" can appear in various positions, but then I remember numbers from 790 to 799 exceed 400. So, let’s focus on valid candidates!\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Checking primality of numbers with "79"**
+**Determining valid primes**
 
-I’m looking at numbers that contain "79" as a substring and checking if they are prime. The valid numbers are 79, 179, 279, and 379. \n\
-
-For 79, it is indeed prime since it’s not divisible by any small primes. \n\
-
-179 is also prime after checking divisibility against smaller primes. \n\
-
-However, 279 is composite because its digits sum to 18, which is divisible by 3, and thus it’s ruled out. \n\
-
-I still need to check the primality of 379!\
+I realize that numbers 790-799 are irrelevant since they're greater than 400. For the numbers below 400, I can only consider "x79," meaning the last two digits would be 79. That includes 79, 179, 279, and 379. 79 counts as itself, but I have to remember that other combinations like 97 or separated digits don't work since the substring must be consecutive. Now, let’s check the primality of 179, since I need to find all the primes under 400.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Confirming prime counts with "79"**
+**Identifying prime candidates**
 
-I’m checking the primality of 379. I verified it against smaller primes: it isn’t divisible by 2, 3, 5, 7, 11, 13, 17, or 19. So, it turns out 379 is prime!
-
-Now, counting the primes: we have 79, 179, and 379, bringing the total to three. I checked for additional numbers under 400 with the substring "79," but only found those three. Numbers like 197 and 97 don’t count, so the final answer is three.\
+I have the candidates to consider: 79 and 179 are primes, but 279 isn’t since it’s divisible by 3. I also look at 379, which seems prime. I think about 97 and 197, but neither contains "79". For 379, I check divisibility: it isn't divisible by primes up to about 19, confirming that it is prime. Then, I check 179: the same method shows it’s not divisible by primes up to 13, meaning 179 is also prime.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Finalizing prime count**
+**Confirming prime counts**
 
-I want to double-check the primality of 179. It has a remainder of 4 when divided by 7, 3 when divided by 11, and 10 when divided by 13, confirming that it's prime. So, I can confidently say we have three primes under 400. It’s important to clarify that we're looking for primes strictly less than 400. \n\
+Alright, I've confirmed that 79, 179, and 379 are indeed primes, making a total of three primes. I'm also checking if there are any other forms of numbers under 400 that contain the substring "79." The only 2-digit representation is 79. For 3-digit numbers, "x79" works, while "79x" exceeds 400. \n\
 
-The final answer is simply "3." Great, let's go with that!\
+I ruled out any combinations like "7 9" since the substring needs to be consecutive. Besides 279 being composite, I've checked that 179 and 379 contain "79." That means my count remains three primes, and I also checked if 297 contains "79."\
+""",
+                                    "type": "summary_text",
+                                },
+                                {
+                                    "text": """\
+**Finalizing the count of primes**
+
+I checked that 297 doesn’t contain the substring "79," so it doesn't count. I also looked at 97, which isn’t "79" either. This confirms that the count is still three. I made sure I didn't overlook anything with 3-digit numbers starting with "79," which would be 790-799, and those exceed 400. \n\
+
+Finally, I’ve verified that both 179 and 379 are indeed primes. So, I’ll return the final count: "3."\
 """,
                                     "type": "summary_text",
                                 },
                             ],
                             "type": "reasoning",
+                            "response_id": "resp_03efd3e35645773100690a20ab24d88190be5d1d2fd174909f",
                         },
                         {
-                            "id": "msg_0ab4ebd2bc7242170068f967b1153c8195a162cecc2604f8db",
+                            "id": "msg_03efd3e35645773100690a20c8401081909c0f265d52fec173",
                             "content": [
                                 {
                                     "annotations": [],
@@ -310,12 +278,13 @@ The final answer is simply "3." Great, let's go with that!\
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0ab4ebd2bc7242170068f967b2afc08195ad15d0afaf6cec91",
+                            "id": "rs_03efd3e35645773100690a20c96dd48190a7806ac3d88183ac",
                             "summary": [],
                             "type": "reasoning",
+                            "response_id": "resp_03efd3e35645773100690a20c8d71881908a9e639c1d6cd4d0",
                         },
                         {
-                            "id": "msg_0ab4ebd2bc7242170068f967b2d81081958962a3e63e620d52",
+                            "id": "msg_03efd3e35645773100690a20c9b38c8190badf0fe60cccad56",
                             "content": [
                                 {
                                     "annotations": [],
@@ -354,36 +323,29 @@ stream_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Counting primes with substring '79'**
+**Counting prime numbers with '79'**
 
-I need to count prime numbers less than 400 that contain '79' as a substring. This means I’m looking for numbers like 79, 179, and 279, but I realized that 197 doesn't fit because it contains 97 instead. So the valid numbers are 79, 179, 279, and 379. For three-digit numbers starting with '79', the range is 790-799, which exceeds 400, so they’re not applicable. My focus remains on 79, 179, 279, and 379 only.\
+I'm looking for prime numbers less than 400 that have the substring "79." First, I’ll identify all primes below 400. Then, I’ll check two-digit and three-digit numbers that contain "79." \n\
+
+In the two-digit range, we only have 79 itself. For three-digit numbers, the relevant candidates are 179, 279, and 379. However, numbers like 790 or above don’t count since they exceed 400. So, the confirmed candidates are 79, 179, 279, and 379.\
 """
                         ),
                         Thought(
                             thought="""\
-**Evaluating primes with '79'**
+**Verifying prime status of candidates**
 
-I’ve got three-digit numbers like 179, 279, and 379 that have '79.' For two-digit, there's 79 itself. Now, I need to check which of these are prime. We know 79 is prime. I think 179 is also prime, but 279 is not since it’s divisible by 3. For 379, it appears to be prime; I checked and '79' indeed appears consecutively within it. However, 797 exceeds 400, so I won't count that. So, the primes I'm left with are 79, 179, and 379.\
+I need to ensure that "79" is specifically in that order, which means I’m working with four candidates: 79, 179, 279, and 379. \n\
+
+First, I know 79 is prime. For 179, I’ll check primality by testing divisibility against primes up to its square root. It passes all the tests, so it’s prime. \n\
+
+Next, I check 279; it’s divisible by 3, so it's not prime. Lastly, I test 379, and it also checks out as prime after verifying divisibility.\
 """
                         ),
                         Thought(
                             thought="""\
-**Identifying numbers with '79'**
+**Confirming prime count**
 
-Let’s find all numbers under 400 that contain '79.' The two-digit number is 79. For three-digit numbers, the possible patterns are 179, 279, and 379 while anything starting with '79' (like 790-799) is out since they're above 400. So, the valid numbers are just 79, 179, 279, and 379. \n\
-
-Now, I need to check for primes among them. I know that 79 is prime. For 179, I confirmed it’s not divisible by 3, 5, 7, 11, or 13, so it should be prime too!\
-"""
-                        ),
-                        Thought(
-                            thought="""\
-**Verifying primes and counts**
-
-For 179, I checked it against several primes and confirmed that it’s indeed prime. As for 279, it’s divisible by 3, so it’s not prime. \n\
-
-Then I turned to 379. The square root is about 19.467, so I checked against all prime numbers up to 19 and found that none divide it evenly. Thus, 379 is also prime. \n\
-
-So, I have three primes: 79, 179, and 379. I made sure to rule out other numbers containing '79' and concluded that the answer is 3 primes altogether.\
+I’ve identified the primes below 400 that contain "79": they are 79, 179, and 379, totaling three primes. I've confirmed that 279 is not prime and that 1979 exceeds 400. Additionally, 97 doesn't count since it doesn't have "79." I checked 297 for containment, and it doesn't apply either. Just to be thorough, I noted that "79" occurs in "279," but it’s not prime. So, my final answer is simply: 3.\
 """
                         ),
                         Text(text="3"),
@@ -392,51 +354,44 @@ So, I have three primes: 79, 179, and 379. I made sure to rule out other numbers
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0322c5b1ca9ff7880068f967837b6c8197a69ef0a078c97a0e",
+                            "id": "rs_049d8e19d65d9d4d00690a2090bfb88197be797d1935059879",
                             "summary": [
                                 {
                                     "text": """\
-**Counting primes with substring '79'**
+**Counting prime numbers with '79'**
 
-I need to count prime numbers less than 400 that contain '79' as a substring. This means I’m looking for numbers like 79, 179, and 279, but I realized that 197 doesn't fit because it contains 97 instead. So the valid numbers are 79, 179, 279, and 379. For three-digit numbers starting with '79', the range is 790-799, which exceeds 400, so they’re not applicable. My focus remains on 79, 179, 279, and 379 only.\
+I'm looking for prime numbers less than 400 that have the substring "79." First, I’ll identify all primes below 400. Then, I’ll check two-digit and three-digit numbers that contain "79." \n\
+
+In the two-digit range, we only have 79 itself. For three-digit numbers, the relevant candidates are 179, 279, and 379. However, numbers like 790 or above don’t count since they exceed 400. So, the confirmed candidates are 79, 179, 279, and 379.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Evaluating primes with '79'**
+**Verifying prime status of candidates**
 
-I’ve got three-digit numbers like 179, 279, and 379 that have '79.' For two-digit, there's 79 itself. Now, I need to check which of these are prime. We know 79 is prime. I think 179 is also prime, but 279 is not since it’s divisible by 3. For 379, it appears to be prime; I checked and '79' indeed appears consecutively within it. However, 797 exceeds 400, so I won't count that. So, the primes I'm left with are 79, 179, and 379.\
+I need to ensure that "79" is specifically in that order, which means I’m working with four candidates: 79, 179, 279, and 379. \n\
+
+First, I know 79 is prime. For 179, I’ll check primality by testing divisibility against primes up to its square root. It passes all the tests, so it’s prime. \n\
+
+Next, I check 279; it’s divisible by 3, so it's not prime. Lastly, I test 379, and it also checks out as prime after verifying divisibility.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Identifying numbers with '79'**
+**Confirming prime count**
 
-Let’s find all numbers under 400 that contain '79.' The two-digit number is 79. For three-digit numbers, the possible patterns are 179, 279, and 379 while anything starting with '79' (like 790-799) is out since they're above 400. So, the valid numbers are just 79, 179, 279, and 379. \n\
-
-Now, I need to check for primes among them. I know that 79 is prime. For 179, I confirmed it’s not divisible by 3, 5, 7, 11, or 13, so it should be prime too!\
-""",
-                                    "type": "summary_text",
-                                },
-                                {
-                                    "text": """\
-**Verifying primes and counts**
-
-For 179, I checked it against several primes and confirmed that it’s indeed prime. As for 279, it’s divisible by 3, so it’s not prime. \n\
-
-Then I turned to 379. The square root is about 19.467, so I checked against all prime numbers up to 19 and found that none divide it evenly. Thus, 379 is also prime. \n\
-
-So, I have three primes: 79, 179, and 379. I made sure to rule out other numbers containing '79' and concluded that the answer is 3 primes altogether.\
+I’ve identified the primes below 400 that contain "79": they are 79, 179, and 379, totaling three primes. I've confirmed that 279 is not prime and that 1979 exceeds 400. Additionally, 97 doesn't count since it doesn't have "79." I checked 297 for containment, and it doesn't apply either. Just to be thorough, I noted that "79" occurs in "279," but it’s not prime. So, my final answer is simply: 3.\
 """,
                                     "type": "summary_text",
                                 },
                             ],
                             "type": "reasoning",
+                            "response_id": "resp_049d8e19d65d9d4d00690a209028b081979bb792da41dd6c13",
                         },
                         {
-                            "id": "msg_0322c5b1ca9ff7880068f9679731808197b75d13ae2de5a285",
+                            "id": "msg_049d8e19d65d9d4d00690a20a83d7481978d09e51d19ce822f",
                             "content": [
                                 {
                                     "annotations": [],
@@ -464,12 +419,13 @@ So, I have three primes: 79, 179, and 379. I made sure to rule out other numbers
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_0322c5b1ca9ff7880068f9679857988197b0db6ead99086fd3",
+                            "id": "rs_049d8e19d65d9d4d00690a20aa0f6c8197a18f7003fe24148f",
                             "summary": [],
                             "type": "reasoning",
+                            "response_id": "resp_049d8e19d65d9d4d00690a20a92a64819799ec460e235c6a49",
                         },
                         {
-                            "id": "msg_0322c5b1ca9ff7880068f9679893288197903c261cea7774dc",
+                            "id": "msg_049d8e19d65d9d4d00690a20aa50148197a23142e2a293fe62",
                             "content": [
                                 {
                                     "annotations": [],
@@ -509,53 +465,55 @@ async_stream_snapshot = snapshot(
                     content=[
                         Thought(
                             thought="""\
-**Counting substring primes**
+**Counting primes with substring "79"**
 
-I need to count the prime numbers less than 400 that contain "79" as a substring, which means the digits should include "79" together. \n\
-
-Okay, so I start with 79, which is prime. Next is 179; that also works since it has "79" at the end. For 197, it doesn’t count because the digits are 1-9-7. I check others too, like 279, 379—actually, 379 works—now for others up to 399. \n\
-
-But 793 is over my limit, so I’ll focus only on numbers below 400.\
+I need to count prime numbers less than 400 that contain "79" as a substring. I’ll start by considering two-digit and three-digit numbers. The two-digit number is 79 itself. For three-digit numbers, anything in the form of 79x (like 790-799) exceeds 400, so those don’t count. However, the format x79 yields 179, 279, and 379—all less than 400. I have to keep in mind that I need to check which of these are prime!\
 """
                         ),
                         Thought(
                             thought="""\
-**Analyzing prime candidates**
+**Identifying primes with "79"**
 
-I’m looking into numbers with "79" in them. For three-digit numbers below 400, I see patterns: those ending in 79 (like 179, 279, 379) and starting with 79 don’t count since they exceed 400. \n\
+Next, I’m looking for numbers where the hundreds and tens digits are 7 and 9. For two digits, it's just 79, and for three-digit numbers, I've already covered 79x and x79. \n\
 
-The only two-digit option is 79 itself. I already checked the endings; now I realize 279 isn't prime because it's divisible by 3. So, I need to verify if 379 is prime next. \n\
+Now, checking 297, it contains "97," but not "79." So, I only want the exact "79" in order. \n\
 
-That narrows down my candidates for primes containing "79"!\
+The candidates less than 400 with "79" are 79, 179, 279, and 379. Additionally, I have ruled out others like 709, since it doesn’t contain "79" consecutively.\
 """
                         ),
                         Thought(
                             thought="""\
-**Verifying prime numbers**
+**Testing primality of candidates**
 
-I’m testing if 379 is prime. The square root is around 19.4, so I’ll check primality against smaller primes like 3, 5, 7, 11, 13, 17, and 19. It’s not divisible by any of those. \n\
+I can rule out any four-digit numbers since they exceed 400. So, I just need to test the primality of 79, 179, 279, and 379. \n\
 
-Next, I check 179, and it’s prime too. So far, I have 79, 179, and 379 as primes. I wonder if there are others below 400. \n\
+First, 79 is prime—no doubt there. For 179, I check divisibility using primes up to around √179, confirming it's also prime. \n\
 
-But 297 doesn’t count, since it doesn't have "79" together, and 790 is over my limit. So, I’m stuck with those three!\
+Now, 279 is divisible by 3 because the sum of its digits is 18, so it's not prime. Finally, I check 379 against several primes, and it turns out to be prime as well! \n\
+
+This gives me three primes: 79, 179, and 379.\
 """
                         ),
                         Thought(
                             thought="""\
-**Finalizing prime count**
+**Final checks on candidates with "79"**
 
-I realize that since "substring" refers to something contiguous, 97 can't count as "79" reversed. So, I still think there are 3 valid primes: 79, 179, and 379. I double-check other three-digit possibilities starting with "79," but none qualify since they’d exceed 400. \n\
+I’m going over the numbers less than 400 again for any that contain "79." \n\
 
-I confirmed each candidate: 79, 179, and 379 are primes, while 279 isn’t. Thus, the total count remains three. I’ll summarize the answer as “3” and make sure everything is accurate.\
+Checking 297 and 197, neither fit since 197 has "19" and not "79." I already ruled out 279 as composite, and 379 is prime. For other combinations like "x79" and patterns with "79" in the middle, only 179, 279, and 379 qualify. I also remember checking 397, but it has "97," not "79."
+
+After thorough checks, the only primes are 79, 179, and 379, totaling three.\
 """
                         ),
                         Thought(
                             thought="""\
-**Delivering the answer**
+**Confirming substring criteria**
 
-The user wants a straightforward response, just the number without explanations. I need to stick to that and confirm again: the count is indeed "3." \n\
+I realize that "substring" means I’m only looking for consecutive digits. So, that confirms my answer is just 3. \n\
 
-I’ll double-check for any primes like 197, but it doesn't have "79." And 297 isn’t prime, nor does it contain the substring. So I’m all set to deliver the answer without any additional text. The final output is "3."\
+Still, I want to double-check any other potential candidates like 179, 197, 279, 297, 379, and 397. However, they don't have the consecutive "79" pairs. \n\
+
+Therefore, I'm confident in concluding that the final answer is indeed just 3! It’s good to be thorough!\
 """
                         ),
                         Text(text="3"),
@@ -564,69 +522,72 @@ I’ll double-check for any primes like 197, but it doesn't have "79." And 297 i
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_00b850169f72b9300068f967b4c96481948d13a53c8867e8d8",
+                            "id": "rs_0c1021cd9b668f0300690a20cbbf848195837624e59b466ea8",
                             "summary": [
                                 {
                                     "text": """\
-**Counting substring primes**
+**Counting primes with substring "79"**
 
-I need to count the prime numbers less than 400 that contain "79" as a substring, which means the digits should include "79" together. \n\
-
-Okay, so I start with 79, which is prime. Next is 179; that also works since it has "79" at the end. For 197, it doesn’t count because the digits are 1-9-7. I check others too, like 279, 379—actually, 379 works—now for others up to 399. \n\
-
-But 793 is over my limit, so I’ll focus only on numbers below 400.\
+I need to count prime numbers less than 400 that contain "79" as a substring. I’ll start by considering two-digit and three-digit numbers. The two-digit number is 79 itself. For three-digit numbers, anything in the form of 79x (like 790-799) exceeds 400, so those don’t count. However, the format x79 yields 179, 279, and 379—all less than 400. I have to keep in mind that I need to check which of these are prime!\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Analyzing prime candidates**
+**Identifying primes with "79"**
 
-I’m looking into numbers with "79" in them. For three-digit numbers below 400, I see patterns: those ending in 79 (like 179, 279, 379) and starting with 79 don’t count since they exceed 400. \n\
+Next, I’m looking for numbers where the hundreds and tens digits are 7 and 9. For two digits, it's just 79, and for three-digit numbers, I've already covered 79x and x79. \n\
 
-The only two-digit option is 79 itself. I already checked the endings; now I realize 279 isn't prime because it's divisible by 3. So, I need to verify if 379 is prime next. \n\
+Now, checking 297, it contains "97," but not "79." So, I only want the exact "79" in order. \n\
 
-That narrows down my candidates for primes containing "79"!\
+The candidates less than 400 with "79" are 79, 179, 279, and 379. Additionally, I have ruled out others like 709, since it doesn’t contain "79" consecutively.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Verifying prime numbers**
+**Testing primality of candidates**
 
-I’m testing if 379 is prime. The square root is around 19.4, so I’ll check primality against smaller primes like 3, 5, 7, 11, 13, 17, and 19. It’s not divisible by any of those. \n\
+I can rule out any four-digit numbers since they exceed 400. So, I just need to test the primality of 79, 179, 279, and 379. \n\
 
-Next, I check 179, and it’s prime too. So far, I have 79, 179, and 379 as primes. I wonder if there are others below 400. \n\
+First, 79 is prime—no doubt there. For 179, I check divisibility using primes up to around √179, confirming it's also prime. \n\
 
-But 297 doesn’t count, since it doesn't have "79" together, and 790 is over my limit. So, I’m stuck with those three!\
+Now, 279 is divisible by 3 because the sum of its digits is 18, so it's not prime. Finally, I check 379 against several primes, and it turns out to be prime as well! \n\
+
+This gives me three primes: 79, 179, and 379.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Finalizing prime count**
+**Final checks on candidates with "79"**
 
-I realize that since "substring" refers to something contiguous, 97 can't count as "79" reversed. So, I still think there are 3 valid primes: 79, 179, and 379. I double-check other three-digit possibilities starting with "79," but none qualify since they’d exceed 400. \n\
+I’m going over the numbers less than 400 again for any that contain "79." \n\
 
-I confirmed each candidate: 79, 179, and 379 are primes, while 279 isn’t. Thus, the total count remains three. I’ll summarize the answer as “3” and make sure everything is accurate.\
+Checking 297 and 197, neither fit since 197 has "19" and not "79." I already ruled out 279 as composite, and 379 is prime. For other combinations like "x79" and patterns with "79" in the middle, only 179, 279, and 379 qualify. I also remember checking 397, but it has "97," not "79."
+
+After thorough checks, the only primes are 79, 179, and 379, totaling three.\
 """,
                                     "type": "summary_text",
                                 },
                                 {
                                     "text": """\
-**Delivering the answer**
+**Confirming substring criteria**
 
-The user wants a straightforward response, just the number without explanations. I need to stick to that and confirm again: the count is indeed "3." \n\
+I realize that "substring" means I’m only looking for consecutive digits. So, that confirms my answer is just 3. \n\
 
-I’ll double-check for any primes like 197, but it doesn't have "79." And 297 isn’t prime, nor does it contain the substring. So I’m all set to deliver the answer without any additional text. The final output is "3."\
+Still, I want to double-check any other potential candidates like 179, 197, 279, 297, 379, and 397. However, they don't have the consecutive "79" pairs. \n\
+
+Therefore, I'm confident in concluding that the final answer is indeed just 3! It’s good to be thorough!\
 """,
                                     "type": "summary_text",
                                 },
                             ],
                             "type": "reasoning",
+                            "response_id": "resp_0c1021cd9b668f0300690a20cb500481958c37063c69f21862",
                         },
                         {
-                            "id": "msg_00b850169f72b9300068f967cac6b08194a3d0922427ac66db",
+                            "id": "msg_0c1021cd9b668f0300690a20e5b9c88195aa321691cf19a81e",
                             "content": [
                                 {
                                     "annotations": [],
@@ -649,21 +610,22 @@ I’ll double-check for any primes like 197, but it doesn't have "79." And 297 i
                     ]
                 ),
                 AssistantMessage(
-                    content=[Text(text="I don't remember.")],
+                    content=[Text(text="I don’t remember.")],
                     provider="openai:responses",
                     model_id="gpt-5",
                     raw_message=[
                         {
-                            "id": "rs_00b850169f72b9300068f967cc559c8194a05a106b3f51420e",
+                            "id": "rs_0c1021cd9b668f0300690a20e6c55081959b805f2d010cc49a",
                             "summary": [],
                             "type": "reasoning",
+                            "response_id": "resp_0c1021cd9b668f0300690a20e6560c8195a98850f36195d7fb",
                         },
                         {
-                            "id": "msg_00b850169f72b9300068f967ccb18081949c250217c44c88b7",
+                            "id": "msg_0c1021cd9b668f0300690a20e70a4c8195a949f875a1d60242",
                             "content": [
                                 {
                                     "annotations": [],
-                                    "text": "I don't remember.",
+                                    "text": "I don’t remember.",
                                     "type": "output_text",
                                     "logprobs": [],
                                 }
@@ -677,7 +639,7 @@ I’ll double-check for any primes like 197, but it doesn't have "79." And 297 i
             ],
             "format": None,
             "tools": [],
-            "n_chunks": 6,
+            "n_chunks": 7,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/openai_responses_gpt_4o_snapshots.py
@@ -28,12 +28,12 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_bzXaB1HDWsWy7n6bMrxJzNNa",
+                            id="call_X8haBK404EekgVGzdjughC6d",
                             name="secret_retrieval_tool",
                             args='{"password":"mellon"}',
                         ),
                         ToolCall(
-                            id="call_Dd4wvykCr6NttXKxRK0BFH96",
+                            id="call_sBsocB1eHoJ5JRek7l2RLAzS",
                             name="secret_retrieval_tool",
                             args='{"password":"radiance"}',
                         ),
@@ -43,18 +43,19 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"password":"mellon"}',
-                            "call_id": "call_bzXaB1HDWsWy7n6bMrxJzNNa",
+                            "call_id": "call_X8haBK404EekgVGzdjughC6d",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_05020a9191cad7ac0068f966b1446c8190b34b78d6f788eeec",
+                            "id": "fc_022c6f9c3ddea69d00690a1f8495fc8190a0638886411c91c0",
                             "status": "completed",
+                            "response_id": "resp_022c6f9c3ddea69d00690a1f83488c819089f3e6f781f3658c",
                         },
                         {
                             "arguments": '{"password":"radiance"}',
-                            "call_id": "call_Dd4wvykCr6NttXKxRK0BFH96",
+                            "call_id": "call_sBsocB1eHoJ5JRek7l2RLAzS",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_05020a9191cad7ac0068f966b16f80819088f6dab6c16c4653",
+                            "id": "fc_022c6f9c3ddea69d00690a1f84b9b48190b6b8ee06c175bc42",
                             "status": "completed",
                         },
                     ],
@@ -62,12 +63,12 @@ sync_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_bzXaB1HDWsWy7n6bMrxJzNNa",
+                            id="call_X8haBK404EekgVGzdjughC6d",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="call_Dd4wvykCr6NttXKxRK0BFH96",
+                            id="call_sBsocB1eHoJ5JRek7l2RLAzS",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -77,10 +78,10 @@ sync_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Here are the secrets:
+Here are the secrets for the given passwords:
 
-- For password "mellon": Welcome to Moria!
-- For password "radiance": Life before Death\
+- **mellon**: Welcome to Moria!
+- **radiance**: Life before Death\
 """
                         )
                     ],
@@ -88,15 +89,15 @@ Here are the secrets:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_05020a9191cad7ac0068f966b29f2c8190b17e1e76b16eb31c",
+                            "id": "msg_022c6f9c3ddea69d00690a1f8628e0819096cd6e52c5329160",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-Here are the secrets:
+Here are the secrets for the given passwords:
 
-- For password "mellon": Welcome to Moria!
-- For password "radiance": Life before Death\
+- **mellon**: Welcome to Moria!
+- **radiance**: Life before Death\
 """,
                                     "type": "output_text",
                                     "logprobs": [],
@@ -105,6 +106,7 @@ Here are the secrets:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_022c6f9c3ddea69d00690a1f854c1c8190b3a8dca5e69a4816",
                         }
                     ],
                 ),
@@ -154,12 +156,12 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_MqvcNQ1vcN1deGFjDbYja1zn",
+                            id="call_tCxqlymiNhUrqr9yhdFzYqqs",
                             name="secret_retrieval_tool",
                             args='{"password":"mellon"}',
                         ),
                         ToolCall(
-                            id="call_EqSzc4ybAc3ffmvwzL4rrdkg",
+                            id="call_t0Am4hCvwG27GqE10jL7ctQZ",
                             name="secret_retrieval_tool",
                             args='{"password":"radiance"}',
                         ),
@@ -169,18 +171,19 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"password":"mellon"}',
-                            "call_id": "call_MqvcNQ1vcN1deGFjDbYja1zn",
+                            "call_id": "call_tCxqlymiNhUrqr9yhdFzYqqs",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_019289b83a1261ca0068f966b5b4848195a23104951bd770cd",
+                            "id": "fc_039f6930b35f776c00690a1fdb58fc8193a4b59d06cd9b812f",
                             "status": "completed",
+                            "response_id": "resp_039f6930b35f776c00690a1fd8db8c8193b45f1fcf7789dce2",
                         },
                         {
                             "arguments": '{"password":"radiance"}',
-                            "call_id": "call_EqSzc4ybAc3ffmvwzL4rrdkg",
+                            "call_id": "call_t0Am4hCvwG27GqE10jL7ctQZ",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_019289b83a1261ca0068f966b6cab881958f1e435d61dcbd63",
+                            "id": "fc_039f6930b35f776c00690a1fdb897881939e51b5240180d4e8",
                             "status": "completed",
                         },
                     ],
@@ -188,12 +191,12 @@ async_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_MqvcNQ1vcN1deGFjDbYja1zn",
+                            id="call_tCxqlymiNhUrqr9yhdFzYqqs",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="call_EqSzc4ybAc3ffmvwzL4rrdkg",
+                            id="call_t0Am4hCvwG27GqE10jL7ctQZ",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -203,7 +206,7 @@ async_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-The secrets for the passwords are:
+Here are the secrets associated with the passwords:
 
 - "mellon": Welcome to Moria!
 - "radiance": Life before Death\
@@ -214,12 +217,12 @@ The secrets for the passwords are:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_019289b83a1261ca0068f966b87fa88195986a24eb8e39c47f",
+                            "id": "msg_039f6930b35f776c00690a1fdda9fc81938f4b068d8adecd6c",
                             "content": [
                                 {
                                     "annotations": [],
                                     "text": """\
-The secrets for the passwords are:
+Here are the secrets associated with the passwords:
 
 - "mellon": Welcome to Moria!
 - "radiance": Life before Death\
@@ -231,6 +234,7 @@ The secrets for the passwords are:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_039f6930b35f776c00690a1fdc42148193b860326a5e088a0e",
                         }
                     ],
                 ),
@@ -279,12 +283,12 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_sKC7OABqf2A2PTLCm0CLeRWV",
+                            id="call_97ayj0C3bp5IcprjGmdcP3YD",
                             name="secret_retrieval_tool",
                             args='{"password":"mellon"}',
                         ),
                         ToolCall(
-                            id="call_OdR3s3xop0vtgkDyWRMLafuH",
+                            id="call_SOHDB5HyLUg7QvE7pUWlXUMQ",
                             name="secret_retrieval_tool",
                             args='{"password":"radiance"}',
                         ),
@@ -294,18 +298,19 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"password":"mellon"}',
-                            "call_id": "call_sKC7OABqf2A2PTLCm0CLeRWV",
+                            "call_id": "call_97ayj0C3bp5IcprjGmdcP3YD",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0c3b09d20eedf2d30068f966bad8b88190af96d232f504ef1f",
+                            "id": "fc_0512b776faee5b9e00690a1fb4afb08193adc53f637ab28645",
                             "status": "completed",
+                            "response_id": "resp_0512b776faee5b9e00690a1fb3e6b4819395a39400dddec77c",
                         },
                         {
                             "arguments": '{"password":"radiance"}',
-                            "call_id": "call_OdR3s3xop0vtgkDyWRMLafuH",
+                            "call_id": "call_SOHDB5HyLUg7QvE7pUWlXUMQ",
                             "name": "secret_retrieval_tool",
                             "type": "function_call",
-                            "id": "fc_0c3b09d20eedf2d30068f966bafd288190a9045fdc554de6d5",
+                            "id": "fc_0512b776faee5b9e00690a1fb4ccd48193a1c954cd4b2e45d6",
                             "status": "completed",
                         },
                     ],
@@ -313,12 +318,140 @@ stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_sKC7OABqf2A2PTLCm0CLeRWV",
+                            id="call_97ayj0C3bp5IcprjGmdcP3YD",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="call_OdR3s3xop0vtgkDyWRMLafuH",
+                            id="call_SOHDB5HyLUg7QvE7pUWlXUMQ",
+                            name="secret_retrieval_tool",
+                            value="Life before Death",
+                        ),
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+Here are the retrieved secrets:
+
+1. **Password "mellon":** Welcome to Moria!
+2. **Password "radiance":** Life before Death\
+"""
+                        )
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-4o",
+                    raw_message=[
+                        {
+                            "id": "msg_0512b776faee5b9e00690a1fb7df488193a4594b67ac6b02cf",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": """\
+Here are the retrieved secrets:
+
+1. **Password "mellon":** Welcome to Moria!
+2. **Password "radiance":** Life before Death\
+""",
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                            "response_id": "resp_0512b776faee5b9e00690a1fb547dc81938da9d903d4a58194",
+                        }
+                    ],
+                ),
+            ],
+            "format": None,
+            "tools": [
+                {
+                    "name": "secret_retrieval_tool",
+                    "description": "A tool that requires a password to retrieve a secret.",
+                    "parameters": """\
+{
+  "properties": {
+    "password": {
+      "title": "Password",
+      "type": "string"
+    }
+  },
+  "required": [
+    "password"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 35,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "openai:responses",
+            "model_id": "gpt-4o",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(content=Text(text="Use parallel tool calling.")),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="call_BnBrJ4EwrnrNrOAgYK5QJtZk",
+                            name="secret_retrieval_tool",
+                            args='{"password":"mellon"}',
+                        ),
+                        ToolCall(
+                            id="call_3rPVUHZLIu5xyoiazpL8PRII",
+                            name="secret_retrieval_tool",
+                            args='{"password":"radiance"}',
+                        ),
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-4o",
+                    raw_message=[
+                        {
+                            "arguments": '{"password":"mellon"}',
+                            "call_id": "call_BnBrJ4EwrnrNrOAgYK5QJtZk",
+                            "name": "secret_retrieval_tool",
+                            "type": "function_call",
+                            "id": "fc_06995068fdb81d8900690a1fe1b9a881959c5d4f9f4d7e6095",
+                            "status": "completed",
+                            "response_id": "resp_06995068fdb81d8900690a1fe11b14819596489c2bd1c2a0b6",
+                        },
+                        {
+                            "arguments": '{"password":"radiance"}',
+                            "call_id": "call_3rPVUHZLIu5xyoiazpL8PRII",
+                            "name": "secret_retrieval_tool",
+                            "type": "function_call",
+                            "id": "fc_06995068fdb81d8900690a1fe1e4c881959e2a3526d6d10ae1",
+                            "status": "completed",
+                        },
+                    ],
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="call_BnBrJ4EwrnrNrOAgYK5QJtZk",
+                            name="secret_retrieval_tool",
+                            value="Welcome to Moria!",
+                        ),
+                        ToolOutput(
+                            id="call_3rPVUHZLIu5xyoiazpL8PRII",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -339,7 +472,7 @@ Here are the secrets associated with each password:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0c3b09d20eedf2d30068f966bc0afc81909ccc6a383749530f",
+                            "id": "msg_06995068fdb81d8900690a1fe319d08195938dc9b93ecbe933",
                             "content": [
                                 {
                                     "annotations": [],
@@ -356,6 +489,7 @@ Here are the secrets associated with each password:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_06995068fdb81d8900690a1fe244c08195a96bae2221a1e526",
                         }
                     ],
                 ),
@@ -384,132 +518,6 @@ Here are the secrets associated with each password:
                 }
             ],
             "n_chunks": 32,
-        }
-    }
-)
-async_stream_snapshot = snapshot(
-    {
-        "response": {
-            "provider": "openai:responses",
-            "model_id": "gpt-4o",
-            "finish_reason": None,
-            "messages": [
-                SystemMessage(content=Text(text="Use parallel tool calling.")),
-                UserMessage(
-                    content=[
-                        Text(
-                            text="Please retrieve the secrets associated with each of these passwords: mellon,radiance"
-                        )
-                    ]
-                ),
-                AssistantMessage(
-                    content=[
-                        ToolCall(
-                            id="call_4l0LYGshWqEvG3DEq9hY8PKo",
-                            name="secret_retrieval_tool",
-                            args='{"password":"mellon"}',
-                        ),
-                        ToolCall(
-                            id="call_hG4DmWUygGVSGrsCV3zwCiZU",
-                            name="secret_retrieval_tool",
-                            args='{"password":"radiance"}',
-                        ),
-                    ],
-                    provider="openai:responses",
-                    model_id="gpt-4o",
-                    raw_message=[
-                        {
-                            "arguments": '{"password":"mellon"}',
-                            "call_id": "call_4l0LYGshWqEvG3DEq9hY8PKo",
-                            "name": "secret_retrieval_tool",
-                            "type": "function_call",
-                            "id": "fc_03573e2d83248b7c0068f966be406c8194b614ddb98cfce9fe",
-                            "status": "completed",
-                        },
-                        {
-                            "arguments": '{"password":"radiance"}',
-                            "call_id": "call_hG4DmWUygGVSGrsCV3zwCiZU",
-                            "name": "secret_retrieval_tool",
-                            "type": "function_call",
-                            "id": "fc_03573e2d83248b7c0068f966be7e148194868e9cbe2160c4ec",
-                            "status": "completed",
-                        },
-                    ],
-                ),
-                UserMessage(
-                    content=[
-                        ToolOutput(
-                            id="call_4l0LYGshWqEvG3DEq9hY8PKo",
-                            name="secret_retrieval_tool",
-                            value="Welcome to Moria!",
-                        ),
-                        ToolOutput(
-                            id="call_hG4DmWUygGVSGrsCV3zwCiZU",
-                            name="secret_retrieval_tool",
-                            value="Life before Death",
-                        ),
-                    ]
-                ),
-                AssistantMessage(
-                    content=[
-                        Text(
-                            text="""\
-Here are the secrets:
-
-- Password "mellon": Welcome to Moria!
-- Password "radiance": Life before Death\
-"""
-                        )
-                    ],
-                    provider="openai:responses",
-                    model_id="gpt-4o",
-                    raw_message=[
-                        {
-                            "id": "msg_03573e2d83248b7c0068f966bf89d081949ff26b5e39341c99",
-                            "content": [
-                                {
-                                    "annotations": [],
-                                    "text": """\
-Here are the secrets:
-
-- Password "mellon": Welcome to Moria!
-- Password "radiance": Life before Death\
-""",
-                                    "type": "output_text",
-                                    "logprobs": [],
-                                }
-                            ],
-                            "role": "assistant",
-                            "status": "completed",
-                            "type": "message",
-                        }
-                    ],
-                ),
-            ],
-            "format": None,
-            "tools": [
-                {
-                    "name": "secret_retrieval_tool",
-                    "description": "A tool that requires a password to retrieve a secret.",
-                    "parameters": """\
-{
-  "properties": {
-    "password": {
-      "title": "Password",
-      "type": "string"
-    }
-  },
-  "required": [
-    "password"
-  ],
-  "additionalProperties": false,
-  "defs": null
-}\
-""",
-                    "strict": False,
-                }
-            ],
-            "n_chunks": 28,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_max_tokens/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/openai_responses_gpt_4o_snapshots.py
@@ -62,6 +62,7 @@ Sure! Here is a list of all 50 U.S. states:
                             "role": "assistant",
                             "status": "incomplete",
                             "type": "message",
+                            "response_id": "resp_043a58ea47ac058e0068f966c095748197bf176643cf204a03",
                         }
                     ],
                 ),
@@ -128,6 +129,7 @@ Sure! Here are all the U.S. states:
                             "role": "assistant",
                             "status": "incomplete",
                             "type": "message",
+                            "response_id": "resp_0d9a87a8899d31be0068f966c2b0b08194979bf347c1bee405",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_refusal/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/openai_responses_gpt_4o_snapshots.py
@@ -40,6 +40,7 @@ sync_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0e0644cfe502d3570068f966c84d6c81958f57dbddc6c44841",
                         }
                     ],
                 ),
@@ -95,6 +96,7 @@ async_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0d0a107ddd23ca6d0068f966ca4d2481959cbbc45ca2cdc4a2",
                         }
                     ],
                 ),
@@ -147,6 +149,7 @@ stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_05f46fd4032c869b0068f966cb89248197969af833ea7a7e33",
                         }
                     ],
                 ),
@@ -200,6 +203,7 @@ async_stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0ee665a65cc07abb0068f966ccd6648197b6c0608c0f3efecc",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/openai_responses_gpt_4o_snapshots.py
@@ -114,6 +114,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0c56259124d74c410068f966cf91c88195984fea0f618dde83",
                         }
                     ],
                 ),
@@ -309,6 +310,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0f9c89c401370d9e0068f966daa3d88196b29f256cd5b4c392",
                         }
                     ],
                 ),
@@ -503,6 +505,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_036491543731fbfb0068f966e29b6c81909d9e98a023c9480d",
                         }
                     ],
                 ),
@@ -698,6 +701,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_00edc40ff3f879d50068f966ea1f78819386de4b37d7121980",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_structured_output/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/openai_responses_gpt_4o_snapshots.py
@@ -43,6 +43,7 @@ sync_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_081b58c650b2c0060068f966d571048194841c88ecb7cf1b74",
                         }
                     ],
                 ),
@@ -122,6 +123,7 @@ async_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0c626afd5c5d31430068f966defcdc8193b23fd3aaaba7556a",
                         }
                     ],
                 ),
@@ -200,6 +202,7 @@ stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_029d5dc66e70cbc20068f966e671a4819398e2c06297bb6f94",
                         }
                     ],
                 ),
@@ -279,6 +282,7 @@ async_stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_09f3508e8ab29e720068f966f0405081969e9f587fc7cbeaf6",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_responses_gpt_4o_snapshots.py
@@ -43,6 +43,7 @@ sync_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_005e0ab32c3df1050068f966ce4bc48190bb2074dac166dfd4",
                         }
                     ],
                 ),
@@ -122,6 +123,7 @@ async_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0e2af4b9d9313f560068f966d84e588197adfc1ada9af92b09",
                         }
                     ],
                 ),
@@ -200,6 +202,7 @@ stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_089d7482d1faaec10068f966e121708196a5c0a755c0348821",
                         }
                     ],
                 ),
@@ -279,6 +282,7 @@ async_stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_09e0316a14ecf6580068f966e872b481938828a164bb08bddf",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_responses_gpt_4o_snapshots.py
@@ -43,6 +43,7 @@ sync_snapshot = snapshot(
                             "type": "function_call",
                             "id": "fc_0ae3ac6597d0b6cf0068f966d381448195858ced56b0b77a5d",
                             "status": "completed",
+                            "response_id": "resp_0ae3ac6597d0b6cf0068f966d246dc81958b2c41989f590f16",
                         }
                     ],
                 ),
@@ -120,6 +121,7 @@ async_snapshot = snapshot(
                             "type": "function_call",
                             "id": "fc_0e92c5605a0410a90068f966ddde608195817fcad49b8d61b9",
                             "status": "completed",
+                            "response_id": "resp_0e92c5605a0410a90068f966dcf62c819599af22e28feba984",
                         }
                     ],
                 ),
@@ -196,6 +198,7 @@ stream_snapshot = snapshot(
                             "type": "function_call",
                             "id": "fc_02081d7ebf3b828d0068f966e5ba288197a988ed7e29d9afe5",
                             "status": "completed",
+                            "response_id": "resp_02081d7ebf3b828d0068f966e51f308197bc16ea0ba76aba75",
                         }
                     ],
                 ),
@@ -273,6 +276,7 @@ async_stream_snapshot = snapshot(
                             "type": "function_call",
                             "id": "fc_0d5546885926d4490068f966ef0e148190ae98875802831707",
                             "status": "completed",
+                            "response_id": "resp_0d5546885926d4490068f966ee45b481909b24858aad2fd2fd",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_responses_gpt_4o_snapshots.py
@@ -62,7 +62,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_vGDl14wuUgjKmbX3QvSPOUOl",
+                            id="call_vgvPxdtt05BqtDlE7j8BW12v",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -72,18 +72,19 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_vGDl14wuUgjKmbX3QvSPOUOl",
+                            "call_id": "call_vgvPxdtt05BqtDlE7j8BW12v",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_099b2074297131ee0068f966f805588195ab0a3266a3485eb2",
+                            "id": "fc_056c95731187f0c900690a1ffe96b88196bc64571058b3dcd9",
                             "status": "completed",
+                            "response_id": "resp_056c95731187f0c900690a1ffdebfc81969b376d9375304c85",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_vGDl14wuUgjKmbX3QvSPOUOl",
+                            id="call_vgvPxdtt05BqtDlE7j8BW12v",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -106,7 +107,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_099b2074297131ee0068f966f961e88195b52bc39cd2c63caf",
+                            "id": "msg_056c95731187f0c900690a1fffe948819689a8586174f6cfd2",
                             "content": [
                                 {
                                     "annotations": [],
@@ -125,6 +126,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_056c95731187f0c900690a1fff2cb88196a3eef8dfd30d1872",
                         }
                     ],
                 ),
@@ -257,7 +259,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_gvc1qWKn09rI7p2qrit1MWSl",
+                            id="call_jllsly7uXP0AHGquf2uNrr24",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -267,18 +269,19 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_gvc1qWKn09rI7p2qrit1MWSl",
+                            "call_id": "call_jllsly7uXP0AHGquf2uNrr24",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_001734ab3b50b4140068f9670a2160819488ed306c0f9ae85f",
+                            "id": "fc_0492f3235a2f2ceb00690a20ef1b388195aa731bdc3cf13059",
                             "status": "completed",
+                            "response_id": "resp_0492f3235a2f2ceb00690a20ee9b6c8195a12dad3f218c7cbd",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_gvc1qWKn09rI7p2qrit1MWSl",
+                            id="call_jllsly7uXP0AHGquf2uNrr24",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -301,7 +304,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_001734ab3b50b4140068f9670b55e88194a0e018fd79284d50",
+                            "id": "msg_0492f3235a2f2ceb00690a20f00a5481959339a8063c2645ff",
                             "content": [
                                 {
                                     "annotations": [],
@@ -320,6 +323,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0492f3235a2f2ceb00690a20efa040819588c5338fb4df536d",
                         }
                     ],
                 ),
@@ -451,7 +455,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_V1BAu6CPIaeWyMim4iiKLay2",
+                            id="call_3dRVRGLC0ZOgqqAqqwxLP1oA",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -461,18 +465,19 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_V1BAu6CPIaeWyMim4iiKLay2",
+                            "call_id": "call_3dRVRGLC0ZOgqqAqqwxLP1oA",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0f1f1f1012662e2a0068f9671c3ef08194bfaebc9329d2baf8",
+                            "id": "fc_0ba0218446ccdbff00690a20fb00dc81948a3a6ff990f79e12",
                             "status": "completed",
+                            "response_id": "resp_0ba0218446ccdbff00690a20f9cf80819484e26f182a9b9648",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_V1BAu6CPIaeWyMim4iiKLay2",
+                            id="call_3dRVRGLC0ZOgqqAqqwxLP1oA",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -495,7 +500,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0f1f1f1012662e2a0068f9671dde588194a49f52a567767f75",
+                            "id": "msg_0ba0218446ccdbff00690a20fc504c81948b5d07e9d1829604",
                             "content": [
                                 {
                                     "annotations": [],
@@ -514,6 +519,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0ba0218446ccdbff00690a20fbb9248194a1737b7ca1166ecc",
                         }
                     ],
                 ),
@@ -646,7 +652,7 @@ Respond only with valid JSON that matches this exact schema:
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_WeASSdshXbzOg7UDwf1RHvre",
+                            id="call_EvbQN4bviS5tMkqeccx4QAqK",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -656,18 +662,19 @@ Respond only with valid JSON that matches this exact schema:
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_WeASSdshXbzOg7UDwf1RHvre",
+                            "call_id": "call_EvbQN4bviS5tMkqeccx4QAqK",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0075d4e9136cabd30068f9672aa9b481938088b390244ed3ec",
+                            "id": "fc_02f36303af99bf2d00690a2108724c81979d716e2b2c5602dc",
                             "status": "completed",
+                            "response_id": "resp_02f36303af99bf2d00690a2107d73481979e58d6ed7df16089",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_WeASSdshXbzOg7UDwf1RHvre",
+                            id="call_EvbQN4bviS5tMkqeccx4QAqK",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -690,7 +697,7 @@ Respond only with valid JSON that matches this exact schema:
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0075d4e9136cabd30068f9672c86288193a65c26fdd8affb48",
+                            "id": "msg_02f36303af99bf2d00690a2109cb44819798fc869fb0318573",
                             "content": [
                                 {
                                     "annotations": [],
@@ -709,6 +716,7 @@ Respond only with valid JSON that matches this exact schema:
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_02f36303af99bf2d00690a210932048197a680b67d9debbae0",
                         }
                     ],
                 ),

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_responses_gpt_4o_snapshots.py
@@ -26,7 +26,7 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_SmNW61tutwvPA0YUTTaUAhwW",
+                            id="call_JHb3vjQwImlahWGrcL3D4vA9",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -36,18 +36,19 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_SmNW61tutwvPA0YUTTaUAhwW",
+                            "call_id": "call_JHb3vjQwImlahWGrcL3D4vA9",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0871003aa9e429a90068f966fed81c8195901e8a42ac152214",
+                            "id": "fc_069de437d28d423100690a203f41fc8194a84f3c9b17f03be8",
                             "status": "completed",
+                            "response_id": "resp_069de437d28d423100690a203e63c081949efefa862a9b95aa",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_SmNW61tutwvPA0YUTTaUAhwW",
+                            id="call_JHb3vjQwImlahWGrcL3D4vA9",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -57,13 +58,16 @@ sync_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
+                        ),
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        ),
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0871003aa9e429a90068f9670271708195888ba08cec82b733",
+                            "id": "msg_069de437d28d423100690a204141a0819491dd13b70d2f38b1",
                             "content": [
                                 {
                                     "annotations": [],
@@ -75,7 +79,22 @@ sync_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        }
+                            "response_id": "resp_069de437d28d423100690a20401ba0819481b079a4e5cf55ee",
+                        },
+                        {
+                            "id": "msg_069de437d28d423100690a204308008194afa387ff220e8698",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
                     ],
                 ),
             ],
@@ -142,7 +161,7 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_l1pEC3Hp56CVet5CPK5tNewC",
+                            id="call_ViCt1vdkXorn9cYIcdBZpPpa",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -152,18 +171,19 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_l1pEC3Hp56CVet5CPK5tNewC",
+                            "call_id": "call_ViCt1vdkXorn9cYIcdBZpPpa",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_02e355744182d07f0068f967132284819095b0b6d616453530",
+                            "id": "fc_0a53a10a692f207a00690a215a0c188196842dcbe8c33f9dc8",
                             "status": "completed",
+                            "response_id": "resp_0a53a10a692f207a00690a2158c6b48196b9756474a4cef9e7",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_l1pEC3Hp56CVet5CPK5tNewC",
+                            id="call_ViCt1vdkXorn9cYIcdBZpPpa",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -179,7 +199,7 @@ async_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_02e355744182d07f0068f96715cfb48190b191f6a524b089ae",
+                            "id": "msg_0a53a10a692f207a00690a215c22a88196a884947954ea852e",
                             "content": [
                                 {
                                     "annotations": [],
@@ -191,6 +211,7 @@ async_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_0a53a10a692f207a00690a215aa23c8196bfaf720159c58c01",
                         }
                     ],
                 ),
@@ -257,7 +278,7 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_Wg2va0blJgvoHylhrTA6FZN9",
+                            id="call_sluavrUJS6H6lgKYY4nwdO5u",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -267,18 +288,19 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_Wg2va0blJgvoHylhrTA6FZN9",
+                            "call_id": "call_sluavrUJS6H6lgKYY4nwdO5u",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0d7f412d0c19301b0068f96723543881969470ecd4e85502b3",
+                            "id": "fc_07813cfec04bdc3200690a215be5f88196833a36241574585e",
                             "status": "completed",
+                            "response_id": "resp_07813cfec04bdc3200690a215b45e8819696b73f66013b562f",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_Wg2va0blJgvoHylhrTA6FZN9",
+                            id="call_sluavrUJS6H6lgKYY4nwdO5u",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -288,13 +310,16 @@ stream_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
+                        ),
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        ),
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0d7f412d0c19301b0068f96724a3dc8196b4a7c40ebdc64b71",
+                            "id": "msg_07813cfec04bdc3200690a215daf08819688c764ac58736f4d",
                             "content": [
                                 {
                                     "annotations": [],
@@ -306,7 +331,22 @@ stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        }
+                            "response_id": "resp_07813cfec04bdc3200690a215c7ea081969c24d07d0ac2e008",
+                        },
+                        {
+                            "id": "msg_07813cfec04bdc3200690a215ed2948196a489a4ae5150ccea",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
                     ],
                 ),
             ],
@@ -352,7 +392,7 @@ stream_snapshot = snapshot(
                     "strict": False,
                 }
             ],
-            "n_chunks": 29,
+            "n_chunks": 58,
         }
     }
 )
@@ -373,7 +413,7 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_GS0nL2200gVPzwISOcNTBALX",
+                            id="call_4fq8qlDGU2rabJ7ZLxVwc2dd",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -383,18 +423,19 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_GS0nL2200gVPzwISOcNTBALX",
+                            "call_id": "call_4fq8qlDGU2rabJ7ZLxVwc2dd",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_08be1f3e41d5b6620068f9673498888193a5642869a59089ea",
+                            "id": "fc_0918a05a3af60ce100690a2160cd488194b84ef38b2de7d5bf",
                             "status": "completed",
+                            "response_id": "resp_0918a05a3af60ce100690a21601ce08194ae606b9836a9f217",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_GS0nL2200gVPzwISOcNTBALX",
+                            id="call_4fq8qlDGU2rabJ7ZLxVwc2dd",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -404,13 +445,16 @@ async_stream_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
+                        ),
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        ),
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_08be1f3e41d5b6620068f96736143c819396d70e1812a03c96",
+                            "id": "msg_0918a05a3af60ce100690a21624a788194a388dff99c783902",
                             "content": [
                                 {
                                     "annotations": [],
@@ -422,7 +466,22 @@ async_stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        }
+                            "response_id": "resp_0918a05a3af60ce100690a2161763881949873e93ccae9aace",
+                        },
+                        {
+                            "id": "msg_0918a05a3af60ce100690a216357108194893f899395309b5e",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
                     ],
                 ),
             ],
@@ -468,7 +527,7 @@ async_stream_snapshot = snapshot(
                     "strict": False,
                 }
             ],
-            "n_chunks": 29,
+            "n_chunks": 58,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_responses_gpt_4o_snapshots.py
@@ -26,7 +26,7 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_yBfd3l5PeRVQWhs9vmdZhStl",
+                            id="call_zxgY1DEIKCOcyOrrmelOyBRl",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -36,18 +36,19 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_yBfd3l5PeRVQWhs9vmdZhStl",
+                            "call_id": "call_zxgY1DEIKCOcyOrrmelOyBRl",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0c13bc8721cd88030068f966f3b4388195b2e2e33cacbfd11c",
+                            "id": "fc_0de064b6028cd86900690a1ffb9f64819585a566791b343c52",
                             "status": "completed",
+                            "response_id": "resp_0de064b6028cd86900690a1ffa528881959ceaaa03c558c131",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_yBfd3l5PeRVQWhs9vmdZhStl",
+                            id="call_zxgY1DEIKCOcyOrrmelOyBRl",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -57,16 +58,13 @@ sync_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        ),
-                        Text(
-                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        ),
+                        )
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0c13bc8721cd88030068f966f553088195bddd767eb493daa8",
+                            "id": "msg_0de064b6028cd86900690a1ffd41688195a4854b13fe155588",
                             "content": [
                                 {
                                     "annotations": [],
@@ -78,21 +76,8 @@ sync_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        },
-                        {
-                            "id": "msg_0c13bc8721cd88030068f966f655388195874978bc34ebc7a9",
-                            "content": [
-                                {
-                                    "annotations": [],
-                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                                    "type": "output_text",
-                                    "logprobs": [],
-                                }
-                            ],
-                            "role": "assistant",
-                            "status": "completed",
-                            "type": "message",
-                        },
+                            "response_id": "resp_0de064b6028cd86900690a1ffc828c8195bcfaad65c47214f4",
+                        }
                     ],
                 ),
             ],
@@ -159,7 +144,7 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_17eYs2P0KfuDdmU5nJx09OK5",
+                            id="call_s30hnkfzfRW58bmTPVdMjFjG",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -169,18 +154,19 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_17eYs2P0KfuDdmU5nJx09OK5",
+                            "call_id": "call_s30hnkfzfRW58bmTPVdMjFjG",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0f268704e49f9e100068f9670573ac8196a8eb7a71df67a311",
+                            "id": "fc_0de0b5d5ea0bb5bb00690a20eb67048195b062584e7cfb102e",
                             "status": "completed",
+                            "response_id": "resp_0de0b5d5ea0bb5bb00690a20eaa63c819594a8a8d110caaa76",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_17eYs2P0KfuDdmU5nJx09OK5",
+                            id="call_s30hnkfzfRW58bmTPVdMjFjG",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -190,13 +176,16 @@ async_snapshot = snapshot(
                     content=[
                         Text(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
+                        ),
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        ),
                     ],
                     provider="openai:responses",
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0f268704e49f9e100068f96706d6dc8196bc4a4005e8401f2b",
+                            "id": "msg_0de0b5d5ea0bb5bb00690a20ec7acc8195b31e5ddfe746ab20",
                             "content": [
                                 {
                                     "annotations": [],
@@ -208,7 +197,22 @@ async_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
-                        }
+                            "response_id": "resp_0de0b5d5ea0bb5bb00690a20ebcec8819591d5c7d975c415e1",
+                        },
+                        {
+                            "id": "msg_0de0b5d5ea0bb5bb00690a20ed6aa08195af70fbeae41ea830",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                        },
                     ],
                 ),
             ],
@@ -274,7 +278,7 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_DKUnanrHFNzdv0dwE1kN17XB",
+                            id="call_BN7teDnGzxfSWoRXGsgqX1F0",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -284,18 +288,137 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_DKUnanrHFNzdv0dwE1kN17XB",
+                            "call_id": "call_BN7teDnGzxfSWoRXGsgqX1F0",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_0b0d1528ca873fd80068f96717b898819584210b5eea6ab9e8",
+                            "id": "fc_001c8b1138c31f9e00690a20f7980c8197a9267bd1cd80f411",
                             "status": "completed",
+                            "response_id": "resp_001c8b1138c31f9e00690a20f6eabc8197844abbb91cc1c206",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_DKUnanrHFNzdv0dwE1kN17XB",
+                            id="call_BN7teDnGzxfSWoRXGsgqX1F0",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
+                        )
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-4o",
+                    raw_message=[
+                        {
+                            "id": "msg_001c8b1138c31f9e00690a20f91474819782a5d74838f8b539",
+                            "content": [
+                                {
+                                    "annotations": [],
+                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
+                                    "type": "output_text",
+                                    "logprobs": [],
+                                }
+                            ],
+                            "role": "assistant",
+                            "status": "completed",
+                            "type": "message",
+                            "response_id": "resp_001c8b1138c31f9e00690a20f83cc8819785df31b537a55a06",
+                        }
+                    ],
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 29,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "openai:responses",
+            "model_id": "gpt-4o",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="call_WvUTcxwhMmj1z37Za716EaPu",
+                            name="get_book_info",
+                            args='{"isbn":"0-7653-1178-X"}',
+                        )
+                    ],
+                    provider="openai:responses",
+                    model_id="gpt-4o",
+                    raw_message=[
+                        {
+                            "arguments": '{"isbn":"0-7653-1178-X"}',
+                            "call_id": "call_WvUTcxwhMmj1z37Za716EaPu",
+                            "name": "get_book_info",
+                            "type": "function_call",
+                            "id": "fc_06e779162f023f0000690a21040c688196bbe44f08d4dcd25a",
+                            "status": "completed",
+                            "response_id": "resp_06e779162f023f0000690a21036d688196a70b366c0eda5ce7",
+                        }
+                    ],
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="call_WvUTcxwhMmj1z37Za716EaPu",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -314,7 +437,7 @@ stream_snapshot = snapshot(
                     model_id="gpt-4o",
                     raw_message=[
                         {
-                            "id": "msg_0b0d1528ca873fd80068f9671943208195b33ccddef86b60ad",
+                            "id": "msg_06e779162f023f0000690a21059be481969a8e0ce27fd9ba66",
                             "content": [
                                 {
                                     "annotations": [],
@@ -326,9 +449,10 @@ stream_snapshot = snapshot(
                             "role": "assistant",
                             "status": "completed",
                             "type": "message",
+                            "response_id": "resp_06e779162f023f0000690a2104b1308196be43ce550a1af79f",
                         },
                         {
-                            "id": "msg_0b0d1528ca873fd80068f9671acf048195ba12d93440ea4eca",
+                            "id": "msg_06e779162f023f0000690a2106943c81968f113b2de635c96f",
                             "content": [
                                 {
                                     "annotations": [],
@@ -387,122 +511,6 @@ stream_snapshot = snapshot(
                 }
             ],
             "n_chunks": 58,
-        }
-    }
-)
-async_stream_snapshot = snapshot(
-    {
-        "response": {
-            "provider": "openai:responses",
-            "model_id": "gpt-4o",
-            "finish_reason": None,
-            "messages": [
-                UserMessage(
-                    content=[
-                        Text(
-                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
-                        )
-                    ]
-                ),
-                AssistantMessage(
-                    content=[
-                        ToolCall(
-                            id="call_KP5QYSrxpHlZcPeYYd3ixkWE",
-                            name="get_book_info",
-                            args='{"isbn":"0-7653-1178-X"}',
-                        )
-                    ],
-                    provider="openai:responses",
-                    model_id="gpt-4o",
-                    raw_message=[
-                        {
-                            "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_KP5QYSrxpHlZcPeYYd3ixkWE",
-                            "name": "get_book_info",
-                            "type": "function_call",
-                            "id": "fc_0568f6e6bd681de70068f96726f79481948b834ce45b33e8ca",
-                            "status": "completed",
-                        }
-                    ],
-                ),
-                UserMessage(
-                    content=[
-                        ToolOutput(
-                            id="call_KP5QYSrxpHlZcPeYYd3ixkWE",
-                            name="get_book_info",
-                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
-                        )
-                    ]
-                ),
-                AssistantMessage(
-                    content=[
-                        Text(
-                            text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
-                        )
-                    ],
-                    provider="openai:responses",
-                    model_id="gpt-4o",
-                    raw_message=[
-                        {
-                            "id": "msg_0568f6e6bd681de70068f96728689881949f30b2eac2de51a8",
-                            "content": [
-                                {
-                                    "annotations": [],
-                                    "text": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                                    "type": "output_text",
-                                    "logprobs": [],
-                                }
-                            ],
-                            "role": "assistant",
-                            "status": "completed",
-                            "type": "message",
-                        }
-                    ],
-                ),
-            ],
-            "format": {
-                "name": "BookSummary",
-                "description": None,
-                "schema": {
-                    "properties": {
-                        "title": {"title": "Title", "type": "string"},
-                        "author": {"title": "Author", "type": "string"},
-                        "pages": {"title": "Pages", "type": "integer"},
-                        "publication_year": {
-                            "title": "Publication Year",
-                            "type": "integer",
-                        },
-                    },
-                    "required": ["title", "author", "pages", "publication_year"],
-                    "title": "BookSummary",
-                    "type": "object",
-                },
-                "mode": "strict",
-                "formatting_instructions": None,
-            },
-            "tools": [
-                {
-                    "name": "get_book_info",
-                    "description": "Look up book information by ISBN.",
-                    "parameters": """\
-{
-  "properties": {
-    "isbn": {
-      "title": "Isbn",
-      "type": "string"
-    }
-  },
-  "required": [
-    "isbn"
-  ],
-  "additionalProperties": false,
-  "defs": null
-}\
-""",
-                    "strict": False,
-                }
-            ],
-            "n_chunks": 29,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_responses_gpt_4o_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_responses_gpt_4o_snapshots.py
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_IuCdtIU6YCdcMtwf1c7S6Yfl",
+                            id="call_xV2ykjefTYETx0PRDOFPlqjb",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -42,18 +42,19 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_IuCdtIU6YCdcMtwf1c7S6Yfl",
+                            "call_id": "call_xV2ykjefTYETx0PRDOFPlqjb",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_07423eaa444131890068f966fb8fec8190a4ec45736cc700e4",
+                            "id": "fc_0016c1949f6d6d7b00690a2001c5608193823711af9fd3bb9c",
                             "status": "completed",
+                            "response_id": "resp_0016c1949f6d6d7b00690a2000db04819385ceae2447821cb8",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_IuCdtIU6YCdcMtwf1c7S6Yfl",
+                            id="call_xV2ykjefTYETx0PRDOFPlqjb",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -70,11 +71,12 @@ sync_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_nxjq0vnJeUsYtbtOM7vz28o3",
+                            "call_id": "call_fHTBLQP9c5WxCUtMDPEm5Pte",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_07423eaa444131890068f966fd474081909b1a0ed0b6d74b64",
+                            "id": "fc_0016c1949f6d6d7b00690a200334f08193b8d80adadbd6116c",
                             "status": "completed",
+                            "response_id": "resp_0016c1949f6d6d7b00690a20028e2881938c3f8d62c9b4bca8",
                         }
                     ],
                 ),
@@ -147,7 +149,7 @@ async_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_C0smUQ1bxK7gmQHnQ28ypd1y",
+                            id="call_pOImBErJqJ0UKbROhqaizXm8",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -157,18 +159,19 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_C0smUQ1bxK7gmQHnQ28ypd1y",
+                            "call_id": "call_pOImBErJqJ0UKbROhqaizXm8",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_07b6a8da9d6df7110068f9670e17e4819098b4ec0838d0ba42",
+                            "id": "fc_0dbab3ab5438119500690a20f1a0d08194bd492a0f9416fa82",
                             "status": "completed",
+                            "response_id": "resp_0dbab3ab5438119500690a20f11a748194adf947c22d577d3d",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_C0smUQ1bxK7gmQHnQ28ypd1y",
+                            id="call_pOImBErJqJ0UKbROhqaizXm8",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -185,11 +188,12 @@ async_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_uK7x776U3ITlPH9I78HJNNPK",
+                            "call_id": "call_NLfHwIQCbySGTGAYozxnQbUN",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_07b6a8da9d6df7110068f967100bd88190b431d57097d4cea6",
+                            "id": "fc_0dbab3ab5438119500690a20f3536c81948aff9d144861035b",
                             "status": "completed",
+                            "response_id": "resp_0dbab3ab5438119500690a20f227388194bb8c64f06b2cba13",
                         }
                     ],
                 ),
@@ -261,7 +265,7 @@ stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_0C0lm2bJk0qtb2BrgwgmvKMy",
+                            id="call_N66aZ6aFsMUMljMdRITvljUZ",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -271,18 +275,19 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_0C0lm2bJk0qtb2BrgwgmvKMy",
+                            "call_id": "call_N66aZ6aFsMUMljMdRITvljUZ",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_080ef7d1f38539e70068f9672052888190a6319058cac902c6",
+                            "id": "fc_0d3c00fa56b7a15000690a20fe21348194a227d1f327985117",
                             "status": "completed",
+                            "response_id": "resp_0d3c00fa56b7a15000690a20fd4654819498b7323202bf4a61",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_0C0lm2bJk0qtb2BrgwgmvKMy",
+                            id="call_N66aZ6aFsMUMljMdRITvljUZ",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -299,11 +304,12 @@ stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_JGRho7xlgYVKcbpEXdylfeCy",
+                            "call_id": "call_6z4qGHD8LfRVZz9FKPDJGgQm",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_080ef7d1f38539e70068f96721ae8881908235ebaaf99bab30",
+                            "id": "fc_0d3c00fa56b7a15000690a20ff6d3c81949040e650e8737b42",
                             "status": "completed",
+                            "response_id": "resp_0d3c00fa56b7a15000690a20fed050819482baf817ee693d47",
                         }
                     ],
                 ),
@@ -376,7 +382,7 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="call_MFflVGir2tx2To8GUNv7JNr8",
+                            id="call_Ebrf4w4HjSIKEfrqSWJlQEOP",
                             name="get_book_info",
                             args='{"isbn":"0-7653-1178-X"}',
                         )
@@ -386,18 +392,19 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"isbn":"0-7653-1178-X"}',
-                            "call_id": "call_MFflVGir2tx2To8GUNv7JNr8",
+                            "call_id": "call_Ebrf4w4HjSIKEfrqSWJlQEOP",
                             "name": "get_book_info",
                             "type": "function_call",
-                            "id": "fc_01419a96ead129020068f9673014dc81908c7a1d7d800aface",
+                            "id": "fc_07d4b736b402fe6b00690a210b9f188190add6ee3cd019fef1",
                             "status": "completed",
+                            "response_id": "resp_07d4b736b402fe6b00690a210af02c8190ba21bf39a0514369",
                         }
                     ],
                 ),
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="call_MFflVGir2tx2To8GUNv7JNr8",
+                            id="call_Ebrf4w4HjSIKEfrqSWJlQEOP",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -414,11 +421,12 @@ async_stream_snapshot = snapshot(
                     raw_message=[
                         {
                             "arguments": '{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}',
-                            "call_id": "call_pM0ZrNyD2lmX46nJN8fOi4vG",
+                            "call_id": "call_54XIsBCfIoLdIc2lYjjXWxrQ",
                             "name": "__mirascope_formatted_output_tool__",
                             "type": "function_call",
-                            "id": "fc_01419a96ead129020068f96732d5a88190b1b0575a4c665b6d",
+                            "id": "fc_07d4b736b402fe6b00690a210d2d94819086092a898d9c95b0",
                             "status": "completed",
+                            "response_id": "resp_07d4b736b402fe6b00690a210c43088190b5d10264d5c33aa0",
                         }
                     ],
                 ),


### PR DESCRIPTION
This PR implements previous_response_id support for the OpenAI Responses API. This is required for Azure OpenAI integration, as Azure's Responses API does not
support sending full conversation history and requires previous_response_id to maintain conversation continuity.

Changes:

- [decode.py](http://decode.py): Added provider parameter to decode_response() and store response_id in serialized output items
- [encode.py](http://encode.py): Implemented logic to detect the last assistant message with a valid response_id and only send subsequent messages when using previous_response_id.
Fixed tool_choice handling to restrict to format tool only when resuming with previous_response_id.
- [clients.py](http://clients.py): Updated all decode_response() calls to pass provider parameterf

The implementation correctly handles cross-provider resume by checking both message.provider and message.model_id before using previous_response_id. When switching
providers (e.g., Anthropic → OpenAI), it sends full conversation history without previous_response_id.