### PR TITLE
nit: only regenerate api docs when python/mirascope changes

### DIFF
--- a/docs/scripts/sync-website.ts
+++ b/docs/scripts/sync-website.ts
@@ -177,7 +177,7 @@ function startWatching(): void {
   }
 
   // Watch Python source for API doc regeneration
-  const pythonSourcePath = resolve(V2_ROOT, "python");
+  const pythonSourcePath = resolve(V2_ROOT, "python/mirascope");
 
   if (existsSync(pythonSourcePath)) {
     let regenerateTimeout: NodeJS.Timeout | null = null;


### PR DESCRIPTION
Test changes or examples changes don't need to regenerate api docs.