### PR TITLE
feat: refactor llm Model context management

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -74,7 +74,7 @@ from .messages import (
     UserContent,
     UserMessage,
 )
-from .models import Model, model
+from .models import Model, model, use_model
 from .prompts import prompt
 from .responses import (
     AsyncChunkIterator,
@@ -208,4 +208,5 @@ __all__ = [
     "tool",
     "tools",
     "types",
+    "use_model",
 ]

--- a/python/mirascope/llm/models/__init__.py
+++ b/python/mirascope/llm/models/__init__.py
@@ -1,15 +1,16 @@
 """The `llm.models` module for implementing the `Model` interface and utilities.
 
 This module provides a unified interface for interacting with different LLM models
-through the `Model` abstract class. The `llm.model` context manager allows you to
-easily run an LLM call with a model specified at runtime rather than definition
-time.
+through the `Model` class. The `llm.model()` context manager allows you to override
+the model at runtime, and `llm.use_model()` retrieves the model from context or
+creates a default one.
 """
 
-from .models import Model, get_model_from_context, model
+from .models import Model, get_model_from_context, model, use_model
 
 __all__ = [
     "Model",
     "get_model_from_context",
     "model",
+    "use_model",
 ]

--- a/python/tests/llm/models/test_model.py
+++ b/python/tests/llm/models/test_model.py
@@ -7,7 +7,7 @@ from mirascope import llm
 
 def test_client_pulled_from_context_at_call_time() -> None:
     """Test that models get client at call time, not construction time."""
-    model = llm.model(provider="openai:completions", model_id="gpt-4o")
+    model = llm.use_model(provider="openai:completions", model_id="gpt-4o")
 
     custom_client = llm.client("openai:completions", api_key="test-key")
 
@@ -18,3 +18,29 @@ def test_client_pulled_from_context_at_call_time() -> None:
         model.call(messages=[llm.messages.user("Hello")])
 
     mock_call.assert_called_once()
+
+
+def test_use_model_without_context() -> None:
+    """Test that use_model creates a new Model when no context is set."""
+    model = llm.use_model(provider="openai:completions", model_id="gpt-4o")
+
+    assert model.provider == "openai:completions"
+    assert model.model_id == "gpt-4o"
+
+
+def test_use_model_with_context() -> None:
+    """Test that use_model returns the context model when one is set."""
+    with llm.model(provider="anthropic", model_id="claude-sonnet-4-0"):
+        model = llm.use_model(provider="openai:completions", model_id="gpt-4o")
+
+        assert model.provider == "anthropic"
+        assert model.model_id == "claude-sonnet-4-0"
+
+
+def test_direct_model_instantiation_ignores_context() -> None:
+    """Test that direct Model instantiation ignores context (hardcoding behavior)."""
+    with llm.model(provider="anthropic", model_id="claude-sonnet-4-0"):
+        model = llm.Model(provider="openai:completions", model_id="gpt-4o")
+
+        assert model.provider == "openai:completions"
+        assert model.model_id == "gpt-4o"


### PR DESCRIPTION
- llm.use_model gets model from context, or uses default params
- llm.model is just a context manager
- llm.Model is not a context manager