### PR TITLE
fix: suppress MCP import errors

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -8,13 +8,14 @@ code that works with multiple LLM providers without changing your application lo
 # TODO: Across the API, audit docstrings to ensure they are compliant Google-style docstrings
 # (Write some tooling to ensure this happens consistently + in CI)
 
+from contextlib import suppress
+
 from . import (
     calls,
     clients,
     content,
     exceptions,
     formatting,
-    mcp,
     messages,
     models,
     prompts,
@@ -22,6 +23,9 @@ from . import (
     tools,
     types,
 )
+
+with suppress(ImportError):
+    from . import mcp
 from .calls import call
 from .clients import ModelId, Params, Provider, client, get_client
 from .content import (


### PR DESCRIPTION
I followed the v1 pattern, and I left mcp in `__all__` even if mcp
failed to import, but perhaps it'd be more correct to only add it to
`__all__` if import actually succeeded?