### PR TITLE
fix: resolve import error with python 3.13.9

### DIFF
--- a/python/mirascope/llm/tools/decorator.py
+++ b/python/mirascope/llm/tools/decorator.py
@@ -20,14 +20,14 @@ class ToolDecorator:
     @overload
     def __call__(  # pyright:ignore[reportOverlappingOverload]
         self, fn: ContextToolFn[DepsT, P, JsonableCovariantT]
-    ) -> ContextTool[DepsT, P, JsonableCovariantT]:
+    ) -> ContextTool[DepsT, JsonableCovariantT, P]:
         """Call the decorator with a context function."""
         ...
 
     @overload
     def __call__(  # pyright:ignore[reportOverlappingOverload]
         self, fn: AsyncContextToolFn[DepsT, P, JsonableCovariantT]
-    ) -> AsyncContextTool[DepsT, P, JsonableCovariantT]:
+    ) -> AsyncContextTool[DepsT, JsonableCovariantT, P]:
         """Call the decorator with an async context function."""
         ...
 
@@ -52,8 +52,8 @@ class ToolDecorator:
         | ToolFn[P, JsonableCovariantT]
         | AsyncToolFn[P, JsonableCovariantT],
     ) -> (
-        ContextTool[DepsT, P, JsonableCovariantT]
-        | AsyncContextTool[DepsT, P, JsonableCovariantT]
+        ContextTool[DepsT, JsonableCovariantT, P]
+        | AsyncContextTool[DepsT, JsonableCovariantT, P]
         | Tool[P, JsonableCovariantT]
         | AsyncTool[P, JsonableCovariantT]
     ):
@@ -62,11 +62,11 @@ class ToolDecorator:
         is_async = _tool_utils.is_async_tool_fn(fn)
 
         if is_context and is_async:
-            return AsyncContextTool[DepsT, P, JsonableCovariantT](
+            return AsyncContextTool[DepsT, JsonableCovariantT, P](
                 fn, strict=self.strict
             )
         elif is_context:
-            return ContextTool[DepsT, P, JsonableCovariantT](fn, strict=self.strict)
+            return ContextTool[DepsT, JsonableCovariantT, P](fn, strict=self.strict)
         elif is_async:
             return AsyncTool[P, JsonableCovariantT](fn, strict=self.strict)
         else:
@@ -76,7 +76,7 @@ class ToolDecorator:
 @overload
 def tool(  # pyright:ignore[reportOverlappingOverload]
     __fn: AsyncContextToolFn[DepsT, P, JsonableCovariantT],
-) -> AsyncContextTool[DepsT, P, JsonableCovariantT]:
+) -> AsyncContextTool[DepsT, JsonableCovariantT, P]:
     """Overload for async context tool functions."""
     ...
 
@@ -84,7 +84,7 @@ def tool(  # pyright:ignore[reportOverlappingOverload]
 @overload
 def tool(  # pyright:ignore[reportOverlappingOverload]
     __fn: ContextToolFn[DepsT, P, JsonableCovariantT],
-) -> ContextTool[DepsT, P, JsonableCovariantT]:
+) -> ContextTool[DepsT, JsonableCovariantT, P]:
     """Overload for context tool functions."""
     ...
 
@@ -116,8 +116,8 @@ def tool(
     *,
     strict: bool = False,
 ) -> (
-    ContextTool[DepsT, P, JsonableCovariantT]
-    | AsyncContextTool[DepsT, P, JsonableCovariantT]
+    ContextTool[DepsT, JsonableCovariantT, P]
+    | AsyncContextTool[DepsT, JsonableCovariantT, P]
     | Tool[P, JsonableCovariantT]
     | AsyncTool[P, JsonableCovariantT]
     | ToolDecorator

--- a/python/mirascope/llm/tools/tools.py
+++ b/python/mirascope/llm/tools/tools.py
@@ -89,7 +89,7 @@ class AsyncTool(
 
 class ContextTool(
     ToolSchema[ContextToolFn[DepsT, AnyP, JsonableCovariantT]],
-    Generic[DepsT, AnyP, JsonableCovariantT],
+    Generic[DepsT, JsonableCovariantT, AnyP],
 ):
     """Protocol defining a tool that can be used by LLMs.
 
@@ -130,7 +130,7 @@ class ContextTool(
 
 class AsyncContextTool(
     ToolSchema[AsyncContextToolFn[DepsT, AnyP, JsonableCovariantT]],
-    Generic[DepsT, AnyP, JsonableCovariantT],
+    Generic[DepsT, JsonableCovariantT, AnyP],
 ):
     """Protocol defining an async tool that can be used by LLMs with context.
 

--- a/python/typechecking/tool.py
+++ b/python/typechecking/tool.py
@@ -57,7 +57,7 @@ def decorate_context_tool_fn(
     fn: llm.tools.protocols.ContextToolFn[
         llm.context.DepsT, llm.types.P, llm.types.JsonableCovariantT
     ],
-) -> llm.ContextTool[llm.context.DepsT, llm.types.P, llm.types.JsonableCovariantT]:
+) -> llm.ContextTool[llm.context.DepsT, llm.types.JsonableCovariantT, llm.types.P]:
     """Decorating a ContextToolFn returns a Tool"""
     return llm.tool(fn)
 
@@ -66,6 +66,6 @@ def decorate_async_context_tool_fn(
     fn: llm.tools.protocols.AsyncContextToolFn[
         llm.context.DepsT, llm.types.P, llm.types.JsonableCovariantT
     ],
-) -> llm.AsyncContextTool[llm.context.DepsT, llm.types.P, llm.types.JsonableCovariantT]:
+) -> llm.AsyncContextTool[llm.context.DepsT, llm.types.JsonableCovariantT, llm.types.P]:
     """Decorating an AsyncToolFn returns an AsyncTool"""
     return llm.tool(fn)


### PR DESCRIPTION
In python 3.13.9, attempting to import Mirascope results in the
following error:

> TypeError: can only concatenate list (not "tuple") to list

After extensive investigation, it turns out this is due to a bug in
cpython, discussed here: https://github.com/python/cpython/issues/138859

The issue involves paramspecs with `default=...` (as our `AnyP` uses)
when that paramspec is not the last type argument. It has already been
fixed, but the fix has not yet made it into a 3.13 release (likely will
be fixed in 3.13.10).

To ensure immediate compatibility with 3.13, we can work around the bug
by re-ordering the paramspec argument to the last generic type arg to
`ContextTool` and `AsyncContextTool`.

This should fully resolve issues with python 3.13. I've added 3.13 to
the list of python versions under test.

Props to chatgpt-pro for ingesting a (still quite complex) minimal repro
and finding the correct underlying issue in cpython. Claude hallucinated
"helpful" but incorrect solutions, and Gemini was stumped too.
chatgpt-pro took 9 minutes to do research, but came back with
information that was actually correct.