### PR TITLE
fix: add top level pyrightconfig that points to python/

### DIFF
--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,7 @@
+{
+  "executionEnvironments": [
+    {
+      "root": "python"
+    }
+  ]
+}

--- a/python/lint-staged.ts
+++ b/python/lint-staged.ts
@@ -29,7 +29,7 @@ try {
   }
 
   // Run pyright on the whole project (doesn't work well with individual files)
-  await $`uv run pyright`.cwd("./python");
+  await $`uv run pyright .`.cwd("./python");
 
   await $`bun run codespell`;
 


### PR DESCRIPTION
This fixed some issues I was having with vscode pylance reporting
spurious type errors.