### PR TITLE
fix: fix the website build

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -289,9 +289,9 @@ For type safety, the `llm.ContextResponse[DepsT, FormatT]`. The first is the typ
 
 If you'd like to learn more about Mirascope v2, consider the following resources:
 
-- We have some [additional examples](/examples) that you may peruse.
+- We have some [additional examples](/docs/mirascope/v2/examples) that you may peruse.
 - We have extensive [end-to-end snapshot testing](https://github.com/Mirascope/mirascope/tree/v2/python/tests/e2e) which consists of real runnable Mirascope code, and snapshots that serialize the expected output. For example, here are [end to end tests for cross-provider thinking support](https://github.com/Mirascope/mirascope/blob/v2/python/tests/e2e/output/test_call_with_thinking_true.py) and [here are the corresponding snapshots](https://github.com/Mirascope/mirascope/tree/v2/python/tests/e2e/output/snapshots/test_call_with_thinking_true).
-- The [API reference](/api) documents all of the public functionality in Mirascope.
+- The [API reference](/docs/mirascope/v2/api) documents all of the public functionality in Mirascope.
 - You can hop on our [Discord](/discord-invite) and ask us questions directly!
 
 We welcome your feedback, questions, and bug reports.

--- a/docs/scripts/sync-website.ts
+++ b/docs/scripts/sync-website.ts
@@ -91,6 +91,8 @@ function generateApiDocs(): void {
       pythonSourcePath,
       "--package",
       "mirascope.llm",
+      "--api-root",
+      "/docs/mirascope/v2/api",
       "--output",
       apiDocsOutput,
     ],


### PR DESCRIPTION
This adapts to two changes I made on the website side:
- I enabled prerendering of the v2 docs (while keeping them hidden from
  sitemap / robots meta), upshot of which is: we now know about broken
  links! Fixed links in index.mdx to properly link to within the v2
  sections of the docs.
- As part of cleaning up broken links, I added a mandatory api-root
  argument to the api generator, so that api links will correctly point
  within /docs/mirascope/v2/api