### PR TITLE
Add OpenTelemetry instrumentation for Model.stream

### DIFF
--- a/python/tests/ops/cassettes/test_model_stream_exports_genai_span.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_exports_genai_span.yaml
@@ -1,0 +1,180 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"What is 4200 + 42?","role":"user"}],"model":"gpt-4o","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '89'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_01691512c894e96f00691abed521808193aad4f20d2e029ad7","object":"response","created_at":1763360469,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_01691512c894e96f00691abed521808193aad4f20d2e029ad7","object":"response","created_at":1763360469,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"oqeYe4v3JHXCd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"w3WuJS06yVaMGdb"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"c1VZioubbh88ox"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"mcNMb5JJEnr9XOW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"BW26dg9pncbCcA"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"
+        equals","logprobs":[],"obfuscation":"uPIQO7XU9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"BicQ75ZB0vO6xAV"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"xVR0nMaOZmOxn"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"4p2nsb81DfSZlcD"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"kj9CeXDdMDSE8up"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"text":"4200
+        + 42 equals 4242.","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_01691512c894e96f00691abed521808193aad4f20d2e029ad7","object":"response","created_at":1763360469,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_01691512c894e96f00691abed606d88193b18761ebef4ec2e1","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":27},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd20515c454b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:09 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=VSmBqvBc7A6YQrGAiOKnsXp_J1MMlSCkTRuVYYgIGJw-1763360469-1.0.1.1-mighkdMhtbNh2ksaQsy86VDGmILwbAPjRfpMFQLFZYMxj_M0mvU3jy1tl0hlIxz9lsF7TUy8kND2mPPLDn6x3D5lh76amFAvjZLrpGasfC4;
+        path=/; expires=Mon, 17-Nov-25 06:51:09 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '35'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '40'
+      x-request-id:
+      - req_93058c78ccd84b408964d8515e6ce6d9
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_model_stream_records_response_id.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_records_response_id.yaml
@@ -1,0 +1,176 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"What is 4200 + 42?","role":"user"}],"model":"gpt-4o","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '89'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_03cb7f69ecd3cb9100691abedeb65081939eaf2cd74b44f0e2","object":"response","created_at":1763360478,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_03cb7f69ecd3cb9100691abedeb65081939eaf2cd74b44f0e2","object":"response","created_at":1763360478,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"Yut8dmel0bfvy"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"cGj1ba7S2llLf4b"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"Toa1wif6R3SvcD"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"f50xpJB0c3jdy27"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"4bUzk4Mx3nKMBx"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"
+        equals","logprobs":[],"obfuscation":"bLm8RH15B"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"dUzCLCVs5A2q6UL"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"HARZPqa6PjdP9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"mAJ3GbjFuw3yjMR"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"F3aSXskn1G0y62X"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"text":"4200
+        + 42 equals 4242.","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_03cb7f69ecd3cb9100691abedeb65081939eaf2cd74b44f0e2","object":"response","created_at":1763360478,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_03cb7f69ecd3cb9100691abedf1ea48193a6b796f1d3f6cbd8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":27},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd208ebdb04b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:18 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '61'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '159'
+      x-request-id:
+      - req_3227eb031fdd4ec8b35f4832583d3700
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_model_stream_records_untracked_params_event.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_records_untracked_params_event.yaml
@@ -1,0 +1,176 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"What is 4200 + 42?","role":"user"}],"model":"gpt-4o","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '89'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_04c0b2adec46751e00691abeda8fac8194a699ffbc497b8565","object":"response","created_at":1763360474,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_04c0b2adec46751e00691abeda8fac8194a699ffbc497b8565","object":"response","created_at":1763360474,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"Tenq6pOG8QS4n"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"PN0Afl3unLGp8ji"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"j7doo0OEDImRf9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"AKYEaw0d61ygAEF"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"ukHMNqeVoqFPOU"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"
+        equals","logprobs":[],"obfuscation":"0WrnXmUt6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"Tp7IZiKu5Ev4z3C"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"4tJNZ9hgufVhe"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"vJtmaddYjpaMSxe"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"7eZmxe9XZMjnOes"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"text":"4200
+        + 42 equals 4242.","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_04c0b2adec46751e00691abeda8fac8194a699ffbc497b8565","object":"response","created_at":1763360474,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_04c0b2adec46751e00691abedb8a248194b84e06fbbf4dc42e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":27},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd20736f654b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:14 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '34'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '39'
+      x-request-id:
+      - req_49af05419a7a4d6bbcfc818fa260a470
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_model_stream_with_json_format.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_with_json_format.yaml
@@ -1,0 +1,282 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"developer","content":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output."},{"content":"Please
+      recommend the most popular book by Patrick Rothfuss","role":"user"}],"model":"gpt-4o","stream":true,"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '1151'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_04d1713f8d493de200691abed91edc819084fd53f757f7ba39","object":"response","created_at":1763360473,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        this tool to extract data in Book format for a final response.\nA book with
+        a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+        testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+        author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+        Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_04d1713f8d493de200691abed91edc819084fd53f757f7ba39","object":"response","created_at":1763360473,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        this tool to extract data in Book format for a final response.\nA book with
+        a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+        testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+        author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+        Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","type":"function_call","status":"in_progress","arguments":"","call_id":"call_ilZoWo2BBNh09HGIJFqSUs2j","name":"__mirascope_formatted_output_tool__"}}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"{\"","obfuscation":"ddBNxeEHkjIlxF"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"title","obfuscation":"GINEnunlS3p"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\":\"","obfuscation":"VxhPtlQE8nwD0"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"THE","obfuscation":"z1TXAcndwd2zR"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"
+        NAME","obfuscation":"5j22qBZA65R"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"
+        OF","obfuscation":"q3Y8eD7j4ITsU"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"
+        THE","obfuscation":"F0RgjoWFnthl"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":10,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"
+        WIND","obfuscation":"1I9OqgDYXYb"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":11,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\",\"","obfuscation":"Rd1jXIDsjAxr4"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":12,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"author","obfuscation":"vQKV7cxags"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\":{\"","obfuscation":"evlsoimxBDJF"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"first","obfuscation":"wixC9M3qhC7"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"_name","obfuscation":"ZHgGiypPuLk"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\":\"","obfuscation":"1UGD8e0kpHO2c"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"Patrick","obfuscation":"0sxuUMlZi"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\",\"","obfuscation":"fcOFDHGDwQv3y"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":19,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"last","obfuscation":"2iFuwqUvfkKV"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":20,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"_name","obfuscation":"e3aelApxeOK"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":21,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\":\"","obfuscation":"fJRTVE2A24LZk"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":22,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"R","obfuscation":"meijDcQXQYzsA2U"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":23,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"oth","obfuscation":"8qA0Z3O8ABUAS"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":24,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"f","obfuscation":"tDNdvrljKKE1Dt5"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":25,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"uss","obfuscation":"5uTN9Ae7MaJV7"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":26,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\"}","obfuscation":"hD8nOyLuXI0znp"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":27,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":",\"","obfuscation":"6a4qm24D49uhKE"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":28,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"rating","obfuscation":"aU6JCvUhhv"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":29,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"\":","obfuscation":"RZ6NKpV3kX4vy2"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":30,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"7","obfuscation":"vqqTtxnnrogiEDs"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":31,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"delta":"}","obfuscation":"4ZDv73Jqwox0xPR"}
+
+
+        event: response.function_call_arguments.done
+
+        data: {"type":"response.function_call_arguments.done","sequence_number":32,"item_id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","output_index":0,"arguments":"{\"title\":\"THE
+        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}"}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":33,"output_index":0,"item":{"id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
+        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_ilZoWo2BBNh09HGIJFqSUs2j","name":"__mirascope_formatted_output_tool__"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":34,"response":{"id":"resp_04d1713f8d493de200691abed91edc819084fd53f757f7ba39","object":"response","created_at":1763360473,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_04d1713f8d493de200691abed9dfbc81908275caede276f470","type":"function_call","status":"completed","arguments":"{\"title\":\"THE
+        NAME OF THE WIND\",\"author\":{\"first_name\":\"Patrick\",\"last_name\":\"Rothfuss\"},\"rating\":7}","call_id":"call_ilZoWo2BBNh09HGIJFqSUs2j","name":"__mirascope_formatted_output_tool__"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":{"type":"function","name":"__mirascope_formatted_output_tool__"},"tools":[{"type":"function","description":"Use
+        this tool to extract data in Book format for a final response.\nA book with
+        a rating. The title should be in all caps!","name":"__mirascope_formatted_output_tool__","parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+        testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+        author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+        Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object","additionalProperties":false}},"type":"object"},"strict":true}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":170,"input_tokens_details":{"cached_tokens":0},"output_tokens":30,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":200},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd206a4d534b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:13 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '35'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '42'
+      x-request-id:
+      - req_c303bbbc326648b2ab1494890c160fe9
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_model_stream_with_none_parameters.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_with_none_parameters.yaml
@@ -1,0 +1,171 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"What is 4200 + 42?","role":"user"}],"max_output_tokens":64,"model":"gpt-4o","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '112'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_05cfc66cc56de8b700691abedc5a9081969872b2038ea4fed1","object":"response","created_at":1763360476,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":64,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_05cfc66cc56de8b700691abedc5a9081969872b2038ea4fed1","object":"response","created_at":1763360476,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":64,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"nIZWKOaPDL9V3"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"o0E5GwIft8uKQhy"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"RFtqi79bPG6WAo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"Z8m6SSIrjnJDHQc"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"lPXpQYFcLcutKT"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"
+        =","logprobs":[],"obfuscation":"nZ8qNAnUv7pmhd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"JFziGtbtr3DeFLd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"1OHPZKOqJJkAs"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"zcI7uEE6hL8fWP1"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":13,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"text":"4200
+        + 42 = 4242","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":14,"item_id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 = 4242"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":15,"output_index":0,"item":{"id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 = 4242"}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":16,"response":{"id":"resp_05cfc66cc56de8b700691abedc5a9081969872b2038ea4fed1","object":"response","created_at":1763360476,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":64,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_05cfc66cc56de8b700691abedd5c108196913e573d8b77781b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 = 4242"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":10,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":26},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd207e8b844b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:16 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '75'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '84'
+      x-request-id:
+      - req_ba924e651cf441e5979a90bc4f3ea913
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_model_stream_with_tools.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_with_tools.yaml
@@ -1,0 +1,193 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"developer","content":"Use parallel tool calling."},{"content":"Please
+      retrieve the secrets associated with each of these passwords: mellon,radiance","role":"user"}],"model":"gpt-4o","stream":true,"tools":[{"type":"function","name":"secret_retrieval_tool","description":"A
+      tool that requires a password to retrieve a secret.","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '508'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0c57cb9aeff79ad100691abed6df4c819087fdcddbba99dcea","object":"response","created_at":1763360470,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0c57cb9aeff79ad100691abed6df4c819087fdcddbba99dcea","object":"response","created_at":1763360470,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","type":"function_call","status":"in_progress","arguments":"","call_id":"call_tVwplip8EyrgMsD2ZarNBIFJ","name":"secret_retrieval_tool"}}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":3,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"delta":"{","obfuscation":"BnOU4POqqDxcoYM"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":4,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"delta":"\"password","obfuscation":"CrkJZLl"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":5,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"delta":"\":","obfuscation":"UsNI4jz9p6Tf9g"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":6,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"delta":"\"m","obfuscation":"quwOdsiLLy3bir"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":7,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"delta":"ell","obfuscation":"ukyd5e4RFY2D2"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":8,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"delta":"on","obfuscation":"li1VdqBYJvlRyj"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":9,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"delta":"\"}","obfuscation":"SQzNe56azxdY8W"}
+
+
+        event: response.function_call_arguments.done
+
+        data: {"type":"response.function_call_arguments.done","sequence_number":10,"item_id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","output_index":0,"arguments":"{\"password\":\"mellon\"}"}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":11,"output_index":0,"item":{"id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_tVwplip8EyrgMsD2ZarNBIFJ","name":"secret_retrieval_tool"}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":12,"output_index":1,"item":{"id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","type":"function_call","status":"in_progress","arguments":"","call_id":"call_MHKI6t2Q3p5qwBAm21ysBMIc","name":"secret_retrieval_tool"}}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":13,"item_id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","output_index":1,"delta":"{","obfuscation":"0nk5p6nERDhvObX"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":14,"item_id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","output_index":1,"delta":"\"password","obfuscation":"8YFGOUF"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":15,"item_id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","output_index":1,"delta":"\":","obfuscation":"0eufic6bqAIdjG"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":16,"item_id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","output_index":1,"delta":"\"radi","obfuscation":"b6Zi7NuXRcg"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":17,"item_id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","output_index":1,"delta":"ance","obfuscation":"gIb9Dv2KPwhu"}
+
+
+        event: response.function_call_arguments.delta
+
+        data: {"type":"response.function_call_arguments.delta","sequence_number":18,"item_id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","output_index":1,"delta":"\"}","obfuscation":"liDX4on9bSjnvu"}
+
+
+        event: response.function_call_arguments.done
+
+        data: {"type":"response.function_call_arguments.done","sequence_number":19,"item_id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","output_index":1,"arguments":"{\"password\":\"radiance\"}"}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":20,"output_index":1,"item":{"id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_MHKI6t2Q3p5qwBAm21ysBMIc","name":"secret_retrieval_tool"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":21,"response":{"id":"resp_0c57cb9aeff79ad100691abed6df4c819087fdcddbba99dcea","object":"response","created_at":1763360470,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"fc_0c57cb9aeff79ad100691abed81afc8190a539b51a4ab18928","type":"function_call","status":"completed","arguments":"{\"password\":\"mellon\"}","call_id":"call_tVwplip8EyrgMsD2ZarNBIFJ","name":"secret_retrieval_tool"},{"id":"fc_0c57cb9aeff79ad100691abed8557481908ec08e70dac2c1f2","type":"function_call","status":"completed","arguments":"{\"password\":\"radiance\"}","call_id":"call_MHKI6t2Q3p5qwBAm21ysBMIc","name":"secret_retrieval_tool"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[{"type":"function","description":"A
+        tool that requires a password to retrieve a secret.","name":"secret_retrieval_tool","parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"strict":false}],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":36,"input_tokens_details":{"cached_tokens":0},"output_tokens":54,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":90},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd205bcf0f4b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:11 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '78'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '93'
+      x-request-id:
+      - req_eab45426affd49408e6ce8f2daea873c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_model_stream_with_tracer_set_to_none.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_with_tracer_set_to_none.yaml
@@ -1,0 +1,176 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"What is 4200 + 42?","role":"user"}],"model":"gpt-4o","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '89'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_018d4228dae52e1c00691abee196688190ba188115b4fb7651","object":"response","created_at":1763360481,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_018d4228dae52e1c00691abee196688190ba188115b4fb7651","object":"response","created_at":1763360481,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"A60miYRzmEp6a"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"9Gdt2YhNywptV0U"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"kX9SRlkCSrPHUT"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"xdDTNA5hXNj5hHv"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"ao7KgyibPd7ctU"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"
+        equals","logprobs":[],"obfuscation":"rc8uH7qzf"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"4vo9vWgiVzewEge"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"CdExBW7K3AukY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"FSPZuAw7lkophzH"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"3sYeVRfnY26amo6"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"text":"4200
+        + 42 equals 4242.","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_018d4228dae52e1c00691abee196688190ba188115b4fb7651","object":"response","created_at":1763360481,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_018d4228dae52e1c00691abee229808190a35126d282755c26","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":27},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd209e6f1e4b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:21 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '471'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '605'
+      x-request-id:
+      - req_f8a47fc87eb443ff9c6a28b1d624f4d4
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_model_stream_without_instrumentation.yaml
+++ b/python/tests/ops/cassettes/test_model_stream_without_instrumentation.yaml
@@ -1,0 +1,176 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"What is 4200 + 42?","role":"user"}],"model":"gpt-4o","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '89'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_09fa247c866d757f00691abedfea748193bb1fc9160da43642","object":"response","created_at":1763360479,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_09fa247c866d757f00691abedfea748193bb1fc9160da43642","object":"response","created_at":1763360479,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"420","logprobs":[],"obfuscation":"u0GdiERece3Qt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"0","logprobs":[],"obfuscation":"gDFsMGxArxPh2t0"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"
+        +","logprobs":[],"obfuscation":"Kk3hqyQpCQTMD0"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"19XkmkVqGa0ptzv"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"42","logprobs":[],"obfuscation":"WcbJSwezxKhDld"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"
+        equals","logprobs":[],"obfuscation":"1RJiZ0IE4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"
+        ","logprobs":[],"obfuscation":"2zeeS5nZB8rM6yk"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"424","logprobs":[],"obfuscation":"AwOKZkRgtC6xv"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"pZIqx80L1PriK0Q"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"GFtJGeiWoZ1BctC"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":14,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"text":"4200
+        + 42 equals 4242.","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":15,"item_id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":16,"output_index":0,"item":{"id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":17,"response":{"id":"resp_09fa247c866d757f00691abedfea748193bb1fc9160da43642","object":"response","created_at":1763360479,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-2024-08-06","output":[{"id":"msg_09fa247c866d757f00691abee0a98c8193818c76aab500b51f","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"4200
+        + 42 equals 4242."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":11,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":27},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 99fd20950e504b50-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Mon, 17 Nov 2025 06:21:20 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '27'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '32'
+      x-request-id:
+      - req_514ef90fd2c993aeb1fe5313ce0fa85e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/test_model_stream.py
+++ b/python/tests/ops/test_model_stream.py
@@ -1,0 +1,417 @@
+"""OpenTelemetry integration tests for `llm.Model.stream`."""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Iterator, Mapping
+from typing import TypedDict
+from unittest.mock import Mock, patch
+
+import httpx
+import openai
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from pydantic import BaseModel, Field
+
+from mirascope import llm, ops
+from mirascope.llm.clients import Params
+from mirascope.llm.content.text import TextChunk, TextStartChunk
+from mirascope.llm.responses import StreamResponseChunk
+from mirascope.llm.responses.stream_response import StreamResponse
+from mirascope.ops._internal.configuration import set_tracer
+from tests.ops.utils import span_snapshot
+
+
+@pytest.fixture(autouse=True, scope="function")
+def initialize() -> Generator[None, None, None]:
+    """Initialize ops configuration and LLM instrumentation for each test."""
+    ops.configure()
+    ops.instrument_llm()
+    yield
+    ops.uninstrument_llm()
+
+
+def _math_messages() -> list[llm.Message]:
+    """Return a simple math prompt for streaming tests."""
+    return [llm.messages.user("What is 4200 + 42?")]
+
+
+@pytest.mark.vcr()
+def test_model_stream_exports_genai_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.instrument_llm()
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+
+    response = model.stream(messages=_math_messages())
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+
+
+@pytest.mark.vcr()
+def test_model_stream_with_tools(span_exporter: InMemorySpanExporter) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.instrument_llm()
+
+    @llm.tool
+    def secret_retrieval_tool(password: str) -> str:
+        """A tool that requires a password to retrieve a secret."""
+
+        return f"Retrieved secret for {password}"
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+    messages = [
+        llm.messages.system("Use parallel tool calling."),
+        llm.messages.user(
+            "Please retrieve the secrets associated with each of these passwords: mellon,radiance"
+        ),
+    ]
+
+    response = model.stream(messages=messages, tools=[secret_retrieval_tool])
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.output.type": "text",
+                "gen_ai.tool.definitions": '[{"name":"secret_retrieval_tool","description":"A tool that requires a password to retrieve a secret.","strict":false,"parameters":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"$defs":null}}]',
+                "gen_ai.response.model": "gpt-4o",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.system_instructions": '[{"type":"text","content":"Use parallel tool calling."}]',
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"Please retrieve the secrets associated with each of these passwords: mellon,radiance"}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"tool_call","id":"call_tVwplip8EyrgMsD2ZarNBIFJ","name":"secret_retrieval_tool","arguments":{"password":"mellon"}},{"type":"tool_call","id":"call_MHKI6t2Q3p5qwBAm21ysBMIc","name":"secret_retrieval_tool","arguments":{"password":"radiance"}}],"finish_reason":"stop"}]',
+            },
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_model_stream_with_json_format(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+
+    class Author(BaseModel):
+        """The author of a book."""
+
+        first_name: str
+        last_name: str
+
+    class Book(BaseModel):
+        """A book with a rating. The title should be in all caps!"""
+
+        title: str
+        author: Author
+        rating: int = Field(description="For testing purposes, the rating should be 7")
+
+    ops.instrument_llm()
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+    messages = [
+        llm.messages.system(
+            "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+        ),
+        llm.messages.user("Please recommend the most popular book by Patrick Rothfuss"),
+    ]
+
+    response_format = llm.format(Book, mode="tool")
+    response = model.stream(messages=messages, format=response_format)
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.output.type": "json",
+                "gen_ai.tool.definitions": '[{"name":"__mirascope_formatted_output_tool__","description":"Use this tool to extract data in Book format for a final response.\\nA book with a rating. The title should be in all caps!","strict":true,"parameters":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}}}}]',
+                "gen_ai.response.model": "gpt-4o",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.system_instructions": '[{"type":"text","content":"Always respond to the user\'s query using the __mirascope_formatted_output_tool__ tool for structured output."}]',
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"Please recommend the most popular book by Patrick Rothfuss"}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"text","content":"{\\"title\\":\\"THE NAME OF THE WIND\\",\\"author\\":{\\"first_name\\":\\"Patrick\\",\\"last_name\\":\\"Rothfuss\\"},\\"rating\\":7}"}],"finish_reason":"stop"}]',
+            },
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_model_stream_records_untracked_params_event(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.instrument_llm()
+
+    class _NonSerializable:
+        """Dummy object that stringifies cleanly for untracked params tests."""
+
+        def __str__(self) -> str:
+            return "custom-param"
+
+    class _BadStr:
+        """Dummy object whose __str__ intentionally raises."""
+
+        def __str__(self) -> str:  # pragma: no cover - forced failure path
+            raise ValueError("cannot stringify")
+
+    class _TraceMetadata(TypedDict):
+        """Trace metadata payload."""
+
+        id: str
+        tags: list[str]
+
+    class _Metadata(TypedDict):
+        """Metadata container for trace info."""
+
+        trace: _TraceMetadata
+
+    class _ExtraParams(Params, total=False):
+        """Params with unsupported and serializable extras for testing."""
+
+        metadata: _Metadata
+        unsupported_list: list[int]
+        non_serializable: _NonSerializable
+        bad_str: _BadStr
+
+    extra_params: _ExtraParams = {
+        "metadata": {"trace": {"id": "abc123", "tags": ["otel"]}},
+        "unsupported_list": [1, 2, 3],
+        "non_serializable": _NonSerializable(),
+        "bad_str": _BadStr(),
+    }
+    model = llm.Model(
+        provider="openai:responses",
+        model_id="gpt-4o",
+        **extra_params,
+    )
+
+    response = model.stream(messages=_math_messages())
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    events = spans[0].events
+    event = events[-1]
+    event_attributes: Mapping[str, object] = event.attributes or {}
+    event_snapshot = {
+        "name": event.name,
+        "attributes": {
+            key: list(value) if isinstance(value, tuple) else value
+            for key, value in event_attributes.items()
+        },
+    }
+    assert event_snapshot == snapshot(
+        {
+            "name": "gen_ai.request.params.untracked",
+            "attributes": {
+                "gen_ai.untracked_params.count": 4,
+                "gen_ai.untracked_params.keys": [
+                    "metadata",
+                    "unsupported_list",
+                    "non_serializable",
+                    "bad_str",
+                ],
+                "gen_ai.untracked_params.json": '{"metadata":{"trace":{"id":"abc123","tags":["otel"]}},"unsupported_list":[1,2,3],"non_serializable":"custom-param","bad_str":"<_BadStr>"}',
+            },
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_model_stream_with_none_parameters(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.instrument_llm()
+    model = llm.Model(
+        provider="openai:responses",
+        model_id="gpt-4o",
+        temperature=None,  # type: ignore[arg-type]
+        max_tokens=64,
+        top_p=None,  # type: ignore[arg-type]
+    )
+
+    response = model.stream(messages=_math_messages())
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.output.type": "text",
+                "gen_ai.request.max_tokens": 64,
+                "gen_ai.response.model": "gpt-4o",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"What is 4200 + 42?"}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"text","content":"4200 + 42 = 4242"}],"finish_reason":"stop"}]',
+            },
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_model_stream_records_response_id(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.instrument_llm()
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+
+    response = model.stream(messages=_math_messages())
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attrs = spans[0].attributes or {}
+    assert "gen_ai.response.id" not in attrs
+    first_span_dict = span_snapshot(spans[0])
+    assert first_span_dict == snapshot(
+        {
+            "name": "chat gpt-4o",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.output.type": "text",
+                "gen_ai.response.model": "gpt-4o",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"What is 4200 + 42?"}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"text","content":"4200 + 42 equals 4242."}],"finish_reason":"stop"}]',
+            },
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_model_stream_without_instrumentation(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.uninstrument_llm()
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+    response = model.stream(messages=_math_messages())
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 0
+
+
+@pytest.mark.vcr()
+def test_model_stream_with_tracer_set_to_none(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    ops.instrument_llm()
+    set_tracer(None)
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+    response = model.stream(messages=_math_messages())
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 0
+
+
+def test_model_stream_with_error(span_exporter: InMemorySpanExporter) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.instrument_llm()
+
+    mock_client = Mock()
+    mock_client.stream.side_effect = openai.APIError(
+        "Server error occurred",
+        request=httpx.Request("POST", "https://example.com"),
+        body=None,
+    )
+
+    with patch("mirascope.llm.models.models.get_client", return_value=mock_client):
+        model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+        with pytest.raises(openai.APIError):
+            model.stream(messages=_math_messages())
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o",
+            "kind": "CLIENT",
+            "status": "ERROR",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o",
+                "gen_ai.output.type": "text",
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"What is 4200 + 42?"}]}]',
+                "error.type": "APIError",
+                "error.message": "Server error occurred",
+            },
+        }
+    )
+
+
+def test_model_stream_iterator_error_records_exception(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    ops.instrument_llm()
+
+    def _chunk_iterator() -> Iterator[StreamResponseChunk]:
+        """Return a chunk iterator that raises to simulate stream failure."""
+        yield TextStartChunk()
+        yield TextChunk(delta="partial")
+        raise RuntimeError("chunk boom")
+
+    mock_client = Mock()
+    mock_client.stream.return_value = StreamResponse(
+        provider="openai:responses",
+        model_id="gpt-4o",
+        params={},
+        tools=None,
+        format=None,
+        input_messages=_math_messages(),
+        chunk_iterator=_chunk_iterator(),
+    )
+
+    with patch("mirascope.llm.models.models.get_client", return_value=mock_client):
+        model = llm.Model(provider="openai:responses", model_id="gpt-4o")
+        response = model.stream(messages=_math_messages())
+        with pytest.raises(RuntimeError):
+            response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span = spans[0]
+    assert span.status.status_code.name == "ERROR"
+    attrs = span.attributes or {}
+    assert attrs["error.type"] == "RuntimeError"
+    assert attrs["error.message"] == "chunk boom"


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry instrumentation for `Model.stream()` to track streaming LLM calls.

### What changed?

- Extended OpenTelemetry instrumentation to support streaming LLM calls via `Model.stream()`
- Added a new `activate` parameter to the span context manager to control span activation
- Implemented proper span lifecycle management for streaming responses
- Added support for extracting response IDs and recording exceptions during streaming
- Created comprehensive test suite for streaming instrumentation
- Made the span context manager more robust by handling both activated and non-activated spans

### How to test?

1. Enable OpenTelemetry instrumentation:
   ```python
   from mirascope import llm
   llm.instrument_opentelemetry()
   ```

2. Use streaming with a model:
   ```python
   model = llm.Model(provider="openai:responses", model_id="gpt-4o")
   response = model.stream(messages=[llm.messages.user("What is 4200 + 42?")])
   for chunk in response:
       print(chunk, end="")
   ```

3. Verify spans are exported to your OpenTelemetry backend with proper attributes

### Why make this change?

This change completes the OpenTelemetry instrumentation by adding support for streaming LLM calls. Previously, only non-streaming calls were instrumented, leaving a gap in observability for streaming use cases. With this change, users can now track and monitor both streaming and non-streaming LLM interactions in their observability platforms, providing a complete picture of LLM usage, performance, and errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add OpenTelemetry GenAI instrumentation for Model.stream with proper span lifecycle, response/error handling, and comprehensive tests.
> 
> - **Instrumentation (llm.py)**:
>   - Add streaming wrapper `Model.stream` via `_instrumented_model_stream` with span activation control (`activate=False`), using `otel_trace.use_span`, and iterator wrapping to close/end spans on completion or errors.
>   - Extend `_start_model_span` with `activate` flag; support manual span start/end when not activated.
>   - Record untracked params as event (`gen_ai.request.params.untracked`) and attach dropped param metadata.
>   - Make `_attach_response` resilient (`FormattableT | None`, safe `raw` access); capture `gen_ai.response.id` when available.
>   - Wire up `_wrap_model_stream`/`_unwrap_model_stream`; update `instrument_llm`/`uninstrument_llm` to manage streaming instrumentation.
> - **Tests**:
>   - Add integration tests and VCR cassettes for streaming: basic span emission, tools, JSON format, untracked params event, None params, response ID, tracer=None, without instrumentation, API error, and iterator error handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3c2bcd96286897e041bc207e5297a0d547d0db8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->