### PR TITLE
Add OpenTelemetry instrumentation for Model.context_call

### DIFF
--- a/python/tests/ops/cassettes/test_model_context_call_exports_genai_span.yaml
+++ b/python/tests/ops/cassettes/test_model_context_call_exports_genai_span.yaml
@@ -1,0 +1,111 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"developer","content":"You are a concise assistant."},{"content":"Say
+      hello to the user named Kai.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '156'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3xUwW7bMAy99ys0nZvBjpPYyWXXDvuEYjAYiU61yqIhUVmDIv8+WI4de2t3s/nI
+        J5LvSe8PQkij5UFIj6Grs3Wxbo55o7aVLjcFZNlunwNu9sVG7VSV70vYVWVV7RXutkWxxp187Cno
+        +AsVjzTkAg5x5REYdQ09lpe7oiizvMgTFhg4hr5GUdtZZNRD0RHU68lTdH1fDdiAQ9hYa9xJHsT7
+        gxBCyA4u6Pt6jWe01KGXD0JcUzJ6Tz3morUpYNx4Sq2RwdiwRAP7qNiQW8RbeKspche5ZnrFf0Em
+        srUCu6RrSaPtOzt1vNrQqjXOrNbZerPKylVe3XaWeOVBPKdxhqEmOdpw+o8auNFVr0a1h+1GN4iw
+        V6VqBubEwpcOEw+GACe8A5+tPYGKHKO7NzVvbEE7LgXfeKpOCeAcMYyLfP65AC2dOk/HD5BEdBDy
+        Ca2lR/EDzBfxRL+FAie+CwjBBBYXioJJw+WbnGqvt6+JTnqyqcWhCBwPyX1iSpIdeLAW7VI89nHw
+        WefxbCiGerRynRSZxO08tR3XCtQL1q94+RTz2O/SkJtneIRAbuFjbBryPEvqVYptC37knmwdoEG+
+        1Eb3xI3BhcUD+rNRWLMZr0UD0Q76yMDkcT4mY9uhB44pnH/NbtGkw62zhnwL9/+Z/ilv2Out4zP6
+        IwXDl8F12sT2fh2HTb+QUYM0kUlOwN0OkqmrZybJpmA379FHp+C2WKlNgKMd346YzD4NYNzi6q63
+        j//GZ+/BNGYSUN8Ls8Wof78I+foj4CPeSf3PqJkY7B0symmFMSzVbpFBA0NPf324/gEAAP//AwD+
+        Uu7DygUAAA==
+    headers:
+      CF-RAY:
+      - 99fe0c367c3edb4f-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 Nov 2025 09:02:12 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=QkoZjRCyuW2mCuA5Y8KlS1SItPETvBpKDrfy1sy_Sr0-1763370132-1.0.1.1-amz.RBfpY1WOYCYS4FHlKqjNGdoPtHy515.FrHO2ToAwBd2dMfRS4IxHckduuNMEtg4QorX38hSLtBovkDcXB0xpkeB01KpoHeZxoDFUk_Y;
+        path=/; expires=Mon, 17-Nov-25 09:32:12 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=GFEa0D8EZ9P.KYmlDNg3y8Oa.jsfUeu_CDUXj4tU3Xc-1763370132254-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '893'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '896'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999956'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_d8c0ca8733664918ba5f54d18a908875
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/test_model_context_call.py
+++ b/python/tests/ops/test_model_context_call.py
@@ -1,0 +1,62 @@
+"""OpenTelemetry integration tests for `llm.Model.context_call`."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from mirascope import llm, ops
+from tests.ops.utils import span_snapshot
+
+
+@pytest.fixture(autouse=True, scope="function")
+def initialize() -> Generator[None, None, None]:
+    """Initialize ops configuration and LLM instrumentation for each test."""
+    ops.configure()
+    ops.instrument_llm()
+    yield
+    ops.uninstrument_llm()
+
+
+@pytest.mark.vcr()
+def test_model_context_call_exports_genai_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Ensure context_call emits a GenAI span with expected attributes."""
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={"tenant": "kai"})
+    messages = [
+        llm.messages.system("You are a concise assistant."),
+        llm.messages.user("Say hello to the user named Kai."),
+    ]
+
+    response = model.context_call(ctx=ctx, messages=messages)
+    assert "Kai" in response.pretty()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.output.type": "text",
+                "gen_ai.response.model": "gpt-4o-mini",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.response.id": "resp_0232fb1fc58d743a00691ae4934c6c8197a687889ce65332e6",
+                "gen_ai.system_instructions": '[{"type":"text","content":"You are a concise assistant."}]',
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"Say hello to the user named Kai."}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"text","content":"Hello, Kai! How can I assist you today?"}],"finish_reason":"stop"}]',
+            },
+        }
+    )


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry instrumentation support for `Model.context_call` method.

### What changed?

- Added instrumentation for the `Model.context_call` method to track and export telemetry data
- Added necessary imports for context-related types and tools
- Updated type annotations to support context-based tools and dependencies
- Added tracking variables to manage the wrapping state of the context call method
- Implemented wrapping and unwrapping functions for the context call method
- Added tests to verify the instrumentation works correctly with context calls

### How to test?

1. Run the new test `test_model_context_call_exports_genai_span` to verify that OpenTelemetry spans are correctly exported when using `Model.context_call`
2. Verify that the instrumentation correctly captures context-based calls with appropriate attributes in the span

### Why make this change?

This change completes the OpenTelemetry instrumentation coverage by adding support for the `context_call` method, which was previously not instrumented. This ensures consistent telemetry data collection across all model interaction methods, providing better observability for applications using context-based calls.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds GenAI span instrumentation for `llm.Model.context_call` and integrates it into instrument/uninstrument flows with tests.
> 
> - **Instrumentation (GenAI/OTel)**:
>   - Implement `_instrumented_model_context_call` wrapper for `llm.Model.context_call`, attaching request/response span attributes and untracked param events.
>   - Add wrap/unwrap hooks (`_wrap_model_context_call`, `_unwrap_model_context_call`) and state flags; wire into `instrument_llm()` and `uninstrument_llm()`.
> - **Types/Imports**:
>   - Introduce context-aware types (`Context`, `DepsT`, `ContextTool`, `ContextToolkit`, `ContextResponse`) into instrumentation signatures.
> - **Tests**:
>   - Add `test_model_context_call.py` verifying a GenAI span is exported for `context_call`.
>   - Include VCR cassette `test_model_context_call_exports_genai_span.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 000c3efa145c49e3a0d4358869d118b06122a385. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->