### PR TITLE
Add OpenTelemetry instrumentation for Model.context_call_async

### DIFF
--- a/python/tests/ops/cassettes/test_model_context_call_async_exports_genai_span.yaml
+++ b/python/tests/ops/cassettes/test_model_context_call_async_exports_genai_span.yaml
@@ -1,0 +1,109 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"developer","content":"You are a concise assistant."},{"content":"Say
+      hello to the user named Kai.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '156'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RUTZObMAy951e4Pm86kI8Fcul1O/0JOx1GgMi6ayyPLaeb2cl/72ACgW5yAz3p
+        WdJ79udKCKkaeRDSobdlsq32ebNtsrxKsk1eJ8lzkQLmFWBe7PK0yPIMq32e1XlRtGny3MinnoKq
+        P1jzSEPG4xCvHQJjU0KPpdnzdpulabGLmGfg4PuamjqrkfFKVkH9fnQUTN9XC9rjEFZaK3OUB/G5
+        EkIIaeGMrq9v8ISaLDq5EuISk9E56jETtI4BZcZTygYZlPZL1LMLNSsyi3gHHyUFtoFLpnf8CjKR
+        LmvQS7qOGtR9Z0fL6x2tO2XUepNsduskW6f5dWeRVx7EaxxnGGqSo/PHx2pU+a7KezUAkwaSrCj2
+        UO1ws4/MkYXPFiMPeg9HvAGP1h7BmgyjuTU1b2xBOy4FP3iqjglgDDGMi3z9vQA1Ha2j6g4SiQ5C
+        vqDW9CR+gfomXuivqMGInwK8V57FmYJgauD8Q061l+vXRCcd6djiUASGh+Q+MSZJCw60Rr0Uj10Y
+        fGYdnhQFX45WLqMik7jWUWe5rKF+w/Idzw8xh/0uFZl5hkPwZBY+xrYlx7OkXqXQdeBG7snWHlrk
+        c6manrhVuLC4R3dSNZasxmvRQtCDPtIzOZyPydhZdMAhhtPvyTUadbh21pLr4PY/0z/mDXu9dnxC
+        V5FXfB5c16jQ3a7jsOk3UvUgTWCSE3Czg2Sy5cwkyRS08x5dMDVcFysb5aHS49sRotmnAZRZXN3N
+        /ulrfPYeTGNGAZtbYbIY9f8XId3cA+7xTuo/omZi0Ddwm00rDH6pdocMDTD09JfV5R8AAAD//wMA
+        BcOc3soFAAA=
+    headers:
+      CF-RAY:
+      - 99fe262f5970688d-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 17 Nov 2025 09:19:55 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=_V0pimBnfyIbT.oCYt2DsYGZQEGTpAhcphM2SG3oay0-1763371195-1.0.1.1-ZjCqcpfIVtVbz5w.zNkMADYrEekg6bmqWVEM_61T.wOBAly2WQKAMfj9X0aso7I2nSP5iqIlfEmhmOT.cg3NpQ0vr4z2aRtPHXFLGvZQ0pI;
+        path=/; expires=Mon, 17-Nov-25 09:49:55 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '873'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '880'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999956'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_b0ff98f589994f78ab299157616ffd0e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/test_model_context_call_async.py
+++ b/python/tests/ops/test_model_context_call_async.py
@@ -1,0 +1,63 @@
+"""OpenTelemetry integration tests for `llm.Model.context_call_async`."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from mirascope import llm, ops
+from tests.ops.utils import span_snapshot
+
+
+@pytest.fixture(autouse=True, scope="function")
+def initialize() -> Generator[None, None, None]:
+    """Initialize ops configuration and LLM instrumentation for each test."""
+    ops.configure()
+    ops.instrument_llm()
+    yield
+    ops.uninstrument_llm()
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_model_context_call_async_exports_genai_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test OpenTelemetry instrumentation with context."""
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={"tenant": "kai"})
+    messages = [
+        llm.messages.system("You are a concise assistant."),
+        llm.messages.user("Say hello to the user named Kai."),
+    ]
+
+    response = await model.context_call_async(ctx=ctx, messages=messages)
+    assert "Kai" in response.pretty()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.output.type": "text",
+                "gen_ai.response.model": "gpt-4o-mini",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.response.id": "resp_03b58d3d78b0728c00691ae8bae894819787eb587c899f106d",
+                "gen_ai.system_instructions": '[{"type":"text","content":"You are a concise assistant."}]',
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"Say hello to the user named Kai."}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"text","content":"Hello, Kai! How can I assist you today?"}],"finish_reason":"stop"}]',
+            },
+        }
+    )


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry instrumentation for `Model.context_call_async` method.

### What changed?

- Added instrumentation for the `Model.context_call_async` method to track telemetry data
- Implemented wrapper function `_instrumented_model_context_call_async` with proper type annotations
- Added helper functions to wrap and unwrap the async context call method
- Updated the `instrument_opentelemetry` and `uninstrument_opentelemetry` functions to include the new wrapper
- Modified the `is_instrumented` check to verify the async context call is wrapped
- Added tests to verify the instrumentation works correctly

### How to test?

Run the new test case `test_model_context_call_async_exports_genai_span` which verifies that:
1. The async context call is properly instrumented
2. The generated span contains the expected attributes
3. The response includes the expected content

```bash
pytest python/tests/llm/otel/test_model_context_call_async.py -v
```

### Why make this change?

This change completes the OpenTelemetry instrumentation coverage by adding support for the `context_call_async` method. This ensures that all async operations with context dependencies can be properly traced and monitored, maintaining consistency with the rest of the instrumented methods in the codebase.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds OpenTelemetry instrumentation for `Model.context_call_async`, wires it into instrument/uninstrument, and adds an integration test with VCR cassette.
> 
> - **Instrumentation (LLM)**:
>   - Add `async` wrapper `_instrumented_model_context_call_async` with overloads and span attachment.
>   - Add wrap/unwrap helpers for `Model.context_call_async` and track wrapped state.
>   - Include async context call in `instrument_llm()` and `uninstrument_llm()`.
>   - Import async context response/tool types to support new wrapper.
> - **Tests**:
>   - New integration test `test_model_context_call_async_exports_genai_span` validating span attributes.
>   - Add VCR cassette `test_model_context_call_async_exports_genai_span.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e71afce061890c16dce8c26352a628676ef90aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->