### PR TITLE
Add OpenTelemetry instrumentation for Model.context_stream

### DIFF
--- a/python/tests/ops/cassettes/test_model_context_stream_exports_genai_span.yaml
+++ b/python/tests/ops/cassettes/test_model_context_stream_exports_genai_span.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"developer","content":"You are a concise assistant."},{"content":"Say
+      hello to the user named Kai.","role":"user"}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0f62205e7cf7668900691f28eafd248197a4ca4d562119f3c5","object":"response","created_at":1763649770,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0f62205e7cf7668900691f28eafd248197a4ca4d562119f3c5","object":"response","created_at":1763649770,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","output_index":0,"content_index":0,"delta":"Hello","logprobs":[],"obfuscation":"E8waGUUPFKq"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"YtF2ZwzuSKXAGdC"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","output_index":0,"content_index":0,"delta":"
+        Kai","logprobs":[],"obfuscation":"MN8rbrShN6y4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"SAsjxR2dPPKg87x"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":8,"item_id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","output_index":0,"content_index":0,"text":"Hello,
+        Kai!","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":9,"item_id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Hello,
+        Kai!"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":10,"output_index":0,"item":{"id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Hello,
+        Kai!"}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":11,"response":{"id":"resp_0f62205e7cf7668900691f28eafd248197a4ca4d562119f3c5","object":"response","created_at":1763649770,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_0f62205e7cf7668900691f28ebc97881979087ce3793414ad8","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Hello,
+        Kai!"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":25,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":30},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9a18b75a1e43c8d8-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 20 Nov 2025 14:42:51 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=LAqiHoZIHQ8tcC3f7RPH.w7fON.FcCF9xnUIdXu328M-1763649771-1.0.1.1-kAox_lkZVuk7w3ebKHfKhnJe.9Olj.SqhldYgQTILioX5cvofHy076y8VvGthCDKtwKKDIJT1gp_Zgs8gOj3b8N.WzUaONzW65bAGUhHnGQ;
+        path=/; expires=Thu, 20-Nov-25 15:12:51 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '34'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '40'
+      x-request-id:
+      - req_c7fbe99601d94b8ab639fcc0afb0cd50
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/test_model_context_stream.py
+++ b/python/tests/ops/test_model_context_stream.py
@@ -1,0 +1,142 @@
+"""OpenTelemetry integration tests for `llm.Model.context_stream`."""
+
+from __future__ import annotations
+
+from collections.abc import Generator, Sequence
+from typing import Any
+
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from mirascope import llm, ops
+from mirascope.ops._internal.configuration import set_tracer
+from mirascope.ops._internal.instrumentation.llm import llm as instrument_module
+from tests.ops.utils import span_snapshot
+
+
+@pytest.fixture(autouse=True, scope="function")
+def initialize() -> Generator[None, None, None]:
+    """Initialize ops configuration and LLM instrumentation for each test."""
+    ops.configure()
+    ops.instrument_llm()
+    yield
+    ops.uninstrument_llm()
+
+
+@pytest.mark.vcr()
+def test_model_context_stream_exports_genai_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={"tenant": "kai"})
+    messages = [
+        llm.messages.system("You are a concise assistant."),
+        llm.messages.user("Say hello to the user named Kai."),
+    ]
+
+    response = model.context_stream(ctx=ctx, messages=messages)
+    response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.output.type": "text",
+                "gen_ai.response.model": "gpt-4o-mini",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.system_instructions": '[{"type":"text","content":"You are a concise assistant."}]',
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"Say hello to the user named Kai."}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"text","content":"Hello, Kai!"}],"finish_reason":"stop"}]',
+            },
+        }
+    )
+
+
+def test_model_context_stream_without_tracer_returns_response(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that streaming a model call returns the response object."""
+    set_tracer(None)
+    dummy_response = object()
+
+    def _fake_context_stream(
+        self: llm.Model,
+        *,
+        ctx: llm.Context[Any],
+        messages: Sequence[llm.Message],
+        tools: object | None = None,
+        format: object | None = None,
+    ) -> object:
+        return dummy_response
+
+    monkeypatch.setattr(
+        instrument_module, "_ORIGINAL_MODEL_CONTEXT_STREAM", _fake_context_stream
+    )
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={})
+    messages = [llm.messages.user("hi")]
+
+    response = model.context_stream(ctx=ctx, messages=messages)
+
+    assert response is dummy_response
+    assert span_exporter.get_finished_spans() == ()
+
+
+def test_model_context_stream_records_error_on_exception(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+
+    def _failing_context_stream(
+        self: llm.Model,
+        *,
+        ctx: llm.Context[Any],
+        messages: Sequence[llm.Message],
+        tools: object | None = None,
+        format: object | None = None,
+    ) -> object:
+        raise ValueError("error")
+
+    monkeypatch.setattr(
+        instrument_module, "_ORIGINAL_MODEL_CONTEXT_STREAM", _failing_context_stream
+    )
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={})
+    messages = [llm.messages.user("hi")]
+
+    with pytest.raises(ValueError, match="error"):
+        model.context_stream(ctx=ctx, messages=messages)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "kind": "CLIENT",
+            "status": "ERROR",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.output.type": "text",
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"hi"}]}]',
+                "error.type": "ValueError",
+                "error.message": "error",
+            },
+        }
+    )


### PR DESCRIPTION
### TL;DR

Added instrumentation support for `Model.context_stream` method to enable OpenTelemetry tracing.

### What changed?

- Implemented `_instrumented_model_context_stream` function to wrap the original `Model.context_stream` method
- Added functions to wrap and unwrap the context stream method (`_wrap_model_context_stream` and `_unwrap_model_context_stream`)
- Updated the `instrument_llm` and `uninstrument_llm` functions to include the new context stream wrapper
- Modified the `is_instrumented` function to check if context stream is wrapped
- Updated `_attach_stream_span_handlers` to support `ContextStreamResponse` types
- Added tests for the new instrumentation functionality

### How to test?

- Run the new tests in `test_model_context_stream.py` to verify the instrumentation works correctly
- Test both successful and error cases for the `context_stream` method
- Verify that spans are properly created and exported with the expected attributes
- Check that the instrumentation can be enabled and disabled properly

### Why make this change?

This change completes the OpenTelemetry instrumentation coverage for Mirascope's LLM methods. Previously, the `context_stream` method was not instrumented, which meant that telemetry data was not being collected for streaming responses in context-aware scenarios. This implementation ensures consistent tracing across all LLM interaction patterns, providing better observability for applications using the streaming context API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Instrument `llm.Model.context_stream` with OTEL spans and integrate wrap/unwrap with instrumentation lifecycle; add focused tests and cassette.
> 
> - **Instrumentation (GenAI/OTEL)**:
>   - Add `*_ORIGINAL_MODEL_CONTEXT_STREAM` and `*_MODEL_CONTEXT_STREAM_WRAPPED` tracking in `ops/_internal/instrumentation/llm/llm.py`.
>   - Implement `'_instrumented_model_context_stream'` (with overloads) to wrap `Model.context_stream` and emit spans.
>   - Extend `_attach_stream_span_handlers` to accept `ContextStreamResponse`.
>   - Add `_wrap_model_context_stream` and `_unwrap_model_context_stream`.
>   - Register in `instrument_llm()` and unregister in `uninstrument_llm()`.
> - **Tests**:
>   - New `python/tests/ops/test_model_context_stream.py` validating span export, passthrough without tracer, and error recording.
>   - Add VCR cassette `python/tests/ops/cassettes/test_model_context_stream_exports_genai_span.yaml` for streaming interaction.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31d1c997dea255e691ce20dccf562b072f032af5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->