### PR TITLE
Add OpenTelemetry instrumentation for Model.context_stream_async

### DIFF
--- a/python/tests/ops/cassettes/test_model_context_stream_async_exports_genai_span.yaml
+++ b/python/tests/ops/cassettes/test_model_context_stream_async_exports_genai_span.yaml
@@ -1,0 +1,148 @@
+interactions:
+- request:
+    body: '{"input":[{"role":"developer","content":"You are a concise assistant."},{"content":"Say
+      hello to the user named Kai.","role":"user"}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '170'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_059e023db00a851000691f2a7325388194a40938fc5a3ba31f","object":"response","created_at":1763650163,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_059e023db00a851000691f2a7325388194a40938fc5a3ba31f","object":"response","created_at":1763650163,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","output_index":0,"content_index":0,"delta":"Hello","logprobs":[],"obfuscation":"DcDJDtVGjWF"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"uvya0f2t5zcZfeh"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","output_index":0,"content_index":0,"delta":"
+        Kai","logprobs":[],"obfuscation":"IYp6l8aBL2mm"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"IPwHjPtFPVOQQZY"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":8,"item_id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","output_index":0,"content_index":0,"text":"Hello,
+        Kai!","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":9,"item_id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"Hello,
+        Kai!"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":10,"output_index":0,"item":{"id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Hello,
+        Kai!"}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":11,"response":{"id":"resp_059e023db00a851000691f2a7325388194a40938fc5a3ba31f","object":"response","created_at":1763650163,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_059e023db00a851000691f2a73e17081948d7803eaad776686","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"Hello,
+        Kai!"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":25,"input_tokens_details":{"cached_tokens":0},"output_tokens":5,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":30},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9a18c0ed2db3e0b0-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Thu, 20 Nov 2025 14:49:23 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=lef7axwFTcu.JESprpXRpBbchQ1hsr97aXsyA.6Vv1I-1763650163-1.0.1.1-KHlLhVSzZKLGH0PqjfXoLs0vkrqVmCGNG3vA503jaNx1nF8SluoCuxYIPHuwKvPna187_7tT3nzGxqDK7u.yKopX4PrgUl6EHZ1g7vBa2QA;
+        path=/; expires=Thu, 20-Nov-25 15:19:23 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '33'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '40'
+      x-request-id:
+      - req_4e64d586eb29417fb62d32c7e5190c09
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/test_model_context_stream_async.py
+++ b/python/tests/ops/test_model_context_stream_async.py
@@ -1,0 +1,217 @@
+"""OpenTelemetry integration tests for `llm.Model.context_stream_async`."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Generator, Sequence
+from typing import Any
+
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+
+from mirascope import llm, ops
+from mirascope.llm.messages import Message
+from mirascope.llm.responses import AsyncContextStreamResponse, StreamResponseChunk
+from mirascope.ops._internal.configuration import set_tracer
+from mirascope.ops._internal.instrumentation.llm import llm as instrument_module
+from tests.ops.utils import span_snapshot
+
+
+@pytest.fixture(autouse=True, scope="function")
+def initialize() -> Generator[None, None, None]:
+    """Initialize ops configuration and LLM instrumentation for each test."""
+    ops.configure()
+    ops.instrument_llm()
+    yield
+    ops.uninstrument_llm()
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_model_context_stream_async_exports_genai_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={"tenant": "kai"})
+    messages: list[Message] = [
+        llm.messages.system("You are a concise assistant."),
+        llm.messages.user("Say hello to the user named Kai."),
+    ]
+
+    response = await model.context_stream_async(ctx=ctx, messages=messages)
+    await response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "kind": "CLIENT",
+            "status": "UNSET",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.output.type": "text",
+                "gen_ai.response.model": "gpt-4o-mini",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.system_instructions": '[{"type":"text","content":"You are a concise assistant."}]',
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"Say hello to the user named Kai."}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[{"type":"text","content":"Hello, Kai!"}],"finish_reason":"stop"}]',
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_context_stream_async_without_tracer_returns_response(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that streaming a model call returns the response object."""
+    set_tracer(None)
+    dummy_response = object()
+
+    async def _fake_context_stream_async(
+        self: llm.Model,
+        *,
+        ctx: llm.Context[Any],
+        messages: Sequence[llm.Message],
+        tools: object | None = None,
+        format: object | None = None,
+    ) -> object:
+        return dummy_response
+
+    monkeypatch.setattr(
+        instrument_module,
+        "_ORIGINAL_MODEL_CONTEXT_STREAM_ASYNC",
+        _fake_context_stream_async,
+    )
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={})
+    messages: list[Message] = [llm.messages.user("hi")]
+
+    response = await model.context_stream_async(ctx=ctx, messages=messages)
+
+    assert response is dummy_response
+    assert span_exporter.get_finished_spans() == ()
+
+
+@pytest.mark.asyncio
+async def test_model_context_stream_async_records_error_on_exception(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+
+    async def _failing_context_stream_async(
+        self: llm.Model,
+        *,
+        ctx: llm.Context[Any],
+        messages: Sequence[llm.Message],
+        tools: object | None = None,
+        format: object | None = None,
+    ) -> object:
+        raise ValueError("error")
+
+    monkeypatch.setattr(
+        instrument_module,
+        "_ORIGINAL_MODEL_CONTEXT_STREAM_ASYNC",
+        _failing_context_stream_async,
+    )
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={})
+    messages: list[Message] = [llm.messages.user("hi")]
+
+    with pytest.raises(ValueError, match="error"):
+        await model.context_stream_async(ctx=ctx, messages=messages)
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "kind": "CLIENT",
+            "status": "ERROR",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.output.type": "text",
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"hi"}]}]',
+                "error.type": "ValueError",
+                "error.message": "error",
+            },
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_model_context_stream_async_records_error_on_chunk_failure(
+    span_exporter: InMemorySpanExporter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test that streaming a model call exports the correct OpenTelemetry span."""
+
+    async def _chunk_error_iterator() -> AsyncIterator[StreamResponseChunk]:
+        raise RuntimeError("chunk-error")
+        yield  # pragma: no cover
+
+    async def _chunk_failure_context_stream_async(
+        self: llm.Model,
+        *,
+        ctx: llm.Context[Any],
+        messages: list[Message],
+        tools: object | None = None,
+        format: object | None = None,
+    ) -> AsyncContextStreamResponse[Any, None]:
+        return AsyncContextStreamResponse(
+            provider="openai:responses",
+            model_id="gpt-4o-mini",
+            params={},
+            tools=None,
+            format=None,
+            input_messages=messages,
+            chunk_iterator=_chunk_error_iterator(),
+        )
+
+    monkeypatch.setattr(
+        instrument_module,
+        "_ORIGINAL_MODEL_CONTEXT_STREAM_ASYNC",
+        _chunk_failure_context_stream_async,
+    )
+
+    model = llm.Model(provider="openai:responses", model_id="gpt-4o-mini")
+    ctx = llm.Context(deps={})
+    messages: list[Message] = [llm.messages.user("hi")]
+
+    with pytest.raises(RuntimeError, match="chunk-error"):
+        response = await model.context_stream_async(ctx=ctx, messages=messages)
+        await response.finish()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    span_dict = span_snapshot(spans[0])
+    assert span_dict == snapshot(
+        {
+            "name": "chat gpt-4o-mini",
+            "kind": "CLIENT",
+            "status": "ERROR",
+            "attributes": {
+                "gen_ai.operation.name": "chat",
+                "gen_ai.provider.name": "openai:responses",
+                "gen_ai.request.model": "gpt-4o-mini",
+                "gen_ai.output.type": "text",
+                "gen_ai.response.model": "gpt-4o-mini",
+                "gen_ai.response.finish_reasons": ["stop"],
+                "gen_ai.input.messages": '[{"role":"user","parts":[{"type":"text","content":"hi"}]}]',
+                "gen_ai.output.messages": '[{"role":"assistant","parts":[],"finish_reason":"stop"}]',
+                "error.type": "RuntimeError",
+                "error.message": "chunk-error",
+            },
+        }
+    )


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry instrumentation support for `Model.context_stream_async` method.

### What changed?

- Added instrumentation wrapper for `Model.context_stream_async` to capture telemetry data
- Implemented `_attach_async_stream_span_handlers` to handle async stream response spans
- Added necessary imports including `AsyncIterator` and `AsyncContextStreamResponse`
- Created test cases for the new instrumented method, including:
  - Successful span export test with VCR cassette
  - Test for handling when no tracer is available
  - Error handling tests for both method exceptions and chunk failures
- Updated the instrument/uninstrument functions to include the new wrapper

### How to test?

Run the new test cases in `test_model_context_stream_async.py`:
```bash
pytest python/tests/ops/test_model_context_stream_async.py -v
```

The tests verify that:
- Spans are properly exported when streaming async responses
- The system handles cases with no tracer gracefully
- Errors are properly recorded in spans for both method exceptions and chunk failures

### Why make this change?

This change completes the OpenTelemetry instrumentation coverage by adding support for the async streaming context method. This ensures that all LLM interaction patterns (sync/async, streaming/non-streaming) are properly instrumented, allowing for comprehensive telemetry data collection and monitoring of LLM operations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds OTEL span instrumentation and async stream span handling for `Model.context_stream_async`, with comprehensive tests and VCR cassette.
> 
> - **Instrumentation (GenAI/OTEL)**:
>   - Instrument `Model.context_stream_async` via `_instrumented_model_context_stream_async` with span creation, error recording, and dropped-param events.
>   - Add `_attach_async_stream_span_handlers` to close spans on async stream completion or errors.
>   - Wire into lifecycle: update `instrument_llm()`/`uninstrument_llm()` to wrap/unwrap `context_stream_async`.
>   - Minor: import `AsyncIterator`; handle `AsyncContextStreamResponse`.
> - **Tests**:
>   - Add `test_model_context_stream_async.py` covering successful span export (VCR), no-tracer passthrough, method exception, and chunk-failure error cases.
>   - Include VCR cassette `test_model_context_stream_async_exports_genai_span.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 17490e064e0965653d22fd5bea24b05aedb89100. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->