### PR TITLE
refactor: cloud/ git ignores into cloud/.gitignore + update STRUCTURE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,11 +176,4 @@ cython_debug/
 #sqlite
 database.db
 
-# Cloud / Cloudflare
-.wrangler
-.tanstack
-.dev.vars
-.env.local
-!cloud/src/lib
-
 node_modules

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -200,6 +200,10 @@ cloud/
 │   ├── reportWebVitals.ts   # Performance monitoring
 │   └── routeTree.gen.ts     # Auto-generated route tree
 ├── worker/                # Backend Cloudflare Workers
+│   ├── api/                 # API route handlers
+│   ├── health/              # Health check endpoints
+│   ├── app.ts               # Hono app configuration
+│   ├── environment.ts       # Environment type definitions
 │   └── index.ts             # Worker entry point
 ├── public/                # Static assets
 │   ├── fonts/               # Custom fonts

--- a/cloud/.gitignore
+++ b/cloud/.gitignore
@@ -1,0 +1,8 @@
+# Cloud-specific Ignores
+.wrangler
+.tanstack
+.dev.vars
+.env.local
+!cloud/src/lib
+
+docker/data


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Relocates cloud-specific gitignore rules to `cloud/.gitignore` (including `docker/data`) and updates `STRUCTURE.md` to reflect the Cloud worker layout and config files.
> 
> - **Git Ignore**:
>   - Move Cloudflare-related patterns from root `.gitignore` to `cloud/.gitignore`.
>   - Add `docker/data` to cloud ignore list.
> - **Docs**:
>   - Update `STRUCTURE.md` to detail `cloud/worker` structure (`api/`, `health/`, `app.ts`, `environment.ts`, `index.ts`).
>   - Include additional cloud files in overview (`vite.config.ts`, `vitest.config.ts`, `wrangler.jsonc`, `eslint.config.ts`, `index.html`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0a39d1bdaf36a9b27c6e65a5d2263d3ae18af12. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->