### PR TITLE
chore: remove implicit unknown types in example code

### DIFF
--- a/python/examples/intro/context/decorator.py
+++ b/python/examples/intro/context/decorator.py
@@ -14,13 +14,13 @@ def get_book_info(ctx: llm.Context[Library], book: str) -> str:
 
 @llm.call(provider="openai", model_id="gpt-5", tools=[get_book_info])
 # [!code highlight:2]
-def librarian(ctx: llm.Context[Library], query: str):
+def librarian(ctx: llm.Context[Library], query: str) -> list[llm.Message]:
     book_list = "\n".join(ctx.deps.available_books)
     return [
         llm.messages.system(
             f"You are a librarian, with access to these books: ${book_list}"
         ),
-        query,
+        llm.messages.user(query),
     ]
 
 

--- a/python/examples/intro/system_messages/decorator.py
+++ b/python/examples/intro/system_messages/decorator.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 @llm.call(provider="openai", model_id="gpt-5")
-def recommend_book(genre: str):
+def recommend_book(genre: str) -> list[llm.Message]:
     return [
         # [!code highlight]
         llm.messages.system("Always recommend kid-friendly books."),

--- a/python/examples/sazed/sazed.py
+++ b/python/examples/sazed/sazed.py
@@ -5,7 +5,7 @@ from mirascope import llm
     provider="openai",
     model_id="gpt-4o-mini",
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async.py
+++ b/python/examples/sazed/sazed_async.py
@@ -7,7 +7,7 @@ from mirascope import llm
     provider="openai",
     model_id="gpt-4o-mini",
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_context.py
+++ b/python/examples/sazed/sazed_async_context.py
@@ -13,7 +13,7 @@ class Coppermind:
     provider="openai",
     model_id="gpt-4o-mini",
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_context_structured.py
+++ b/python/examples/sazed/sazed_async_context_structured.py
@@ -22,7 +22,7 @@ class Coppermind:
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream.py
+++ b/python/examples/sazed/sazed_async_stream.py
@@ -7,7 +7,7 @@ from mirascope import llm
     provider="openai",
     model_id="gpt-4o-mini",
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream_context.py
+++ b/python/examples/sazed/sazed_async_stream_context.py
@@ -13,7 +13,7 @@ class Coppermind:
     provider="openai",
     model_id="gpt-4o-mini",
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream_context_structured.py
+++ b/python/examples/sazed/sazed_async_stream_context_structured.py
@@ -22,7 +22,7 @@ class Coppermind:
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream_structured.py
+++ b/python/examples/sazed/sazed_async_stream_structured.py
@@ -16,7 +16,7 @@ class KeeperEntry(BaseModel):
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream_tools.py
+++ b/python/examples/sazed/sazed_async_stream_tools.py
@@ -14,7 +14,7 @@ async def search_coppermind(query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream_tools_context.py
+++ b/python/examples/sazed/sazed_async_stream_tools_context.py
@@ -22,7 +22,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_context_structured.py
@@ -31,7 +31,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_structured.py
@@ -23,7 +23,7 @@ async def search_coppermind(query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_structured.py
+++ b/python/examples/sazed/sazed_async_structured.py
@@ -16,7 +16,7 @@ class KeeperEntry(BaseModel):
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_tools.py
+++ b/python/examples/sazed/sazed_async_tools.py
@@ -14,7 +14,7 @@ async def search_coppermind(query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_tools_context.py
+++ b/python/examples/sazed/sazed_async_tools_context.py
@@ -22,7 +22,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_tools_context_structured.py
+++ b/python/examples/sazed/sazed_async_tools_context_structured.py
@@ -31,7 +31,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-async def sazed(ctx: llm.Context[Coppermind], query: str):
+async def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_async_tools_structured.py
+++ b/python/examples/sazed/sazed_async_tools_structured.py
@@ -23,7 +23,7 @@ async def search_coppermind(query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-async def sazed(query: str):
+async def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_context.py
+++ b/python/examples/sazed/sazed_context.py
@@ -12,7 +12,7 @@ class Coppermind:
     provider="openai",
     model_id="gpt-4o-mini",
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_context_structured.py
+++ b/python/examples/sazed/sazed_context_structured.py
@@ -21,7 +21,7 @@ class Coppermind:
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream.py
+++ b/python/examples/sazed/sazed_stream.py
@@ -5,7 +5,7 @@ from mirascope import llm
     provider="openai",
     model_id="gpt-4o-mini",
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream_context.py
+++ b/python/examples/sazed/sazed_stream_context.py
@@ -12,7 +12,7 @@ class Coppermind:
     provider="openai",
     model_id="gpt-4o-mini",
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream_context_structured.py
+++ b/python/examples/sazed/sazed_stream_context_structured.py
@@ -21,7 +21,7 @@ class Coppermind:
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream_structured.py
+++ b/python/examples/sazed/sazed_stream_structured.py
@@ -14,7 +14,7 @@ class KeeperEntry(BaseModel):
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream_tools.py
+++ b/python/examples/sazed/sazed_stream_tools.py
@@ -12,7 +12,7 @@ def search_coppermind(query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream_tools_context.py
+++ b/python/examples/sazed/sazed_stream_tools_context.py
@@ -21,7 +21,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_context_structured.py
@@ -30,7 +30,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_structured.py
@@ -21,7 +21,7 @@ def search_coppermind(query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_structured.py
+++ b/python/examples/sazed/sazed_structured.py
@@ -14,7 +14,7 @@ class KeeperEntry(BaseModel):
     model_id="gpt-4o-mini",
     format=KeeperEntry,
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_tools.py
+++ b/python/examples/sazed/sazed_tools.py
@@ -12,7 +12,7 @@ def search_coppermind(query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_tools_context.py
+++ b/python/examples/sazed/sazed_tools_context.py
@@ -21,7 +21,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     model_id="gpt-4o-mini",
     tools=[search_coppermind],
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_tools_context_structured.py
+++ b/python/examples/sazed/sazed_tools_context_structured.py
@@ -30,7 +30,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-def sazed(ctx: llm.Context[Coppermind], query: str):
+def sazed(ctx: llm.Context[Coppermind], query: str) -> list[llm.Message]:
     system_prompt = f"""
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/examples/sazed/sazed_tools_structured.py
+++ b/python/examples/sazed/sazed_tools_structured.py
@@ -21,7 +21,7 @@ def search_coppermind(query: str) -> str:
     tools=[search_coppermind],
     format=KeeperEntry,
 )
-def sazed(query: str):
+def sazed(query: str) -> list[llm.Message]:
     system_prompt = """
     You are Sazed, a Keeper from Brandon Sanderson's Mistborn series. As a member of
     the Terris people, you are a living repository of knowledge, faithfully

--- a/python/scripts/example_generator.ts
+++ b/python/scripts/example_generator.ts
@@ -178,10 +178,14 @@ ${this._async}def search_coppermind(${this.ctx_argdef(true)}query: str) -> str:
 
   private get function_def(): string {
     if (this.agent) {
-      return `${this._async}def sazed(${this.ctx_argdef()}):
+      return `${
+        this._async
+      }def sazed(${this.ctx_argdef()}) -> list[llm.Message]:
     return ${this.system_prompt}`;
     } else {
-      return `${this._async}def sazed(${this.ctx_argdef(true)}query: str):
+      return `${this._async}def sazed(${this.ctx_argdef(
+        true
+      )}query: str) -> list[llm.Message]:
     system_prompt = ${this.system_prompt}
     return [llm.messages.system(system_prompt), llm.messages.user(query)]`;
     }


### PR DESCRIPTION
One of the necessary changes to allow us to disable implicit unknown
parameter and return types. Also, catches a bug in the examples in the
process (where we have a list of llm.messages but actually one of the
returned content pieces is a bare string, not a message)