### PR TITLE
chore: fix unknown type issues in client code

### DIFF
--- a/python/mirascope/llm/agents/decorator.py
+++ b/python/mirascope/llm/agents/decorator.py
@@ -158,7 +158,7 @@ def agent(
     model_id: ModelId,
     tools: list[AgentToolT] | None = None,
     format: type[FormattableT] | None = None,
-    client: BaseClient | None = None,
+    client: BaseClient[str, Any, Any] | None = None,
     **params: Unpack[Params],
 ) -> AgentDecorator[..., AgentToolT, FormattableT]:
     """Decorator for creating an agent or structured agent.

--- a/python/mirascope/llm/clients/anthropic/clients.py
+++ b/python/mirascope/llm/clients/anthropic/clients.py
@@ -36,8 +36,8 @@ from ..base import BaseClient, Params
 from . import _utils
 from .model_ids import AnthropicModelId
 
-ANTHROPIC_CLIENT_CONTEXT: ContextVar["AnthropicClient | None"] = ContextVar(
-    "ANTHROPIC_CLIENT_CONTEXT", default=None
+ANTHROPIC_CLIENT_CONTEXT: ContextVar["AnthropicClient"] = ContextVar(
+    "ANTHROPIC_CLIENT_CONTEXT"
 )
 
 
@@ -76,15 +76,15 @@ def get_client() -> "AnthropicClient":
         The current Anthropic client from context if available, otherwise
         a global default client based on environment variables.
     """
-    ctx_client = ANTHROPIC_CLIENT_CONTEXT.get()
+    ctx_client = ANTHROPIC_CLIENT_CONTEXT.get(None)
     return ctx_client or client()
 
 
-class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
+class AnthropicClient(BaseClient[AnthropicModelId, Anthropic, "AnthropicClient"]):
     """The client for the Anthropic LLM model."""
 
     @property
-    def _context_var(self) -> ContextVar["AnthropicClient | None"]:
+    def _context_var(self) -> ContextVar["AnthropicClient"]:
         return ANTHROPIC_CLIENT_CONTEXT
 
     def __init__(

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -37,9 +37,7 @@ from ..base import BaseClient, Params
 from . import _utils
 from .model_ids import GoogleModelId
 
-GOOGLE_CLIENT_CONTEXT: ContextVar["GoogleClient | None"] = ContextVar(
-    "GOOGLE_CLIENT_CONTEXT", default=None
-)
+GOOGLE_CLIENT_CONTEXT: ContextVar["GoogleClient"] = ContextVar("GOOGLE_CLIENT_CONTEXT")
 
 
 @lru_cache(maxsize=256)
@@ -75,15 +73,15 @@ def get_client() -> "GoogleClient":
         The current Google client from context if available, otherwise
         a global default client based on environment variables.
     """
-    ctx_client = GOOGLE_CLIENT_CONTEXT.get()
+    ctx_client = GOOGLE_CLIENT_CONTEXT.get(None)
     return ctx_client or client()
 
 
-class GoogleClient(BaseClient[GoogleModelId, Client]):
+class GoogleClient(BaseClient[GoogleModelId, Client, "GoogleClient"]):
     """The client for the Google LLM model."""
 
     @property
-    def _context_var(self) -> ContextVar["GoogleClient | None"]:
+    def _context_var(self) -> ContextVar["GoogleClient"]:
         return GOOGLE_CLIENT_CONTEXT
 
     def __init__(

--- a/python/mirascope/llm/clients/openai/completions/clients.py
+++ b/python/mirascope/llm/clients/openai/completions/clients.py
@@ -36,8 +36,8 @@ from ...base import BaseClient, Params
 from . import _utils
 from .model_ids import OpenAICompletionsModelId
 
-OPENAI_COMPLETIONS_CLIENT_CONTEXT: ContextVar["OpenAICompletionsClient | None"] = (
-    ContextVar("OPENAI_COMPLETIONS_CLIENT_CONTEXT", default=None)
+OPENAI_COMPLETIONS_CLIENT_CONTEXT: ContextVar["OpenAICompletionsClient"] = ContextVar(
+    "OPENAI_COMPLETIONS_CLIENT_CONTEXT"
 )
 
 
@@ -76,15 +76,17 @@ def get_client() -> "OpenAICompletionsClient":
         The current OpenAI client from context if available, otherwise
         a global default client based on environment variables.
     """
-    ctx_client = OPENAI_COMPLETIONS_CLIENT_CONTEXT.get()
+    ctx_client = OPENAI_COMPLETIONS_CLIENT_CONTEXT.get(None)
     return ctx_client or client()
 
 
-class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
+class OpenAICompletionsClient(
+    BaseClient[OpenAICompletionsModelId, OpenAI, "OpenAICompletionsClient"]
+):
     """The client for the OpenAI LLM model."""
 
     @property
-    def _context_var(self) -> ContextVar["OpenAICompletionsClient | None"]:
+    def _context_var(self) -> ContextVar["OpenAICompletionsClient"]:
         return OPENAI_COMPLETIONS_CLIENT_CONTEXT
 
     def __init__(

--- a/python/mirascope/llm/clients/openai/responses/clients.py
+++ b/python/mirascope/llm/clients/openai/responses/clients.py
@@ -36,8 +36,8 @@ from ...base import BaseClient, Params
 from . import _utils
 from .model_ids import OpenAIResponsesModelId
 
-OPENAI_RESPONSES_CLIENT_CONTEXT: ContextVar["OpenAIResponsesClient | None"] = (
-    ContextVar("OPENAI_RESPONSES_CLIENT_CONTEXT", default=None)
+OPENAI_RESPONSES_CLIENT_CONTEXT: ContextVar["OpenAIResponsesClient"] = ContextVar(
+    "OPENAI_RESPONSES_CLIENT_CONTEXT"
 )
 
 
@@ -60,18 +60,20 @@ def client(
 
 def get_client() -> "OpenAIResponsesClient":
     """Get the current `OpenAIResponsesClient` from context."""
-    current_client = OPENAI_RESPONSES_CLIENT_CONTEXT.get()
+    current_client = OPENAI_RESPONSES_CLIENT_CONTEXT.get(None)
     if current_client is None:
         current_client = client()
         OPENAI_RESPONSES_CLIENT_CONTEXT.set(current_client)
     return current_client
 
 
-class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
+class OpenAIResponsesClient(
+    BaseClient[OpenAIResponsesModelId, OpenAI, "OpenAIResponsesClient"]
+):
     """The client for the OpenAI Responses API."""
 
     @property
-    def _context_var(self) -> ContextVar["OpenAIResponsesClient | None"]:
+    def _context_var(self) -> ContextVar["OpenAIResponsesClient"]:
         return OPENAI_RESPONSES_CLIENT_CONTEXT
 
     def __init__(

--- a/python/tests/llm/clients/test_providers.py
+++ b/python/tests/llm/clients/test_providers.py
@@ -50,4 +50,4 @@ def test_get_client_openai_responses() -> None:
 def test_get_client_unknown_provider() -> None:
     """Test that get_client raises ValueError for unknown providers."""
     with pytest.raises(ValueError, match="Unknown provider: unknown"):
-        llm.get_client("unknown")  # type: ignore
+        llm.get_client("unknown")  # pyright: ignore[reportArgumentType, reportCallIssue]


### PR DESCRIPTION
Setting the base context_var property as ContextVar[Any] is not my first
choice (ContextVar[Self] is more accurate) but it was necessary to work
around some variance issues (the TypeVar for ContextVar is invariant).
Since it's a private property I think it's okay. (Also we are planning
to move the clients out of the public API anyway I think.)