### PR TITLE
chore: enable strictListInference in pyright

### DIFF
--- a/python/examples/intro/context/decorator.py
+++ b/python/examples/intro/context/decorator.py
@@ -20,7 +20,7 @@ def librarian(ctx: llm.Context[Library], query: str):
         llm.messages.system(
             f"You are a librarian, with access to these books: ${book_list}"
         ),
-        query,
+        llm.messages.user(query),
     ]
 
 

--- a/python/examples/intro/context/model.py
+++ b/python/examples/intro/context/model.py
@@ -20,7 +20,7 @@ def librarian(ctx: llm.Context[Library], query: str):
         llm.messages.system(
             f"You are a librarian, with access to these books: ${book_list}"
         ),
-        query,
+        llm.messages.user(query),
     ]
     # [!code highlight:2]
     return model.context_call(ctx=ctx, messages=messages, tools=[get_book_info])

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -293,7 +293,7 @@ class Model:
     async def stream_async(
         self,
         *,
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
     ) -> AsyncStreamResponse:
@@ -304,7 +304,7 @@ class Model:
     async def stream_async(
         self,
         *,
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
     ) -> AsyncStreamResponse[FormattableT]:
@@ -315,7 +315,7 @@ class Model:
     async def stream_async(
         self,
         *,
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
@@ -325,7 +325,7 @@ class Model:
     async def stream_async(
         self,
         *,
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
@@ -572,7 +572,7 @@ class Model:
         self,
         *,
         ctx: Context[DepsT],
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
@@ -586,7 +586,7 @@ class Model:
         self,
         *,
         ctx: Context[DepsT],
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
@@ -600,7 +600,7 @@ class Model:
         self,
         *,
         ctx: Context[DepsT],
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
@@ -616,7 +616,7 @@ class Model:
         self,
         *,
         ctx: Context[DepsT],
-        messages: list[Message],
+        messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,

--- a/python/mirascope/llm/prompts/_utils.py
+++ b/python/mirascope/llm/prompts/_utils.py
@@ -1,4 +1,5 @@
 import inspect
+from collections.abc import Sequence
 from typing_extensions import TypeIs
 
 from ..context import DepsT, _utils as _context_utils
@@ -20,8 +21,8 @@ from .protocols import (
 
 
 def is_messages(
-    messages_or_content: list[Message] | UserContent,
-) -> TypeIs[list[Message]]:
+    messages_or_content: Sequence[Message] | UserContent,
+) -> TypeIs[Sequence[Message]]:
     if not messages_or_content:
         raise ValueError("Prompt returned empty content")
     return isinstance(messages_or_content, list) and isinstance(
@@ -29,7 +30,7 @@ def is_messages(
     )
 
 
-def promote_to_messages(result: list[Message] | UserContent) -> list[Message]:
+def promote_to_messages(result: Sequence[Message] | UserContent) -> Sequence[Message]:
     """Promote a prompt result to a list of messages.
 
     If the result is already a list of Messages, returns it as-is.

--- a/python/mirascope/llm/prompts/decorator.py
+++ b/python/mirascope/llm/prompts/decorator.py
@@ -1,5 +1,6 @@
 """The `prompt` decorator for writing messages as string templates."""
 
+from collections.abc import Sequence
 from typing import overload
 
 from ..context import Context, DepsT
@@ -79,7 +80,7 @@ class PromptDecorator:
 
             async def async_context_prompt(
                 ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
-            ) -> list[Message]:
+            ) -> Sequence[Message]:
                 result = await fn(ctx, *args, **kwargs)
                 return _utils.promote_to_messages(result)
 
@@ -89,7 +90,7 @@ class PromptDecorator:
 
             def context_prompt(
                 ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
-            ) -> list[Message]:
+            ) -> Sequence[Message]:
                 result = fn(ctx, *args, **kwargs)
                 return _utils.promote_to_messages(result)
 
@@ -97,7 +98,9 @@ class PromptDecorator:
         elif is_async:
             fn  # pyright: ignore[reportUnusedExpression]  # noqa: B018
 
-            async def async_prompt(*args: P.args, **kwargs: P.kwargs) -> list[Message]:
+            async def async_prompt(
+                *args: P.args, **kwargs: P.kwargs
+            ) -> Sequence[Message]:
                 result = await fn(*args, **kwargs)
                 return _utils.promote_to_messages(result)
 
@@ -105,7 +108,7 @@ class PromptDecorator:
         else:
             fn  # pyright: ignore[reportUnusedExpression]  # noqa: B018
 
-            def prompt(*args: P.args, **kwargs: P.kwargs) -> list[Message]:
+            def prompt(*args: P.args, **kwargs: P.kwargs) -> Sequence[Message]:
                 result = fn(*args, **kwargs)
                 return _utils.promote_to_messages(result)
 
@@ -231,7 +234,7 @@ def prompt(
     """Prompt decorator for turning functions (or "Prompts") into prompts.
 
     This decorator transforms a function into a Prompt, i.e. a function that
-    returns `list[llm.Message]`. Its behavior depends on whether it's called with a spec
+    returns `Sequence[llm.Message]`. Its behavior depends on whether it's called with a spec
     string.
 
     If the first parameter is named 'ctx' or typed as `llm.Context[T]`, it creates

--- a/python/mirascope/llm/prompts/protocols.py
+++ b/python/mirascope/llm/prompts/protocols.py
@@ -1,5 +1,6 @@
 """Types for prompt functions."""
 
+from collections.abc import Sequence
 from typing import Any, Protocol, TypeVar
 
 from ..context import Context, DepsT
@@ -12,57 +13,59 @@ PromptT = TypeVar(
 )
 """Type variable for prompt types.
 
-This type var represents a resolved prompt, i.e. one that returns a list of messages.
+This type var represents a resolved prompt, i.e. one that returns a Sequence of messages.
 """
 
 
 class Prompt(Protocol[P]):
-    """Protocol for a `Prompt`, which returns `list[Message]`."""
+    """Protocol for a `Prompt`, which returns `Sequence[Message]`."""
 
-    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> list[Message]: ...
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> Sequence[Message]: ...
 
 
 class Promptable(Protocol[P]):
-    """Protocol for a `Promptable` that returns `UserContent` or `list[Message]`.
+    """Protocol for a `Promptable` that returns `UserContent` or `Sequence[Message]`.
 
     May be be converted by the `prompt` decorator into a `Prompt`.
     """
 
     def __call__(
         self, *args: P.args, **kwargs: P.kwargs
-    ) -> UserContent | list[Message]: ...
+    ) -> UserContent | Sequence[Message]: ...
 
 
 class AsyncPrompt(Protocol[P]):
-    """Protocol for an `AsyncPrompt`, which returns `list[Message]`."""
+    """Protocol for an `AsyncPrompt`, which returns `Sequence[Message]`."""
 
-    async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> list[Message]: ...
+    async def __call__(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> Sequence[Message]: ...
 
 
 class AsyncPromptable(Protocol[P]):
-    """Protocol for an `AsyncPromptable` that returns `UserContent` or `list[Message]`.
+    """Protocol for an `AsyncPromptable` that returns `UserContent` or `Sequence[Message]`.
 
     May be converted by the `prompt` decorator into an `AsyncPrompt`.
     """
 
     async def __call__(
         self, *args: P.args, **kwargs: P.kwargs
-    ) -> UserContent | list[Message]: ...
+    ) -> UserContent | Sequence[Message]: ...
 
 
 class ContextPrompt(Protocol[P, DepsT]):
-    """Protocol for a `ContextPrompt`, which returns `list[Message]`."""
+    """Protocol for a `ContextPrompt`, which returns `Sequence[Message]`."""
 
     def __call__(
         self,
         ctx: Context[DepsT],
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> list[Message]: ...
+    ) -> Sequence[Message]: ...
 
 
 class ContextPromptable(Protocol[P, DepsT]):
-    """Protocol for a `ContextPromptable` that returns `UserContent` or `list[Message]`.
+    """Protocol for a `ContextPromptable` that returns `UserContent` or `Sequence[Message]`.
 
     May be converted by the `prompt` decorator into a `ContextPrompt`.
     """
@@ -72,22 +75,22 @@ class ContextPromptable(Protocol[P, DepsT]):
         ctx: Context[DepsT],
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> UserContent | list[Message]: ...
+    ) -> UserContent | Sequence[Message]: ...
 
 
 class AsyncContextPrompt(Protocol[P, DepsT]):
-    """Protocol for an `AsyncContextPrompt`, which returns `list[Message]`."""
+    """Protocol for an `AsyncContextPrompt`, which returns `Sequence[Message]`."""
 
     async def __call__(
         self,
         ctx: Context[DepsT],
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> list[Message]: ...
+    ) -> Sequence[Message]: ...
 
 
 class AsyncContextPromptable(Protocol[P, DepsT]):
-    """Protocol for an `AsyncContextPromptable` that returns `UserContent` or `list[Message]`.
+    """Protocol for an `AsyncContextPromptable` that returns `UserContent` or `Sequence[Message]`.
 
     May be converted by the `prompt` decorator into an `AsyncContextPrompt`.
     """
@@ -97,4 +100,4 @@ class AsyncContextPromptable(Protocol[P, DepsT]):
         ctx: Context[DepsT],
         *args: P.args,
         **kwargs: P.kwargs,
-    ) -> UserContent | list[Message]: ...
+    ) -> UserContent | Sequence[Message]: ...

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -166,6 +166,7 @@ reportUnnecessaryTypeIgnoreComment = "error"
 reportUnknownParameterType = "error"
 reportMissingParameterType = "error"
 reportMissingTypeArgument = "error"
+strictListInference = true
 
 executionEnvironments = [
     { root = "examples", reportUnknownParameterType = "none" },

--- a/python/tests/llm/responses/test_stream_response.py
+++ b/python/tests/llm/responses/test_stream_response.py
@@ -11,7 +11,7 @@ from mirascope.llm.tools import FORMAT_TOOL_NAME
 
 
 def create_sync_stream_response(
-    chunks: list[llm.StreamResponseChunk],
+    chunks: Sequence[llm.StreamResponseChunk],
 ) -> llm.StreamResponse:
     """Create a llm.StreamResponse with a functioning iterator for testing."""
 
@@ -31,7 +31,7 @@ def create_sync_stream_response(
 
 
 def create_async_stream_response(
-    chunks: list[llm.StreamResponseChunk],
+    chunks: Sequence[llm.StreamResponseChunk],
 ) -> llm.AsyncStreamResponse:
     """Create a llm.StreamResponse with a functioning iterator for testing."""
 
@@ -71,7 +71,7 @@ def example_tool_call() -> llm.ToolCall:
 
 
 @pytest.fixture
-def example_text_chunks() -> list[llm.StreamResponseChunk]:
+def example_text_chunks() -> Sequence[llm.StreamResponseChunk]:
     """Create a complete text chunk sequence for testing."""
     return [
         llm.TextStartChunk(),
@@ -83,7 +83,7 @@ def example_text_chunks() -> list[llm.StreamResponseChunk]:
 
 
 @pytest.fixture
-def example_thought_chunks() -> list[llm.StreamResponseChunk]:
+def example_thought_chunks() -> Sequence[llm.StreamResponseChunk]:
     """Create a complete thought chunk sequence for testing."""
     return [
         llm.ThoughtStartChunk(),
@@ -94,7 +94,7 @@ def example_thought_chunks() -> list[llm.StreamResponseChunk]:
 
 
 @pytest.fixture
-def example_tool_call_chunks() -> list[llm.StreamResponseChunk]:
+def example_tool_call_chunks() -> Sequence[llm.StreamResponseChunk]:
     """Create a complete tool call chunk sequence for testing."""
     return [
         llm.ToolCallStartChunk(
@@ -130,7 +130,7 @@ def check_stream_response_consistency(
 
 
 def test_sync_initialization(
-    example_text_chunks: list[llm.StreamResponseChunk],
+    example_text_chunks: Sequence[llm.StreamResponseChunk],
 ) -> None:
     """Test llm.StreamResponse initialization with sync iterator."""
     stream_response = create_sync_stream_response(example_text_chunks)
@@ -147,7 +147,7 @@ def test_sync_initialization(
 
 @pytest.mark.asyncio
 async def test_async_initialization(
-    example_text_chunks: list[llm.StreamResponseChunk],
+    example_text_chunks: Sequence[llm.StreamResponseChunk],
 ) -> None:
     """Test llm.StreamResponse initialization with async iterator."""
     stream_response = create_async_stream_response(example_text_chunks)
@@ -167,9 +167,9 @@ class TestChunkStream:
 
     def test_sync_basic_streaming(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
         example_thought: llm.Thought,
         example_tool_call: llm.ToolCall,
@@ -198,9 +198,9 @@ class TestChunkStream:
     @pytest.mark.asyncio
     async def test_async_basic_streaming(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
         example_thought: llm.Thought,
         example_tool_call: llm.ToolCall,
@@ -228,7 +228,7 @@ class TestChunkStream:
 
     def test_sync_replay_functionality(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that streaming can be replayed from cache with sync response."""
@@ -247,7 +247,7 @@ class TestChunkStream:
     @pytest.mark.asyncio
     async def test_async_replay_functionality(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that streaming can be replayed from cache with async response."""
@@ -265,7 +265,7 @@ class TestChunkStream:
 
     def test_sync_partial_iteration_and_resume(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test breaking iteration and resuming from cached state with sync response."""
@@ -296,7 +296,7 @@ class TestChunkStream:
     @pytest.mark.asyncio
     async def test_async_partial_iteration_and_resume(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test breaking iteration and resuming from cached state with async response."""
@@ -326,7 +326,7 @@ class TestChunkStream:
 
     def test_sync_partial_iteration_and_restart(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test breaking iteration and restarting with sync response."""
@@ -357,7 +357,7 @@ class TestChunkStream:
     @pytest.mark.asyncio
     async def test_async_partial_iteration_and_restart(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test breaking iteration and restarting with async response."""
@@ -390,8 +390,8 @@ class TestChunkStream:
 
 @dataclass
 class ChunkProcessingTestCase:
-    chunks: list[llm.StreamResponseChunk]
-    expected_contents: list[list[llm.AssistantContentPart]]
+    chunks: Sequence[llm.StreamResponseChunk]
+    expected_contents: Sequence[Sequence[llm.AssistantContentPart]]
 
 
 CHUNK_PROCESSING_TEST_CASES: dict[str, ChunkProcessingTestCase] = {
@@ -479,7 +479,7 @@ class TestToolCallSupport:
 
     def test_sync_tool_call_streaming(
         self,
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_tool_call: llm.ToolCall,
     ) -> None:
         """Test tool call streaming functionality with sync response."""
@@ -496,7 +496,7 @@ class TestToolCallSupport:
     @pytest.mark.asyncio
     async def test_async_tool_call_streaming(
         self,
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_tool_call: llm.ToolCall,
     ) -> None:
         """Test tool call streaming functionality with async response."""
@@ -585,7 +585,7 @@ class TestChunkProcessing:
 
     def test_sync_finish_reason_chunk_processing(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that FinishReasonChunk sets the finish_reason on the response with sync response."""
@@ -605,7 +605,7 @@ class TestChunkProcessing:
     @pytest.mark.asyncio
     async def test_async_finish_reason_chunk_processing(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that FinishReasonChunk sets the finish_reason on the response with async response."""
@@ -651,7 +651,7 @@ class TestChunkProcessing:
 
 @dataclass
 class InvalidChunkSequenceTestCase:
-    chunks: list[llm.StreamResponseChunk]
+    chunks: Sequence[llm.StreamResponseChunk]
     expected_error: str
 
 
@@ -788,8 +788,8 @@ class TestErrorHandling:
 
     def test_sync_chunks_after_finish_reason(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that chunks after finish reason raise RuntimeError with sync response."""
@@ -809,8 +809,8 @@ class TestErrorHandling:
     @pytest.mark.asyncio
     async def test_async_chunks_after_finish_reason(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that chunks after finish reason raise RuntimeError with async response."""
@@ -831,7 +831,7 @@ class TestErrorHandling:
 class TestPrettyStream:
     def test_sync_pretty_stream_text_only(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
     ) -> None:
         stream_response = create_sync_stream_response(example_text_chunks)
 
@@ -843,7 +843,7 @@ class TestPrettyStream:
     @pytest.mark.asyncio
     async def test_async_pretty_stream_text_only(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
     ) -> None:
         stream_response = create_async_stream_response(example_text_chunks)
 
@@ -856,9 +856,9 @@ class TestPrettyStream:
 
     def test_sync_pretty_stream_mixed_content(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
     ) -> None:
         chunks = [
             *example_text_chunks,
@@ -885,9 +885,9 @@ Hello world
     @pytest.mark.asyncio
     async def test_async_pretty_stream_mixed_content(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
     ) -> None:
         chunks = [
             *example_text_chunks,
@@ -1096,7 +1096,7 @@ class TestRawContentChunkTracking:
 
 
 @pytest.fixture
-def example_format_tool_chunks() -> list[llm.StreamResponseChunk]:
+def example_format_tool_chunks() -> Sequence[llm.StreamResponseChunk]:
     return [
         llm.ToolCallStartChunk(
             id="call_format_123",
@@ -1109,7 +1109,7 @@ def example_format_tool_chunks() -> list[llm.StreamResponseChunk]:
 
 
 @pytest.fixture
-def example_format_tool_chunks_processed() -> list[llm.AssistantContentChunk]:
+def example_format_tool_chunks_processed() -> Sequence[llm.AssistantContentChunk]:
     return [
         llm.TextStartChunk(),
         llm.TextChunk(delta='{"title": "The Hobbit"'),
@@ -1119,7 +1119,7 @@ def example_format_tool_chunks_processed() -> list[llm.AssistantContentChunk]:
 
 
 @pytest.fixture
-def example_format_tool_chunks_mixed() -> list[llm.StreamResponseChunk]:
+def example_format_tool_chunks_mixed() -> Sequence[llm.StreamResponseChunk]:
     return [
         llm.ToolCallStartChunk(id="call_007", name="ring_tool"),
         llm.ToolCallChunk(delta='{"ring_purpose": "to_rule_them_all"}'),
@@ -1138,7 +1138,7 @@ def example_format_tool_chunks_mixed() -> list[llm.StreamResponseChunk]:
 
 
 @pytest.fixture
-def example_format_tool_chunks_mixed_processed() -> list[llm.AssistantContentChunk]:
+def example_format_tool_chunks_mixed_processed() -> Sequence[llm.AssistantContentChunk]:
     return [
         llm.ToolCallStartChunk(id="call_007", name="ring_tool"),
         llm.ToolCallChunk(delta='{"ring_purpose": "to_rule_them_all"}'),
@@ -1154,7 +1154,7 @@ def example_format_tool_chunks_mixed_processed() -> list[llm.AssistantContentChu
 
 
 @pytest.fixture
-def example_format_tool_chunks_max_tokens() -> list[llm.StreamResponseChunk]:
+def example_format_tool_chunks_max_tokens() -> Sequence[llm.StreamResponseChunk]:
     return [
         llm.ToolCallStartChunk(
             id="call_format_123",
@@ -1166,7 +1166,7 @@ def example_format_tool_chunks_max_tokens() -> list[llm.StreamResponseChunk]:
 
 
 @pytest.fixture
-def example_format_tool_chunks_max_tokens_processed() -> list[
+def example_format_tool_chunks_max_tokens_processed() -> Sequence[
     llm.AssistantContentChunk
 ]:
     return [
@@ -1180,8 +1180,8 @@ class TestFormatToolHandling:
 
     def test_sync_format_tool_conversion(
         self,
-        example_format_tool_chunks: list[llm.StreamResponseChunk],
-        example_format_tool_chunks_processed: list[llm.AssistantContentChunk],
+        example_format_tool_chunks: Sequence[llm.StreamResponseChunk],
+        example_format_tool_chunks_processed: Sequence[llm.AssistantContentChunk],
     ) -> None:
         """Test that FORMAT_TOOL_NAME tool calls are converted to text."""
         stream_response = create_sync_stream_response(example_format_tool_chunks)
@@ -1197,8 +1197,8 @@ class TestFormatToolHandling:
 
     def test_sync_mixed_regular_and_format_tools(
         self,
-        example_format_tool_chunks_mixed: list[llm.StreamResponseChunk],
-        example_format_tool_chunks_mixed_processed: list[llm.AssistantContentChunk],
+        example_format_tool_chunks_mixed: Sequence[llm.StreamResponseChunk],
+        example_format_tool_chunks_mixed_processed: Sequence[llm.AssistantContentChunk],
     ) -> None:
         """Test streaming with both regular and format tools."""
         stream_response = create_sync_stream_response(example_format_tool_chunks_mixed)
@@ -1221,8 +1221,8 @@ class TestFormatToolHandling:
 
     def test_sync_format_tool_no_finish_reason_change(
         self,
-        example_format_tool_chunks_max_tokens: list[llm.StreamResponseChunk],
-        example_format_tool_chunks_max_tokens_processed: list[
+        example_format_tool_chunks_max_tokens: Sequence[llm.StreamResponseChunk],
+        example_format_tool_chunks_max_tokens_processed: Sequence[
             llm.AssistantContentChunk
         ],
     ) -> None:
@@ -1241,8 +1241,8 @@ class TestFormatToolHandling:
     @pytest.mark.asyncio
     async def test_async_format_tool_conversion(
         self,
-        example_format_tool_chunks: list[llm.StreamResponseChunk],
-        example_format_tool_chunks_processed: list[llm.AssistantContentChunk],
+        example_format_tool_chunks: Sequence[llm.StreamResponseChunk],
+        example_format_tool_chunks_processed: Sequence[llm.AssistantContentChunk],
     ) -> None:
         """Test that FORMAT_TOOL_NAME tool calls are converted to text in async."""
         stream_response = create_async_stream_response(example_format_tool_chunks)
@@ -1258,8 +1258,8 @@ class TestFormatToolHandling:
     @pytest.mark.asyncio
     async def test_async_mixed_regular_and_format_tools(
         self,
-        example_format_tool_chunks_mixed: list[llm.StreamResponseChunk],
-        example_format_tool_chunks_mixed_processed: list[llm.StreamResponseChunk],
+        example_format_tool_chunks_mixed: Sequence[llm.StreamResponseChunk],
+        example_format_tool_chunks_mixed_processed: Sequence[llm.StreamResponseChunk],
     ) -> None:
         """Test streaming with both regular and format tools in async."""
         stream_response = create_async_stream_response(example_format_tool_chunks_mixed)
@@ -1283,8 +1283,8 @@ class TestFormatToolHandling:
     @pytest.mark.asyncio
     async def test_async_format_tool_no_finish_reason_change(
         self,
-        example_format_tool_chunks_max_tokens: list[llm.StreamResponseChunk],
-        example_format_tool_chunks_max_tokens_processed: list[
+        example_format_tool_chunks_max_tokens: Sequence[llm.StreamResponseChunk],
+        example_format_tool_chunks_max_tokens_processed: Sequence[
             llm.AssistantContentChunk
         ],
     ) -> None:
@@ -1427,7 +1427,7 @@ class TestStreams:
 
     def test_sync_streams_single_text(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test streams() yields a single TextStream for text content."""
@@ -1459,7 +1459,7 @@ class TestStreams:
 
     def test_sync_streams_outer_iteration_consumes(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that iterating the outer streams() iterator consumes each stream."""
@@ -1492,7 +1492,7 @@ class TestStreams:
 
     def test_sync_streams_replay_semantics(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that calling streams() multiple times replays from cache."""
@@ -1509,7 +1509,7 @@ class TestStreams:
 
     def test_sync_streams_single_thought(
         self,
-        example_thought_chunks: list[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
         example_thought: llm.Thought,
     ) -> None:
         """Test streams() yields a ThoughtStream for a single thought content part."""
@@ -1544,7 +1544,7 @@ class TestStreams:
 
     def test_sync_streams_single_tool_call(
         self,
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_tool_call: llm.ToolCall,
     ) -> None:
         """Test streams() yields a ToolCallStream for a single tool call content part."""
@@ -1581,9 +1581,9 @@ class TestStreams:
 
     def test_sync_streams_mixed_content(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
         example_thought: llm.Thought,
         example_tool_call: llm.ToolCall,
@@ -1619,7 +1619,7 @@ class TestAsyncStreams:
 
     async def test_async_streams_single_text(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test async streams() yields a single AsyncTextStream for text content."""
@@ -1651,7 +1651,7 @@ class TestAsyncStreams:
 
     async def test_async_streams_outer_iteration_consumes(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that iterating the outer async streams() iterator consumes each stream."""
@@ -1684,7 +1684,7 @@ class TestAsyncStreams:
 
     async def test_async_streams_replay_semantics(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
     ) -> None:
         """Test that calling async streams() multiple times replays from cache."""
@@ -1701,7 +1701,7 @@ class TestAsyncStreams:
 
     async def test_async_streams_single_thought(
         self,
-        example_thought_chunks: list[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
         example_thought: llm.Thought,
     ) -> None:
         """Test async streams() yields an AsyncThoughtStream for a single thought content part."""
@@ -1736,7 +1736,7 @@ class TestAsyncStreams:
 
     async def test_async_streams_single_tool_call(
         self,
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_tool_call: llm.ToolCall,
     ) -> None:
         """Test async streams() yields an AsyncToolCallStream for a single tool call content part."""
@@ -1773,9 +1773,9 @@ class TestAsyncStreams:
 
     async def test_async_streams_mixed_content(
         self,
-        example_text_chunks: list[llm.StreamResponseChunk],
-        example_thought_chunks: list[llm.StreamResponseChunk],
-        example_tool_call_chunks: list[llm.StreamResponseChunk],
+        example_text_chunks: Sequence[llm.StreamResponseChunk],
+        example_thought_chunks: Sequence[llm.StreamResponseChunk],
+        example_tool_call_chunks: Sequence[llm.StreamResponseChunk],
         example_text: llm.Text,
         example_thought: llm.Thought,
         example_tool_call: llm.ToolCall,


### PR DESCRIPTION
Now we evaluate lists as the specific types we assign in them, not
`list[Unknown]`. This catches the existing type issues in the examples,
which is good. Needed to change a lot of `list` to `Sequence` in our API
to avoid variance issues, but `Sequence` is a better type where
appropriate.