### PR TITLE
Port over the Lilypad exporters and integrate with dummy trace API

### DIFF
--- a/python/mirascope/ops/_internal/exporters/__init__.py
+++ b/python/mirascope/ops/_internal/exporters/__init__.py
@@ -1,0 +1,26 @@
+"""Mirascope OpenTelemetry exporters for two-phase telemetry.
+
+This package provides a two-phase export system for OpenTelemetry tracing:
+1. Immediate start event transmission for real-time visibility
+2. Batched end event transmission for efficiency
+"""
+
+from .exporters import MirascopeOTLPExporter
+from .processors import MirascopeSpanProcessor
+from .types import (
+    Link,
+    SpanContextDict,
+    SpanEvent,
+    SpanEventType,
+    Status,
+)
+
+__all__ = [
+    "Link",
+    "MirascopeOTLPExporter",
+    "MirascopeSpanProcessor",
+    "SpanContextDict",
+    "SpanEvent",
+    "SpanEventType",
+    "Status",
+]

--- a/python/mirascope/ops/_internal/exporters/exporters.py
+++ b/python/mirascope/ops/_internal/exporters/exporters.py
@@ -1,0 +1,342 @@
+"""Exporter implementation for OpenTelemetry exporters.
+
+This module provides the export layer for sending OpenTelemetry span
+events to the Mirascope ingestion endpoint. It wraps the Fern-generated
+Mirascope client to provide the interface needed by OpenTelemetry exporters.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Sequence
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.util.types import AttributeValue
+
+from ....api._generated.traces.types import (
+    TracesCreateRequestResourceSpansItem,
+    TracesCreateRequestResourceSpansItemResource,
+    TracesCreateRequestResourceSpansItemResourceAttributesItem,
+    TracesCreateRequestResourceSpansItemResourceAttributesItemValue,
+    TracesCreateRequestResourceSpansItemScopeSpansItem,
+    TracesCreateRequestResourceSpansItemScopeSpansItemScope,
+    TracesCreateRequestResourceSpansItemScopeSpansItemSpansItem,
+    TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItem,
+    TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItemValue,
+    TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemStatus,
+)
+from ....api.client import Mirascope
+
+logger = logging.getLogger(__name__)
+
+
+class MirascopeOTLPExporter(SpanExporter):
+    """OTLP/HTTP exporter for completed spans.
+
+    This exporter implements the OpenTelemetry SpanExporter interface
+    for exporting completed spans in OTLP format over HTTP. It's
+    designed to work with BatchSpanProcessor for efficient batching.
+
+    This uses the Fern auto-generated client for sending converted spans.
+
+    Attributes:
+        exporter: Export client for sending events.
+        timeout: Request timeout in seconds.
+    """
+
+    def __init__(
+        self,
+        client: Mirascope,
+        timeout: float = 30.0,
+        max_retry_attempts: int = 3,
+    ) -> None:
+        """Initialize the telemetry exporter.
+
+        Args:
+            client: The Fern-generated Mirascope client instance.
+                In the future, this will accept the enhanced client from
+                mirascope.api.client that provides error handling and caching
+                capabilities.
+            timeout: Request timeout in seconds for telemetry operations.
+            max_retry_attempts: Maximum number of retry attempts for failed exports.
+        """
+        self.client = client
+        self.timeout = timeout
+        self.max_retry_attempts = max_retry_attempts
+        self._shutdown = False
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        """Export a batch of spans to the telemetry endpoint.
+
+        This is the standard OpenTelemetry export interface.
+
+        Args:
+            spans: Sequence of ReadableSpan objects to export.
+
+        Returns:
+            SpanExportResult indicating success or failure.
+        """
+        if self._shutdown:
+            return SpanExportResult.FAILURE
+
+        if not spans:
+            return SpanExportResult.SUCCESS
+
+        exceptions: list[Exception] = []
+        delay = 0.1
+
+        for i in range(self.max_retry_attempts):
+            if i > 0:
+                time.sleep(delay)
+                delay = min(delay * 2, 5.0)
+
+            try:
+                otlp_data = self._convert_spans_to_otlp(spans)
+                response = self.client.traces.create(resource_spans=otlp_data)
+
+                if (
+                    response
+                    and hasattr(response, "partial_success")
+                    and response.partial_success
+                ):
+                    partial_success = response.partial_success
+                    if hasattr(partial_success, "rejected_spans"):
+                        rejected = partial_success.rejected_spans
+                        if rejected is not None and rejected > 0:
+                            return SpanExportResult.FAILURE
+
+                return SpanExportResult.SUCCESS
+
+            except Exception as e:
+                exceptions.append(e)
+                logger.warning(
+                    f"Export attempt {i + 1} failed, retrying in {delay}s: {e}"
+                )
+
+        logger.error(
+            f"Failed to export spans after {self.max_retry_attempts} attempts: {exceptions}"
+        )
+
+        return SpanExportResult.FAILURE
+
+    def _convert_spans_to_otlp(
+        self, spans: Sequence[ReadableSpan]
+    ) -> list[TracesCreateRequestResourceSpansItem]:
+        """Convert OpenTelemetry spans to OTLP format.
+
+        Args:
+            spans: Sequence of ReadableSpan objects.
+
+        Returns:
+            List of ResourceSpans in OTLP format.
+        """
+        resource_spans_map = {}
+
+        for span in spans:
+            try:
+                otlp_span = self._convert_span(span)
+            except ValueError as e:
+                logger.warning(f"Skipping span due to error: {e}")
+                continue
+
+            resource_key = id(span.resource) if span.resource else "default"
+
+            if resource_key not in resource_spans_map:
+                resource = None
+                if span.resource:
+                    resource_attrs = []
+                    for key, value in span.resource.attributes.items():
+                        attr_value = self._convert_resource_attribute_value(value)
+                        resource_attrs.append(
+                            TracesCreateRequestResourceSpansItemResourceAttributesItem(
+                                key=key,
+                                value=attr_value,
+                            )
+                        )
+                    resource = TracesCreateRequestResourceSpansItemResource(
+                        attributes=resource_attrs
+                    )
+
+                resource_spans_map[resource_key] = {
+                    "resource": resource,
+                    "scope_spans": {},
+                }
+
+            scope_key = (
+                span.instrumentation_scope.name
+                if span.instrumentation_scope
+                else "unknown"
+            )
+
+            if scope_key not in resource_spans_map[resource_key]["scope_spans"]:
+                scope = None
+                if span.instrumentation_scope:
+                    scope = TracesCreateRequestResourceSpansItemScopeSpansItemScope(
+                        name=span.instrumentation_scope.name,
+                        version=span.instrumentation_scope.version,
+                    )
+
+                resource_spans_map[resource_key]["scope_spans"][scope_key] = {
+                    "scope": scope,
+                    "spans": [],
+                }
+
+            resource_spans_map[resource_key]["scope_spans"][scope_key]["spans"].append(
+                otlp_span
+            )
+
+        result = []
+        for resource_data in resource_spans_map.values():
+            scope_spans = []
+            for scope_data in resource_data["scope_spans"].values():
+                scope_spans.append(
+                    TracesCreateRequestResourceSpansItemScopeSpansItem(
+                        scope=scope_data["scope"],
+                        spans=scope_data["spans"],
+                    )
+                )
+
+            result.append(
+                TracesCreateRequestResourceSpansItem(
+                    resource=resource_data["resource"],
+                    scope_spans=scope_spans,
+                )
+            )
+
+        return result
+
+    def _convert_span(
+        self, span: ReadableSpan
+    ) -> TracesCreateRequestResourceSpansItemScopeSpansItemSpansItem:
+        """Convert a single ReadableSpan to OTLP format."""
+        context = span.get_span_context()
+        if not context or not context.is_valid:
+            raise ValueError(f"Cannot export span without valid context: {span.name}")
+
+        attributes = []
+        if span.attributes:
+            for key, value in span.attributes.items():
+                attr_value = self._convert_attribute_value(value)
+                attributes.append(
+                    TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItem(
+                        key=key,
+                        value=attr_value,
+                    )
+                )
+
+        status = None
+        if span.status:
+            status = TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemStatus(
+                code=span.status.status_code.value,
+                message=span.status.description or "",
+            )
+
+        trace_id = format(context.trace_id, "032x")
+        span_id = format(context.span_id, "016x")
+
+        return TracesCreateRequestResourceSpansItemScopeSpansItemSpansItem(
+            trace_id=trace_id,
+            span_id=span_id,
+            parent_span_id=(
+                format(span.parent.span_id, "016x")
+                if span.parent and span.parent.span_id
+                else None
+            ),
+            name=span.name,
+            kind=span.kind.value if span.kind else 0,
+            start_time_unix_nano=str(span.start_time) if span.start_time else "0",
+            end_time_unix_nano=str(span.end_time) if span.end_time else "0",
+            attributes=attributes or None,
+            status=status,
+        )
+
+    def _convert_attribute_value(
+        self, value: AttributeValue
+    ) -> TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItemValue:
+        """Convert OpenTelemetry AttributeValue to Mirascope API's KeyValueValue.
+
+        This conversion is necessary because the Fern-generated API client
+        expects KeyValueValue objects, not OpenTelemetry's AttributeValue types.
+
+        Args:
+            value: An OpenTelemetry AttributeValue (bool, int, float, str, or Sequence)
+
+        Returns:
+            A KeyValueValue object for the Mirascope API
+        """
+        match value:
+            case str():
+                return TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItemValue(
+                    string_value=value
+                )
+            case bool():
+                return TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItemValue(
+                    bool_value=value
+                )
+            case int():
+                return TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItemValue(
+                    int_value=str(value)
+                )
+            case float():
+                return TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItemValue(
+                    double_value=value
+                )
+            case _:
+                return TracesCreateRequestResourceSpansItemScopeSpansItemSpansItemAttributesItemValue(
+                    string_value=str(list(value))
+                )
+
+    def _convert_resource_attribute_value(
+        self, value: AttributeValue
+    ) -> TracesCreateRequestResourceSpansItemResourceAttributesItemValue:
+        """Convert OpenTelemetry AttributeValue to Mirascope API's resource KeyValueValue.
+
+        This conversion is necessary because the Fern-generated API client
+        expects KeyValueValue objects, not OpenTelemetry's AttributeValue types.
+
+        Args:
+            value: An OpenTelemetry AttributeValue (bool, int, float, str, or Sequence)
+
+        Returns:
+            A KeyValueValue object for the Mirascope API resource attributes
+        """
+        match value:
+            case str():
+                return TracesCreateRequestResourceSpansItemResourceAttributesItemValue(
+                    string_value=value
+                )
+            case bool():
+                return TracesCreateRequestResourceSpansItemResourceAttributesItemValue(
+                    bool_value=value
+                )
+            case int():
+                return TracesCreateRequestResourceSpansItemResourceAttributesItemValue(
+                    int_value=str(value)
+                )
+            case float():
+                return TracesCreateRequestResourceSpansItemResourceAttributesItemValue(
+                    double_value=value
+                )
+            case _:
+                return TracesCreateRequestResourceSpansItemResourceAttributesItemValue(
+                    string_value=str(list(value))
+                )
+
+    def shutdown(self) -> None:
+        """Shutdown the exporter. Subsequent exports will return FAILURE."""
+        self._shutdown = True
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Force flush any pending data.
+
+        No-op since this exporter does not buffer data internally.
+
+        Args:
+            timeout_millis: Maximum time to wait in milliseconds (unused).
+
+        Returns:
+            Always True since there is no internal buffer to flush.
+        """
+        return True

--- a/python/mirascope/ops/_internal/exporters/processors.py
+++ b/python/mirascope/ops/_internal/exporters/processors.py
@@ -1,0 +1,104 @@
+"""Span processors for two-phase export system.
+
+This module implements a custom SpanProcessor that sends immediate
+start events and batches end events for efficient export.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+
+from opentelemetry.context import Context
+from opentelemetry.sdk.trace import ReadableSpan, SpanProcessor
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from .exporters import MirascopeOTLPExporter
+
+
+class MirascopeSpanProcessor(SpanProcessor):
+    """Two-phase span processor for Mirascope telemetry.
+
+    This processor implements a two-phase export strategy:
+    1. Immediate transmission of minimal start events for real-time visibility
+    2. Batched transmission of complete events for efficiency
+
+    The processor uses a thread pool to ensure start events don't block
+    the application while maintaining compatibility with OpenTelemetry's
+    synchronous SDK.
+
+    Attributes:
+        start_exporter: Exporter for immediate start events.
+        batch_processor: Standard batch processor for completed spans.
+        executor: Thread pool for non-blocking start event transmission.
+    """
+
+    def __init__(
+        self,
+        otlp_exporter: MirascopeOTLPExporter,
+        batch_processor: BatchSpanProcessor | None = None,
+        executor: ThreadPoolExecutor | None = None,
+    ) -> None:
+        """Initialize the two-phase processor.
+
+        Args:
+            start_exporter: Exporter for immediate start events.
+            batch_processor: Optional batch processor for end events.
+            executor: Optional thread pool executor (creates default if None).
+        """
+        self.otlp_exporter = otlp_exporter
+        self.batch_processor = batch_processor
+        self.executor = executor or ThreadPoolExecutor(
+            max_workers=2, thread_name_prefix="mirascope-span-processor"
+        )
+        self._shutdown = False
+
+    def on_start(
+        self, span: ReadableSpan, parent_context: Context | None = None
+    ) -> None:
+        """Handle span start by sending immediate start event.
+
+        This method extracts minimal span data and sends it immediately
+        via the start exporter in a non-blocking manner.
+
+        Args:
+            span: The span that just started.
+            parent_context: Optional parent context for the span.
+        """
+        if self._shutdown:
+            return
+
+        self.executor.submit(self.otlp_exporter.export, [span])
+
+    def on_end(self, span: ReadableSpan) -> None:
+        """Handle span end by delegating to batch processor.
+
+        Args:
+            span: The span that just ended.
+        """
+        if self.batch_processor and not self._shutdown:
+            self.batch_processor.on_end(span)
+
+    def shutdown(self) -> None:
+        """Gracefully shutdown the processor.
+
+        This ensures all pending start events are sent and the
+        batch processor is properly shutdown.
+        """
+        self._shutdown = True
+
+        if self.batch_processor:
+            self.batch_processor.shutdown()
+
+        self.executor.shutdown(wait=True)
+        self.otlp_exporter.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        """Force flush all pending data.
+
+        Args:
+            timeout_millis: Maximum time to wait in milliseconds.
+
+        Returns:
+            True if flush completed successfully.
+        """
+        if self.batch_processor:
+            return self.batch_processor.force_flush(timeout_millis)
+        return True

--- a/python/mirascope/ops/_internal/exporters/types.py
+++ b/python/mirascope/ops/_internal/exporters/types.py
@@ -1,0 +1,165 @@
+"""Type definitions for the two-phase export system.
+
+This module defines the event types and data structures used for
+immediate start event transmission and batched end event export.
+"""
+
+from enum import Enum
+from typing import Literal, TypedDict
+
+from opentelemetry.util.types import AttributeValue
+
+# TODO: unify/DRY types in the _internal package
+
+SpanKind = Literal["CLIENT", "SERVER", "PRODUCER", "CONSUMER", "INTERNAL"]
+StatusCode = Literal["UNSET", "OK", "ERROR"]
+
+
+class SpanEventType(str, Enum):
+    """Event types for span lifecycle tracking."""
+
+    SPAN_STARTED = "span_started"
+    SPAN_UPDATED = "span_updated"
+    SPAN_COMPLETED = "span_completed"
+
+
+class SpanEvent(TypedDict):
+    """Individual event within a span."""
+
+    name: str
+    """The name of the event."""
+
+    timestamp: int
+    """Nanoseconds since epoch (OTel standard)."""
+
+    attributes: dict[str, AttributeValue]
+    """Event-specific attributes."""
+
+
+class Status(TypedDict):
+    """Status representation for serialization."""
+
+    code: StatusCode
+    """The status code: UNSET, OK, or ERROR."""
+
+    description: str | None
+    """Optional human-readable description of the status."""
+
+
+class SpanContextDict(TypedDict):
+    """Span context for links and parent references."""
+
+    trace_id: str
+    """The trace ID as a 32-character hex string."""
+
+    span_id: str
+    """The span ID as a 16-character hex string."""
+
+    trace_flags: int
+    """Trace flags (e.g., for sampling decisions)."""
+
+    trace_state: str | None
+    """Optional vendor-specific trace state."""
+
+
+class Link(TypedDict):
+    """Link representation for span relationships."""
+
+    context: SpanContextDict
+    """The linked span's context."""
+
+    attributes: dict[str, AttributeValue]
+    """Attributes describing the link."""
+
+
+class SpanStartEvent(TypedDict):
+    """Minimal span data for immediate transmission.
+
+    This event is sent immediately when a span starts to provide
+    real-time visibility into long-running operations.
+    """
+
+    trace_id: str
+    """The trace ID as a 32-character hex string."""
+
+    span_id: str
+    """The span ID as a 16-character hex string."""
+
+    parent_span_id: str | None
+    """The parent span ID if this is a child span."""
+
+    name: str
+    """The name of the span."""
+
+    start_time: int
+    """Nanoseconds since epoch."""
+
+    kind: SpanKind
+    """The span kind: CLIENT, SERVER, PRODUCER, CONSUMER, or INTERNAL."""
+
+    attributes: dict[str, AttributeValue]
+    """Minimal required attributes only."""
+
+
+class SpanUpdateEvent(TypedDict, total=False):
+    """Incremental updates to span data.
+
+    These events are batched and sent periodically to update
+    span attributes or add events without waiting for completion.
+    """
+
+    trace_id: str
+    """The trace ID as a 32-character hex string."""
+
+    span_id: str
+    """The span ID as a 16-character hex string."""
+
+    timestamp: int
+    """Nanoseconds since epoch."""
+
+    attributes: dict[str, AttributeValue]
+    """Additional or updated attributes."""
+
+    events: list[SpanEvent]
+    """New events to add to the span."""
+
+
+class SpanCompleteEvent(TypedDict):
+    """Complete span data for batch export.
+
+    This event contains all span data and is sent when the span
+    completes, typically in batches for efficiency.
+    """
+
+    trace_id: str
+    """The trace ID as a 32-character hex string."""
+
+    span_id: str
+    """The span ID as a 16-character hex string."""
+
+    parent_span_id: str | None
+    """The parent span ID if this is a child span."""
+
+    name: str
+    """The name of the span."""
+
+    kind: SpanKind
+    """The span kind: CLIENT, SERVER, PRODUCER, CONSUMER, or INTERNAL."""
+
+    start_time: int
+    """Nanoseconds since epoch."""
+
+    end_time: int
+    """Nanoseconds since epoch."""
+
+    status: Status
+    """The final status of the span."""
+
+    attributes: dict[str, AttributeValue]
+    """All span attributes."""
+
+    events: list[SpanEvent]
+    """All events that occurred during the span."""
+
+    links: list[Link]
+    """Links to other spans."""

--- a/python/mirascope/ops/_internal/spans.py
+++ b/python/mirascope/ops/_internal/spans.py
@@ -16,8 +16,8 @@ from opentelemetry.trace import (
 )
 from opentelemetry.util.types import AttributeValue
 
-from mirascope.ops import current_session
-from mirascope.ops._internal.utils import json_dumps
+from .session import current_session
+from .utils import json_dumps
 
 if TYPE_CHECKING:
     from opentelemetry.context import Context
@@ -114,10 +114,7 @@ class Span:
         """
         if self._span and not self._finished:
             for key, value in attributes.items():
-                if isinstance(value, list):
-                    self._span.set_attribute(key, json_dumps(value))
-                else:
-                    self._span.set_attribute(key, value)
+                self._span.set_attribute(key, value)
 
     def event(self, name: str, **attributes: AttributeValue) -> None:
         """Record an event within the span.
@@ -127,13 +124,7 @@ class Span:
             **attributes: Event attributes as key-value pairs.
         """
         if self._span and not self._finished:
-            serialized_attrs = {}
-            for key, value in attributes.items():
-                if isinstance(value, list):
-                    serialized_attrs[key] = json_dumps(value)
-                else:
-                    serialized_attrs[key] = value
-            self._span.add_event(name, attributes=serialized_attrs)
+            self._span.add_event(name, attributes=attributes)
 
     def debug(self, message: str, **additional_attributes: AttributeValue) -> None:
         """Log a debug message within the span.

--- a/python/tests/ops/_internal/__init__.py
+++ b/python/tests/ops/_internal/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for _internal."""

--- a/python/tests/ops/_internal/exporters/__init__.py
+++ b/python/tests/ops/_internal/exporters/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for exporters."""

--- a/python/tests/ops/_internal/exporters/conftest.py
+++ b/python/tests/ops/_internal/exporters/conftest.py
@@ -1,0 +1,98 @@
+"""Test fixtures for exporters module."""
+
+import os
+import time
+from unittest.mock import Mock
+
+import pytest
+from dotenv import load_dotenv
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import SpanContext, SpanKind, Status, StatusCode
+
+from mirascope.api.client import Mirascope, get_sync_client
+from mirascope.ops._internal.exporters.exporters import MirascopeOTLPExporter
+from mirascope.ops._internal.exporters.processors import MirascopeSpanProcessor
+
+
+@pytest.fixture
+def mirascope_api_key() -> str:
+    """Get Mirascope API key from environment or return dummy key."""
+    load_dotenv()
+    return os.getenv("MIRASCOPE_API_KEY", "test-api-key")
+
+
+@pytest.fixture
+def span() -> Mock:
+    """Create a mock ReadableSpan for testing."""
+    span = Mock(spec=ReadableSpan)
+    span.name = "test_span"
+
+    context = Mock(spec=SpanContext)
+    context.trace_id = 0x0102030405060708090A0B0C0D0E0F10
+    context.span_id = 0x0102030405060708
+    context.is_remote = False
+    context.trace_flags = 1
+    context.trace_state = None
+
+    span.context = context
+    span.get_span_context = Mock(return_value=context)
+
+    span.parent = None
+    span.kind = SpanKind.SERVER
+    span.start_time = int(time.time() * 1e9)
+    span.end_time = int(time.time() * 1e9) + 1000000
+    span.status = Mock(spec=Status)
+    span.status.status_code = StatusCode.OK
+    span.status.description = None
+    span.attributes = {}
+    span.events = []
+    span.links = []
+    span.resource = Mock()
+    span.resource.attributes = {"service.name": "test-service"}
+    span.instrumentation_scope = Mock()
+    span.instrumentation_scope.name = "test-scope"
+    span.instrumentation_scope.version = "1.0.0"
+    return span
+
+
+@pytest.fixture
+def mirascope_base_url() -> str:
+    """Get Mirascope base URL from environment or return default."""
+    load_dotenv()
+    return os.getenv("MIRASCOPE_BASE_URL", "http://localhost:3000")
+
+
+@pytest.fixture
+def mirascope_client(mirascope_api_key: str, mirascope_base_url: str) -> Mirascope:
+    """Create real Fern-generated client for VCR tests."""
+    return get_sync_client(
+        api_key=mirascope_api_key,
+        base_url=mirascope_base_url,
+    )
+
+
+@pytest.fixture
+def otlp_exporter(mirascope_client: Mirascope) -> MirascopeOTLPExporter:
+    """Create MirascopeOTLPExporter with transport."""
+    return MirascopeOTLPExporter(
+        client=mirascope_client, timeout=30.0, max_retry_attempts=3
+    )
+
+
+@pytest.fixture
+def batch_processor(otlp_exporter: MirascopeOTLPExporter) -> BatchSpanProcessor:
+    """Create BatchSpanProcessor with OTLP exporter."""
+    return BatchSpanProcessor(otlp_exporter)
+
+
+@pytest.fixture
+def mirascope_processor(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+) -> MirascopeSpanProcessor:
+    """Create MirascopeSpanProcessor with both exporters."""
+    return MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+    )

--- a/python/tests/ops/_internal/exporters/test_exporters.py
+++ b/python/tests/ops/_internal/exporters/test_exporters.py
@@ -1,0 +1,484 @@
+"""Test MirascopeOTLPExporter functionality including retry logic and error handling."""
+
+from collections.abc import Generator
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import (
+    BatchSpanProcessor,
+    SimpleSpanProcessor,
+    SpanExportResult,
+)
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+from opentelemetry.trace import INVALID_SPAN_CONTEXT, set_tracer_provider
+from opentelemetry.util.types import AttributeValue
+
+from mirascope.api.client import Mirascope
+from mirascope.ops._internal.exporters.exporters import MirascopeOTLPExporter
+from mirascope.ops._internal.exporters.processors import MirascopeSpanProcessor
+
+
+class UnsupportedAttribute:
+    """Represents an attribute type unsupported by OTLP."""
+
+    def __str__(self) -> str:
+        return "unsupported"
+
+
+SpanAttributesDict = dict[str, AttributeValue | UnsupportedAttribute]
+ResourceAttributesDict = dict[str, AttributeValue]
+
+
+@patch("mirascope.ops._internal.exporters.exporters.time.sleep")
+def test_retry_on_network_error(mock_sleep: Mock, span: Mock) -> None:
+    """Test that export retries on network errors."""
+    client = Mock()
+    exporter = MirascopeOTLPExporter(client=client, max_retry_attempts=3)
+
+    success_response = Mock()
+    success_response.partial_success = None
+
+    client.traces.create = Mock(
+        side_effect=[
+            Exception("Connection error"),
+            Exception("Timeout error"),
+            success_response,
+        ]
+    )
+
+    result = exporter.export([span])
+
+    assert result == snapshot(SpanExportResult.SUCCESS)
+    assert client.traces.create.call_count == snapshot(3)
+    assert mock_sleep.call_count == snapshot(2)
+
+    sleep_calls = [call[0][0] for call in mock_sleep.call_args_list]
+    assert sleep_calls == snapshot([0.1, 0.2])
+
+
+@patch("mirascope.ops._internal.exporters.exporters.time.sleep")
+def test_max_retries_exceeded(mock_sleep: Mock, span: Mock) -> None:
+    """Test that export fails after max retries exceeded."""
+    client = Mock()
+    exporter = MirascopeOTLPExporter(client=client, max_retry_attempts=3)
+
+    client.traces.create = Mock(side_effect=Exception("Persistent connection error"))
+
+    result = exporter.export([span])
+
+    assert result == snapshot(SpanExportResult.FAILURE)
+    assert client.traces.create.call_count == snapshot(3)
+
+
+def test_no_retry_on_partial_failure(span: Mock) -> None:
+    """Test that export doesn't retry on partial failures (invalid data)."""
+    client = Mock()
+    exporter = MirascopeOTLPExporter(client=client, max_retry_attempts=3)
+
+    response = Mock()
+    response.partial_success = Mock()
+    response.partial_success.rejected_spans = 1
+
+    client.traces.create = Mock(return_value=response)
+
+    result = exporter.export([span])
+
+    assert result == snapshot(SpanExportResult.FAILURE)
+    assert client.traces.create.call_count == snapshot(1)
+
+
+def test_immediate_success(span: Mock) -> None:
+    """Test that successful export doesn't retry."""
+    client = Mock()
+    exporter = MirascopeOTLPExporter(client=client, max_retry_attempts=3)
+
+    success_response = Mock()
+    success_response.partial_success = None
+    client.traces.create = Mock(return_value=success_response)
+
+    result = exporter.export([span])
+
+    assert result == snapshot(SpanExportResult.SUCCESS)
+    assert client.traces.create.call_count == snapshot(1)
+
+
+@patch("mirascope.ops._internal.exporters.exporters.time.sleep")
+def test_exponential_backoff_cap(mock_sleep: Mock, span: Mock) -> None:
+    """Test that exponential backoff is capped at 5 seconds."""
+    client = Mock()
+    exporter = MirascopeOTLPExporter(client=client, max_retry_attempts=5)
+
+    success_response = Mock()
+    success_response.partial_success = None
+    client.traces.create = Mock(
+        side_effect=[Exception("Error")] * 4 + [success_response]
+    )
+
+    result = exporter.export([span])
+
+    assert result == snapshot(SpanExportResult.SUCCESS)
+    assert mock_sleep.call_count == snapshot(4)
+
+    calls = [call[0][0] for call in mock_sleep.call_args_list]
+    assert calls == snapshot([0.1, 0.2, 0.4, 0.8])
+
+
+def test_missing_telemetry_endpoint_returns_failure(span: Mock) -> None:
+    """Test that export fails when client doesn't have telemetry endpoint."""
+    client = Mock()
+    del client.telemetry
+
+    exporter = MirascopeOTLPExporter(client=client, max_retry_attempts=3)
+
+    result = exporter.export([span])
+
+    assert result == snapshot(SpanExportResult.FAILURE)
+    assert hasattr(client, "telemetry") == snapshot(False)
+
+
+def test_empty_spans_still_success() -> None:
+    """Test that empty span list returns success without checking endpoint."""
+    client = Mock()
+
+    del client.telemetry
+
+    exporter = MirascopeOTLPExporter(client=client)
+
+    result = exporter.export([])
+
+    assert result == snapshot(SpanExportResult.SUCCESS)
+
+
+@pytest.fixture
+def mock_span_ids() -> Generator[None, None, None]:
+    """Mock trace and span ID generation for consistent testing."""
+    trace_counter = 0
+    span_counter = 0
+
+    def generate_trace_id() -> int:
+        nonlocal trace_counter
+        trace_counter += 1
+        return trace_counter
+
+    def generate_span_id() -> int:
+        nonlocal span_counter
+        span_counter += 1
+        return span_counter
+
+    with (
+        patch.object(
+            RandomIdGenerator, "generate_trace_id", side_effect=generate_trace_id
+        ),
+        patch.object(
+            RandomIdGenerator, "generate_span_id", side_effect=generate_span_id
+        ),
+    ):
+        yield
+
+
+@pytest.fixture
+def resource() -> Resource:
+    """Create a test resource."""
+    return Resource.create({"service.name": "test-service"})
+
+
+@pytest.fixture
+def provider_with_memory_exporter(
+    resource: Resource, mock_span_ids: None
+) -> tuple[TracerProvider, InMemorySpanExporter]:
+    """Create TracerProvider with InMemorySpanExporter."""
+
+    provider = TracerProvider(resource=resource, id_generator=RandomIdGenerator())
+    memory_exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(memory_exporter)
+    provider.add_span_processor(processor)
+
+    return provider, memory_exporter
+
+
+def test_transport_export_single_span(
+    mirascope_client: Mirascope,
+    provider_with_memory_exporter: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    """Test exporting a single span with real client."""
+    mirascope_client.traces.create = MagicMock(return_value=None)
+
+    otlp_exporter = MirascopeOTLPExporter(
+        client=mirascope_client,
+        timeout=30.0,
+        max_retry_attempts=3,
+    )
+
+    provider, memory_exporter = provider_with_memory_exporter
+    tracer = provider.get_tracer("test-tracer", "1.0.0")
+
+    with tracer.start_as_current_span("test-operation") as span:
+        span.set_attribute("test.key", "test-value")
+        span.set_attribute("float", 1.0)
+        span.set_attribute("sequence", ["a", "b"])
+
+    provider.force_flush()
+    spans = memory_exporter.get_finished_spans()
+
+    result = otlp_exporter.export(spans)
+    assert result == SpanExportResult.SUCCESS
+
+    mirascope_client.traces.create.assert_called_once()
+    sent_data = mirascope_client.traces.create.call_args[1]["resource_spans"]
+    assert len(sent_data) == 1
+    assert sent_data[0].scope_spans is not None
+    assert len(sent_data[0].scope_spans) == 1
+    assert len(sent_data[0].scope_spans[0].spans) == 1
+    assert sent_data[0].scope_spans[0].spans[0].name == "test-operation"
+
+
+def test_transport_export_batch(
+    mirascope_client: Mirascope,
+    provider_with_memory_exporter: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    """Test exporting multiple spans in a batch."""
+    mirascope_client.traces.create = MagicMock(return_value=None)
+
+    otlp_exporter = MirascopeOTLPExporter(
+        client=mirascope_client,
+        timeout=30.0,
+        max_retry_attempts=3,
+    )
+
+    provider, memory_exporter = provider_with_memory_exporter
+    tracer = provider.get_tracer("batch-tracer")
+
+    for index in range(3):
+        with tracer.start_as_current_span(f"operation-{index}") as span:
+            span.set_attribute("index", index)
+
+    provider.force_flush()
+    spans = memory_exporter.get_finished_spans()
+
+    result = otlp_exporter.export(spans)
+    assert result == SpanExportResult.SUCCESS
+
+    mirascope_client.traces.create.assert_called_once()
+    sent_data = mirascope_client.traces.create.call_args[1]["resource_spans"]
+    assert len(sent_data) == 1
+    assert sent_data[0].scope_spans is not None
+    assert len(sent_data[0].scope_spans) == 1
+    assert len(sent_data[0].scope_spans[0].spans) == 3
+
+
+def test_immediate_start_exporter(
+    mirascope_client: Mirascope,
+    provider_with_memory_exporter: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    """Test ImmediateStartExporter with real client."""
+    mirascope_client.traces.create = MagicMock(return_value=None)
+
+    otlp_exporter = MirascopeOTLPExporter(
+        client=mirascope_client, timeout=30.0, max_retry_attempts=2
+    )
+
+    provider, memory_exporter = provider_with_memory_exporter
+    tracer = provider.get_tracer("start-tracer", "1.0.0")
+
+    with tracer.start_as_current_span("start-event-test") as span:
+        span.set_attribute("event.type", "start")
+
+    provider.force_flush()
+    spans = memory_exporter.get_finished_spans()
+
+    if spans:
+        result = otlp_exporter.export([spans[0]])
+        assert result == SpanExportResult.SUCCESS
+
+        mirascope_client.traces.create.assert_called_once()
+        sent_data = mirascope_client.traces.create.call_args[1]["resource_spans"]
+        assert len(sent_data) == 1
+
+
+def test_otlp_exporter(
+    mirascope_client: Mirascope,
+    provider_with_memory_exporter: tuple[TracerProvider, InMemorySpanExporter],
+) -> None:
+    """Test MirascopeOTLPExporter with real client."""
+    mirascope_client.traces.create = MagicMock(return_value=None)
+
+    otlp_exporter = MirascopeOTLPExporter(client=mirascope_client, timeout=30.0)
+
+    provider, memory_exporter = provider_with_memory_exporter
+    tracer = provider.get_tracer("otlp-tracer", "2.0.0")
+
+    for index in range(2):
+        with tracer.start_as_current_span(f"otlp-span-{index}") as span:
+            span.set_attribute("otlp.test", True)
+            span.set_attribute("index", index)
+
+    provider.force_flush()
+    spans = memory_exporter.get_finished_spans()
+
+    result = otlp_exporter.export(spans)
+    assert result == SpanExportResult.SUCCESS
+
+    mirascope_client.traces.create.assert_called_once()
+    sent_data = mirascope_client.traces.create.call_args[1]["resource_spans"]
+    assert len(sent_data) == 1
+    assert sent_data[0].scope_spans is not None
+    assert len(sent_data[0].scope_spans[0].spans) == 2
+
+
+def test_full_pipeline(
+    mirascope_client: Mirascope,
+    mock_span_ids: None,
+) -> None:
+    """Test complete pipeline with two-phase export."""
+    mirascope_client.traces.create = MagicMock(return_value=None)
+
+    otlp_exporter = MirascopeOTLPExporter(
+        client=mirascope_client,
+        timeout=30.0,
+        max_retry_attempts=3,
+    )
+
+    batch_processor = BatchSpanProcessor(
+        span_exporter=otlp_exporter,
+        max_queue_size=2048,
+        schedule_delay_millis=5000,
+        export_timeout_millis=30000,
+        max_export_batch_size=512,
+    )
+
+    executor = ThreadPoolExecutor(
+        max_workers=2,
+        thread_name_prefix="mirascope-span-processor",
+    )
+
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+        executor=executor,
+    )
+
+    provider = TracerProvider(id_generator=RandomIdGenerator())
+    provider.add_span_processor(processor)
+    set_tracer_provider(provider)
+
+    tracer = provider.get_tracer("full-pipeline-tracer", "1.0.0")
+
+    with tracer.start_as_current_span("parent-operation") as parent:
+        parent.set_attribute("operation.type", "parent")
+        parent.set_attribute("test.framework", "pytest")
+
+        with tracer.start_as_current_span("child-operation-1") as child1:
+            child1.set_attribute("operation.type", "child")
+            child1.set_attribute("child.index", 1)
+
+        with tracer.start_as_current_span("child-operation-2") as child2:
+            child2.set_attribute("operation.type", "child")
+            child2.set_attribute("child.index", 2)
+
+    processor.force_flush(timeout_millis=30000)
+
+    provider.shutdown()
+
+    assert mirascope_client.traces.create.call_count >= snapshot(4)
+
+
+def test_spans_with_invalid_context_are_skipped(
+    mirascope_client: Mirascope,
+) -> None:
+    """Tests that the exporter skips any spans that do not have a valid context."""
+    mirascope_client.traces.create = MagicMock(return_value=None)
+    exporter = MirascopeOTLPExporter(client=mirascope_client)
+
+    invalid_span = ReadableSpan(name="invalid", context=INVALID_SPAN_CONTEXT)
+
+    result = exporter.export([invalid_span])
+    assert result == snapshot(SpanExportResult.SUCCESS)
+    mirascope_client.traces.create.assert_called_once_with(resource_spans=[])
+
+
+def test_export_with_various_resource_attribute_types(
+    mirascope_client: Mirascope,
+    mock_span_ids: None,
+) -> None:
+    """Test exporting spans with various resource attribute types (bool, int, float, sequence)."""
+    mirascope_client.traces.create = MagicMock(return_value=None)
+
+    resource = Resource.create(
+        {
+            "service.name": "test-service",
+            "service.enabled": True,
+            "service.instance.count": 42,
+            "service.load": 3.14,
+            "service.tags": ["tag1", "tag2"],
+        }
+    )
+
+    provider = TracerProvider(resource=resource, id_generator=RandomIdGenerator())
+    memory_exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(memory_exporter)
+    provider.add_span_processor(processor)
+
+    otlp_exporter = MirascopeOTLPExporter(client=mirascope_client)
+
+    tracer = provider.get_tracer("resource-test-tracer")
+    with tracer.start_as_current_span("resource-test-span"):
+        pass
+
+    provider.force_flush()
+    spans = memory_exporter.get_finished_spans()
+
+    result = otlp_exporter.export(spans)
+    assert result == SpanExportResult.SUCCESS
+
+    mirascope_client.traces.create.assert_called_once()
+    sent_data = mirascope_client.traces.create.call_args[1]["resource_spans"]
+    assert len(sent_data) == 1
+
+    resource_attrs = {
+        attr.key: (
+            attr.value.string_value
+            or attr.value.bool_value
+            or attr.value.int_value
+            or attr.value.double_value
+        )
+        for attr in sent_data[0].resource.attributes
+    }
+
+    assert resource_attrs == snapshot(
+        {
+            "telemetry.sdk.language": "python",
+            "telemetry.sdk.name": "opentelemetry",
+            "telemetry.sdk.version": "1.38.0",
+            "service.name": "test-service",
+            "service.enabled": True,
+            "service.instance.count": "42",
+            "service.load": 3.14,
+            "service.tags": "['tag1', 'tag2']",
+        }
+    )
+
+
+def test_export_after_shutdown_returns_failure(span: Mock) -> None:
+    """Test that export returns FAILURE after shutdown is called."""
+    client = Mock()
+    exporter = MirascopeOTLPExporter(client=client)
+
+    exporter.shutdown()
+
+    result = exporter.export([span])
+    assert result == SpanExportResult.FAILURE
+    client.traces.create.assert_not_called()
+
+
+def test_force_flush_returns_true() -> None:
+    """Test that force_flush always returns True."""
+    client = Mock()
+    exporter = MirascopeOTLPExporter(client=client)
+
+    assert exporter.force_flush() is True
+    assert exporter.force_flush(timeout_millis=1000) is True

--- a/python/tests/ops/_internal/exporters/test_processors.py
+++ b/python/tests/ops/_internal/exporters/test_processors.py
@@ -1,0 +1,210 @@
+"""Unit tests for MirascopeSpanProcessor focusing on interface behavior."""
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from unittest.mock import Mock
+
+import pytest
+from inline_snapshot import snapshot
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+from mirascope.ops._internal.exporters import (
+    MirascopeOTLPExporter,
+    MirascopeSpanProcessor,
+)
+
+from .utils import create_mock_span
+
+
+@pytest.fixture
+def mock_span() -> Mock:
+    """Create a mock span for processor tests."""
+    return create_mock_span()
+
+
+@pytest.fixture
+def mock_spans() -> list[Mock]:
+    """Create multiple mock spans for processor tests."""
+    shared_resource = Mock(attributes={"service.name": "test-service"})
+    return [
+        create_mock_span(
+            name=f"test-span-{index}",
+            span_id=0x1234567890ABCDE0 + index,
+            shared_resource=shared_resource,
+        )
+        for index in range(3)
+    ]
+
+
+def test_processor_sends_start_events_immediately(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+    mock_span: Mock,
+) -> None:
+    """Test that processor sends start events immediately when spans start."""
+    otlp_exporter.export = Mock(return_value=True)
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+    )
+
+    processor.on_start(mock_span)
+    processor.shutdown()
+
+    assert otlp_exporter.export.call_count == snapshot(1)
+    otlp_exporter.export.assert_called_once_with([mock_span])
+
+
+def test_processor_batches_end_events(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+    mock_spans: list[Mock],
+) -> None:
+    """Test that processor batches end events through batch processor."""
+    batch_processor.on_end = Mock()
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+    )
+
+    for span in mock_spans:
+        processor.on_end(span)
+
+    assert batch_processor.on_end.call_count == snapshot(3)
+    for span in mock_spans:
+        batch_processor.on_end.assert_any_call(span)
+
+
+def test_processor_handles_concurrent_spans(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+    mock_spans: list[Mock],
+) -> None:
+    """Test that processor correctly handles concurrent span operations."""
+    otlp_exporter.export = Mock(return_value=True)
+    batch_processor.on_end = Mock()
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+    )
+
+    for span in mock_spans:
+        processor.on_start(span)
+        processor.on_end(span)
+
+    processor.shutdown()
+
+    assert otlp_exporter.export.call_count == snapshot(3)
+    assert batch_processor.on_end.call_count == snapshot(3)
+
+
+def test_processor_graceful_shutdown(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+    mock_span: Mock,
+) -> None:
+    """Test that processor shuts down gracefully and completes pending work."""
+    otlp_exporter.export = Mock(return_value=True)
+    otlp_exporter.shutdown = Mock()
+    batch_processor.shutdown = Mock()
+
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+    )
+
+    processor.on_start(mock_span)
+    processor.shutdown()
+
+    assert otlp_exporter.shutdown.call_count == snapshot(1)
+    assert batch_processor.shutdown.call_count == snapshot(1)
+    assert otlp_exporter.export.call_count == snapshot(1)
+    otlp_exporter.export.assert_called_once_with([mock_span])
+
+
+def test_processor_force_flush_completes_pending_work(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+    mock_spans: list[Mock],
+) -> None:
+    """Test that force flush completes all pending work."""
+    batch_processor.force_flush = Mock(return_value=True)
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+    )
+
+    for span in mock_spans:
+        processor.on_end(span)
+
+    result = processor.force_flush(timeout_millis=5000)
+
+    assert result == snapshot(True)
+    assert batch_processor.force_flush.call_count == snapshot(1)
+    batch_processor.force_flush.assert_called_once_with(5000)
+
+
+def test_processor_works_without_batch_processor(
+    otlp_exporter: MirascopeOTLPExporter,
+    mock_span: Mock,
+) -> None:
+    """Test that processor works correctly without batch processor (start-only mode)."""
+    otlp_exporter.export = Mock(return_value=True)
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=None,
+    )
+
+    processor.on_start(mock_span)
+    processor.on_end(mock_span)
+    result = processor.force_flush()
+    processor.shutdown()
+
+    assert otlp_exporter.export.call_count == snapshot(1)
+    otlp_exporter.export.assert_called_once_with([mock_span])
+    assert result == snapshot(True)
+
+
+def test_processor_ignores_operations_after_shutdown(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+    mock_span: Mock,
+) -> None:
+    """Test that processor ignores operations after shutdown."""
+    otlp_exporter.export = Mock(return_value=True)
+    batch_processor.on_end = Mock()
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+    )
+
+    processor.shutdown()
+    processor.on_start(mock_span)
+    processor.on_end(mock_span)
+
+    assert otlp_exporter.export.call_count == snapshot(0)
+    assert batch_processor.on_end.call_count == snapshot(0)
+
+
+def test_processor_with_custom_executor(
+    otlp_exporter: MirascopeOTLPExporter,
+    batch_processor: BatchSpanProcessor,
+    mock_span: Mock,
+) -> None:
+    """Test that processor works with custom executor."""
+    custom_executor = ThreadPoolExecutor(max_workers=5)
+    custom_executor.submit = Mock(return_value=Mock(spec=Future))
+
+    processor = MirascopeSpanProcessor(
+        otlp_exporter=otlp_exporter,
+        batch_processor=batch_processor,
+        executor=custom_executor,
+    )
+
+    processor.on_start(mock_span)
+
+    assert custom_executor.submit.call_count == snapshot(1)
+    call_args = custom_executor.submit.call_args[0]
+    assert call_args[0] == otlp_exporter.export
+    assert call_args[1][0] == mock_span
+
+    processor.shutdown()

--- a/python/tests/ops/_internal/exporters/utils.py
+++ b/python/tests/ops/_internal/exporters/utils.py
@@ -1,0 +1,133 @@
+"""Shared test helpers for exporter tests."""
+
+import time
+from typing import Any
+from unittest.mock import Mock
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import SpanContext, SpanKind, Status, StatusCode, TraceFlags
+from opentelemetry.trace.span import TraceState
+
+
+def create_mock_span(
+    name: str = "test-span",
+    span_id: int = 0x1234567890ABCDEF,
+    trace_id: int = 0x123456789ABCDEF0123456789ABCDEF0,
+    parent_span_id: int | None = None,
+    shared_resource: Mock | None = None,
+    kind: SpanKind = SpanKind.INTERNAL,
+    status_code: StatusCode = StatusCode.OK,
+    attributes: dict[str, Any] | None = None,
+) -> Mock:
+    """Create a mock ReadableSpan with common setup.
+
+    Args:
+        name: The span name
+        span_id: The span ID (64-bit hex)
+        trace_id: The trace ID (128-bit hex)
+        parent_span_id: Optional parent span ID for nested spans
+        shared_resource: Optional shared resource mock
+        kind: The span kind (INTERNAL, SERVER, CLIENT, etc.)
+        status_code: The span status code
+        attributes: Optional span attributes
+
+    Returns:
+        A configured mock ReadableSpan
+    """
+    span = Mock(spec=ReadableSpan)
+    span.name = name
+
+    context = Mock(spec=SpanContext)
+    context.trace_id = trace_id
+    context.span_id = span_id
+    context.trace_flags = TraceFlags(0x01)
+    context.trace_state = TraceState()
+    context.is_remote = False
+    context.is_valid = True
+
+    span.context = context
+    span.get_span_context = Mock(return_value=context)
+
+    if parent_span_id:
+        span.parent = Mock(
+            trace_id=trace_id,
+            span_id=parent_span_id,
+            trace_flags=TraceFlags(0x01),
+            trace_state=TraceState(),
+            is_remote=False,
+            is_valid=True,
+        )
+    else:
+        span.parent = None
+
+    span.start_time = 1000000000000000000
+    span.end_time = 1000000001000000000
+    span.attributes = attributes or {}
+
+    status_mock = Mock(spec=Status)
+    status_mock.status_code = status_code
+    status_mock.description = None
+    span.status = status_mock
+
+    span.events = []
+    span.links = []
+    span.kind = kind
+
+    if shared_resource:
+        span.resource = shared_resource
+    else:
+        span.resource = Mock()
+        span.resource.attributes = {"service.name": "test-service"}
+
+    span.instrumentation_scope = Mock()
+    span.instrumentation_scope.name = "test-instrumentation"
+    span.instrumentation_scope.version = "1.0.0"
+
+    return span
+
+
+def create_mock_span_with_time(
+    name: str = "test_span",
+    trace_id: int = 0x0102030405060708090A0B0C0D0E0F10,
+    span_id: int = 0x0102030405060708,
+) -> Mock:
+    """Create a mock span with current time for retry/transport tests.
+
+    This variant uses current time for start/end times and different
+    default IDs for compatibility with existing retry tests.
+    """
+    span = Mock(spec=ReadableSpan)
+    span.name = name
+
+    context = Mock(spec=SpanContext)
+    context.trace_id = trace_id
+    context.span_id = span_id
+    context.is_remote = False
+    context.trace_flags = TraceFlags(0x01)
+    context.trace_state = None
+
+    span.context = context
+    span.get_span_context = Mock(return_value=context)
+
+    span.parent = None
+    span.kind = SpanKind.SERVER
+    span.start_time = int(time.time() * 1e9)
+    span.end_time = int(time.time() * 1e9) + 1000000
+
+    status_mock = Mock(spec=Status)
+    status_mock.status_code = StatusCode.OK
+    status_mock.description = None
+    span.status = status_mock
+
+    span.attributes = {}
+    span.events = []
+    span.links = []
+
+    span.resource = Mock()
+    span.resource.attributes = {"service.name": "test-service"}
+
+    span.instrumentation_scope = Mock()
+    span.instrumentation_scope.name = "test-scope"
+    span.instrumentation_scope.version = "1.0.0"
+
+    return span

--- a/python/tests/ops/test_span.py
+++ b/python/tests/ops/test_span.py
@@ -322,10 +322,10 @@ def test_noop_span_logs_once(
     assert len(warnings) == 1
 
 
-def test_span_serializes_complex_attributes(
+def test_span_preserves_complex_attributes(
     span_exporter: InMemorySpanExporter,
 ) -> None:
-    """Test that complex attributes and events are serialized as JSON strings."""
+    """Test that complex attributes and events are preserved as sequences/strings."""
     with mirascope.ops.span("complex") as span:
         span.set(numbers=[1, 2, 3], payload='{"ok": true}')
         span.event("details", points=[1, 2], info='{"nested": "yes"}')
@@ -339,7 +339,7 @@ def test_span_serializes_complex_attributes(
             "name": "complex",
             "attributes": {
                 "mirascope.type": "trace",
-                "numbers": "[1,2,3]",
+                "numbers": (1, 2, 3),
                 "payload": '{"ok": true}',
             },
             "status": {"status_code": "UNSET", "description": None},
@@ -347,7 +347,7 @@ def test_span_serializes_complex_attributes(
                 {
                     "name": "details",
                     "attributes": {
-                        "points": "[1,2]",
+                        "points": (1, 2),
                         "info": '{"nested": "yes"}',
                     },
                 }
@@ -526,7 +526,7 @@ def test_span_with_initial_attributes(span_exporter: InMemorySpanExporter) -> No
 def test_span_with_initial_complex_attributes(
     span_exporter: InMemorySpanExporter,
 ) -> None:
-    """Test that span serializes complex initial attributes as JSON."""
+    """Test that span accepts complex initial attributes without serialization."""
     with mirascope.ops.span("complex-init", tags=["a", "b"], config='{"key":"val"}'):
         pass
 
@@ -539,7 +539,7 @@ def test_span_with_initial_complex_attributes(
             "name": "complex-init",
             "attributes": {
                 "mirascope.type": "trace",
-                "tags": '["a","b"]',
+                "tags": ("a", "b"),
                 "config": '{"key":"val"}',
             },
             "status": {"status_code": "UNSET", "description": None},


### PR DESCRIPTION
### TL;DR

Added OpenTelemetry exporters for Mirascope's two-phase telemetry system, enabling real-time visibility with efficient batching.

### What changed?

Implemented a complete OpenTelemetry integration for Mirascope's telemetry system:

- Created `MirascopeOTLPExporter` that converts OpenTelemetry spans to OTLP format and sends them to Mirascope's ingestion endpoint
- Developed `MirascopeSpanProcessor` that implements a two-phase export strategy:
  1. Immediate transmission of span start events for real-time visibility
  2. Batched transmission of completed spans for efficiency
- Added type definitions, constants, and utility functions to support the exporters
- Included comprehensive test coverage for all components

The implementation handles retry logic, error handling, and proper resource cleanup during shutdown.

### How to test?

1. Create a Mirascope client with your API key:
```python
from mirascope.api.client import get_sync_client
client = get_sync_client(api_key="your-api-key")
```

2. Set up the OpenTelemetry pipeline with the Mirascope exporters:
```python
from opentelemetry.sdk.trace import TracerProvider
from opentelemetry.sdk.trace.export import BatchSpanProcessor
from mirascope.ops._internal.exporters import MirascopeOTLPExporter, MirascopeSpanProcessor

exporter = MirascopeOTLPExporter(client=client)
batch_processor = BatchSpanProcessor(exporter)
processor = MirascopeSpanProcessor(otlp_exporter=exporter, batch_processor=batch_processor)

provider = TracerProvider()
provider.add_span_processor(processor)
```

3. Create and use a tracer to generate spans:
```python
tracer = provider.get_tracer("test-tracer")
with tracer.start_as_current_span("test-operation") as span:
    span.set_attribute("test.key", "test-value")
```

4. Verify spans appear in the Mirascope dashboard

### Why make this change?

This implementation provides a critical telemetry infrastructure that balances real-time visibility with performance. By sending span start events immediately while batching completed spans, we get the best of both worlds:

- Immediate visibility into long-running operations
- Efficient resource usage through batching
- Full compatibility with the OpenTelemetry ecosystem

This enables better monitoring, debugging, and performance analysis of applications using Mirascope.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce Mirascope OpenTelemetry OTLP exporter and two-phase span processor with comprehensive tests, and update span handling to preserve complex attributes/events.
> 
> - **Telemetry (OTel integration)**:
>   - **Exporter**: Add `MirascopeOTLPExporter` (`python/mirascope/ops/_internal/exporters/exporters.py`) to convert `ReadableSpan`s to OTLP and send via `Mirascope.traces.create`, with retry/backoff, shutdown, and attribute/resource conversion.
>   - **Processor**: Add `MirascopeSpanProcessor` (`processors.py`) implementing two-phase export (immediate start via thread pool + batched end via `BatchSpanProcessor`).
>   - **Types**: Add event/type definitions in `types.py` and package init in `__init__.py`.
> - **Span behavior**:
>   - Update `python/mirascope/ops/_internal/spans.py` to preserve complex attributes/events (no JSON serialization of sequences) and switch to relative imports (`.session`, `.utils`).
> - **Tests**:
>   - Add unit/integration tests for exporter retry/backoff, partial failures, shutdown, resource attribute handling, and processor behavior under concurrency (`python/tests/ops/_internal/exporters/*`).
>   - Adjust span tests to expect preserved sequences and initial complex attributes (`python/tests/ops/test_span.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50c938101e8bd554ac40c798999743c2acaacd8a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->