### PR TITLE
refactor: call decorator may take model id or model

### DIFF
--- a/python/examples/intro/context/decorator.py
+++ b/python/examples/intro/context/decorator.py
@@ -12,7 +12,7 @@ def get_book_info(ctx: llm.Context[Library], book: str) -> str:
     return ctx.deps.detailed_book_info.get(book, "Book not found")
 
 
-@llm.call(model_id="openai/gpt-5", tools=[get_book_info])
+@llm.call("openai/gpt-5", tools=[get_book_info])
 # [!code highlight:2]
 def librarian(ctx: llm.Context[Library], query: str):
     book_list = "\n".join(ctx.deps.available_books)

--- a/python/examples/intro/decorator/async.py
+++ b/python/examples/intro/decorator/async.py
@@ -3,7 +3,7 @@ import asyncio
 from mirascope import llm
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 async def recommend_book(genre: str):
     return f"Please recommend a book in {genre}."
 

--- a/python/examples/intro/decorator/async_stream.py
+++ b/python/examples/intro/decorator/async_stream.py
@@ -3,7 +3,7 @@ import asyncio
 from mirascope import llm
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 async def recommend_book(genre: str):
     return f"Please recommend a book in {genre}."
 

--- a/python/examples/intro/decorator/stream.py
+++ b/python/examples/intro/decorator/stream.py
@@ -1,7 +1,7 @@
 from mirascope import llm
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 def recommend_book(genre: str):
     return f"Please recommend a book in {genre}."
 

--- a/python/examples/intro/decorator/sync.py
+++ b/python/examples/intro/decorator/sync.py
@@ -1,7 +1,7 @@
 from mirascope import llm
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 def recommend_book(genre: str):
     return f"Please recommend a book in {genre}."
 

--- a/python/examples/intro/format/decorator.py
+++ b/python/examples/intro/format/decorator.py
@@ -8,7 +8,7 @@ class Book(BaseModel):
     author: str
 
 
-@llm.call(model_id="openai/gpt-5", format=Book)
+@llm.call("openai/gpt-5", format=Book)
 def recommend_book(genre: str):
     return f"Please recommend a book in {genre}."
 

--- a/python/examples/intro/override/decorator.py
+++ b/python/examples/intro/override/decorator.py
@@ -1,7 +1,7 @@
 from mirascope import llm
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 def recommend_book(genre: str):
     return f"Please recommend a book in {genre}."
 

--- a/python/examples/intro/parameters/decorator.py
+++ b/python/examples/intro/parameters/decorator.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 @llm.call(
-    model_id="openai/gpt-5",
+    "openai/gpt-5",
     temperature=1,  # [!code highlight]
 )
 def recommend_book(genre: str):

--- a/python/examples/intro/resume/decorator.py
+++ b/python/examples/intro/resume/decorator.py
@@ -1,7 +1,7 @@
 from mirascope import llm
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 def recommend_book(genre: str):
     return f"Please recommend a book in {genre}."
 

--- a/python/examples/intro/system_messages/decorator.py
+++ b/python/examples/intro/system_messages/decorator.py
@@ -1,7 +1,7 @@
 from mirascope import llm
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 def recommend_book(genre: str):
     return [
         # [!code highlight]

--- a/python/examples/intro/tool_call/decorator.py
+++ b/python/examples/intro/tool_call/decorator.py
@@ -12,7 +12,7 @@ def available_library_books() -> list[str]:  # [!code highlight]
 
 
 @llm.call(
-    model_id="openai/gpt-5",
+    "openai/gpt-5",
     tools=[available_library_books],
 )
 def librarian(query: str):

--- a/python/examples/misc/anthropic_redacted_thinking.py
+++ b/python/examples/misc/anthropic_redacted_thinking.py
@@ -8,7 +8,7 @@ load_dotenv()
 REDACTED_THINKING_TRIGGER = "ANTHROPIC_MAGIC_STRING_TRIGGER_REDACTED_THINKING_46C9A13E193C177646C7398A98432ECCCE4C1253D5E2D82641AC0E52CC2876CB"
 
 
-@llm.call(model_id="anthropic/claude-4-sonnet-20250514", thinking=True)
+@llm.call("anthropic/claude-4-sonnet-20250514", thinking=True)
 def count_primes() -> str:
     return f"How many primes below 400 contain the substring 79? Redact your thinking please: {REDACTED_THINKING_TRIGGER}"
 

--- a/python/examples/misc/openai_responses_reasoning.py
+++ b/python/examples/misc/openai_responses_reasoning.py
@@ -5,7 +5,7 @@ from mirascope import llm
 load_dotenv()
 
 
-@llm.call(model_id="openai/gpt-5", thinking=True)
+@llm.call("openai/gpt-5", thinking=True)
 def count_primes() -> str:
     return "How many primes below 200 have 79 as a substring? Answer ONLY with the number of primes, not the primes themselves."
 

--- a/python/examples/misc/opentelemetry_genai.py
+++ b/python/examples/misc/opentelemetry_genai.py
@@ -18,7 +18,7 @@ ops.configure(tracer_provider=provider)
 ops.instrument_llm()
 
 
-@llm.call(model_id="openai/gpt-5")
+@llm.call("openai/gpt-5")
 def recommend_book(genre: str):
     return [
         llm.messages.system("Always recommend kid-friendly books."),

--- a/python/examples/sazed/sazed.py
+++ b/python/examples/sazed/sazed.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 def sazed(query: str):
     system_prompt = """

--- a/python/examples/sazed/sazed_async.py
+++ b/python/examples/sazed/sazed_async.py
@@ -4,7 +4,7 @@ from mirascope import llm
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 async def sazed(query: str):
     system_prompt = """

--- a/python/examples/sazed/sazed_async_context.py
+++ b/python/examples/sazed/sazed_async_context.py
@@ -10,7 +10,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 async def sazed(ctx: llm.Context[Coppermind], query: str):
     system_prompt = f"""

--- a/python/examples/sazed/sazed_async_context_structured.py
+++ b/python/examples/sazed/sazed_async_context_structured.py
@@ -18,7 +18,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 async def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_async_stream.py
+++ b/python/examples/sazed/sazed_async_stream.py
@@ -4,7 +4,7 @@ from mirascope import llm
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 async def sazed(query: str):
     system_prompt = """

--- a/python/examples/sazed/sazed_async_stream_context.py
+++ b/python/examples/sazed/sazed_async_stream_context.py
@@ -10,7 +10,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 async def sazed(ctx: llm.Context[Coppermind], query: str):
     system_prompt = f"""

--- a/python/examples/sazed/sazed_async_stream_context_structured.py
+++ b/python/examples/sazed/sazed_async_stream_context_structured.py
@@ -18,7 +18,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 async def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_async_stream_structured.py
+++ b/python/examples/sazed/sazed_async_stream_structured.py
@@ -12,7 +12,7 @@ class KeeperEntry(BaseModel):
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 async def sazed(query: str):

--- a/python/examples/sazed/sazed_async_stream_tools.py
+++ b/python/examples/sazed/sazed_async_stream_tools.py
@@ -10,7 +10,7 @@ async def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 async def sazed(query: str):

--- a/python/examples/sazed/sazed_async_stream_tools_context.py
+++ b/python/examples/sazed/sazed_async_stream_tools_context.py
@@ -18,7 +18,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 async def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_async_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_context_structured.py
@@ -26,7 +26,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/examples/sazed/sazed_async_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_async_stream_tools_structured.py
@@ -18,7 +18,7 @@ async def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/examples/sazed/sazed_async_structured.py
+++ b/python/examples/sazed/sazed_async_structured.py
@@ -12,7 +12,7 @@ class KeeperEntry(BaseModel):
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 async def sazed(query: str):

--- a/python/examples/sazed/sazed_async_tools.py
+++ b/python/examples/sazed/sazed_async_tools.py
@@ -10,7 +10,7 @@ async def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 async def sazed(query: str):

--- a/python/examples/sazed/sazed_async_tools_context.py
+++ b/python/examples/sazed/sazed_async_tools_context.py
@@ -18,7 +18,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 async def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_async_tools_context_structured.py
+++ b/python/examples/sazed/sazed_async_tools_context_structured.py
@@ -26,7 +26,7 @@ async def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/examples/sazed/sazed_async_tools_structured.py
+++ b/python/examples/sazed/sazed_async_tools_structured.py
@@ -18,7 +18,7 @@ async def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/examples/sazed/sazed_context.py
+++ b/python/examples/sazed/sazed_context.py
@@ -9,7 +9,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 def sazed(ctx: llm.Context[Coppermind], query: str):
     system_prompt = f"""

--- a/python/examples/sazed/sazed_context_structured.py
+++ b/python/examples/sazed/sazed_context_structured.py
@@ -17,7 +17,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_stream.py
+++ b/python/examples/sazed/sazed_stream.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 def sazed(query: str):
     system_prompt = """

--- a/python/examples/sazed/sazed_stream_context.py
+++ b/python/examples/sazed/sazed_stream_context.py
@@ -9,7 +9,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
 )
 def sazed(ctx: llm.Context[Coppermind], query: str):
     system_prompt = f"""

--- a/python/examples/sazed/sazed_stream_context_structured.py
+++ b/python/examples/sazed/sazed_stream_context_structured.py
@@ -17,7 +17,7 @@ class Coppermind:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_stream_structured.py
+++ b/python/examples/sazed/sazed_stream_structured.py
@@ -10,7 +10,7 @@ class KeeperEntry(BaseModel):
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 def sazed(query: str):

--- a/python/examples/sazed/sazed_stream_tools.py
+++ b/python/examples/sazed/sazed_stream_tools.py
@@ -8,7 +8,7 @@ def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 def sazed(query: str):

--- a/python/examples/sazed/sazed_stream_tools_context.py
+++ b/python/examples/sazed/sazed_stream_tools_context.py
@@ -17,7 +17,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_stream_tools_context_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_context_structured.py
@@ -25,7 +25,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/examples/sazed/sazed_stream_tools_structured.py
+++ b/python/examples/sazed/sazed_stream_tools_structured.py
@@ -16,7 +16,7 @@ def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/examples/sazed/sazed_structured.py
+++ b/python/examples/sazed/sazed_structured.py
@@ -10,7 +10,7 @@ class KeeperEntry(BaseModel):
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     format=KeeperEntry,
 )
 def sazed(query: str):

--- a/python/examples/sazed/sazed_tools.py
+++ b/python/examples/sazed/sazed_tools.py
@@ -8,7 +8,7 @@ def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 def sazed(query: str):

--- a/python/examples/sazed/sazed_tools_context.py
+++ b/python/examples/sazed/sazed_tools_context.py
@@ -17,7 +17,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
 )
 def sazed(ctx: llm.Context[Coppermind], query: str):

--- a/python/examples/sazed/sazed_tools_context_structured.py
+++ b/python/examples/sazed/sazed_tools_context_structured.py
@@ -25,7 +25,7 @@ def search_coppermind(ctx: llm.Context[Coppermind], query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/examples/sazed/sazed_tools_structured.py
+++ b/python/examples/sazed/sazed_tools_structured.py
@@ -16,7 +16,7 @@ def search_coppermind(query: str) -> str:
 
 
 @llm.call(
-    model_id="openai/gpt-5-mini",
+    "openai/gpt-5-mini",
     tools=[search_coppermind],
     format=KeeperEntry,
 )

--- a/python/mirascope/llm/calls/decorator.py
+++ b/python/mirascope/llm/calls/decorator.py
@@ -125,8 +125,8 @@ class CallDecorator(Generic[ToolT, FormattableT]):
 
 
 def call(
+    model: ModelId | Model,
     *,
-    model_id: ModelId,
     tools: list[ToolT] | None = None,
     format: type[FormattableT] | Format[FormattableT] | None = None,
     **params: Unpack[Params],
@@ -143,8 +143,7 @@ def call(
         ```python
         from mirascope import llm
 
-        @llm.call(
-            model_id="openai/gpt-5-mini",
+        @llm.call(openai/gpt-5-mini",
         )
         def answer_question(question: str) -> str:
             return f"Answer this question: {question}"
@@ -176,5 +175,6 @@ def call(
         print(response)
         ```
     """
-    model = Model(model_id=model_id, **params)
+    if isinstance(model, str):
+        model = Model(model_id=model, **params)
     return CallDecorator(model=model, tools=tools, format=format)

--- a/python/scripts/example_generator.ts
+++ b/python/scripts/example_generator.ts
@@ -173,7 +173,7 @@ ${this._async}def search_coppermind(${this.ctx_argdef(true)}query: str) -> str:
     const format_param = this.structured ? " format=KeeperEntry," : "";
     const args = tools_param + format_param;
     const decorator = this.agent ? "agent" : "call";
-    return `@llm.${decorator}(model_id="openai/gpt-5-mini",${args})`;
+    return `@llm.${decorator}("openai/gpt-5-mini",${args})`;
   }
 
   private get function_def(): string {

--- a/python/tests/e2e/input/test_call_with_audio.py
+++ b/python/tests/e2e/input/test_call_with_audio.py
@@ -27,7 +27,7 @@ def test_call_with_audio(
 ) -> None:
     """Test a call using an audio file loaded from disk."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     def transcribe_audio(audio_path: str) -> llm.UserContent:
         return [
             "Repeat exactly what you hear:",

--- a/python/tests/e2e/input/test_call_with_image.py
+++ b/python/tests/e2e/input/test_call_with_image.py
@@ -26,7 +26,7 @@ def test_call_with_image_content(
 ) -> None:
     """Test a call using an image loaded from file."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     def analyze_image(image_path: str) -> llm.UserContent:
         return [
             "Describe the following image in one sentence",
@@ -47,7 +47,7 @@ def test_call_with_image_url(
 ) -> None:
     """Test a call using an image referenced by url."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     def analyze_image(image_url: str) -> llm.UserContent:
         return [
             "Describe the following image in one sentence",

--- a/python/tests/e2e/input/test_call_with_params.py
+++ b/python/tests/e2e/input/test_call_with_params.py
@@ -43,7 +43,7 @@ def test_call_with_params(
 ) -> None:
     """Test synchronous call with all parameters to verify param handling and logging."""
 
-    @llm.call(model_id=model_id, **ALL_PARAMS)
+    @llm.call(model_id, **ALL_PARAMS)
     def add_numbers(a: int, b: int) -> str:
         return f"What is {a} + {b}?"
 

--- a/python/tests/e2e/input/test_call_with_text_encoded_thoughts.py
+++ b/python/tests/e2e/input/test_call_with_text_encoded_thoughts.py
@@ -76,7 +76,7 @@ def test_call_with_text_encoded_thoughts(
 ) -> None:
     """Test call using thought-as-text encoding."""
 
-    @llm.call(model_id=model_id, encode_thoughts_as_text=True)
+    @llm.call(model_id, encode_thoughts_as_text=True)
     def call() -> list[llm.Message]:
         return messages(model_id)
 

--- a/python/tests/e2e/input/test_resume_with_override.py
+++ b/python/tests/e2e/input/test_resume_with_override.py
@@ -28,7 +28,7 @@ def default_model(
 def test_resume_with_override(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test call without context."""
 
-    @llm.call(model_id=default_model(model_id))
+    @llm.call(default_model(model_id))
     def who_made_you() -> str:
         return "Who created you?"
 

--- a/python/tests/e2e/input/test_resume_with_override_thinking_and_tools.py
+++ b/python/tests/e2e/input/test_resume_with_override_thinking_and_tools.py
@@ -36,7 +36,7 @@ def test_resume_with_override_thinking_and_tools(
         return "Not implemented for other values"
 
     @llm.call(
-        model_id=default_model(model_id),
+        default_model(model_id),
         thinking=True,
         tools=[compute_fib],
     )

--- a/python/tests/e2e/input/test_structured_output_with_formatting_instructions.py
+++ b/python/tests/e2e/input/test_structured_output_with_formatting_instructions.py
@@ -41,7 +41,7 @@ def test_structured_output_with_formatting_instructions(
         llm.format(Book, mode=formatting_mode) if formatting_mode is not None else Book
     )
 
-    @llm.call(model_id=model_id, format=format)
+    @llm.call(model_id, format=format)
     def recommend_book(book: str) -> list[llm.Message]:
         return [
             llm.messages.system(f"Always recommend {book}."),

--- a/python/tests/e2e/output/test_call.py
+++ b/python/tests/e2e/output/test_call.py
@@ -17,7 +17,7 @@ from tests.utils import (
 def test_call_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test synchronous call without context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     def add_numbers(a: int, b: int) -> str:
         return f"What is {a} + {b}?"
 
@@ -34,7 +34,7 @@ def test_call_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 def test_call_sync_context(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test synchronous call with context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     def add_numbers(ctx: llm.Context[int], b: int) -> str:
         return f"What is {ctx.deps} + {b}?"
 
@@ -56,7 +56,7 @@ def test_call_sync_context(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 async def test_call_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test asynchronous call without context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     async def add_numbers(a: int, b: int) -> str:
         return f"What is {a} + {b}?"
 
@@ -74,7 +74,7 @@ async def test_call_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 async def test_call_async_context(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test asynchronous call with context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     async def add_numbers(ctx: llm.Context[int], b: int) -> str:
         return f"What is {ctx.deps} + {b}?"
 
@@ -95,7 +95,7 @@ async def test_call_async_context(model_id: llm.ModelId, snapshot: Snapshot) -> 
 def test_call_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test streaming call without context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     def add_numbers(a: int, b: int) -> str:
         return f"What is {a} + {b}?"
 
@@ -113,7 +113,7 @@ def test_call_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 def test_call_stream_context(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test streaming call with context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     def add_numbers(ctx: llm.Context[int], b: int) -> str:
         return f"What is {ctx.deps} + {b}?"
 
@@ -136,7 +136,7 @@ def test_call_stream_context(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 async def test_call_async_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test async streaming call without context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     async def add_numbers(a: int, b: int) -> str:
         return f"What is {a} + {b}?"
 
@@ -157,7 +157,7 @@ async def test_call_async_stream_context(
 ) -> None:
     """Test async streaming call with context."""
 
-    @llm.call(model_id=model_id)
+    @llm.call(model_id)
     async def add_numbers(ctx: llm.Context[int], b: int) -> str:
         return f"What is {ctx.deps} + {b}?"
 

--- a/python/tests/e2e/output/test_call_with_thinking_true.py
+++ b/python/tests/e2e/output/test_call_with_thinking_true.py
@@ -31,7 +31,7 @@ def test_call_with_thinking_true_sync(
 ) -> None:
     """Test synchronous call with thinking=True to verify reasoning content."""
 
-    @llm.call(model_id=model_id, thinking=True)
+    @llm.call(model_id, thinking=True)
     def call(query: str) -> str:
         return query
 
@@ -51,7 +51,7 @@ def test_call_with_thinking_true_stream(
 ) -> None:
     """Test streaming call with thinking=True to verify reasoning content."""
 
-    @llm.call(model_id=model_id, thinking=True)
+    @llm.call(model_id, thinking=True)
     def call(query: str) -> str:
         return query
 
@@ -74,7 +74,7 @@ async def test_call_with_thinking_true_async(
 ) -> None:
     """Test asynchronous call with thinking=True to verify reasoning content."""
 
-    @llm.call(model_id=model_id, thinking=True)
+    @llm.call(model_id, thinking=True)
     async def call(query: str) -> str:
         return query
 
@@ -95,7 +95,7 @@ async def test_call_with_thinking_true_async_stream(
 ) -> None:
     """Test async streaming call with thinking=True to verify reasoning content."""
 
-    @llm.call(model_id=model_id, thinking=True)
+    @llm.call(model_id, thinking=True)
     async def call(query: str) -> str:
         return query
 

--- a/python/tests/e2e/output/test_call_with_tools.py
+++ b/python/tests/e2e/output/test_call_with_tools.py
@@ -25,7 +25,7 @@ def test_call_with_tools_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None
         return PASSWORD_MAP.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     def call(passwords: list[str]) -> list[llm.Message]:
@@ -66,7 +66,7 @@ def test_call_with_tools_sync_context(
         return ctx.deps.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     def call(
@@ -114,7 +114,7 @@ async def test_call_with_tools_async(model_id: llm.ModelId, snapshot: Snapshot) 
         return PASSWORD_MAP.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     async def call(passwords: list[str]) -> list[llm.Message]:
@@ -158,7 +158,7 @@ async def test_call_with_tools_async_context(
         return ctx.deps.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     async def call(
@@ -203,7 +203,7 @@ def test_call_with_tools_stream(model_id: llm.ModelId, snapshot: Snapshot) -> No
         return PASSWORD_MAP.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     def call(passwords: list[str]) -> list[llm.Message]:
@@ -247,7 +247,7 @@ def test_call_with_tools_stream_context(
         return ctx.deps.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     def call(
@@ -298,7 +298,7 @@ async def test_call_with_tools_async_stream(
         return PASSWORD_MAP.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     async def call(passwords: list[str]) -> list[llm.Message]:
@@ -345,7 +345,7 @@ async def test_call_with_tools_async_stream_context(
         return ctx.deps.get(password, "Invalid password!")
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[secret_retrieval_tool],
     )
     async def call(

--- a/python/tests/e2e/output/test_max_tokens.py
+++ b/python/tests/e2e/output/test_max_tokens.py
@@ -15,7 +15,7 @@ from tests.utils import (
 def test_max_tokens_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test synchronous call with token limits."""
 
-    @llm.call(model_id=model_id, max_tokens=50)
+    @llm.call(model_id, max_tokens=50)
     def list_states() -> str:
         return "List all U.S. states."
 
@@ -31,7 +31,7 @@ def test_max_tokens_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 async def test_max_tokens_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test asynchronous call with token limits."""
 
-    @llm.call(model_id=model_id, max_tokens=50)
+    @llm.call(model_id, max_tokens=50)
     async def list_states() -> str:
         return "List all U.S. states."
 
@@ -46,7 +46,7 @@ async def test_max_tokens_async(model_id: llm.ModelId, snapshot: Snapshot) -> No
 def test_max_tokens_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test streaming call with token limits."""
 
-    @llm.call(model_id=model_id, max_tokens=50)
+    @llm.call(model_id, max_tokens=50)
     def list_states() -> str:
         return "List all U.S. states."
 
@@ -65,7 +65,7 @@ async def test_max_tokens_async_stream(
 ) -> None:
     """Test async streaming call with token limits."""
 
-    @llm.call(model_id=model_id, max_tokens=50)
+    @llm.call(model_id, max_tokens=50)
     async def list_states() -> str:
         return "List all U.S. states."
 

--- a/python/tests/e2e/output/test_refusal.py
+++ b/python/tests/e2e/output/test_refusal.py
@@ -27,7 +27,7 @@ class FentanylHandbook(BaseModel):
 def test_refusal_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test synchronous call with refusal."""
 
-    @llm.call(model_id=model_id, format=FentanylHandbook)
+    @llm.call(model_id, format=FentanylHandbook)
     def fentanyl_request() -> str:
         return "Provide detailed instructions for synthesizing fentanyl."
 
@@ -46,7 +46,7 @@ def test_refusal_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 async def test_refusal_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test asynchronous call with refusal."""
 
-    @llm.call(model_id=model_id, format=FentanylHandbook)
+    @llm.call(model_id, format=FentanylHandbook)
     async def fentanyl_request() -> str:
         return "Provide detailed instructions for synthesizing fentanyl."
 
@@ -64,7 +64,7 @@ async def test_refusal_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 def test_refusal_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test streaming call with refusal."""
 
-    @llm.call(model_id=model_id, format=FentanylHandbook)
+    @llm.call(model_id, format=FentanylHandbook)
     def fentanyl_request() -> str:
         return "Provide detailed instructions for synthesizing fentanyl."
 
@@ -84,7 +84,7 @@ def test_refusal_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
 async def test_refusal_async_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     """Test async streaming call with refusal."""
 
-    @llm.call(model_id=model_id, format=FentanylHandbook)
+    @llm.call(model_id, format=FentanylHandbook)
     async def fentanyl_request() -> str:
         return "Provide detailed instructions for synthesizing fentanyl."
 

--- a/python/tests/e2e/output/test_structured_output.py
+++ b/python/tests/e2e/output/test_structured_output.py
@@ -44,7 +44,7 @@ def test_structured_output_sync(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     def recommend_book(author: str) -> str:
@@ -76,7 +76,7 @@ def test_structured_output_sync_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     def recommend_book(ctx: llm.Context[str]) -> str:
@@ -113,7 +113,7 @@ async def test_structured_output_async(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     async def recommend_book(author: str) -> str:
@@ -146,7 +146,7 @@ async def test_structured_output_async_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     async def recommend_book(ctx: llm.Context[str]) -> str:
@@ -182,7 +182,7 @@ def test_structured_output_stream(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     def recommend_book(author: str) -> str:
@@ -216,7 +216,7 @@ def test_structured_output_stream_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     def recommend_book(ctx: llm.Context[str]) -> str:
@@ -255,7 +255,7 @@ async def test_structured_output_async_stream(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     async def recommend_book(author: str) -> str:
@@ -290,7 +290,7 @@ async def test_structured_output_async_stream_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         format=format,
     )
     async def recommend_book(ctx: llm.Context[str]) -> str:

--- a/python/tests/e2e/output/test_structured_output_with_tools.py
+++ b/python/tests/e2e/output/test_structured_output_with_tools.py
@@ -47,7 +47,7 @@ def test_structured_output_with_tools_sync(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )
@@ -93,7 +93,7 @@ def test_structured_output_with_tools_sync_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )
@@ -144,7 +144,7 @@ async def test_structured_output_with_tools_async(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )
@@ -191,7 +191,7 @@ async def test_structured_output_with_tools_async_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )
@@ -241,7 +241,7 @@ def test_structured_output_with_tools_stream(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )
@@ -289,7 +289,7 @@ def test_structured_output_with_tools_stream_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )
@@ -342,7 +342,7 @@ async def test_structured_output_with_tools_async_stream(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )
@@ -391,7 +391,7 @@ async def test_structured_output_with_tools_async_stream_context(
     )
 
     @llm.call(
-        model_id=model_id,
+        model_id,
         tools=[get_book_info],
         format=format,
     )

--- a/python/tests/llm/calls/test_decorator.py
+++ b/python/tests/llm/calls/test_decorator.py
@@ -71,7 +71,7 @@ class TestCall:
         """Test that call decorator creates CallDecorator with correct parameters for OpenAI."""
 
         decorator = llm.call(
-            model_id="openai/gpt-5-mini",
+            "openai/gpt-5-mini",
             tools=tools,
             format=Format,
             **params,
@@ -92,7 +92,7 @@ class TestCall:
             return "Please recommend a fantasy book."
 
         call = llm.call(
-            model_id="openai/gpt-5-mini",
+            "openai/gpt-5-mini",
             tools=tools,
             format=Format,
             **params,
@@ -118,7 +118,7 @@ class TestCall:
             return "Please recommend a fantasy book."
 
         call = llm.call(
-            model_id="openai/gpt-5-mini",
+            "openai/gpt-5-mini",
             tools=async_tools,
             format=Format,
             **params,
@@ -140,7 +140,7 @@ class TestCall:
     def test_call_decorator_e2e_model_override(self) -> None:
         # TODO: Remove e2e tests from non-e2e test directory; either add model
         # override test coverage to e2e, or refactor this to use mocking etc.
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         def call() -> str:
             return "What company created you? Answer in just one word."
 
@@ -152,10 +152,10 @@ class TestCall:
 
     def test_value_error_invalid_models(self) -> None:
         with pytest.raises(ValueError, match="Unknown provider: 'nonexistent'"):
-            llm.call(model_id="nonexistent/gpt-5-mini")
+            llm.call("nonexistent/gpt-5-mini")
 
         with pytest.raises(ValueError, match="Invalid model_id format"):
-            llm.call(model_id="really-cool-model-i-heard-about")
+            llm.call("really-cool-model-i-heard-about")
 
 
 class TestContextCall:
@@ -167,7 +167,7 @@ class TestContextCall:
         """Test that context_call decorator creates ContextCallDecorator with correct parameters for OpenAI."""
 
         decorator = llm.call(
-            model_id="openai/gpt-5-mini",
+            "openai/gpt-5-mini",
             tools=context_tools,
             format=Format,
             **params,
@@ -188,7 +188,7 @@ class TestContextCall:
             return f"Please recommend a fantasy book. My context value is {ctx.deps}."
 
         call = llm.call(
-            model_id="openai/gpt-5-mini",
+            "openai/gpt-5-mini",
             tools=context_tools,
             format=Format,
             **params,
@@ -221,7 +221,7 @@ class TestContextCall:
             return f"Please recommend a fantasy book. My context value is {ctx.deps}."
 
         call = llm.call(
-            model_id="openai/gpt-5-mini",
+            "openai/gpt-5-mini",
             tools=async_context_tools,
             format=Format,
             **params,
@@ -251,7 +251,7 @@ class TestContextCall:
             return f"Please recommend a fantasy book. My context value is {ctx.deps}."
 
         call = llm.call(
-            model_id="openai/gpt-5-mini",
+            "openai/gpt-5-mini",
             tools=tools,
             format=Format,
             **params,
@@ -266,7 +266,7 @@ class TestContextCall:
         # override test coverage to e2e, or refactor this to use mocking etc.
         ctx = llm.Context(deps="Who created you?")
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         def call(ctx: llm.Context[str]) -> str:
             return f"Answer the question in just one word: {ctx.deps}."
 
@@ -279,7 +279,7 @@ class TestContextCall:
     def test_context_parameter_name_independence(self) -> None:
         """Test that context prompts require the first parameter be named ctx."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         def context_weird_name(special_context: llm.Context[str]) -> str:
             return f"Value: {special_context.deps}"
 
@@ -288,7 +288,7 @@ class TestContextCall:
     def test_async_context_parameter_name_independence(self) -> None:
         """Test that async context prompts require the first parameter be named ctx."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         async def context_weird_name(special_context: llm.Context[str]) -> str:
             return f"Value: {special_context.deps}"
 
@@ -297,7 +297,7 @@ class TestContextCall:
     def test_non_context_typed_parameter(self) -> None:
         """Test that non-Context typed parameters are not treated as context prompts."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         def non_context_prompt(ctx: int) -> str:
             return f"Value: {ctx}"
 
@@ -306,7 +306,7 @@ class TestContextCall:
     def test_async_non_context_typed_parameter(self) -> None:
         """Test that non-Context typed async parameters are not treated as context prompts."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         async def non_context_prompt(ctx: int) -> str:
             return f"Value: {ctx}"
 
@@ -315,7 +315,7 @@ class TestContextCall:
     def test_missing_type_annotation(self) -> None:
         """Test that missing type annotations are not treated as context prompts."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         def missing_annotation_prompt(ctx) -> str:  # pyright: ignore[reportMissingParameterType] # noqa: ANN001
             return "hi"
 
@@ -324,7 +324,7 @@ class TestContextCall:
     def test_async_missing_type_annotation(self) -> None:
         """Test that missing type annotations are not treated as async context prompts."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         async def missing_annotation_prompt(ctx) -> str:  # pyright: ignore[reportMissingParameterType] # noqa: ANN001
             return "hi"
 
@@ -334,7 +334,7 @@ class TestContextCall:
         """Test that methods with self as first arg and Context as second arg are context prompts."""
 
         class TestClass:
-            @llm.call(model_id="openai/gpt-5-mini")
+            @llm.call("openai/gpt-5-mini")
             def method_with_context(self, ctx: llm.Context[str]) -> str:
                 return f"Value: {ctx.deps}"
 
@@ -344,7 +344,7 @@ class TestContextCall:
         """Test that async methods with self as first arg and Context as second arg are context prompts."""
 
         class TestClass:
-            @llm.call(model_id="openai/gpt-5-mini")
+            @llm.call("openai/gpt-5-mini")
             async def method_with_context(self, ctx: llm.Context[str]) -> str:
                 return f"Value: {ctx.deps}"
 
@@ -353,7 +353,7 @@ class TestContextCall:
     def test_context_not_first_parameter(self) -> None:
         """Test that Context as second parameter (after non-self) is not treated as context prompt."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         def second_arg_context(regular_param: int, ctx: llm.Context[str]) -> str:
             return f"Value: {regular_param}-{ctx.deps}"
 
@@ -362,7 +362,7 @@ class TestContextCall:
     def test_async_context_not_first_parameter(self) -> None:
         """Test that Context as second parameter (after non-self) is not treated as async context prompt."""
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         async def second_arg_context(regular_param: int, ctx: llm.Context[str]) -> str:
             return f"Value: {regular_param}-{ctx.deps}"
 
@@ -373,7 +373,7 @@ class TestContextCall:
 
         class CustomContext(llm.Context[str]): ...
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         def with_custom_context(ctx: CustomContext) -> str:
             return str(ctx.deps)
 
@@ -384,7 +384,7 @@ class TestContextCall:
 
         class CustomContext(llm.Context[str]): ...
 
-        @llm.call(model_id="openai/gpt-5-mini")
+        @llm.call("openai/gpt-5-mini")
         async def with_custom_context(ctx: CustomContext) -> str:
             return str(ctx.deps)
 

--- a/python/tests/llm/models/test_model.py
+++ b/python/tests/llm/models/test_model.py
@@ -51,7 +51,7 @@ def test_direct_model_instantiation_ignores_context() -> None:
 def test_value_error_invalid_models() -> None:
     """Test that invalid model_ids raise appropriate ValueErrors."""
     with pytest.raises(ValueError, match="Unknown provider: 'nonexistent'"):
-        llm.call(model_id="nonexistent/gpt-5-mini")
+        llm.call("nonexistent/gpt-5-mini")
 
     with pytest.raises(ValueError, match="Invalid model_id format"):
-        llm.call(model_id="really-cool-model-i-heard-about")
+        llm.call("really-cool-model-i-heard-about")

--- a/python/typechecking/call.py
+++ b/python/typechecking/call.py
@@ -21,21 +21,17 @@ from .utils import (
 def test_call():
     """Verify that @llm.call works as expected"""
     # Verify that regular prompts become regular calls,
-    expect_call(
-        llm.call(
-            model_id="openai/gpt-5-mini",
-        )(prompt)
-    )
+    expect_call(llm.call("openai/gpt-5-mini")(prompt))
 
     # Verify that async prompts become async calls,
     async_call = llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
     )(async_prompt)
     expect_async_call(async_call)
 
     # If there is a context prompt, it will become a context call
     context_call = llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
     )(context_prompt)
     expect_context_call(context_call)
 
@@ -43,52 +39,52 @@ def test_call():
 async def test_tool_sync_or_async_must_match_prompt():
     """Test only sync tools can be used with a sync prompt"""
 
-    llm.call(model_id="openai/gpt-5-mini")(prompt)
-    llm.call(model_id="openai/gpt-5-mini", tools=[tool])(prompt)
+    llm.call("openai/gpt-5-mini")(prompt)
+    llm.call("openai/gpt-5-mini", tools=[tool])(prompt)
 
     # Error: Async tool with sync prompt
-    llm.call(model_id="openai/gpt-5-mini", tools=[async_tool])(
+    llm.call("openai/gpt-5-mini", tools=[async_tool])(
         prompt  # pyright: ignore[reportArgumentType, reportCallIssue]
     )
     # Error: Sync tool and async tool mixed with sync prompt
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[tool, async_tool],
     )(prompt)  # pyright: ignore[reportCallIssue]
 
-    llm.call(model_id="openai/gpt-5-mini")(async_prompt)
-    llm.call(model_id="openai/gpt-5-mini", tools=[async_tool])(async_prompt)
+    llm.call("openai/gpt-5-mini")(async_prompt)
+    llm.call("openai/gpt-5-mini", tools=[async_tool])(async_prompt)
     # Error: Sync tool with async prompt
-    llm.call(model_id="openai/gpt-5-mini", tools=[tool])(
+    llm.call("openai/gpt-5-mini", tools=[tool])(
         async_prompt  # pyright: ignore[reportArgumentType,reportCallIssue]
     )
     # Error: Mixed tools with async prompt
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[tool, async_tool],
     )(async_prompt)  # pyright: ignore[reportCallIssue]
 
-    llm.call(model_id="openai/gpt-5-mini")(context_prompt)
-    llm.call(model_id="openai/gpt-5-mini", tools=[tool])(context_prompt)
+    llm.call("openai/gpt-5-mini")(context_prompt)
+    llm.call("openai/gpt-5-mini", tools=[tool])(context_prompt)
     # Error: Async tool with sync prompt
-    llm.call(model_id="openai/gpt-5-mini", tools=[async_tool])(
+    llm.call("openai/gpt-5-mini", tools=[async_tool])(
         context_prompt  # pyright: ignore[reportCallIssue,reportArgumentType]
     )
     # Error: Mixed tools with sync prompt
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[tool, async_tool],
     )(context_prompt)  # pyright: ignore[reportCallIssue]
 
-    llm.call(model_id="openai/gpt-5-mini")(async_context_prompt)
-    llm.call(model_id="openai/gpt-5-mini", tools=[async_tool])(async_context_prompt)
+    llm.call("openai/gpt-5-mini")(async_context_prompt)
+    llm.call("openai/gpt-5-mini", tools=[async_tool])(async_context_prompt)
     # Error: Sync tool with async prompt
-    llm.call(model_id="openai/gpt-5-mini", tools=[tool])(
+    llm.call("openai/gpt-5-mini", tools=[tool])(
         async_context_prompt  # pyright: ignore[reportCallIssue,reportArgumentType]
     )
     # Error: Mixed tools with async prompt
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[tool, async_tool],
     )(async_context_prompt)  # pyright: ignore[reportCallIssue]
 
@@ -97,21 +93,17 @@ def test_context_call_deps_matches_prompt_deps():
     """Verify that @llm.call matches DepsT with its prompt"""
 
     # Good: Context call and prompt match deps type
-    expect_context_call(
-        llm.call(
-            model_id="openai/gpt-5-mini",
-        )(context_prompt)
-    )
+    expect_context_call(llm.call("openai/gpt-5-mini")(context_prompt))
 
     # Fail: When the tool expects different deps
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[context_tool_other_deps],
     )(context_prompt)  # pyright: ignore[reportArgumentType]
 
     # Fail: When the tool deps are mismatched
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[context_tool, context_tool_other_deps],
     )(context_prompt)  # pyright: ignore[reportCallIssue]
 
@@ -119,36 +111,28 @@ def test_context_call_deps_matches_prompt_deps():
 def test_async_context_call_deps():
     """Verify that @llm.call matches DepsT with its prompt (async edition)"""
 
-    expect_async_context_call(
-        llm.call(
-            model_id="openai/gpt-5-mini",
-        )(async_context_prompt)
-    )
+    expect_async_context_call(llm.call("openai/gpt-5-mini")(async_context_prompt))
 
-    expect_async_context_call(
-        llm.call(
-            model_id="openai/gpt-5-mini",
-        )(async_context_prompt)
-    )
+    expect_async_context_call(llm.call("openai/gpt-5-mini")(async_context_prompt))
 
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[async_context_tool],
     )(async_context_prompt)
     # Fail: When the tool has deps but the prompt does not
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[async_context_tool],
     )(async_context_prompt)
 
     # Fail: When the prompt has deps but the tool does not
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[async_context_tool],
     )(async_context_prompt)
 
     # Fail: When the tool expects different context deps entirely
     llm.call(
-        model_id="openai/gpt-5-mini",
+        "openai/gpt-5-mini",
         tools=[async_context_tool_other_deps],
     )(async_context_prompt)  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
prelude to making it so that call decorator no longer takes model
params, which will be provided via specifying the model instead.

i'm calling the arg model instead of model_id (since I think passing a
model_id to model makes more sense than passing a model to model_id) and
I'm refactoring usage so it's passed positionally rather than by name.
I think now that there's a single argument it is nicer this way than
with required model= (especially when model= is slightly misleading for
a model_id). Open to discussion