### PR TITLE
refactor: allow positional model_id arg in `llm.model`

### DIFF
--- a/python/examples/intro/context/model.py
+++ b/python/examples/intro/context/model.py
@@ -14,7 +14,7 @@ def get_book_info(ctx: llm.Context[Library], book: str) -> str:
 
 # [!code highlight:2]
 def librarian(ctx: llm.Context[Library], query: str):
-    model = llm.use_model(model_id="openai/gpt-5")
+    model = llm.use_model("openai/gpt-5")
     book_list = "\n".join(ctx.deps.available_books)
     messages = [
         llm.messages.system(

--- a/python/examples/intro/format/model.py
+++ b/python/examples/intro/format/model.py
@@ -9,7 +9,7 @@ class Book(BaseModel):
 
 
 def recommend_book(genre: str) -> llm.Response[Book]:
-    model: llm.Model = llm.use_model(model_id="openai/gpt-5")
+    model: llm.Model = llm.use_model("openai/gpt-5")
     message = llm.messages.user(f"Please recommend a book in {genre}.")
     return model.call(
         messages=[message],

--- a/python/examples/intro/model/async.py
+++ b/python/examples/intro/model/async.py
@@ -4,7 +4,7 @@ from mirascope import llm
 
 
 async def recommend_book(genre: str) -> llm.AsyncResponse:
-    model: llm.Model = llm.use_model(model_id="openai/gpt-5")
+    model: llm.Model = llm.use_model("openai/gpt-5")
     message = llm.messages.user(f"Please recommend a book in {genre}.")
     return await model.call_async(messages=[message])
 

--- a/python/examples/intro/model/async_stream.py
+++ b/python/examples/intro/model/async_stream.py
@@ -4,7 +4,7 @@ from mirascope import llm
 
 
 async def recommend_book(genre: str) -> llm.AsyncStreamResponse:
-    model: llm.Model = llm.use_model(model_id="openai/gpt-5")
+    model: llm.Model = llm.use_model("openai/gpt-5")
     message = llm.messages.user(f"Please recommend a book in {genre}.")
     return await model.stream_async(messages=[message])
 

--- a/python/examples/intro/model/stream.py
+++ b/python/examples/intro/model/stream.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 def recommend_book(genre: str) -> llm.StreamResponse:
-    model: llm.Model = llm.use_model(model_id="openai/gpt-5")
+    model: llm.Model = llm.use_model("openai/gpt-5")
     message = llm.messages.user(f"Please recommend a book in {genre}.")
     return model.stream(messages=[message])
 

--- a/python/examples/intro/model/sync.py
+++ b/python/examples/intro/model/sync.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 def recommend_book(genre: str) -> llm.Response:
-    model: llm.Model = llm.use_model(model_id="openai/gpt-5")
+    model: llm.Model = llm.use_model("openai/gpt-5")
     message = llm.messages.user(f"Please recommend a book in {genre}.")
     return model.call(messages=[message])
 

--- a/python/examples/intro/override/decorator.py
+++ b/python/examples/intro/override/decorator.py
@@ -8,7 +8,7 @@ def recommend_book(genre: str):
 
 def main():
     # [!code highlight:2]
-    with llm.model(model_id="anthropic/claude-sonnet-4-0", temperature=1):
+    with llm.model("anthropic/claude-sonnet-4-0", temperature=1):
         response: llm.Response = recommend_book("fantasy")
         print(response.pretty())
 

--- a/python/examples/intro/override/model.py
+++ b/python/examples/intro/override/model.py
@@ -3,14 +3,14 @@ from mirascope import llm
 
 def recommend_book(genre: str) -> llm.Response:
     # [!code highlight:2]
-    model = llm.use_model(model_id="openai/gpt-5-mini")
+    model = llm.use_model("openai/gpt-5-mini")
     message = llm.messages.user(f"Please recommend a book in {genre}.")
     return model.call(messages=[message])
 
 
 def main():
     # [!code highlight:2]
-    with llm.model(model_id="anthropic/claude-sonnet-4-0", temperature=1):
+    with llm.model("anthropic/claude-sonnet-4-0", temperature=1):
         response: llm.Response = recommend_book("fantasy")
         print(response.pretty())
 

--- a/python/examples/intro/resume/model.py
+++ b/python/examples/intro/resume/model.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 def recommend_book(genre: str) -> llm.Response:
-    model: llm.Model = llm.use_model(model_id="openai/gpt-5")
+    model: llm.Model = llm.use_model("openai/gpt-5")
     message = llm.messages.user(f"Please recommend a book in {genre}.")
     return model.call(messages=[message])
 

--- a/python/examples/intro/system_messages/model.py
+++ b/python/examples/intro/system_messages/model.py
@@ -2,7 +2,7 @@ from mirascope import llm
 
 
 def recommend_book(genre: str) -> llm.Response:
-    model = llm.use_model(model_id="openai/gpt-5")
+    model = llm.use_model("openai/gpt-5")
     return model.call(
         messages=[
             # [!code highlight]

--- a/python/examples/intro/tool_call/model.py
+++ b/python/examples/intro/tool_call/model.py
@@ -12,7 +12,7 @@ def available_library_books() -> list[str]:  # [!code highlight]
 
 
 def librarian(query: str) -> llm.Response:
-    model = llm.use_model(model_id="openai/gpt-5")
+    model = llm.use_model("openai/gpt-5")
     message = llm.messages.user(query)
     return model.call(
         messages=[message],

--- a/python/examples/misc/openai_responses_reasoning.py
+++ b/python/examples/misc/openai_responses_reasoning.py
@@ -13,7 +13,7 @@ def count_primes() -> str:
 response = count_primes()
 print(response.pretty())
 
-with llm.model(model_id="openai/gpt-5", thinking=False):
+with llm.model("openai/gpt-5", thinking=False):
     response = response.resume(
         "If you remember the primes, list them. Or say 'I dont remember'"
     )

--- a/python/mirascope/llm/calls/decorator.py
+++ b/python/mirascope/llm/calls/decorator.py
@@ -176,5 +176,5 @@ def call(
         ```
     """
     if isinstance(model, str):
-        model = Model(model_id=model, **params)
+        model = Model(model, **params)
     return CallDecorator(model=model, tools=tools, format=format)

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -1149,7 +1149,6 @@ class Model:
 
 @contextmanager
 def model(
-    *,
     model_id: ModelId,
     **params: Unpack[Params],
 ) -> Iterator[None]:
@@ -1189,7 +1188,6 @@ def model(
 
 
 def use_model(
-    *,
     model_id: ModelId,
     **params: Unpack[Params],
 ) -> Model:

--- a/python/tests/e2e/input/test_resume_with_override.py
+++ b/python/tests/e2e/input/test_resume_with_override.py
@@ -35,7 +35,7 @@ def test_resume_with_override(model_id: llm.ModelId, snapshot: Snapshot) -> None
     with snapshot_test(snapshot) as snap:
         response = who_made_you()
 
-        with llm.model(model_id=model_id):
+        with llm.model(model_id):
             response = response.resume("Can you double-check that?")
 
         snap.set_response(response)

--- a/python/tests/e2e/input/test_resume_with_override_thinking_and_tools.py
+++ b/python/tests/e2e/input/test_resume_with_override_thinking_and_tools.py
@@ -50,7 +50,7 @@ def test_resume_with_override_thinking_and_tools(
         )
 
         tool_outputs = primer_response.execute_tools()
-        with llm.model(model_id=model_id, thinking=False):
+        with llm.model(model_id, thinking=False):
             response = primer_response.resume(tool_outputs)
 
         snap.set_response(response)

--- a/python/tests/e2e/output/test_call_with_thinking_true.py
+++ b/python/tests/e2e/output/test_call_with_thinking_true.py
@@ -37,7 +37,7 @@ def test_call_with_thinking_true_sync(
 
     with snapshot_test(snapshot, caplog) as snap:
         response = call(PROMPT)
-        with llm.model(model_id=model_id, thinking=False):
+        with llm.model(model_id, thinking=False):
             response = response.resume(RESUME_PROMPT)
         snap.set_response(response)
 
@@ -58,7 +58,7 @@ def test_call_with_thinking_true_stream(
     with snapshot_test(snapshot, caplog) as snap:
         response = call.stream(PROMPT)
         response.finish()
-        with llm.model(model_id=model_id, thinking=False):
+        with llm.model(model_id, thinking=False):
             response = response.resume(RESUME_PROMPT)
         response.finish()
         snap.set_response(response)
@@ -80,7 +80,7 @@ async def test_call_with_thinking_true_async(
 
     with snapshot_test(snapshot, caplog) as snap:
         response = await call(PROMPT)
-        with llm.model(model_id=model_id, thinking=False):
+        with llm.model(model_id, thinking=False):
             response = await response.resume(RESUME_PROMPT)
         snap.set_response(response)
 
@@ -102,7 +102,7 @@ async def test_call_with_thinking_true_async_stream(
     with snapshot_test(snapshot, caplog) as snap:
         response = await call.stream(PROMPT)
         await response.finish()
-        with llm.model(model_id=model_id, thinking=False):
+        with llm.model(model_id, thinking=False):
             response = await response.resume(RESUME_PROMPT)
         await response.finish()
         snap.set_response(response)

--- a/python/tests/llm/calls/test_decorator.py
+++ b/python/tests/llm/calls/test_decorator.py
@@ -145,9 +145,9 @@ class TestCall:
             return "What company created you? Answer in just one word."
 
         assert call().pretty() == snapshot("OpenAI.")
-        with llm.model(model_id="google/gemini-2.0-flash"):
+        with llm.model("google/gemini-2.0-flash"):
             assert call().pretty() == snapshot("Google.\n")
-            with llm.model(model_id="anthropic/claude-sonnet-4-0"):
+            with llm.model("anthropic/claude-sonnet-4-0"):
                 assert call().pretty() == snapshot("Anthropic")
 
     def test_value_error_invalid_models(self) -> None:
@@ -271,9 +271,9 @@ class TestContextCall:
             return f"Answer the question in just one word: {ctx.deps}."
 
         assert call(ctx).pretty() == snapshot("OpenAI.")
-        with llm.model(model_id="google/gemini-2.0-flash"):
+        with llm.model("google/gemini-2.0-flash"):
             assert call(ctx).pretty() == snapshot("Google.\n")
-            with llm.model(model_id="anthropic/claude-sonnet-4-0"):
+            with llm.model("anthropic/claude-sonnet-4-0"):
                 assert call(ctx).pretty() == snapshot("Anthropic.")
 
     def test_context_parameter_name_independence(self) -> None:

--- a/python/tests/llm/models/test_model.py
+++ b/python/tests/llm/models/test_model.py
@@ -9,7 +9,7 @@ from mirascope import llm
 
 def test_client_pulled_from_context_at_call_time() -> None:
     """Test that models get client at call time, not construction time."""
-    model = llm.use_model(model_id="openai/gpt-4o")
+    model = llm.use_model("openai/gpt-4o")
 
     custom_client = llm.client("openai", api_key="test-key")
 
@@ -24,7 +24,7 @@ def test_client_pulled_from_context_at_call_time() -> None:
 
 def test_use_model_without_context() -> None:
     """Test that use_model creates a new Model when no context is set."""
-    model = llm.use_model(model_id="openai/gpt-4o")
+    model = llm.use_model("openai/gpt-4o")
 
     assert model.provider == "openai"
     assert model.model_id == "openai/gpt-4o"
@@ -32,8 +32,8 @@ def test_use_model_without_context() -> None:
 
 def test_use_model_with_context() -> None:
     """Test that use_model returns the context model when one is set."""
-    with llm.model(model_id="anthropic/claude-sonnet-4-0"):
-        model = llm.use_model(model_id="openai/gpt-4o")
+    with llm.model("anthropic/claude-sonnet-4-0"):
+        model = llm.use_model("openai/gpt-4o")
 
         assert model.provider == "anthropic"
         assert model.model_id == "anthropic/claude-sonnet-4-0"
@@ -41,8 +41,8 @@ def test_use_model_with_context() -> None:
 
 def test_direct_model_instantiation_ignores_context() -> None:
     """Test that direct Model instantiation ignores context (hardcoding behavior)."""
-    with llm.model(model_id="openai/claude-sonnet-4-0"):
-        model = llm.Model(model_id="openai/gpt-4o")
+    with llm.model("openai/claude-sonnet-4-0"):
+        model = llm.Model("openai/gpt-4o")
 
         assert model.provider == "openai"
         assert model.model_id == "openai/gpt-4o"


### PR DESCRIPTION
More consistent with call decorator; prelude to allowing model or
model_id as arg