### PR TITLE
Integrate call-level tracing into @llm.call decorator

### DIFF
--- a/python/examples/misc/opentelemetry_call_trace.py
+++ b/python/examples/misc/opentelemetry_call_trace.py
@@ -1,0 +1,84 @@
+"""Example showing how to use @ops.trace with @llm.call for tracing."""
+
+from __future__ import annotations
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+
+from mirascope import llm, ops
+
+# Configure an SDK tracer provider with a simple console exporter.
+provider = TracerProvider()
+provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+
+# Enable GenAI 1.38 instrumentation.
+ops.configure(tracer_provider=provider)
+ops.instrument_llm()
+
+
+@ops.trace
+@llm.call("openai/gpt-4o-mini")
+def recommend_book(genre: str):
+    """Traced LLM call using @ops.trace decorator.
+
+    This creates a TracedCall where:
+    - recommend_book("fantasy") returns Response directly (but execution is traced)
+    - recommend_book.call("fantasy") returns Response directly (same as __call__)
+    - recommend_book.stream("fantasy") returns StreamResponse directly
+    - recommend_book.wrapped("fantasy") returns Trace[Response] with span info
+    - recommend_book.wrapped.call("fantasy") returns Response directly
+    - recommend_book.wrapped_stream("fantasy") returns Trace[StreamResponse]
+    """
+    return [
+        llm.messages.system("Always recommend kid-friendly books."),
+        llm.messages.user(f"Please recommend a book in {genre}."),
+    ]
+
+
+@ops.trace(tags=["production", "recommendations"])
+@llm.call("openai/gpt-4o-mini")
+def recommend_book_with_tags(genre: str):
+    """Traced LLM call with custom tags."""
+    return [
+        llm.messages.system("Always recommend kid-friendly books."),
+        llm.messages.user(f"Please recommend a book in {genre}."),
+    ]
+
+
+print("=== TracedCall: recommend_book('fantasy') returns Response directly ===")
+response = recommend_book("fantasy")
+print(f"Content: {response.content}")
+
+print(
+    "\n=== TracedCall.wrapped: recommend_book.wrapped('fantasy') returns Trace[Response] ==="
+)
+trace = recommend_book.wrapped("fantasy")
+print(f"Span ID: {trace.span_id}")
+print(f"Content: {trace.result.content}")
+
+print(
+    "\n=== TracedCall.wrapped.call: recommend_book.wrapped.call('fantasy') returns Response directly ==="
+)
+response = recommend_book.call("fantasy")
+print(f"Content: {response.content}")
+
+print("\n=== TracedCall with custom tags (returns Response directly) ===")
+response = recommend_book_with_tags("science fiction")
+print(f"Content: {response.content}")
+
+print(
+    "\n=== TracedCall.wrapped_stream: recommend_book.wrapped_stream('adventure') returns Trace[StreamResponse] ==="
+)
+traced_stream = recommend_book.wrapped_stream("adventure")
+print(f"Span ID: {traced_stream.span_id}")
+for chunk in traced_stream.result.pretty_stream():
+    print(chunk, end="", flush=True)
+print()
+
+print(
+    "\n=== TracedCall.stream: recommend_book.stream('mystery') returns StreamResponse directly ==="
+)
+stream_response = recommend_book.stream("mystery")
+for chunk in stream_response.pretty_stream():
+    print(chunk, end="", flush=True)
+print()

--- a/python/mirascope/ops/__init__.py
+++ b/python/mirascope/ops/__init__.py
@@ -25,12 +25,20 @@ try:
         session,
     )
     from ._internal.spans import Span, span
-    from ._internal.tracing import (
+    from ._internal.traced_call import (
+        TracedAsyncCall,
+        TracedAsyncContextCall,
+        TracedCall,
+        TracedContextCall,
+    )
+    from ._internal.traced_functions import (
+        AsyncTrace,
         AsyncTracedFunction,
-        AsyncTracedResult,
-        TraceDecorator,
+        Trace,
         TracedFunction,
-        TracedResult,
+    )
+    from ._internal.tracing import (
+        TraceDecorator,
         trace,
     )
 except ImportError:  # pragma: no cover
@@ -64,26 +72,35 @@ except ImportError:  # pragma: no cover
     session = _create_otel_import_error_stub("session")
     Span = _create_otel_import_error_stub("Span")
     span = _create_otel_import_error_stub("span")
+    AsyncTrace = _create_otel_import_error_stub("AsyncTrace")
     AsyncTracedFunction = _create_otel_import_error_stub("AsyncTracedFunction")
-    AsyncTracedResult = _create_otel_import_error_stub("AsyncTracedResult")
+    Trace = _create_otel_import_error_stub("Trace")
     TraceDecorator = _create_otel_import_error_stub("TraceDecorator")
+    TracedAsyncCall = _create_otel_import_error_stub("TracedAsyncCall")
+    TracedAsyncContextCall = _create_otel_import_error_stub("TracedAsyncContextCall")
+    TracedCall = _create_otel_import_error_stub("TracedCall")
+    TracedContextCall = _create_otel_import_error_stub("TracedContextCall")
     TracedFunction = _create_otel_import_error_stub("TracedFunction")
-    TracedResult = _create_otel_import_error_stub("TracedResult")
     trace = _create_otel_import_error_stub("trace")
     configure = _create_otel_import_error_stub("configure")
     tracer_context = _create_otel_import_error_stub("tracer_context")
 
+
 __all__ = [
     "SESSION_HEADER_NAME",
+    "AsyncTrace",
     "AsyncTracedFunction",
-    "AsyncTracedResult",
     "ContextPropagator",
     "PropagatorFormat",
     "SessionContext",
     "Span",
+    "Trace",
     "TraceDecorator",
+    "TracedAsyncCall",
+    "TracedAsyncContextCall",
+    "TracedCall",
+    "TracedContextCall",
     "TracedFunction",
-    "TracedResult",
     "configure",
     "current_session",
     "extract_context",

--- a/python/mirascope/ops/_internal/protocols.py
+++ b/python/mirascope/ops/_internal/protocols.py
@@ -6,6 +6,7 @@ import inspect
 from typing import Protocol
 from typing_extensions import TypeIs
 
+from ...llm.context import Context, DepsT
 from .types import P, R
 
 
@@ -22,6 +23,24 @@ class AsyncFunction(Protocol[P, R]):
 
     async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
         """The function's required asynchronous call method."""
+        ...  # pragma: no cover
+
+
+class SyncContextFunction(Protocol[P, DepsT, R]):
+    """Protocol for synchronous callable functions with Context parameter."""
+
+    def __call__(self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs) -> R:
+        """The function required a synchronous call method with context."""
+        ...  # pragma: no cover
+
+
+class AsyncContextFunction(Protocol[P, DepsT, R]):
+    """Protocol for asynchronous callable functions with Context parameter."""
+
+    async def __call__(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> R:
+        """The function's required asynchronous call method with context."""
         ...  # pragma: no cover
 
 

--- a/python/mirascope/ops/_internal/traced_call.py
+++ b/python/mirascope/ops/_internal/traced_call.py
@@ -1,0 +1,355 @@
+"""Traced call wrappers for @ops.trace decorated @llm.call functions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Generic
+from typing_extensions import TypeIs
+
+from ...llm.calls import AsyncCall, AsyncContextCall, Call, ContextCall
+from ...llm.context import Context, DepsT
+from ...llm.formatting import FormattableT
+from ...llm.responses import (
+    AsyncContextResponse,
+    AsyncContextStreamResponse,
+    AsyncResponse,
+    AsyncStreamResponse,
+    ContextResponse,
+    ContextStreamResponse,
+    Response,
+    StreamResponse,
+)
+from ...llm.types import P
+from .protocols import (
+    AsyncFunction,
+    R,
+    SyncFunction,
+)
+from .traced_functions import (
+    AsyncTrace,
+    AsyncTracedContextFunction,
+    AsyncTracedFunction,
+    Trace,
+    TracedContextFunction,
+    TracedFunction,
+)
+
+
+def is_call_type(
+    fn: (
+        SyncFunction[P, R]
+        | AsyncFunction[P, R]
+        | ContextCall[P, DepsT, FormattableT]
+        | AsyncContextCall[P, DepsT, FormattableT]
+        | Call[P, FormattableT]
+        | AsyncCall[P, FormattableT]
+    ),
+) -> TypeIs[
+    ContextCall[P, DepsT, FormattableT]
+    | AsyncContextCall[P, DepsT, FormattableT]
+    | Call[P, FormattableT]
+    | AsyncCall[P, FormattableT]
+]:
+    """Check if fn is any of the Call types."""
+    return isinstance(fn, Call | AsyncCall | ContextCall | AsyncContextCall)
+
+
+def wrap_call(
+    fn: (
+        ContextCall[P, DepsT, FormattableT]
+        | AsyncContextCall[P, DepsT, FormattableT]
+        | Call[P, FormattableT]
+        | AsyncCall[P, FormattableT]
+    ),
+    tags: tuple[str, ...],
+) -> (
+    TracedContextCall[P, DepsT, FormattableT]
+    | TracedAsyncContextCall[P, DepsT, FormattableT]
+    | TracedCall[P, FormattableT]
+    | TracedAsyncCall[P, FormattableT]
+):
+    """Wrap a Call object with the appropriate TracedCall type."""
+    if isinstance(fn, AsyncContextCall):
+        return TracedAsyncContextCall(_call=fn, tags=tags)
+    elif isinstance(fn, ContextCall):
+        return TracedContextCall(_call=fn, tags=tags)
+    elif isinstance(fn, AsyncCall):
+        return TracedAsyncCall(_call=fn, tags=tags)
+    else:
+        return TracedCall(_call=fn, tags=tags)
+
+
+@dataclass(kw_only=True)
+class TracedCall(Generic[P, FormattableT]):
+    """Traced wrapper for synchronous Call objects.
+
+    When @ops.trace decorates an @llm.call, it returns a TracedCall that wraps
+    the call and stream methods with tracing capabilities.
+
+    Example:
+        ```python
+        @ops.trace
+        @llm.call(provider="openai", model_id="gpt-4o-mini")
+        def recommend_book(genre: str):
+            return f"Recommend a {genre} book"
+
+        # Returns Response directly (but execution is traced)
+        response = recommend_book("fantasy")
+        print(response.content)
+
+        # Same as __call__
+        response = recommend_book.call("fantasy")
+
+        # Streaming returns StreamResponse (traced)
+        stream = recommend_book.stream("fantasy")
+        for chunk in stream:
+            print(chunk)
+
+        # Use wrapped to get Trace[Response] with span info
+        trace = recommend_book.wrapped("fantasy")
+        print(trace.result.content)
+        print(trace.span_id)
+
+        # Use wrapped_stream to get Trace[StreamResponse]
+        trace = recommend_book.wrapped_stream("fantasy")
+        ```
+    """
+
+    _call: Call[P, FormattableT]
+    """The wrapped Call object."""
+
+    tags: tuple[str, ...]
+    """Tags to be associated with traced calls."""
+
+    call: TracedFunction[P, Response | Response[FormattableT]] = field(init=False)
+    """TracedFunction wrapping the call method."""
+
+    stream: TracedFunction[P, StreamResponse | StreamResponse[FormattableT]] = field(
+        init=False
+    )
+    """TracedFunction wrapping the stream method."""
+
+    def __post_init__(self) -> None:
+        """Initialize TracedFunction wrappers for call and stream methods."""
+        self.call = TracedFunction(fn=self._call.call, tags=self.tags)
+        self.stream = TracedFunction(fn=self._call.stream, tags=self.tags)
+
+    def __call__(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> Response | Response[FormattableT]:
+        """Call the traced function and return Response directly."""
+        return self.call(*args, **kwargs)
+
+    def wrapped(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> Trace[Response | Response[FormattableT]]:
+        """Call the traced function and return a wrapped Response."""
+        return self.call.wrapped(*args, **kwargs)
+
+    def wrapped_stream(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> Trace[StreamResponse | StreamResponse[FormattableT]]:
+        """Stream the traced function and return a wrapped StreamResponse."""
+        return self.stream.wrapped(*args, **kwargs)
+
+
+@dataclass(kw_only=True)
+class TracedAsyncCall(Generic[P, FormattableT]):
+    """Traced wrapper for asynchronous AsyncCall objects.
+
+    Example:
+        ```python
+        @ops.trace
+        @llm.call(provider="openai", model_id="gpt-4o-mini")
+        async def recommend_book(genre: str):
+            return f"Recommend a {genre} book"
+
+        # Returns AsyncResponse directly (but execution is traced)
+        response = await recommend_book("fantasy")
+        print(response.content)
+
+        # Use wrapped to get AsyncTrace[AsyncResponse] with span info
+        trace = await recommend_book.wrapped("fantasy")
+        print(trace.result.content)
+        print(trace.span_id)
+        ```
+    """
+
+    _call: AsyncCall[P, FormattableT]
+    """The wrapped AsyncCall object."""
+
+    tags: tuple[str, ...]
+    """Tags to be associated with traced calls."""
+
+    call: AsyncTracedFunction[P, AsyncResponse | AsyncResponse[FormattableT]] = field(
+        init=False
+    )
+    """AsyncTracedFunction wrapping the call method."""
+
+    stream: AsyncTracedFunction[
+        P, AsyncStreamResponse | AsyncStreamResponse[FormattableT]
+    ] = field(init=False)
+    """AsyncTracedFunction wrapping the stream method."""
+
+    def __post_init__(self) -> None:
+        """Initialize AsyncTracedFunction wrappers for call and stream methods."""
+        self.call = AsyncTracedFunction(fn=self._call.call, tags=self.tags)
+        self.stream = AsyncTracedFunction(fn=self._call.stream, tags=self.tags)
+
+    async def __call__(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Call the traced function and return AsyncResponse directly."""
+        return await self.call(*args, **kwargs)
+
+    async def wrapped(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncTrace[AsyncResponse | AsyncResponse[FormattableT]]:
+        """Call the traced function and return a wrapped Response."""
+        return await self.call.wrapped(*args, **kwargs)
+
+    async def wrapped_stream(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncTrace[AsyncStreamResponse | AsyncStreamResponse[FormattableT]]:
+        """Stream the traced function and return a wrapped StreamResponse."""
+        return await self.stream.wrapped(*args, **kwargs)
+
+
+@dataclass(kw_only=True)
+class TracedContextCall(Generic[P, DepsT, FormattableT]):
+    """Traced wrapper for synchronous ContextCall objects.
+
+    Example:
+        ```python
+        @ops.trace
+        @llm.call(provider="openai", model_id="gpt-4o-mini")
+        def recommend_book(ctx: llm.Context[str], genre: str):
+            return f"{ctx.deps} Recommend a {genre} book"
+
+        ctx = llm.Context(deps="As a librarian,")
+
+        # Returns ContextResponse directly (but execution is traced)
+        response = recommend_book(ctx, "fantasy")
+        print(response.content)
+
+        # Use wrapped to get Trace[ContextResponse] with span info
+        trace = recommend_book.wrapped(ctx, "fantasy")
+        print(trace.result.content)
+        ```
+    """
+
+    _call: ContextCall[P, DepsT, FormattableT]
+    """The wrapped ContextCall object."""
+
+    tags: tuple[str, ...]
+    """Tags to be associated with traced calls."""
+
+    call: TracedContextFunction[
+        P, DepsT, ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]
+    ] = field(init=False)
+    """TracedContextFunction wrapping the call method."""
+
+    stream: TracedContextFunction[
+        P,
+        DepsT,
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT],
+    ] = field(init=False)
+    """TracedContextFunction wrapping the stream method."""
+
+    def __post_init__(self) -> None:
+        """Initialize TracedContextFunction wrappers for call and stream methods."""
+        self.call = TracedContextFunction(fn=self._call.call, tags=self.tags)
+        self.stream = TracedContextFunction(fn=self._call.stream, tags=self.tags)
+
+    def __call__(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
+        """Call the traced function and return ContextResponse directly."""
+        return self.call(ctx, *args, **kwargs)
+
+    def wrapped(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> Trace[ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]]:
+        """Call the traced function and return a wrapped Response."""
+        return self.call.wrapped(ctx, *args, **kwargs)
+
+    def wrapped_stream(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> Trace[
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
+    ]:
+        """Stream the traced function and return a wrapped StreamResponse."""
+        return self.stream.wrapped(ctx, *args, **kwargs)
+
+
+@dataclass(kw_only=True)
+class TracedAsyncContextCall(Generic[P, DepsT, FormattableT]):
+    """Traced wrapper for asynchronous AsyncContextCall objects.
+
+    Example:
+        ```python
+        @ops.trace
+        @llm.call(provider="openai", model_id="gpt-4o-mini")
+        async def recommend_book(ctx: llm.Context[str], genre: str):
+            return f"{ctx.deps} Recommend a {genre} book"
+
+        ctx = llm.Context(deps="As a librarian,")
+
+        # Returns AsyncContextResponse directly (but execution is traced)
+        response = await recommend_book(ctx, "fantasy")
+        print(response.content)
+
+        # Use wrapped to get AsyncTrace[AsyncContextResponse] with span info
+        trace = await recommend_book.wrapped(ctx, "fantasy")
+        print(trace.result.content)
+        ```
+    """
+
+    _call: AsyncContextCall[P, DepsT, FormattableT]
+    """The wrapped AsyncContextCall object."""
+
+    tags: tuple[str, ...]
+    """Tags to be associated with traced calls."""
+
+    call: AsyncTracedContextFunction[
+        P,
+        DepsT,
+        AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT],
+    ] = field(init=False)
+    """AsyncTracedContextFunction wrapping the call method."""
+
+    stream: AsyncTracedContextFunction[
+        P,
+        DepsT,
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT],
+    ] = field(init=False)
+    """AsyncTracedContextFunction wrapping the stream method."""
+
+    def __post_init__(self) -> None:
+        """Initialize AsyncTracedContextFunction wrappers for call and stream methods."""
+        self.call = AsyncTracedContextFunction(fn=self._call.call, tags=self.tags)
+        self.stream = AsyncTracedContextFunction(fn=self._call.stream, tags=self.tags)
+
+    async def __call__(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
+        """Call the traced function and return AsyncContextResponse directly."""
+        return await self.call(ctx, *args, **kwargs)
+
+    async def wrapped(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncTrace[
+        AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]
+    ]:
+        """Call the traced function and return a wrapped Response."""
+        return await self.call.wrapped(ctx, *args, **kwargs)
+
+    async def wrapped_stream(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncTrace[
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ]:
+        """Stream the traced function and return a wrapped StreamResponse."""
+        return await self.stream.wrapped(ctx, *args, **kwargs)

--- a/python/mirascope/ops/_internal/traced_functions.py
+++ b/python/mirascope/ops/_internal/traced_functions.py
@@ -1,0 +1,387 @@
+"""Tracing decorators for `mirascope.ops`."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from collections.abc import Generator
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Generic,
+    Literal,
+    TypeVar,
+)
+
+from opentelemetry.util.types import AttributeValue
+
+from ...llm.context import Context, DepsT
+from ...llm.responses.root_response import RootResponse
+from .protocols import (
+    AsyncContextFunction,
+    AsyncFunction,
+    SyncContextFunction,
+    SyncFunction,
+)
+from .spans import Span
+from .types import Jsonable, P, R
+from .utils import PrimitiveType, extract_arguments, get_qualified_name, json_dumps
+
+FunctionT = TypeVar(
+    "FunctionT",
+    bound="SyncFunction[..., Any] | AsyncFunction[..., Any]",
+    covariant=True,
+)
+
+
+def _record_result_to_span(span: Span, result: object) -> None:
+    """Records the function result in the given span.
+
+    This is a shared helper function used by all traced function classes
+    to record results consistently.
+    """
+    if result is None:
+        return  # NOTE: we treat `None` valued results as such through omission.
+    elif isinstance(result, PrimitiveType):
+        output: str | int | float | bool = result
+    elif isinstance(result, RootResponse):
+        output = result.pretty()
+    else:
+        try:
+            output = json_dumps(result)
+        except (TypeError, ValueError):
+            output = repr(result)
+    span.set(**{"mirascope.trace.output": output})
+
+
+@dataclass(kw_only=True, frozen=True)
+class _BaseTrace(Generic[R]):
+    """Base class for trace results with shared functionality."""
+
+    result: R
+    """Return value produced by the traced call."""
+
+    span: Span
+    """Span associated with the traced call."""
+
+    @property
+    def span_id(self) -> str | None:
+        """Returns the ID of the span for the trace."""
+        return self.span.span_id
+
+    @property
+    def trace_id(self) -> str | None:
+        """Returns the ID of the trace."""
+        return self.span.trace_id
+
+
+@dataclass(kw_only=True, frozen=True)
+class Trace(_BaseTrace[R]):
+    """Result container returned by traced function calls.
+
+    Provides access to the function result and trace span metadata,
+    as well as per-call operations for annotation, tagging, and assignment.
+    """
+
+    def annotate(
+        self,
+        *,
+        label: Literal["pass", "fail"],
+        reasoning: str | None = None,
+        metadata: dict[str, Jsonable] | None = None,
+    ) -> None:
+        """Annotates the current trace span."""
+        raise NotImplementedError("Trace.annotate not yet implemented")
+
+    def tag(self, *tags: str) -> None:
+        """Adds given tags to the current trace span."""
+        raise NotImplementedError("Trace.tag not yet implemented")
+
+    def assign(self, *emails: str) -> None:
+        """Assigns the trace to users with the given emails."""
+        raise NotImplementedError("Trace.assign not yet implemented")
+
+
+@dataclass(kw_only=True, frozen=True)
+class AsyncTrace(_BaseTrace[R]):
+    """Result container returned by async traced function calls.
+
+    Provides access to the function result and trace span metadata,
+    as well as per-call operations for annotation, tagging, and assignment.
+    """
+
+    async def annotate(
+        self,
+        *,
+        label: str | None = None,
+        data: dict[str, Jsonable] | None = None,
+        reasoning: str | None = None,
+    ) -> None:
+        """Annotates the current trace span."""
+        raise NotImplementedError("AsyncTrace.annotate not yet implemented")
+
+    async def tag(self, *tags: str) -> None:
+        """Adds given tags to the current trace span."""
+        raise NotImplementedError("AsyncTrace.tag not yet implemented")
+
+    async def assign(self, *emails: str) -> None:
+        """Assigns the trace to users with the given emails."""
+        raise NotImplementedError("AsyncTrace.assign not yet implemented")
+
+
+@dataclass(kw_only=True)
+class _BaseFunction(Generic[P, R, FunctionT], ABC):
+    """Abstract base class for base functions to be traced."""
+
+    fn: FunctionT
+    """The function being traced."""
+
+    tags: tuple[str, ...]
+    """Tags to be associated with the trace span."""
+
+    _qualified_name: str = field(init=False)
+    """Fully qualified name of the wrapped function."""
+
+    _module_name: str = field(init=False)
+    """Module name of the wrapped function."""
+
+    _is_async: bool = field(init=False)
+    """Whether the wrapped function is asynchronous."""
+
+    def __post_init__(self) -> None:
+        """Initialize additional attributes after dataclass init."""
+        self._qualified_name = get_qualified_name(self.fn)
+        self._module_name = getattr(self.fn, "__module__", "")
+
+
+@dataclass(kw_only=True)
+class _BaseTracedFunction(_BaseFunction[P, R, FunctionT]):
+    """Abstract base class for traced function wrappers."""
+
+    @contextmanager
+    def _span(self, *args: P.args, **kwargs: P.kwargs) -> Generator[Span, None, None]:
+        """Returns a span context manager populated with call attributes."""
+        arg_types, arg_values = extract_arguments(self.fn, *args, **kwargs)
+        with Span(self._qualified_name) as span:
+            attributes: dict[str, AttributeValue] = {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": self._qualified_name,
+                "mirascope.fn.module": self._module_name,
+                "mirascope.fn.is_async": self._is_async,
+                "mirascope.trace.arg_types": json_dumps(arg_types),
+                "mirascope.trace.arg_values": json_dumps(arg_values),
+            }
+            if self.tags:
+                attributes["mirascope.trace.tags"] = self.tags
+            span.set(**attributes)
+            yield span
+
+
+@dataclass(kw_only=True)
+class BaseSyncTracedFunction(_BaseTracedFunction[P, R, SyncFunction[P, R]]):
+    """Abstract base class for synchronous traced function wrappers."""
+
+    _is_async: bool = field(default=False, init=False)
+    """Whether the wrapped function is asynchronous."""
+
+    @abstractmethod
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Returns the result of the traced function directly."""
+        ...
+
+    @abstractmethod
+    def wrapped(self, *args: P.args, **kwargs: P.kwargs) -> Trace[R]:
+        """Returns the trace containing the function result and span info."""
+        ...
+
+
+@dataclass(kw_only=True)
+class TracedFunction(BaseSyncTracedFunction[P, R]):
+    """Wrapper for synchronous functions with tracing capabilities.
+
+    Provides traced execution of synchronous functions, returning Trace
+    with access to span information.
+    """
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Returns the result of the traced function directly."""
+        with self._span(*args, **kwargs) as span:
+            result = self.fn(*args, **kwargs)
+            _record_result_to_span(span, result)
+            return result
+
+    def wrapped(self, *args: P.args, **kwargs: P.kwargs) -> Trace[R]:
+        """Returns the trace containing the function result and span info."""
+        with self._span(*args, **kwargs) as span:
+            result = self.fn(*args, **kwargs)
+            _record_result_to_span(span, result)
+            return Trace(result=result, span=span)
+
+
+@dataclass(kw_only=True)
+class BaseAsyncTracedFunction(_BaseTracedFunction[P, R, AsyncFunction[P, R]]):
+    """Abstract base class for asynchronous traced function wrappers."""
+
+    _is_async: bool = field(default=True, init=False)
+    """Whether the wrapped function is asynchronous."""
+
+    @abstractmethod
+    async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Returns the result of the traced function directly."""
+        ...
+
+    @abstractmethod
+    async def wrapped(self, *args: P.args, **kwargs: P.kwargs) -> AsyncTrace[R]:
+        """Returns the trace containing the function result and span info."""
+        ...
+
+
+@dataclass(kw_only=True)
+class AsyncTracedFunction(BaseAsyncTracedFunction[P, R]):
+    """Wrapper for asynchronous functions with tracing capabilities.
+
+    Provides traced execution of asynchronous functions, returning AsyncTrace
+    with access to span information.
+    """
+
+    async def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        """Returns the result of the traced function directly."""
+        with self._span(*args, **kwargs) as span:
+            result = await self.fn(*args, **kwargs)
+            _record_result_to_span(span, result)
+            return result
+
+    async def wrapped(self, *args: P.args, **kwargs: P.kwargs) -> AsyncTrace[R]:
+        """Returns the trace containing the function result and span info."""
+        with self._span(*args, **kwargs) as span:
+            result = await self.fn(*args, **kwargs)
+            _record_result_to_span(span, result)
+            return AsyncTrace(result=result, span=span)
+
+
+@dataclass(kw_only=True)
+class _BaseTracedContextFunction(
+    _BaseFunction[P, R, FunctionT], Generic[P, DepsT, R, FunctionT]
+):
+    """Abstract base class for traced function wrappers."""
+
+    _is_async: bool = field(default=False, init=False)
+    """Whether the wrapped function is asynchronous."""
+
+    @contextmanager
+    def _span(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> Generator[Span, None, None]:
+        """Returns a span context manager populated with call attributes."""
+        arg_types, arg_values = extract_arguments(self.fn, ctx, *args, **kwargs)
+        with Span(name=self._qualified_name) as span:
+            attributes = {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": self._qualified_name,
+                "mirascope.fn.module": self.fn.__module__,
+                "mirascope.fn.is_async": self._is_async,
+                "mirascope.trace.arg_types": json_dumps(arg_types),
+                "mirascope.trace.arg_values": json_dumps(arg_values),
+            }
+            if self.tags:
+                attributes["mirascope.trace.tags"] = self.tags
+            span.set(**attributes)
+            yield span
+
+
+@dataclass(kw_only=True)
+class BaseTracedSyncContextFunction(
+    _BaseTracedContextFunction[P, DepsT, R, SyncContextFunction[P, DepsT, R]]
+):
+    """Abstract base class for synchronous traced function wrappers."""
+
+    _is_async: bool = field(default=False, init=False)
+    """Whether the wrapped function is asynchronous."""
+
+    @abstractmethod
+    def __call__(self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs) -> R:
+        """Returns the result of the traced function directly."""
+        ...
+
+    @abstractmethod
+    def wrapped(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> Trace[R]:
+        """Returns the trace containing the function result and span info."""
+        ...
+
+
+@dataclass(kw_only=True)
+class TracedContextFunction(BaseTracedSyncContextFunction[P, DepsT, R]):
+    """Wrapper for synchronous context functions with tracing capabilities.
+
+    Provides traced execution of synchronous functions that take a Context parameter,
+    returning Trace with access to span information.
+    """
+
+    def __call__(self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs) -> R:
+        """Returns the result of the traced function directly."""
+        with self._span(ctx, *args, **kwargs) as span:
+            result = self.fn(ctx, *args, **kwargs)
+            _record_result_to_span(span, result)
+            return result
+
+    def wrapped(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> Trace[R]:
+        """Returns the trace containing the function result and span info."""
+        with self._span(ctx, *args, **kwargs) as span:
+            result = self.fn(ctx, *args, **kwargs)
+            _record_result_to_span(span, result)
+            return Trace(result=result, span=span)
+
+
+@dataclass(kw_only=True)
+class BaseTracedAsyncContextFunction(
+    _BaseTracedContextFunction[P, DepsT, R, AsyncContextFunction[P, DepsT, R]]
+):
+    """Abstract base class for synchronous traced function wrappers."""
+
+    _is_async: bool = field(default=True, init=False)
+    """Whether the wrapped function is asynchronous."""
+
+    @abstractmethod
+    async def __call__(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> R:
+        """Returns the result of the traced function directly."""
+        ...
+
+    @abstractmethod
+    async def wrapped(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncTrace[R]:
+        """Returns the trace containing the function result and span info."""
+        ...
+
+
+@dataclass(kw_only=True)
+class AsyncTracedContextFunction(BaseTracedAsyncContextFunction[P, DepsT, R]):
+    """Wrapper for asynchronous context functions with tracing capabilities.
+
+    Provides traced execution of asynchronous functions that take a Context parameter,
+    returning AsyncTrace with access to span information.
+    """
+
+    async def __call__(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> R:
+        """Returns the result of the traced function directly."""
+        with self._span(ctx, *args, **kwargs) as span:
+            result = await self.fn(ctx, *args, **kwargs)
+            _record_result_to_span(span, result)
+            return result
+
+    async def wrapped(
+        self, ctx: Context[DepsT], *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncTrace[R]:
+        """Returns the trace containing the function result and span info."""
+        with self._span(ctx, *args, **kwargs) as span:
+            result = await self.fn(ctx, *args, **kwargs)
+            _record_result_to_span(span, result)
+            return AsyncTrace(result=result, span=span)

--- a/python/mirascope/ops/_internal/utils.py
+++ b/python/mirascope/ops/_internal/utils.py
@@ -1,9 +1,12 @@
 """Internal utility functions for the Mirascope."""
 
+import inspect
 from collections.abc import Callable
-from typing import Any
+from typing import Any, TypeAlias
 
 import orjson
+
+from .protocols import P
 
 ORJSON_OPTS = (
     orjson.OPT_NON_STR_KEYS
@@ -12,6 +15,8 @@ ORJSON_OPTS = (
     | orjson.OPT_SERIALIZE_DATACLASS
     | orjson.OPT_SERIALIZE_UUID
 )
+
+PrimitiveType: TypeAlias = str | int | float | bool
 
 
 def json_dumps(obj: Any) -> str:  # noqa: ANN401
@@ -32,3 +37,39 @@ def get_qualified_name(fn: Callable[..., Any]) -> str:
     else:
         parts = [part for part in qualified_name.split(".") if part]
         return parts[-1] if parts else qualified_name
+
+
+def extract_arguments(
+    fn: Callable[P, Any],
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> tuple[dict[str, str], dict[str, Any]]:
+    """Returns a tuple of (arg_types, arg_values) dictionaries from function call."""
+    signature = inspect.signature(fn)
+    bound_arguments = signature.bind(*args, **kwargs)
+    bound_arguments.apply_defaults()
+
+    arg_types: dict[str, str] = {}
+    arg_values: dict[str, Any] = {}
+
+    for param_name, param_value in bound_arguments.arguments.items():
+        parameter = signature.parameters[param_name]
+        if parameter.annotation != inspect.Parameter.empty:
+            if hasattr(parameter.annotation, "__name__"):
+                type_str = parameter.annotation.__name__
+            else:
+                type_str = str(parameter.annotation)
+            arg_types[param_name] = type_str
+        else:
+            arg_types[param_name] = type(param_value).__name__
+
+        if isinstance(param_value, PrimitiveType) or param_value is None:
+            arg_values[param_name] = param_value
+        else:
+            try:
+                json_dumps(param_value)
+                arg_values[param_name] = param_value
+            except (TypeError, ValueError):
+                arg_values[param_name] = repr(param_value)
+
+    return arg_types, arg_values

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,7 +15,7 @@ def load_api_keys() -> None:
     This is necessary for e2e tests, but also may be necessary for any tests that
     instantiate a client, as clients may test API key presence at `__init__` time.
     """
-    load_dotenv()
+    load_dotenv(override=True)
     # Set dummy keys if not present so that tests pass in CI.
     os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-anthropic-key")
     os.environ.setdefault("GOOGLE_API_KEY", "dummy-google-key")

--- a/python/tests/ops/cassettes/test_traced_async_call.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_call.yaml
@@ -1,0 +1,113 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a horror book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '86'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFRNb+M4DL33VxC+DFAkgfOd9Bd09rp7m1kYtEzH2siiIVFpjUH/+0Jy
+        4sQz7S3ho55JPvL9egLIdJW9QObId0V+3Ob1Oi/L5XFf7lDl+e64IlyvyrJeHg7L4/5Qbra4Vevt
+        cbXarHGfzSIFl/+RkhsNW09DXDlCoarAiC33u81ut1nm+4R5QQk+vlHcdoaEquFRiep8chxsrKtG
+        42kIa2O0PWUv8OsJACDrsCcX31d0IcMduewJ4CMlk3McMRuMSQFtb18pKhLUxk9RLy4o0Wwn8Rbf
+        Cw7SBSmEz/QnKMymUGimdC1XZGJlp07mG5632ur5Kl9t5vl+vjxcZ5Z4sxf4kdoZmhrlaP3pazXU
+        andMaiDuabdZH1eHzX5bqnViTizSd5R4yHs80R34auwJVGyF7L2ox8ImtLeh0LuMr1MCWsuCt0H+
+        +HcCGj51jstPkET0Atl3cKS4bclW8Pz8M/unIXjFYEXbE3ANr9oYeOXg6WcGZQ9/N9oZ6uEvVGfP
+        9vl5Ad/lmwcEZdB7reDE0mgFDceNAMsXMiANCtB7Z9iRB2moJR/Za0I3A+3ZpA5mgLaKMPjQkbMo
+        waFZQCzKC7seajaG3+Ln4sJ2kaMj7gzBW8PgBXtAAbTApoIWrddsQSISqh60eOjQoWXXogFUoi9a
+        NPnFrZ9vHt6cTs236IVcHYzpoQzaVB6EBsJYZbCEnmbQ4jlmawGENniZO8IKana3CZCVJniNXvwi
+        GyX4uP4aVckcm6R0nKIXtDIkx8SUlMXKjSEzvQFxYTjXztFFc/DFzRGKtNjjjXSO204Khaqh4kz9
+        l5ijuJKa7WOGI/RsJ3ZAdc1OHpLisoe2RXfjHt3BY03SF7qKxLWmiVN4chetqBB9c5cagxnWPIuy
+        02ObQm1HLm5GDC8X+TWa1vlaWR31vf9/OKOUN8z1WvGFXMleSz8cb6VDe3e1YdINazVIE4SzEbhf
+        VSbcFQ+3lo/B7rFGF6zC62CzSnsszc2CQ/KMsQFtJw64XM3+jD/Y6thmErC6P8wnrf5urPvNZ8Bn
+        vKP6X1ELC5o7eNiNIwx+qnZLghUKRvqPp4//AQAA//8DAE016ikRBwAA
+    headers:
+      CF-RAY:
+      - 9a797370de9ad766-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 08:28:30 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Gn590cbOg9oY5z1h3ExecvcNcxZI5KQK3WDr2Id2BAM-1764664110-1.0.1.1-.6XjTGaLBmE7v_SFx9G9oUnnb56MBUNwcQ3FRwXE4wYRZUzXeyG9_IWSKeVww3QVR97ftB5JgOrSmKTsohNo62FbkiQrk6QfSpcuzTPBf9g;
+        path=/; expires=Tue, 02-Dec-25 08:58:30 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=1il_lu2A0UOh3kq89vVVkxj9su98E1W725Af3RkfAKU-1764664110038-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2232'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2235'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999969'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_f966db4afcf4493bbfffc892359ea2f3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_call_call_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_call_call_method.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a horror book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '86'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RUTW/jOAy991dwfSzaIs6H0/S62MPc9jDAHqYLg5ZpW1tJNCQqrTHof19Ibpxk
+        pr3ZfNQTHym+nzcAhW6LJyg8hbFeNQesun21324ft9Vuv1pVh3XXrGmt2u3jY3nYHMqmoW6/U+2u
+        K8v1rrhLFNz8R0pONOwCzXHlCYXaGhNW7qvtfrOpqipjQVBiSGcU29GQUDsfalC99J6jS3V1aALN
+        YW2Mdn3xBD9vAACKESfy6XxLRzI8ki9uAN5zMnnPCXPRmBzQ7nRL3ZKgNuEaDeKjEs3uKm7xreYo
+        Y5Ra+IV+B4XZ1ArNNZ3llkyqrB/lfsv3Vjt9v16tt/er/X35+NGzzFs8wY8sZxa1jMOG/utpbKpN
+        pdI0mh3tqnLf7FV1qPbdNjNnFplGyjwUAvZ0Br5qewYVOyF3LuqysCvaU1PoTZbTOQGdY8FTI3/8
+        ewUa7kfPzSdIJnqC4hsMuh/MBJ4UW0uuhdvb5+L7QPAnNtoBCshA8Jdrgbv8+Q970z4X0EzwN0YD
+        3z3ZxuB0e/sA3wQaQ64NMIZJDWy41woNDJzeB7xqGYDedEiiNZrEZyncAb2Nhr12PXRotZmgnRxa
+        rQKga/Ot2o6oJNXQEXpgB0O06KChAY+a/QOkmoVc0Oygidq0ATAAnhiPqHKbQKJ3AbQTBgSn+0Es
+        eoLXgVy6aYL0p9h1Pg2nTTqDeHQ9+TArQBDyXndTKjga0RYl2qT+Oa5X5SHd2ns9jgn3hEkBCrxq
+        Y+CFaISJY1KQdFHbU1I1cfQQCOWPYpnT+8fXMrrCs8nPAUPQQdDJnJwSc1IxokdjyFwvivg47/To
+        6ag5hvpkG3V+/csijZ7tKLVCNVD9QtOXmKc8QnaXGZ4wsLvyDOo69nKRlDYiWov+xL1YSMCOZKp1
+        m4g7TVd2EsgftaJa9MmCOoxm3oUiCHu6lClkR/IoMYfLh9VHNL/5j8o69hbP/xe7lvPmvn5UfCTf
+        cNAyzRve6mjP1jd3emCt5tFE4WIBzqtXCI/1xUKuluB4WaOPbn6nWaUO2JiTT8dsLIsA7a5sslzf
+        /R6/8N5FZh5gez64upL6q/s+lp8Bn/Eu0/+KWljQnMHDZmlhDNfTtiTYomCif795/x8AAP//AwAw
+        8jApNgcAAA==
+    headers:
+      CF-RAY:
+      - 9a8015a6c8f8eb79-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Dec 2025 03:47:49 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=V9pjpW_RdNCnlg2Us29iqYWMVGg5qTvYTXDVrYHbH8M-1764733669-1.0.1.1-fBjmS6EvpScSBHzYeSqM1Toj8iguTIyR9.r.HZiROmyQTWto19FZ4LT19_VgCZgpivkHycsOScPJwNFQZzRa_VVNnHz5thgMvLaFX.NzG3M;
+        path=/; expires=Wed, 03-Dec-25 04:17:49 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=iKsKoL.HUjknP_mHqdj.ZlurwqDm79YA3bDvg3wE2_E-1764733669040-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2175'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2179'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999969'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_b6d12eaad12a42eaaf0b7810bdd07799
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_call_stream_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_call_stream_method.yaml
@@ -1,0 +1,595 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a adventure book.","role":"user"}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_05263f19d30c9cbf00692fb2e5f1888193920a366e8f32aa01","object":"response","created_at":1764733669,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_05263f19d30c9cbf00692fb2e5f1888193920a366e8f32aa01","object":"response","created_at":1764733669,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"6PKPVG3uOb2sxLY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        recommend","logprobs":[],"obfuscation":"M4LlNt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"XuwMpjtRlw9Yp"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"hRauSrdpamQpkp6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"The","logprobs":[],"obfuscation":"b3UHmPifbF6jE"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        Hobbit","logprobs":[],"obfuscation":"dgSPHo4ZZ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"Kq0nfT6L2BUqTPh"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        by","logprobs":[],"obfuscation":"M9ySWnHbdrKvs"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        J","logprobs":[],"obfuscation":"SLQyCGzdFSgiRK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":".R","logprobs":[],"obfuscation":"bv2QN5uFPDZZaO"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":".R","logprobs":[],"obfuscation":"DAORHq1wsSAdpe"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"hwIERJ7vPbueZR6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        Tolkien","logprobs":[],"obfuscation":"xbesSuYZ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"bmKP49hPy9IyhZ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"2pD9p5NYIRNJFcm"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        This","logprobs":[],"obfuscation":"p20xTqoWQAG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        classic","logprobs":[],"obfuscation":"lmABW43i"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        adventure","logprobs":[],"obfuscation":"zPihX1"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        follows","logprobs":[],"obfuscation":"7bBHjA23"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        Bil","logprobs":[],"obfuscation":"O9rBaNODPvuo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"bo","logprobs":[],"obfuscation":"K06cCrLpNfoWSL"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        B","logprobs":[],"obfuscation":"QGDN5wKF3X96Zp"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"agg","logprobs":[],"obfuscation":"Fo55S8UdtAyoA"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"ins","logprobs":[],"obfuscation":"uYLcFN19kLP9E"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"qIYjtLtUMlm8YAU"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"RhlSV74vFU6ajC"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        hob","logprobs":[],"obfuscation":"sPd9Kzyybb68"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"bit","logprobs":[],"obfuscation":"r8QKdCoh1ajaH"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        who","logprobs":[],"obfuscation":"cmULXAmpYYO1"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        is","logprobs":[],"obfuscation":"j8IwaFLxL6ozw"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        unexpectedly","logprobs":[],"obfuscation":"NCw"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        swept","logprobs":[],"obfuscation":"Nr3ggVTbx9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        into","logprobs":[],"obfuscation":"Q0IbTFoK1W1"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"4rdb4zQiznAbnL"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        quest","logprobs":[],"obfuscation":"aOSm1STK9Y"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        to","logprobs":[],"obfuscation":"RvgwYP3Wbs6td"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        reclaim","logprobs":[],"obfuscation":"YA3lBEVY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"bg4NhU2yyF42Zn"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        stolen","logprobs":[],"obfuscation":"UwHwTQHKK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        treasure","logprobs":[],"obfuscation":"ko38Les"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        guarded","logprobs":[],"obfuscation":"xKPKl7AU"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        by","logprobs":[],"obfuscation":"zabaM4K0xocAg"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"kSeBPVI9WiCw"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        dragon","logprobs":[],"obfuscation":"iM7c75RRj"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        Sm","logprobs":[],"obfuscation":"Qvx06qdMt9ORG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"aug","logprobs":[],"obfuscation":"FBVz2hg0eAO3v"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"pKVDLABnK5otgwS"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        With","logprobs":[],"obfuscation":"st0nCCIhlDz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"fl8QswA91m6oWv"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        mix","logprobs":[],"obfuscation":"DqKTghH8rzF9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"ke2a9x6vHUYO7"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        whimsical","logprobs":[],"obfuscation":"HZNiV9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        characters","logprobs":[],"obfuscation":"CRqLV"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"dFPcJm2d0rSzsk6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        rich","logprobs":[],"obfuscation":"tFZE14Xblkq"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        world","logprobs":[],"obfuscation":"b69YVMdjcx"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"-building","logprobs":[],"obfuscation":"SblQjBu"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"7epxSPPioaqfaOB"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        and","logprobs":[],"obfuscation":"8SQqcotiROUe"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":63,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        themes","logprobs":[],"obfuscation":"GNQXKjQ0u"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":64,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"rcqADXkaVdaba"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":65,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        bravery","logprobs":[],"obfuscation":"6vEaQnAi"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":66,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        and","logprobs":[],"obfuscation":"MhberLX57KQM"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":67,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        friendship","logprobs":[],"obfuscation":"0m5Xo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":68,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"jAAKDynBqXu39cF"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":69,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        it''s","logprobs":[],"obfuscation":"PgKuFhqiJpI"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":70,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"nW32L7iqdfagmX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":71,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        captivating","logprobs":[],"obfuscation":"9e9A"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":72,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        read","logprobs":[],"obfuscation":"zZuabeiRB5s"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":73,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        for","logprobs":[],"obfuscation":"CbIIjk6Y1VLq"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":74,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        all","logprobs":[],"obfuscation":"2yrQ4gvb8rxo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":75,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        ages","logprobs":[],"obfuscation":"EpuBmcTOn8k"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":76,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"sNC6LTUb104UZHM"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":77,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        Enjoy","logprobs":[],"obfuscation":"qOHaKVXJzz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":78,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"0xU1WrE5IYlZ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":79,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        journey","logprobs":[],"obfuscation":"9v6g0DSx"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":80,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        through","logprobs":[],"obfuscation":"K0xhRc56"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":81,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"
+        Middle","logprobs":[],"obfuscation":"TjABvwJjo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":82,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"-earth","logprobs":[],"obfuscation":"AGBUK6Ux3Z"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":83,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"lGkOy22S60whPiE"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":84,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure follows
+        Bilbo Baggins, a hobbit who is unexpectedly swept into a quest to reclaim
+        a stolen treasure guarded by the dragon Smaug. With a mix of whimsical characters,
+        rich world-building, and themes of bravery and friendship, it''s a captivating
+        read for all ages. Enjoy the journey through Middle-earth!","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":85,"item_id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure follows
+        Bilbo Baggins, a hobbit who is unexpectedly swept into a quest to reclaim
+        a stolen treasure guarded by the dragon Smaug. With a mix of whimsical characters,
+        rich world-building, and themes of bravery and friendship, it''s a captivating
+        read for all ages. Enjoy the journey through Middle-earth!"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":86,"output_index":0,"item":{"id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure follows
+        Bilbo Baggins, a hobbit who is unexpectedly swept into a quest to reclaim
+        a stolen treasure guarded by the dragon Smaug. With a mix of whimsical characters,
+        rich world-building, and themes of bravery and friendship, it''s a captivating
+        read for all ages. Enjoy the journey through Middle-earth!"}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":87,"response":{"id":"resp_05263f19d30c9cbf00692fb2e5f1888193920a366e8f32aa01","object":"response","created_at":1764733669,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_05263f19d30c9cbf00692fb2e664c081938012fdb95e3adb6e","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure follows
+        Bilbo Baggins, a hobbit who is unexpectedly swept into a quest to reclaim
+        a stolen treasure guarded by the dragon Smaug. With a mix of whimsical characters,
+        rich world-building, and themes of bravery and friendship, it''s a captivating
+        read for all ages. Enjoy the journey through Middle-earth!"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":12,"input_tokens_details":{"cached_tokens":0},"output_tokens":81,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":93},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9a8015ba7cd2e392-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 03 Dec 2025 03:47:50 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '34'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '38'
+      x-request-id:
+      - req_ab13e3d3ff6a45c29b3e04cafec5f330
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_call_wrapped_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_call_wrapped_method.yaml
@@ -1,0 +1,113 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a horror book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '86'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RU227jOAx971dw/TJA0RTOZRKnX9CZ1923mYXBSHSsjSwKEpWtMei/L2QnTrzT
+        vtk85NHh9dcDQGF08QJFoOjrstxWDa732xVVWq1XZbndr8tmuT9st+WmWmK531VrKmm9PJREelkV
+        T5mCD/+QkisNu0ijXQVCIV1jxpa77aZafl193Q9YFJQUc4zizlsS0mPQAdXpGDi5rKtBG2k0G2uN
+        OxYv8OsBAKDw2FPI8ZrOZNlTKB4A3gdnCoEz5pK1g8G46yu1JkFj4xyNEpISw25m7/Ct5iQ+SS18
+        ot9BYba1Qjun61iTzcqOXhYbXnTGmcWqXG0W5W4x1WzgLV7gx5DOmNTUji4eP++G2myqMnfjsKnU
+        bq3X+/V2W5X6MDAPLNJ7GngoRjzSDfis7AOo2Am5m6h7YTPaa1HoTabowQGdY8FrIX/8PQMtH33g
+        wwfIQPQCxTcIpLjryGl4fPxZ/NUSvGJyYtwRuIFXYy28cor0s4BDD3+2Jljq4TuqU2T3+PgM3+RL
+        BARlMUajwMdetWz5aBRaaDkPBjg+kwVpUYDevOVAEaQlSC6SSB6zbKdgyCmK+WGEPJI+f3pibwmM
+        OxshDcKAEJP3HEnbHtoslzR06KJh9ww5B5SOo28pEJgIlJmfAJ2+Ch+fE9uDJnumCMYJZ0nd+HxD
+        GJ7ARLZDbcfYUfHJ8b9uSrtLURaBUEPDAdD115QbdH8UU8nfL19TF4rAduhsrloUdDI6Z8fBqfAY
+        0Fqy85mXkMb19IHOhlOsrxegHgZ52gkfuPNSK1Qt1SfqP8UC5RE07O49AmFkN1t/ahoOcueUhzt1
+        HYYr93QNIjYkfW10Jm4MzS5DpHA2imox12vSYLLjWBdRONB9mkKdp4CSBvPyubxYh/G9KGs4dHj7
+        v1ubwW+s60XxmcKBo5F+XFZtUne7YmOlWzZqbE0SLibgtkWFsK/vdqucjP5eY0hO4aWwhTYRD/Z6
+        ctNwI6YEjJtdvOXq6Xf73Rmd0hwaqG+B5SzV/x/SXfkR8BHv1P3PqIUF7Q2sVlMJU5x3uyNBjYKZ
+        /v3h/T8AAAD//wMAvmCXhAEHAAA=
+    headers:
+      CF-RAY:
+      - 9a87dda62fba2ed5-LAX
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 04 Dec 2025 02:27:43 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=3pp.o.gLA2f.ifTZjp0lq4rxnrrW482Y0IBk22kpByo-1764815263-1.0.1.1-ngRzRbx6evlpJm2T74132xGDmtOcNsMwVlnKtc1OTvfHvYvikaFpZGApdgQDgdZ3lYopcVCZYe_2vl6Z_PT2f8fU5vtUdzqsnlAHhHZhNpo;
+        path=/; expires=Thu, 04-Dec-25 02:57:43 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=zn9rP3yZb4H2567oKiG4fnZrp36LpgISFBKQppVCFCs-1764815263924-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '4476'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '4480'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999969'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_c2b9900d262b498da2d6b676fb3e8979
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_context_call.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_context_call.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a mystery book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RUTW/jRgy951cQugRYOIH8GTu3bXtZoC2Kdm+LQqBGlDTr0VCd4XijLvLfixnZ
+        stVNTnH4yKdHcvi+3wFkusqeIXPk+yJf02a9Vvi0R1RqWeb57rAiLFeH/bLe7JeH7b7ODxtc1dW2
+        WuJhtc4WkYLLr6TkQsPW0xhXjlCoKjBiy6fdZrfbLbfrhHlBCT7WKO56Q0LVWFSiOjaOg426ajSe
+        xrA2Rtsme4bvdwAAWY8DuVhf0YkM9+SyO4DXlEzOccRsMCYFtL18pahIUBs/R724oESzncU7fCk4
+        SB+kED7Sj6Awm0KhmdN1XJGJyppeHjb80GmrH1b5avOQPz0s9+eZJd7sGb6kdsampnV0vnl/G7hZ
+        b1XcRvm0ybfr7Z5QHVZqNTInFhl6SjzkPTZ0Bd4bewIVWyF7FXUrbEZ7GQq9yFSdEtBaFrwM8svf
+        M9Bw0zsu30AS0TNkn8CR4q4jW8GHzy3B7/wIS/gVK03+Hn4hISX6RPCxIauGD1AO8NHQC9qKHPym
+        fkZj4K9OS/sIn1vtQbXoOm0b6AYv5AaoCSU48vCHI6U5ePgTOxb/jRbwU/yLFu891Np5gZo6NATV
+        5bML+NYyBE8eWnKgrQQdewW0FRyJLHDpyZ3SAMAftTEehMGzOREojIXaptrYZbBahiiUoGQ+gvZQ
+        srRAtsEmio60oTe6Fm2bBXBdk0txCFb/EwhKEyfF9aW9BbShY7dIlSoYCQ4NaOt108ojfJJ7D9LS
+        uT1tAaEkwyeqwJPT5BfQ4TF+QgsgNPF+wQu6KAB61lagZgeOsCLn0zjIfuUBFP87nFVo8o/ZtN3X
+        869p4Zljkx4Req+9oJUxOSampKxHh8aQmZ+XuDA6Qe/oFDdXXMymSDcznV/vuOulUKhaKo40vIs5
+        iq9ds73NcISe7cxpqK7ZyU1SvKPQdegu3JPxeKxJhkJXkbjWNDOh+DS0okL0xbhqDGa8oMwLO7pt
+        U6jryaXXGt3zMT9H06WcldXsOrz+f3OhKW+c61nxiVzJXssw+kKlQ3c1zHHSLWs1riYIZxNwPdhM
+        uC9uzjifgv2tRheswvNgs0p7LM3F3UOyo6kBbWfmutwtfozfOPbUZlpgdS3MZ63+37MPq7eAt3in
+        7b9HLSxobgTn+2mGwc/X3ZFghYKR//Xu9T8AAAD//wMA6Sf2U20HAAA=
+    headers:
+      CF-RAY:
+      - 9a79a562aa8c737a-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 09:02:36 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=YdvaLtpfFgJiUz3kdAgh1wA52G1Zrjibiji6iwWG_ug-1764666156-1.0.1.1-z7VCNNQffS60a9zGW6XJkqeJeIDkuMvGHsuJHdEXplheJ4Yd4VJiJIAddr8glt0ymIH6bVUCJc6QRu_KFqmPh2cCSK_XDM8nDze0r7lklTw;
+        path=/; expires=Tue, 02-Dec-25 09:32:36 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=f1ov8PIBtCQGSm6G4I8VI0Dl8XbJB05UAVwkIKbxXxA-1764666156437-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2868'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2870'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999965'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_2c98b64cef86499cbe6c2118f79ef2f1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_context_call_call_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_context_call_call_method.yaml
@@ -1,0 +1,109 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a mystery book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3xVTY/bNhC976+Y6hJg4V3I9sYfe0vbS4C2KNrcsoUwIkcSY4qjkkNnhWD/e0Da
+        lu1mtydJ82Ye54Pz9O0GoDC6eITCUxiqcr5+/16h1vN5WWNTluVqu2jqRbMoF9uHzXz7gLTUK63q
+        tS5LvcRlMUsUXH8hJScadoEOduUJhXSFCZuvVw/r5XK1WWQsCEoMKUZxP1gS0oegGtWu9RxdyqtB
+        G+hgNtYa1xaP8O0GAKAYcCSf4jXtyfJAvrgBeMnO5D0nzEVrs8G40ymVJkFjwzUaxEclht2Vvcfn
+        iqMMUSrhHf0ICrOtFNprup412ZRZO8jdA9/1xpm7Rbl4uCvXd/PNsWeZt3iEz7mcQ1HTOPrQ/s80
+        Ntv1Jk1jS2pZal2q95vtonmoM3NmkXGgzEMhYEtn4K22Z1CxE3LnpC4Tu6I9NYWeZYrODugcC54a
+        +fmfK9ByO3iuX0Ey0SMUH6EzbWdH8KS478lpuL19Kj51BH/wPczhN9SGwjv4lYSUmD3Bh5acGp8K
+        qEf4YOkZnSYPv6tf0Fr4uzfS3d7ew6fOBFAd+t64FvoxCPkRGkKJngL86UkZjgH+wp4lfKUZ/Jye
+        6PBdgMb4INBQj5ZAn06eAQYIHYHDvWlRKMAefWZRGCjAVyMddOQhOvNvJBjIh+GYNToNOyIHxkk0
+        qV8pR4KaeQe1JacDdLFnPwMVbUpylmOME2/aeC7CUJhBj7tkMQIImqxpO2miBU+ooWEPNUs3FU1O
+        uhgMBgmZUjoOBJY5cyT3wD1Jl760aRry5OQePspTXJTzbQDp6NgS4wAhHJMIDKaBkSOQ+8IjGJkl
+        V0+nuMGSkxF69gTCQM+DZU8/FdNFeDm+TXej8GzzfcMQTBB0cnBOjtmpGNCjtWSvN1F8PIjG4Gmf
+        JlKddKnK6zVt6uC5H6RSqDqqdjS+iXlKi2HYXXp4wsDuSpSoadjLhVNaudj36E/ck0YFbEjGyuhE
+        3Bi60qtAfm8UVWJOGtdgtIdlK4Kwp8syhfqBfL7LSWjvy6M1L9Uxs4Z9j+fvi2XOfoe+HjPek685
+        GBkPEqJN7M/aeuh0x0YdRhOFiwk473YhPFQXG19OxuEyRx+dwmNjC20C1vb0I4hZuaYCjLvS4flq
+        9qP9QtynMvMA9TmwvCr1v/I+L8vXkNeIp/G/xS0saC+o56upiTFcz7snQY2Cif/l5uU7AAAA//8D
+        AJhbe02ZBwAA
+    headers:
+      CF-RAY:
+      - 9a801607ff18a605-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Dec 2025 03:48:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '3049'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '3052'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999965'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_7395008000f84d3985a6f850d8ea32fe
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_context_call_stream_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_context_call_stream_method.yaml
@@ -1,0 +1,273 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a adventure book.","role":"user"}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '119'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_0e23c53a01e922b700692fb2f5b6fc8193a641dcc4ecf4fcee\",\"object\":\"response\",\"created_at\":1764733685,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_0e23c53a01e922b700692fb2f5b6fc8193a641dcc4ecf4fcee\",\"object\":\"response\",\"created_at\":1764733685,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":3,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":4,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"I\",\"logprobs\":[],\"obfuscation\":\"g0MpnDS4nNiLGXc\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":5,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        recommend\",\"logprobs\":[],\"obfuscation\":\"ffz3xu\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":6,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        **\",\"logprobs\":[],\"obfuscation\":\"DdldQKpEwUQV6\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":7,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"\\\"\",\"logprobs\":[],\"obfuscation\":\"Aw1ysKwjAtN83U7\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":8,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"The\",\"logprobs\":[],\"obfuscation\":\"p43Wx7eaLLETd\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":9,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Hobbit\",\"logprobs\":[],\"obfuscation\":\"Tvh8MXELT\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":10,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"\\\"\",\"logprobs\":[],\"obfuscation\":\"meiZyirGimBBRxh\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":11,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        by\",\"logprobs\":[],\"obfuscation\":\"3js1D5DjEx7al\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":12,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        J\",\"logprobs\":[],\"obfuscation\":\"Wly1ZzhXSrsMal\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":13,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\".R\",\"logprobs\":[],\"obfuscation\":\"e2NFGEkGF9hGlm\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":14,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\".R\",\"logprobs\":[],\"obfuscation\":\"BPwKETcXisdOJS\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":15,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"HCsWXP3lkI8kOW0\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":16,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Tolkien\",\"logprobs\":[],\"obfuscation\":\"zNC3zQHZ\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":17,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"**\",\"logprobs\":[],\"obfuscation\":\"18EsMGiOgj6SOL\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":18,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"SMODNvpH4atI69L\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":19,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        This\",\"logprobs\":[],\"obfuscation\":\"aOHoZwPPWQl\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":20,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        classic\",\"logprobs\":[],\"obfuscation\":\"3p1apiCl\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":21,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        fantasy\",\"logprobs\":[],\"obfuscation\":\"9ytt8YTU\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":22,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        adventure\",\"logprobs\":[],\"obfuscation\":\"J0S2ub\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":23,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        follows\",\"logprobs\":[],\"obfuscation\":\"2ZhzpMkw\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":24,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"p6DyEpnvfVoG\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":25,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        journey\",\"logprobs\":[],\"obfuscation\":\"zC2Iefxm\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":26,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"U8TS3hQ9K0cGl\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":27,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Bil\",\"logprobs\":[],\"obfuscation\":\"2BZ5b0wFUvvf\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":28,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"bo\",\"logprobs\":[],\"obfuscation\":\"rnbcyj8S6Q1Yef\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":29,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        B\",\"logprobs\":[],\"obfuscation\":\"rUf3qwFGBrIxe9\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":30,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"agg\",\"logprobs\":[],\"obfuscation\":\"C9ozd5RdNLQM8\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":31,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"ins\",\"logprobs\":[],\"obfuscation\":\"TwAbExlZEyQme\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":32,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"ylR1wLqx8sKreMO\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":33,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        a\",\"logprobs\":[],\"obfuscation\":\"Aj4ZXBglexprS7\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":34,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        hob\",\"logprobs\":[],\"obfuscation\":\"62Q9CFSWUxM4\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":35,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"bit\",\"logprobs\":[],\"obfuscation\":\"qrI8f3cwUo8zw\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":36,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        who\",\"logprobs\":[],\"obfuscation\":\"DhUEuNl6eON2\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":37,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        is\",\"logprobs\":[],\"obfuscation\":\"W9Cg9sYLZk07U\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":38,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        thrust\",\"logprobs\":[],\"obfuscation\":\"1RPsEVwDP\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":39,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        into\",\"logprobs\":[],\"obfuscation\":\"a8FO9hXQnHr\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":40,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        an\",\"logprobs\":[],\"obfuscation\":\"LpB6bRYBG2A3A\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":41,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        epic\",\"logprobs\":[],\"obfuscation\":\"1qTnxCkK6n3\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":42,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        quest\",\"logprobs\":[],\"obfuscation\":\"eXRVizfql0\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":43,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        involving\",\"logprobs\":[],\"obfuscation\":\"PBsdHh\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":44,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        treasure\",\"logprobs\":[],\"obfuscation\":\"Ll6EHlj\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":45,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"zVPwiEKX9rGYxSC\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":46,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        dragons\",\"logprobs\":[],\"obfuscation\":\"dHIRCIAl\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":47,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"3EKrkbVhCkr6wGH\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":48,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        and\",\"logprobs\":[],\"obfuscation\":\"wv5lEqo2fU7i\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":49,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        a\",\"logprobs\":[],\"obfuscation\":\"vJLH12lU7ur1Ch\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":50,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        host\",\"logprobs\":[],\"obfuscation\":\"nwtX15PwJiB\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":51,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"IVyRWOhWYQHYl\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":52,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        fantast\",\"logprobs\":[],\"obfuscation\":\"4ERLDLRv\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":53,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"ical\",\"logprobs\":[],\"obfuscation\":\"jfxod9WyrHA7\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":54,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        creatures\",\"logprobs\":[],\"obfuscation\":\"3GNTr0\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":55,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"PBDtptlxqQrLakV\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":56,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        The\",\"logprobs\":[],\"obfuscation\":\"Etm1MdpTEX1v\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":57,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        themes\",\"logprobs\":[],\"obfuscation\":\"44wZe2PMu\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":58,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"PX33Adwe7AFIi\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":59,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        bravery\",\"logprobs\":[],\"obfuscation\":\"wZMwmRVF\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":60,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"OLjmI6e1qauV1Kc\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":61,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        friendship\",\"logprobs\":[],\"obfuscation\":\"glXhm\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":62,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"ekKXN8JU9QKnlIH\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":63,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        and\",\"logprobs\":[],\"obfuscation\":\"lTbj8ppUz7gy\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":64,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"u9ZthNiYprOU\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":65,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        push\",\"logprobs\":[],\"obfuscation\":\"7DrKMoJf2A3\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":66,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        beyond\",\"logprobs\":[],\"obfuscation\":\"4ri2mAbwF\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":67,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        one\",\"logprobs\":[],\"obfuscation\":\"6d8bJKiD1Eqz\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":68,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"\u2019s\",\"logprobs\":[],\"obfuscation\":\"PvXTcQdBi71b1n\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":69,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        comfort\",\"logprobs\":[],\"obfuscation\":\"1hGFR812\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":70,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        zone\",\"logprobs\":[],\"obfuscation\":\"dullJWbyBag\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":71,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        make\",\"logprobs\":[],\"obfuscation\":\"F80iYNdJYgP\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":72,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        it\",\"logprobs\":[],\"obfuscation\":\"rBdwwnFC8nzKZ\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":73,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        a\",\"logprobs\":[],\"obfuscation\":\"xFQhaWT2c7Pm9T\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":74,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        delightful\",\"logprobs\":[],\"obfuscation\":\"yGiKq\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":75,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        read\",\"logprobs\":[],\"obfuscation\":\"D7WTpsGVFiP\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":76,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        for\",\"logprobs\":[],\"obfuscation\":\"3nKmTXEB05Q0\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":77,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        advent\",\"logprobs\":[],\"obfuscation\":\"cU7mEO0VY\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":78,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"urers\",\"logprobs\":[],\"obfuscation\":\"nfNZWRPiNZX\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":79,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"IvXT662aOqDzs\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":80,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        all\",\"logprobs\":[],\"obfuscation\":\"ieFfbpZJxqfD\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":81,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        ages\",\"logprobs\":[],\"obfuscation\":\"uZFt9czP15W\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":82,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"nvQ1j8RAWApxI0A\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":83,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Plus\",\"logprobs\":[],\"obfuscation\":\"5kVxR0nRQGL\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":84,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"0yBahWfwGROyLPS\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":85,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"ny32Tu0klPqT\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":86,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        richly\",\"logprobs\":[],\"obfuscation\":\"uLNghqBRY\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":87,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        detailed\",\"logprobs\":[],\"obfuscation\":\"L6Hk4uu\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":88,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        world\",\"logprobs\":[],\"obfuscation\":\"FndmfJanUB\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":89,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"pdcpk509Iaw0n\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":90,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Middle\",\"logprobs\":[],\"obfuscation\":\"1ztFoiI12\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":91,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"-earth\",\"logprobs\":[],\"obfuscation\":\"WLDvmdlbJV\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":92,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        is\",\"logprobs\":[],\"obfuscation\":\"FBN1To5oDp5pT\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":93,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        sure\",\"logprobs\":[],\"obfuscation\":\"nvY8GPAYIHb\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":94,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        to\",\"logprobs\":[],\"obfuscation\":\"7CSgW6sES944d\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":95,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        spark\",\"logprobs\":[],\"obfuscation\":\"8SpJF2Xu1B\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":96,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"TACPdoc9WImo\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":97,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        imagination\",\"logprobs\":[],\"obfuscation\":\"khqg\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":98,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"delta\":\"!\",\"logprobs\":[],\"obfuscation\":\"QGK4s5S4OqNfiUi\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":99,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"text\":\"I
+        recommend **\\\"The Hobbit\\\" by J.R.R. Tolkien**. This classic fantasy adventure
+        follows the journey of Bilbo Baggins, a hobbit who is thrust into an epic
+        quest involving treasure, dragons, and a host of fantastical creatures. The
+        themes of bravery, friendship, and the push beyond one\u2019s comfort zone
+        make it a delightful read for adventurers of all ages. Plus, the richly detailed
+        world of Middle-earth is sure to spark the imagination!\",\"logprobs\":[]}\n\nevent:
+        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":100,\"item_id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        recommend **\\\"The Hobbit\\\" by J.R.R. Tolkien**. This classic fantasy adventure
+        follows the journey of Bilbo Baggins, a hobbit who is thrust into an epic
+        quest involving treasure, dragons, and a host of fantastical creatures. The
+        themes of bravery, friendship, and the push beyond one\u2019s comfort zone
+        make it a delightful read for adventurers of all ages. Plus, the richly detailed
+        world of Middle-earth is sure to spark the imagination!\"}}\n\nevent: response.output_item.done\ndata:
+        {\"type\":\"response.output_item.done\",\"sequence_number\":101,\"output_index\":0,\"item\":{\"id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        recommend **\\\"The Hobbit\\\" by J.R.R. Tolkien**. This classic fantasy adventure
+        follows the journey of Bilbo Baggins, a hobbit who is thrust into an epic
+        quest involving treasure, dragons, and a host of fantastical creatures. The
+        themes of bravery, friendship, and the push beyond one\u2019s comfort zone
+        make it a delightful read for adventurers of all ages. Plus, the richly detailed
+        world of Middle-earth is sure to spark the imagination!\"}],\"role\":\"assistant\"}}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":102,\"response\":{\"id\":\"resp_0e23c53a01e922b700692fb2f5b6fc8193a641dcc4ecf4fcee\",\"object\":\"response\",\"created_at\":1764733685,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_0e23c53a01e922b700692fb2f60b888193959c0afd35062228\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        recommend **\\\"The Hobbit\\\" by J.R.R. Tolkien**. This classic fantasy adventure
+        follows the journey of Bilbo Baggins, a hobbit who is thrust into an epic
+        quest involving treasure, dragons, and a host of fantastical creatures. The
+        themes of bravery, friendship, and the push beyond one\u2019s comfort zone
+        make it a delightful read for adventurers of all ages. Plus, the richly detailed
+        world of Middle-earth is sure to spark the imagination!\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":16,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":96,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":112},\"user\":null,\"metadata\":{}}}\n\n"
+    headers:
+      CF-RAY:
+      - 9a80161f197b25fe-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 03 Dec 2025 03:48:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '36'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '40'
+      x-request-id:
+      - req_4df3a4cb8a62439181b9678c021953cc
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_context_call_with_tags.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_context_call_with_tags.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a dystopian book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '105'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFRNb9tIDL3nV3B1KRDEgew4/shtb+1hgQW2t3YhUBrKns1oOOVQToQi
+        /30xI1u22+QkiY/z5pEU388bgMKa4gkKoRiqsizXZrHETbleLZu2KcvVdtGW2zUSlcvNfPtYr7bb
+        x5ao3szLxXaxLO4SBdf/UaMnGvaRxngjhEqmwoTN16vlalsutpuMRUXtYzrTcBccKZnxUI3N8064
+        90lXiy7SGLbOWb8rnuDnDQBAEXAgSecNHchxICluAN5yMolwwnzvXA5Yf7qlMqRoXbxGo0rfqGV/
+        Fe/wteJeQ6+V8jP9Diqzqxp013QdG3JJ2S7obMmzzno7W5SL5axcz+abY88yb/EE33I5Y1HTOLq4
+        +3ga9ePDQ57GFlflQ1mu222zWtemzcyZRYdAmYdixB2dgY/ansGGvZI/i7oUdkV7agq96nQ6J6D3
+        rHhq5Ld/r0DHuyBcv4NkoicovoBQw11H3sDt7ffi657gM3rToTWfInxFR98LqAf4C2WHQgp/6guz
+        ub29h39IwXpAUFZ0VlEseojcWNIBXvYkBC/ckQcUgqhiQyAD3ILuyQqI3e013qUv8HwgB/QaHAvF
+        FOooptQdeUNyB4Ff0gO9AeuNPVjTpzuH+6OgTxHENnsIwpFyWmo35V8Ymj0KNkoSocNnAqtJ9Z77
+        3V5nQfjAzylNCA3oHhWEOrQ+gpCjA3oFZYPDPXxRQBcZBG2kCLYLLJrwHz3FPATAmnsF7JU9d0NW
+        cmxJksiOUs8CSWSPDlohMtzFe/ibpKVGoWUB9AP7lKgkFJVSzWCGqBxSi1ubN+ePYpro2/FtGnKR
+        bkoDxhhtTBLH5JSYk4qAgs6Ru14plX7c/iB0sNzH6mQwVd6TaeWCcBe0arDZU/VMw4eYUPrDLfvL
+        DCGM7K/chdqWRS+S0u70XYdy4p7MJmJLOlTWJOLW0pXxRJKDbahSezKrFns3bk0RlYUuy1TqAglq
+        n8Pz+/IYzdtxVNaydHj+vtjKnDf29aj4QFJztDqMXmBs351Ncuz0nm0zjqZXLibgvKSFcqguVrec
+        guFSo/S+wWNjC2Mj1u7k6H22oKkA668Mdb6++z1+4dJTmXmA5nywvCr1V5/erN4D3uOdpv8RdTaU
+        C8Hlw9TDPl6PuyNFg4qJ/+3m7X8AAAD//wMA88B1ZGEHAAA=
+    headers:
+      CF-RAY:
+      - 9a7bf2ddad92e35a-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 15:45:01 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=yOQe.cYapNriY0F7hKeqhEJW78MISFNs5w600GpVtxI-1764690301-1.0.1.1-LrmTw96eXHRWUbNzbj8haOyHoUNLlehuiI8ekJ1NsNVg_qeBTKHjzyexrlQiENo7b4nNOYThWsRMv99U0CGfMIRuh3NbX1abnYqSeF9Vkko;
+        path=/; expires=Tue, 02-Dec-25 16:15:01 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=An20PAT2HDDnW1h1aqxjZzDvVPhkR231W16Bemmoo0E-1764690301355-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2365'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2369'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999964'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_c6f6c200ec4a402e8be6d47d523fc4fb
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_context_call_wrapped_call_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_context_call_wrapped_call_method.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a thriller book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '104'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFRNb+M4DL33V3B9LJIiX3WS/oHdvc2hwB5mFgYt0Y42siRQdNpg0P++
+        kJw48Ux7S/jIJz7SfD8fAAqjixcomGKoFros63Jf73Rdbupys1iU+1Wz2NaakHa75X5br9TzerNb
+        1VQ2m9X6uZglCl//R0quNN5FGuKKCYV0hQlbbstNudvvntcZi4LSx1SjfBcsCemhqEZ1bNn3LvXV
+        oI00hI21xrXFC/x8AAAoAp6JU72mE1kfiIsHgI+cTMw+Ya63NgeMu75SaRI0Nk7RKNwrMd5N4h2+
+        V76X0Esl/ki/g+K9rRTaKV3nNdnUWRtkvvHzzjgzXy1Wm/liO1/uLjPLvMULfM9yBlHjOrrYfr0N
+        2pb7RdrGXu/Xm/W+pM1GaUUqM2cWOQfKPBQjtnQDvhp7BpV3Qu7W1H1jE9rrUOhdxuqcgM55wesg
+        v/87Aa1vA/v6EyQTvUDxNzAp33XkNDw+/iheDwR/GrbgHciB4JXRuB8F1Gf4hr1F+AvfjsbFx8cn
+        eD2YCCGe1cFb3xqFFuTAxlpieCM8UQTxLcmBOHNZk0K+SVlE8OY7cjOg92A9G9emnG5I8HWkGI13
+        M+io83yeAToNmhSFJPUJ/jFyACMRWjYhpOpgveSs3tF7ICWkQd5MlDjLr0fxfIYjUYjAhJo4XkWS
+        bmnoiwxDJJSY1BEYJ2wUCtkzKMYmcaoDMipJ5em1ocY4IZY340iDQ2aUrLXDI4ERQFAYxJxQUqfp
+        9Sf4RtyQEmg8Q4Mu6459DOQiNb2d3R6aazYnclmBofhHMS7y4/Jr3G3B3ubvBWM0UdDJkJwSc1IR
+        kNFastNLEu6How9MJ+P7WF19pcrnMV5aYN8FqRSqA1VHOn+JMaUP23h3n8GE0buJqVDTeJa7pHQy
+        fdchX7lHj4nYkJwroxNxY2jiN5H4ZBRVYq4e1WBvh2Mp0uToXqZQF4hR+hxePi0u0XwUl84azx3e
+        /t8dY84b5nrp+ERc+2jkPFiANn1388Zh0gdv1LCaXnwxArfbLMSH6u5iF2Mw3PfIvVN4GWyhTcTa
+        Xo28z84zCjBu4qPLcvZ7/M6cR5l5gfpWuJhI/dWed+vPgM94x+1/RS1e0N7A/X4cYR+n2+5IUKNg
+        ov94+PgfAAD//wMAKe77vVcHAAA=
+    headers:
+      CF-RAY:
+      - 9a7be8007c69dfed-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 15:37:37 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=rfLNRcfvIhHXvJY5BpySCUJSsqy3nafCgCcGZ25De8g-1764689857-1.0.1.1-yEwFpnj_2b5H8o.vTdOdPezc0h7Zx1RjZWy89SXgAonFrR6I4_P9RBCWMpWpFEexG4NTGZsR1NKU6.kln_10kYUtAEBChHI.pikqtokTM3g;
+        path=/; expires=Tue, 02-Dec-25 16:07:37 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=WTghTMBfiNbW.ubbG9f.Ag1fpZbpTqc9Li350TwymZA-1764689857799-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '3825'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '3830'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999964'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_543fb9334b8f448f9408b026f60e74ef
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_async_context_call_wrapped_returns_trace.yaml
+++ b/python/tests/ops/cassettes/test_traced_async_context_call_wrapped_returns_trace.yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a biography book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '105'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - AsyncOpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RUy47bOgzdz1cQ3nSTDOxJ4iTzBbdAV2137YVBy7StG0k0JHrSoJh/v5A8ceJ2
+        ZmfzkEeHz98PAJlusmfIPIWhyjdlvcOGmvJJ7XLV5nl5fGrrTanU4Xg4FMcd7jZqu9+pYl9uDk+H
+        Y7aKFFz/R0quNOwCTXblCYWaCiNW7MvtfrM55NuEBUEZQ4xRbAdDQs0UVKM6dZ5HF3W1aAJNZm2M
+        dl32DL8fAACyAS/kY3xDL2R4IJ89ALwmZ/KeI+ZGY5JBu+srVUOC2oQlGsSPSjS7hd3ir4pHGUap
+        hE/0NyjMplJolnSWGzJRWTfIestrq51eP+VP23W+XxeHt5ol3uwZfqR0pqTmdtjQfdyNpigpj92o
+        y3JX7PaHsizadnsoEnNikctAiYdCwI5uwEdlT6BiJ+Ruou6FLWivRaFfMkcnB3SOBa+F/PHvAjTc
+        DZ7rd5BE9AzZZ/Ck2FpyDfzMvvcEn61lL2jgi24JuIV/yHlNIghfUJ3CzwzqC3ylmpRC+HYyzPII
+        33sdICZIaWig1tx5HPoLCBkTQHqCIOwv7zCu4NxzIFDoFHlQKeBMnkDwRA7OWnoeBXrycHJ8NtR0
+        BNpBcdwVgK6BMzkBdiAMdUyHgF3SHp+1HAS0HWJWTiBOUIjRlhqttKMonqBmPoF2Ql7O2lG4ifwU
+        wOiWVun9Fq02l08B4vx2naGwSgriQyS9VmjiW0arqSdRRHoIDXgKhF71K7B4ikXSAggxt66X9eD5
+        hZM58pHrsIs/nrB5zObWvb59zd3MPJs0IRiCDjHDyTk6JqdsQI/GkFnujvhxWvPB04vmMVTXS1Kl
+        hZh3a/BsB6kUqp6qE10+xDzFUdbs7j08YWC3OCPUtuzlzikuyWgt+iv3fFUCtiSXSjeRuNW0uDCB
+        /ItWVIm+XqUWRzOtRxZnje7TFLIDeZQxmYvH/M2a1uBNWcve4u3/bv2S31TXN8Uv5GsOWi7T0jd6
+        tLdrOFW6Z62m1ozC2QzctjETHqq7Hc1n43Cv0Y9umqaUpQ5Ym+vpHtOtmRPQbnE5i3L1t/3uHM9p
+        pgY2t8B8keqfB/mwfw94j3fu/kfUwoLmTnC+mWs4hmW7LQk2KBj5Xx9e/wcAAP//AwDwGj20SgcA
+        AA==
+    headers:
+      CF-RAY:
+      - 9a8019074ef3268f-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Dec 2025 03:50:08 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '3687'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '3691'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999965'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_21d6553d408f4c12a857baaa44a5179a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_call_call_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_call_call_method.yaml
@@ -1,0 +1,111 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a fantasy book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '87'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3xUwY7jNgy9z1ewvhQIJgs7k51M5trTYoGiKAr0sFsYtETbamTJoKjMBov590Jy
+        4sS7Mz3F4SOfSD6S3+8ACqOLZyiYwliXH3cVle2GNkqVuPlYlo/7TdtstN5WG/VU7R/2ZbWlp6eH
+        fVPR0562xX2i8M2/pORC412gya6YUEjXmLBq97jdPTw8PlYZC4ISQ4pRfhgtCekpqEF16NhHl/Jq
+        0QaazMZa47riGb7fAQAUI56IU7ymI1k/Ehd3AK/ZmZh9wly0NhuMu7xSaxI0NizRIByVGO8W9gG/
+        1T7KGKUWf6CfQfHe1grtkm7wmmzKrBtlvfXrwTiz3pSb7brcraunc88yb/EMX3I5U1GzHEPo/kcN
+        3GBWA3GHqm2VblW12+1VZs4schop81AI2NEVeK/tGVTeCblrUreJLWgvTaFvMkdnB3TOC14a+eWf
+        BWh9N7Jv3kAy0TMUn4BJ+WEgp2G1+lr81RP8jgOBb0F6gr+N01+L1QqaE/yBwkYd4E8vfRtD+ACf
+        5NeQ3VrDQaDx/gDGZcvqs3HdwVhLDL/17J1RllYQiA0FQKeh9db6lyk+iOdTevPz0UtP94DQmVZI
+        w8lH18GADl56Dx2nCOPEA4KljpxGPkFrusj0AVL2DplRzJGgseR0gAE7o+5hiCH9pJdRH8lJ5PSO
+        tfDSG0vQEkpk4zpgo3p48Wz1uonG6mRLYcal+lEIVI+MSojhvAoDOTm3AyHpTHl3gAlToQzoTtCi
+        EwwnICd9DAaD/FLMmryev2aZCvY2S48hmCDoZHJOjtmpGJHRWrLLpRCO0/6OTEfjY6gvJ6LOkz4v
+        zch+GKVWqHqqD3R6F2NKM2q8u/VgwuDd4j5Q23qWG6c0/XEYkC/c87kI2JKcaqMTcWtocToC8dEo
+        qsVczk2L0U5zX6RJodsyhYaROGmXzNWH8mzN833OrPU84PX/zV5lv6mv54yPxI0PRk7TNmsTh+uZ
+        mzrde6MmaaL4Ygaua1aIH+ub5Stn43ibI0en8NzYQpuAjb3c5JiPyFyAcYuTWG3uf7bf3Nm5zCyg
+        vgaWi1J/vLS7/VvAW7yz+u9Rixe0V3BfzS2MYan2QIIaBRP9693rfwAAAP//AwDCDPJAIgcAAA==
+    headers:
+      CF-RAY:
+      - 9a8015842ba3a5d6-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Dec 2025 03:47:43 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=H2vV2CUmqQXXskwzNP37BQAb9IOtUqM9xMQ_QmCUV.s-1764733663-1.0.1.1-BDBGrp6HBwAcikBQsafLdnghqo7wFT6pv2J9i_7jdlz.idNSS9nNUJCB6YMNExXpXLQOyLdqJ5ADuhhJ_C6rjikbhowshy84IB2utKYqAMw;
+        path=/; expires=Wed, 03-Dec-25 04:17:43 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2276'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2278'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999969'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_d2d9457f803d42239101e1cb76ab2f3c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_call_stream_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_call_stream_method.yaml
@@ -1,0 +1,242 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a adventure book.","role":"user"}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: "event: response.created\ndata: {\"type\":\"response.created\",\"sequence_number\":0,\"response\":{\"id\":\"resp_08413a8e683edb5f00692fb2e015c48195b5dd436a7edf5173\",\"object\":\"response\",\"created_at\":1764733664,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.in_progress\ndata: {\"type\":\"response.in_progress\",\"sequence_number\":1,\"response\":{\"id\":\"resp_08413a8e683edb5f00692fb2e015c48195b5dd436a7edf5173\",\"object\":\"response\",\"created_at\":1764733664,\"status\":\"in_progress\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}}}\n\nevent:
+        response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"sequence_number\":2,\"output_index\":0,\"item\":{\"id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"role\":\"assistant\"}}\n\nevent:
+        response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"sequence_number\":3,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"}}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":4,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"I\",\"logprobs\":[],\"obfuscation\":\"giC9l5bIFJndlNV\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":5,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        recommend\",\"logprobs\":[],\"obfuscation\":\"FlPixI\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":6,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        \\\"\",\"logprobs\":[],\"obfuscation\":\"miuHzJTPtqHJFh\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":7,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"The\",\"logprobs\":[],\"obfuscation\":\"GlnrpdzAinVMc\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":8,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Call\",\"logprobs\":[],\"obfuscation\":\"yuMO5Haa3WI\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":9,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"Q2zHqoQUjstyL\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":10,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"nDTnsa6NxOfZ\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":11,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Wild\",\"logprobs\":[],\"obfuscation\":\"MVK7lupfWZc\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":12,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"\\\"\",\"logprobs\":[],\"obfuscation\":\"5Ei0JiJuDLG4How\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":13,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        by\",\"logprobs\":[],\"obfuscation\":\"uVQMKXDIW4B86\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":14,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Jack\",\"logprobs\":[],\"obfuscation\":\"STrmYUJQxhi\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":15,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        London\",\"logprobs\":[],\"obfuscation\":\"RIqyXLhtJ\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":16,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"Up1tdzspk3MKFBv\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":17,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        This\",\"logprobs\":[],\"obfuscation\":\"6MhGTpiamiB\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":18,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        classic\",\"logprobs\":[],\"obfuscation\":\"xfk95qJ2\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":19,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        novel\",\"logprobs\":[],\"obfuscation\":\"RlTa8trOJ0\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":20,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        follows\",\"logprobs\":[],\"obfuscation\":\"pkCzsOyG\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":21,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"mFY4Lt2QWNIX\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":22,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        journey\",\"logprobs\":[],\"obfuscation\":\"9Q7JDrQ9\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":23,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"6IKufhcxlt5HB\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":24,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Buck\",\"logprobs\":[],\"obfuscation\":\"XlfaSjircBU\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":25,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"m52lPWaLX5Z4ufo\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":26,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        a\",\"logprobs\":[],\"obfuscation\":\"ZOIEmK0ZXviLzS\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":27,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        domest\",\"logprobs\":[],\"obfuscation\":\"qZc2h6Unj\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":28,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"icated\",\"logprobs\":[],\"obfuscation\":\"BicSG1IuKX\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":29,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        dog\",\"logprobs\":[],\"obfuscation\":\"9EUBZBI2NMhe\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":30,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        who\",\"logprobs\":[],\"obfuscation\":\"sfgeuW7bdCHk\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":31,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        is\",\"logprobs\":[],\"obfuscation\":\"2j1zTaAOiJeQl\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":32,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        thrust\",\"logprobs\":[],\"obfuscation\":\"8h2jQeGgT\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":33,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        into\",\"logprobs\":[],\"obfuscation\":\"K5AfX8loYuO\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":34,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"ywxldNApzO1t\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":35,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        harsh\",\"logprobs\":[],\"obfuscation\":\"4oDh9uOMsK\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":36,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        wilderness\",\"logprobs\":[],\"obfuscation\":\"SAP0O\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":37,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"AO5uudyZ8ymrQ\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":38,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"Pq8138H0OsDH\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":39,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Yukon\",\"logprobs\":[],\"obfuscation\":\"REFvkrLOOa\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":40,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        during\",\"logprobs\":[],\"obfuscation\":\"aE6tvRfB9\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":41,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"6CxKpgkYSKIM\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":42,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Gold\",\"logprobs\":[],\"obfuscation\":\"m3ZG1pbD29a\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":43,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Rush\",\"logprobs\":[],\"obfuscation\":\"A3EDlHb0k9P\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":44,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"uy6ABYb6v7lcUtE\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":45,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        It\",\"logprobs\":[],\"obfuscation\":\"HUe70htfXyUYA\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":46,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"\u2019s\",\"logprobs\":[],\"obfuscation\":\"RgcfqilsYVtR8Z\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":47,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        a\",\"logprobs\":[],\"obfuscation\":\"9UfICFGpl3mvjN\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":48,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        gripping\",\"logprobs\":[],\"obfuscation\":\"dQWRbMd\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":49,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        tale\",\"logprobs\":[],\"obfuscation\":\"RBzLj1mc73h\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":50,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"BqnGfAmDTPuQs\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":51,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        survival\",\"logprobs\":[],\"obfuscation\":\"R5M4tU0\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":52,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"cVdZZiQG7XJzjcy\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":53,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        adventure\",\"logprobs\":[],\"obfuscation\":\"QwiaKS\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":54,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"3IQHQtVjfGPt31K\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":55,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        and\",\"logprobs\":[],\"obfuscation\":\"hxTMCjiQNzqk\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":56,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        self\",\"logprobs\":[],\"obfuscation\":\"aiBlkL13x7W\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":57,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"-dis\",\"logprobs\":[],\"obfuscation\":\"KKQfu3VcK0Wd\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":58,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"covery\",\"logprobs\":[],\"obfuscation\":\"JvwwytmdWY\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":59,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\",\",\"logprobs\":[],\"obfuscation\":\"GNGX45ZJ6tMq1Pn\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":60,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        set\",\"logprobs\":[],\"obfuscation\":\"MusAHMGuAU6z\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":61,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        against\",\"logprobs\":[],\"obfuscation\":\"YUq2Eb5M\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":62,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"mVvhlH7uh94m\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":63,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        backdrop\",\"logprobs\":[],\"obfuscation\":\"MNNzk8p\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":64,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        of\",\"logprobs\":[],\"obfuscation\":\"DSXYAbHQhbHeM\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":65,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        the\",\"logprobs\":[],\"obfuscation\":\"XQdPrS3slqAo\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":66,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        unt\",\"logprobs\":[],\"obfuscation\":\"YcSf2878QoNm\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":67,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"amed\",\"logprobs\":[],\"obfuscation\":\"IlgGsE6Pf5Pl\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":68,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        wilderness\",\"logprobs\":[],\"obfuscation\":\"aXkXY\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":69,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\".\",\"logprobs\":[],\"obfuscation\":\"zp6TtAiGK62Nsuo\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":70,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        Perfect\",\"logprobs\":[],\"obfuscation\":\"vY0p7tfi\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":71,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        for\",\"logprobs\":[],\"obfuscation\":\"CIWomPiQmVli\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":72,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        anyone\",\"logprobs\":[],\"obfuscation\":\"lJptByerF\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":73,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        seeking\",\"logprobs\":[],\"obfuscation\":\"efjgHcGs\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":74,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        an\",\"logprobs\":[],\"obfuscation\":\"bHDYhFOFVdIYw\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":75,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        exciting\",\"logprobs\":[],\"obfuscation\":\"BbjWJYF\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":76,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        and\",\"logprobs\":[],\"obfuscation\":\"opGN4d9eheo9\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":77,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        thought\",\"logprobs\":[],\"obfuscation\":\"ehH4YBhe\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":78,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"-provoking\",\"logprobs\":[],\"obfuscation\":\"cnHDHC\"}\n\nevent:
+        response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"sequence_number\":79,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"
+        read\",\"logprobs\":[],\"obfuscation\":\"HIKIGlAH8PL\"}\n\nevent: response.output_text.delta\ndata:
+        {\"type\":\"response.output_text.delta\",\"sequence_number\":80,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"delta\":\"!\",\"logprobs\":[],\"obfuscation\":\"WzyYIhAlmFd5b8Y\"}\n\nevent:
+        response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"sequence_number\":81,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"text\":\"I
+        recommend \\\"The Call of the Wild\\\" by Jack London. This classic novel
+        follows the journey of Buck, a domesticated dog who is thrust into the harsh
+        wilderness of the Yukon during the Gold Rush. It\u2019s a gripping tale of
+        survival, adventure, and self-discovery, set against the backdrop of the untamed
+        wilderness. Perfect for anyone seeking an exciting and thought-provoking read!\",\"logprobs\":[]}\n\nevent:
+        response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"sequence_number\":82,\"item_id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"output_index\":0,\"content_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        recommend \\\"The Call of the Wild\\\" by Jack London. This classic novel
+        follows the journey of Buck, a domesticated dog who is thrust into the harsh
+        wilderness of the Yukon during the Gold Rush. It\u2019s a gripping tale of
+        survival, adventure, and self-discovery, set against the backdrop of the untamed
+        wilderness. Perfect for anyone seeking an exciting and thought-provoking read!\"}}\n\nevent:
+        response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"sequence_number\":83,\"output_index\":0,\"item\":{\"id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        recommend \\\"The Call of the Wild\\\" by Jack London. This classic novel
+        follows the journey of Buck, a domesticated dog who is thrust into the harsh
+        wilderness of the Yukon during the Gold Rush. It\u2019s a gripping tale of
+        survival, adventure, and self-discovery, set against the backdrop of the untamed
+        wilderness. Perfect for anyone seeking an exciting and thought-provoking read!\"}],\"role\":\"assistant\"}}\n\nevent:
+        response.completed\ndata: {\"type\":\"response.completed\",\"sequence_number\":84,\"response\":{\"id\":\"resp_08413a8e683edb5f00692fb2e015c48195b5dd436a7edf5173\",\"object\":\"response\",\"created_at\":1764733664,\"status\":\"completed\",\"background\":false,\"error\":null,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-4o-mini-2024-07-18\",\"output\":[{\"id\":\"msg_08413a8e683edb5f00692fb2e08ba08195a6c088f31c0e5205\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"I
+        recommend \\\"The Call of the Wild\\\" by Jack London. This classic novel
+        follows the journey of Buck, a domesticated dog who is thrust into the harsh
+        wilderness of the Yukon during the Gold Rush. It\u2019s a gripping tale of
+        survival, adventure, and self-discovery, set against the backdrop of the untamed
+        wilderness. Perfect for anyone seeking an exciting and thought-provoking read!\"}],\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":null,\"reasoning\":{\"effort\":null,\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tools\":[],\"top_logprobs\":0,\"top_p\":1.0,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":12,\"input_tokens_details\":{\"cached_tokens\":0},\"output_tokens\":78,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":90},\"user\":null,\"metadata\":{}}}\n\n"
+    headers:
+      CF-RAY:
+      - 9a801595a929a5d6-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 03 Dec 2025 03:47:44 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '34'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '37'
+      x-request-id:
+      - req_60f49781744347e88773aee5ac8b9a1c
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_call_sync.yaml
+++ b/python/tests/ops/cassettes/test_traced_call_sync.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a fantasy book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '87'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3xUTW/jNhC951dMdVnAsAPZSfyR656CBYqiKNDDbiGMqJHENcURyKGzwiL/vSBl
+        y1Y36SnOvJmn+eB7P+8AMl1lz5A58n2Rb9a7/GGtVP2Ul1g+5Pn2sCF82OT73X6/Xx+eDnWeb/Z7
+        VT3utttN/pQtIwWX30nJhYatpzGuHKFQVWDE1rvt43b7mB+2CfOCEnysUdz1hoSqsahEdWwcBxv7
+        qtF4GsPaGG2b7Bl+3gEAZD0O5GJ9RScy3JPL7gDeUjI5xxGzwZgU0PbylaIiQW38HPXighLNdhbv
+        8EfBQfoghfCRfgWF2RQKzZyu44pM7KzpZfXIq05bvdrkm8dVvlut9+edJd7sGb6mccahpnN0vvmf
+        axDtVLzGPl9jVe+f6idcq7rcJubEIkNPiYe8x4auwEdrT6BiK2SvTd02NqO9LIV+yFSdEtBaFrws
+        8us/M9Bw0zsu30ES0TNkL+BIcdeRrWCx+Jb91RL8jh0B1yAtwd/aVt+yxQLKAf5AcVod4U+Wtg7e
+        38OLfPIprdbOC5TMR9A2RRZftG2O2hhy8Ll1bLUytABPTpMHtBXUbAy/jvVe2A3xm19OLC0tAaHR
+        tVAFAwfbQIcWXluGxsUKbYUBwVBDtkI3QK2b4OgeYvepiZIwiK6DMQOUhmzlocNGqyV0wcc/sYH0
+        UaH0ypfAdU1O2wYQnFZtytBdR87rE8ErO1Pdw0sdGwKy33kA1aJDJeRWldMnsmDRORR9Ig+vWlpA
+        EA6qjXN1gxdyQ2LF6kRWgqMlSKs9aB/HjcoF1bJW9Fs2nert/Gu6XubYpBeB3msvaGVMjokpKevR
+        oTFk5loRF0ZZ945OmoMvLs5RJAFMWuodd70UClVLxZGGDzFH8elqtrcZjtCzndkG1TU7uUmKoghd
+        h+7CPbmIx5pkKHQViWtNM0fx5E5aUSH64kI1BjPKIYu3pNsxhbqeHMY1Ryu8z8/R9OzPndXsOrz+
+        fyO3lDfu9dzxiVzJXsswirzSobu637jpdLt0miCcTcBVfZlwX9xoMp+C/W2PLliF58VmlfZYmotV
+        h+Qt0wDazpxyvVn+Gr+x32nMdMDqWpjPRv2vAe937wHv8U7X/4haWNBcwcNhWmHw82t3JFihYKR/
+        u3v7FwAA//8DAKosCTo5BwAA
+    headers:
+      CF-RAY:
+      - 9a797328695aae17-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 08:28:18 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=2.D5qutj3pSu7MhWJ2mi1ArweQSPB2g15PgDYx.vJAM-1764664098-1.0.1.1-IyfALflnOeDGQr9pLc3GpqDINFmp6RhxMwuJWtpRUABFp5rc3_jiQ_hNJltHSdDAHYoK6M1oMio2i9RGo73hHWYO9_Tsf6cEes._dlIaoqQ;
+        path=/; expires=Tue, 02-Dec-25 08:58:18 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=ip2gKHe8MLHFnE1F33ac3aUsAq3TRpCw3Y5RLLdkjAs-1764664098746-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2157'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2161'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999968'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_e973db555e8349cc88082d47f6afb3ea
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_call_with_tags.yaml
+++ b/python/tests/ops/cassettes/test_traced_call_with_tags.yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a romance book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '87'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//fFRNb9s4EL3nV8zqGNiB5Dp2nD+wbbHAHra3diGMqJHEmuII5NCpUOS/
+        L0jZstUmezHkeTOP8/l+3gFkus6eIXPkhzLfo6oL3FJe75ttgXm+O2wIP2xog1v1VBweD2qr1L7Y
+        P27wqaFDna0iBVffScmFhq2nya4coVBdYsSK/W67222LIk+YF5TgY4zifjAkdCarUB1bx8HGvBo0
+        niazNkbbNnuGn3cAANmAI7kYX9OJDA/ksjuA1+RMznHEbDAmGbS9vFLWJKiNX6JeXFCi2S7sPf4o
+        OcgQpBQ+0u+gMJtSoVnS9VyTiZm1g6y3vO611etNvtmu8/26eDr3LPFmz/A1lTMVNY+j9+3/TOOp
+        2W3jNKpDoR53j1vMC1XUtEnMiUXGgRIPeY8tXYH32p5AxVbIXpO6TWxBe2kK/ZA5OjmgtSx4aeTX
+        fxeg4XZwXL2BJKJnyP62BG1cGnDco1UEFfMRhEGx9bomB9rD/f237EtH8BFF2xb+xJ6+ZVCN8A8a
+        M8KXjp2l+/sH+CTQEEpw5AGhCRbQ1kC2xTYGkqVek18Lrw2fyHnwwm402hJ4EtAWEBS7gR0KATeN
+        VrSCRhtDNbxo6eKPjFChFXKJPNiarMbKEKiOeu3FjQ8Qs61Hi71WUJG8EFmQjkBeGHrUFlSHDpWQ
+        8yv4K6gxcX1m3wVcxZIrlg660LPj4BPYETppyMgKejzGchp2MV8cRJ+mzjjC+gE+NTByALLfeQTf
+        oRug1mi4DZSYELzhl3UVnL20fQXSpVf5GF+vqdFWC5kRXthJB4NW6ckw/JHNc3w9f82jzRybtC7o
+        vfaCVibn6JicsgEdGkNmeUjiwnTzg6OT5uDLi6yU6TrmQxsc94OUClVH5ZHGdzFHca8121sPR+jZ
+        LjSFmoad3DjFiwl9j+7CPUuMx4ZkLHUdiRtNC7nx5E5aUSn6IlENBjPdShaXjG7LFOoHcmlPo04+
+        5GdruolzZg27Hq//b24x+U19PWd8Ilex1zJOClDr0F+lcep0x1pNownC2QxcTzMTHsqbg81n43Cb
+        owtW4bmxWa19XPyzjockPHMB2i5ktNisfrffaPNcZhpgfQ3MF6X+qs6H4i3gLd55+u9RCwuam4Tz
+        D3MPg1+OuyfBGgUj/+vd638AAAD//wMA4vS47FcHAAA=
+    headers:
+      CF-RAY:
+      - 9a79737ffbffae17-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 08:28:32 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2672'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2675'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999969'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_1564816b23a04c46930ce8a356ece317
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_call_wrapped_call_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_call_wrapped_call_method.yaml
@@ -1,0 +1,107 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a scifi book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '85'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFRNb+M4DL33V3B9WaBICjtN89HbAovF9r63mYVBS3SsiSx6JaqdYND/
+        vpCcOPFMe0v4qGeSj3w/7gAKo4tnKDyFoS6f9FPTVqvNI1LVlLuy3OxXhI+rJ0W73a7ab7Fa7560
+        LqtNtW+w3BeLRMHNN1JyoWEXaIwrTyika0xYtd2sN5t1VVYZC4ISQ3qjuB8sCenxUYPqePAcXaqr
+        RRtoDBtrjTsUz/DjDgCgGPBEPr3X9EqWB/LFHcB7TibvOWEuWpsDxl2+UmsSNDbM0SA+KjHsZvEe
+        v9ccZYhSCx/pV1CYba3Qzul61mRTZYdBlmte9saZ5apcrZfldlntzjPLvMUzfMntjE1NcvTh8Lka
+        m6dWZzUaatZ7rbbrTbsiIszMmUVOA2UeCgEPdAU+G3sGFTshdy3qtrAZ7WUo9F2m1zkBnWPByyC/
+        /DsDLR8Gz80HSCZ6huIFPCnue3Ia7u+/Fn9GR18LaE7wl0d3hL/JN+Tl/v4BXuT3AAjKYghGAbcQ
+        lCGnCFqTlVxAIAF2IB2BpkBeYLDoUrCFP7zHowkLeOvIEwyelOEYwFPg6BUFQKdhYGvEKLRgnHhz
+        iAShw4EyZ4tCicpIAOM6bIygk/AA/3Q5oaeQYFJs+XBagCdrDrmwkfqNPPR4JDACCN6ozp7Apq0m
+        DZ5QP8BLCyeOQO4bn8YSVProG3url000Vht3yHSaaIChM5YDD10u+b9IISuxAOlMgIb5CCYNrY9B
+        lukLvxWTCu/nX5MwhWebxU4DDqm1MTkl5qRiQI/Wkp2fgfg4Xuzg6TXNtL6YQp13ezqTwXM/SK1Q
+        dVQf6fQp5iltpWF3m+EJA7uZI1DbspebpLTvse/RX7gngwjYkpxqoxNxa2hmFoH8q1FUi7kYTIvR
+        jpteBGFPt20K9QN5lJjD1UN5juaNPlfWsu/x+v/mknLeONdzxa/kGw5GTuP9ahP7q7GNk+7YqFGa
+        KFxMwPWwCuGhvjm3cgoOtzX66BSeB1toE7CxFxeO2TamBoybmWD1uPg1fuOsU5tZQH19WM5a/dlb
+        t5uPgI94J/U/oxYWtFdwt59GGMNc7Z4ENQom+ve79/8BAAD//wMAoRiXBRQHAAA=
+    headers:
+      CF-RAY:
+      - 9a797349b820ae17-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 08:28:24 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '3058'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '3061'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999968'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_d98fbc1107d74a4298c99e1dc5349ab6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_call_wrapped_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_call_wrapped_method.yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a mystery book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '87'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3xUTW+jSBC951fUcpmLHWHHxibH1UqrkWZOk9tkhcpQQMdNF6ounKBR/vuqwcZm
+        J9kb1Kt6/erz1x1AZIroESIh32ZxuY33m1X6gHnykBy2cZyka8KH9cN6u4v3qzTZFytabw+bON3u
+        k8MujxaBgg8vlOuFhp2n0Z4LoVKRYcBWu2STJJs4TQfMK2rnQ0zOTWtJqRiDDpgfK+HOBV0lWk+j
+        2VhrXBU9wq87AICoxZ4kxBd0IsstSXQH8D44kwgHzHXWDgbjLq9kBSka6+eoV+lyNexm9gbfMu60
+        7TRTPtLvoDLbLEc7p2u4IBuUVa0uN7xsjDPLdbzeLOPdcrU/12zgjR7h55DOmNTUjsZX/9ONPe42
+        oRtp8oAppZvVukw2u3Q7MA8s2rc08JD3WNEV+KzsA5izU3JXUbfCZrSXotCbTtGDAzrHipdC/vxn
+        BlquWuHDB8hA9AjRVxDKuWnIFfAcPdUEfxux8Gq0Bq0J/hKs2METqjI/R3Do4YcaquAbivfs7uGp
+        Nh4qMW1rXAVN75Wkh5Kt5VcPL9yJQ2u8wndzRLLwp+XmeAoGdAXUmB9J4JvxB9IafqBFV5AA+vB8
+        D8adyKupUAkQCsqxIL9kW0BhPLYtoaDLCYwDhFdCq3UPJTbG9kEageMTWaC3lkRtH1xO5IEsNeTU
+        A5fgO9+S87QA41RM1dFikCYmryGvUTBXEjgPfQi7h6/6ZRAIpRGv4fXw8xx9N9aSc6ZrniPwJIb8
+        AjyDKaHnDsi9cA9GF8Fd6IuHhoVAOQi0LPRHNDXp/fw19S0StsMsoPfGKzodnYPj4BS1KGgt2fmW
+        qHTjQrdCJ8Odzy43IxtGf9qiVrhpNcsxryk7Uv8pJhSG1rC79RBCz252MKgsWfTGKaxD1zQoF+7p
+        fngsSfvMFIG4NDS7JZ7kZHLK1FzuT4mdHRch8spCt2kqNS0JajeYV/fx2ToM/FlZydLg9f9m0Qa/
+        sa5nxSeSA3uj/bjehema690bK12zycfWdMrRBFz3LlJus5ttjCdje6tROpfjubBRGPCDvRzpbrgq
+        UwLGzW7kar343X5zeKc0hwYW18B4lup/T+9+8xHwEe/U/c+olRXtFUyTqYSdn3e7IcUCFQP9+937
+        vwAAAP//AwBbkgbJMwcAAA==
+    headers:
+      CF-RAY:
+      - 9a79733969bfae17-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 08:28:21 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2166'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2170'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999969'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_57eef9f114424b70bc364eb98187f1fb
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_call_wrapped_stream.yaml
+++ b/python/tests/ops/cassettes/test_traced_call_wrapped_stream.yaml
@@ -1,0 +1,712 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"Recommend a adventure book.","role":"user"}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_04e0f952a6e89b4a00692ea329625081909eb4d6c84534cbc0","object":"response","created_at":1764664105,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_04e0f952a6e89b4a00692ea329625081909eb4d6c84534cbc0","object":"response","created_at":1764664105,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"ho3wJfgMbplIyD8"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        recommend","logprobs":[],"obfuscation":"iuRJy9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"kF7GKIox22FWW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"axI8JG9d5QaDjss"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"The","logprobs":[],"obfuscation":"bettwMUm5uDvw"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        Hobbit","logprobs":[],"obfuscation":"QVNdCCWGW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"wfh8B2Fmnt35k58"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        by","logprobs":[],"obfuscation":"geUgR8ZxZ9o9T"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        J","logprobs":[],"obfuscation":"zIukW7AfkNg70n"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":".R","logprobs":[],"obfuscation":"LldtGBDCtYpMqa"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":".R","logprobs":[],"obfuscation":"1N7JJmoQcXj5fM"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"5d47dHSu6I4vn0m"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        Tolkien","logprobs":[],"obfuscation":"mOHtbkcl"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"jzXSZoZTkgz4am"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"n5vu9YztJSkqWMz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        This","logprobs":[],"obfuscation":"05siKwhIdkZ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        classic","logprobs":[],"obfuscation":"Gb3kHpmI"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        tale","logprobs":[],"obfuscation":"lEs6UO0GfRs"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        follows","logprobs":[],"obfuscation":"mTTHRXbc"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        Bil","logprobs":[],"obfuscation":"SG2lzNEfKKJX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"bo","logprobs":[],"obfuscation":"hBnBvH7OvlIpxE"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        B","logprobs":[],"obfuscation":"CauFduvg3DTmVW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"agg","logprobs":[],"obfuscation":"2SVsixILe80bC"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"ins","logprobs":[],"obfuscation":"ZdqcnmmUruXLY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"ekrRzHKxGlxNH1p"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"ghVtUUHfpx0yFu"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        hob","logprobs":[],"obfuscation":"ISz2GrqWe97i"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"bit","logprobs":[],"obfuscation":"Ptcv04elkobiM"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        who","logprobs":[],"obfuscation":"th9JfxW6BnC3"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        emb","logprobs":[],"obfuscation":"02NwhfLASsdr"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"arks","logprobs":[],"obfuscation":"1Yv5olxd3Y3f"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        on","logprobs":[],"obfuscation":"JMsqPwB6P6Geq"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        an","logprobs":[],"obfuscation":"CPEGO7tevKisd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        unexpected","logprobs":[],"obfuscation":"eY6QC"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        journey","logprobs":[],"obfuscation":"p8wzb0CD"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        with","logprobs":[],"obfuscation":"LUC7ZLYRZGc"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"3rTOUL1uwdPPmG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        group","logprobs":[],"obfuscation":"thUJzZTLEw"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"lAT1C9JCPea0V"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        dwar","logprobs":[],"obfuscation":"xKhjAPhx9Yn"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"ves","logprobs":[],"obfuscation":"J6hqcBRY1isCo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        and","logprobs":[],"obfuscation":"U6xxyX4B7MFK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"UaXaJy1KsahP"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        wizard","logprobs":[],"obfuscation":"4JUqvxJwh"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        Gand","logprobs":[],"obfuscation":"TCoCucQiOgl"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"alf","logprobs":[],"obfuscation":"KMDLALIndCaJy"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"Hna7coXGZcXUB9y"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        They","logprobs":[],"obfuscation":"YiPoXldPQ3I"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        face","logprobs":[],"obfuscation":"NdOG3NNssgG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        various","logprobs":[],"obfuscation":"Ca7IyTxf"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        challenges","logprobs":[],"obfuscation":"JBhbd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"6BVGjKHLDxOSkX1"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        including","logprobs":[],"obfuscation":"2ARCB9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        trolls","logprobs":[],"obfuscation":"FsL0guzDh"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"zycYlZRUOjlTLz5"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        gob","logprobs":[],"obfuscation":"cfPh3Nlf4RZ9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"lins","logprobs":[],"obfuscation":"EmOUY8VLMIvH"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"XS27N2ttxVxIsgX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        and","logprobs":[],"obfuscation":"9TJTFw0p3PSr"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":63,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"3FwViMVm0oQ3jy"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":64,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        dragon","logprobs":[],"obfuscation":"djXX8iqqK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":65,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        named","logprobs":[],"obfuscation":"hscMZn2hYp"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":66,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        Sm","logprobs":[],"obfuscation":"MAod5sDpFCtBr"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":67,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"aug","logprobs":[],"obfuscation":"jMKaRYRqguRXs"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":68,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"PxNIbZGPbtQoITh"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":69,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        It''s","logprobs":[],"obfuscation":"D7gd9ShQOaU"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":70,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"f6MAOFeSNNLBzL"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":71,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        wonderful","logprobs":[],"obfuscation":"jzfMQ2"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":72,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        mix","logprobs":[],"obfuscation":"hBQgRLp6sYI4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":73,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"YjynojxDV5qwd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":74,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        adventure","logprobs":[],"obfuscation":"rCd3PX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":75,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"yZaT273edeZk28Q"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":76,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        friendship","logprobs":[],"obfuscation":"Vjbar"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":77,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"6gdkDOeEJtXDYn7"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":78,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        and","logprobs":[],"obfuscation":"8GuIhQwotKps"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":79,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"BIgZ8vvfYwXW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":80,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        struggle","logprobs":[],"obfuscation":"4PkQID6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":81,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        between","logprobs":[],"obfuscation":"ylowxjAg"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":82,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        good","logprobs":[],"obfuscation":"vwNkyP5RJWd"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":83,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        and","logprobs":[],"obfuscation":"Tjl1IlRqyLaU"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":84,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        evil","logprobs":[],"obfuscation":"wmbGYKHZJB4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":85,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"JlCWIVhk6ewieIx"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":86,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        all","logprobs":[],"obfuscation":"doHt7NQBCvPY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":87,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        set","logprobs":[],"obfuscation":"cCooitOmCy7d"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":88,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        in","logprobs":[],"obfuscation":"O2vY0Il3ph53Y"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":89,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"x0onwTFBlCir"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":90,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        richly","logprobs":[],"obfuscation":"Em2igXUG3"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":91,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        developed","logprobs":[],"obfuscation":"xTgntm"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":92,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        world","logprobs":[],"obfuscation":"rjlbJsYQtN"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":93,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"v7Uct8ltJVngE"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":94,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        Middle","logprobs":[],"obfuscation":"v7AK4GC1b"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":95,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"-earth","logprobs":[],"obfuscation":"qtd3fEXzYI"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":96,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"ttAeNbeXo4Hx16i"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":97,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        Perfect","logprobs":[],"obfuscation":"mO08KIEz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":98,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        for","logprobs":[],"obfuscation":"RBnBtIq0VaoK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":99,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        readers","logprobs":[],"obfuscation":"DIWY0UYL"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":100,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"9nnQUzldWnUil"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":101,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        all","logprobs":[],"obfuscation":"sE1Fu2NoJIvF"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":102,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"
+        ages","logprobs":[],"obfuscation":"p0RqevUesXb"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":103,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"delta":"!","logprobs":[],"obfuscation":"mpIdZrn56wwHMiq"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":104,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic tale follows
+        Bilbo Baggins, a hobbit who embarks on an unexpected journey with a group
+        of dwarves and the wizard Gandalf. They face various challenges, including
+        trolls, goblins, and a dragon named Smaug. It''s a wonderful mix of adventure,
+        friendship, and the struggle between good and evil, all set in the richly
+        developed world of Middle-earth. Perfect for readers of all ages!","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":105,"item_id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic tale follows
+        Bilbo Baggins, a hobbit who embarks on an unexpected journey with a group
+        of dwarves and the wizard Gandalf. They face various challenges, including
+        trolls, goblins, and a dragon named Smaug. It''s a wonderful mix of adventure,
+        friendship, and the struggle between good and evil, all set in the richly
+        developed world of Middle-earth. Perfect for readers of all ages!"}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":106,"output_index":0,"item":{"id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic tale follows
+        Bilbo Baggins, a hobbit who embarks on an unexpected journey with a group
+        of dwarves and the wizard Gandalf. They face various challenges, including
+        trolls, goblins, and a dragon named Smaug. It''s a wonderful mix of adventure,
+        friendship, and the struggle between good and evil, all set in the richly
+        developed world of Middle-earth. Perfect for readers of all ages!"}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":107,"response":{"id":"resp_04e0f952a6e89b4a00692ea329625081909eb4d6c84534cbc0","object":"response","created_at":1764664105,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_04e0f952a6e89b4a00692ea329cea8819081a31964eabccb6b","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic tale follows
+        Bilbo Baggins, a hobbit who embarks on an unexpected journey with a group
+        of dwarves and the wizard Gandalf. They face various challenges, including
+        trolls, goblins, and a dragon named Smaug. It''s a wonderful mix of adventure,
+        friendship, and the struggle between good and evil, all set in the richly
+        developed world of Middle-earth. Perfect for readers of all ages!"}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":12,"input_tokens_details":{"cached_tokens":0},"output_tokens":101,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":113},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9a79735fda87ae17-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 02 Dec 2025 08:28:25 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '31'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '34'
+      x-request-id:
+      - req_9ad840fe84b94a459f0df6366b5f593d
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_context_call.yaml
+++ b/python/tests/ops/cassettes/test_traced_context_call.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a fantasy book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//fFTBbuM2EL3nK6a6FDDiwLITx861p8UCRVEU6GG3EEbkSOaa4gjk0Flh
+        kX8vSNmy1U16sjxv+PhmhvN+3AEURhcvUHgKfbXaI25L0puN3j89NY+r1Xa/JqzX27Jpdrtyv8It
+        rcunUjXPzaZ8wrq4TxRcfyMlFxp2gca48oRCusKElc/bx+12Wz6tMhYEJYZ0RnHXWxLS46Ea1bH1
+        HF3S1aANNIaNtca1xQv8uAMAKHocyKfzmk5kuSdf3AG85WTynhPmorU5YNzllkqToLFhjgbxUYlh
+        N4t3+L3iKH2USvhIP4PCbCuFdk7XsSablLW9LB952RlnluvV+nG5el6Wu3PPMm/xAl9yOWNR0zi6
+        0P7PNOqNVmkauw3herNpdo+4KxWODcwsMvSUeSgEbOkKfNT2DCp2Qu4q6lbYjPbSFPou0+mcgM6x
+        4KWRX/6ZgZbb3nP9DpKJXqD4BJ4Udx05DYvF1+KvA8Hv2BFwA3Ig+Ns4/bWAeoA/ULxRR/iT5dDE
+        EBaLB/gkv4ac1hgfBGrmIxiXI4vPxrVHYy15+O3g2RllaQGBvKEA6DQ0bC2/jue/cfSOhnTr5xPL
+        ge4BoTWNkIaBo2uhQwevB4Y6yU0MYKklp9EP0Jg2enqAJD4I+wFqwiimidYO8Ep4ogDCLcmBPHTY
+        GnUPXQzpJylBfSIn0adbrQVhq+HVyAHs4I1CC73nQOdyERT2Yk4oxrXgCVMlHtAN7ChLtJzu00Q9
+        vLK3ellHY3XKTpcZl/qIcpYqlLfsl2Kaztv5axpY4dnmR4AhmCDoZExOiTmp6NGjtWTn6yE+jpvc
+        ezoZjqG6mEWV3/y0Pr3nrpdKoTpQdaThQ8xTeq2G3W2GJwzsZk5BTcNebpLSHsSuQ3/hnowjYEMy
+        VEYn4sbQzEQC+ZNRVIm5GE+D0Y4bUKT20W2ZQl1PHtMgk/s9rM7R/NLPyhr2HV7/32xYzhv7elZ8
+        Il9zMDKMe61N7K6GN3b6wEaNo4nCxQRcF64Q7qubNVxNwf5Wo49O4bmxhTYBa3tx55jtZCrAuJk5
+        ltv7n+M3jjuVmQeorwdXs1L/67m79XvAe7zT9D+iFha0V3C/m1oYw3zaHQlqFEz0b3dv/wIAAP//
+        AwBCaQ4MLAcAAA==
+    headers:
+      CF-RAY:
+      - 9a79a54d992c4b50-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 09:02:33 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=eTUZhHblDY1srTWBIMEpld6dA8vfgwVjsepyNmXUToM-1764666153-1.0.1.1-Bo9SSW7XN0mUD77d7vpQXiIAnOKMn1gITe1hY1B.P1ta8U1E_ACvmXJLOHGGGzERrpn2O3MHbWmX6QED9b7uRfjhYLXXWoeryCdx0U0i.ns;
+        path=/; expires=Tue, 02-Dec-25 09:32:33 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=JshoSlng6YZ73GE2VaWAtdDXS9UeXNPlGj6SbVc3Lb4-1764666153063-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2881'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2891'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999965'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_fe3f18daced94da1936a9c505469d168
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_context_call_call_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_context_call_call_method.yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a fantasy book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '103'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RUwW7jRgy95ytYXQos4kB2nDjOtafFAsWiKNDDbiFQM5Q19WgocCgnwiL/XszI
+        lu3d5BSHj3x6JIfvxw1A4WzxDIVQ7Ktyg7Z+qMt6+fCwWpp1WT5uV029ovrJrsqn5XazRYt2ucT7
+        7T2un9ab4jZRcP0fGT3RcIg0xY0QKtkKE7bcPK439/ePm4eMRUUdYqox3PWelOxUVKPZ74SHkHQ1
+        6CNNYee9C7viGX7cAAAUPY4kqd7SgTz3JMUNwFtOJhFOWBi8zwEXTl+pLCk6H6/RqDIYdRyu4h2+
+        VjxoP2ilvKdfQWX2lUF/TdexJZ+U7XpdrHnRueAWq3K1XpSbxfLpOLPMWzzDt9zO1NS8ji7uPt6G
+        Kbebp7SNerPaPmzqR8L11tDDNMDMomNPmYdixB2dgY/GnkHDQSmcRV0Ku6I9DYVeda7OCRgCK54G
+        +e3fK9Dzrheu30Ey0TMUn0HIcNdRsPC9+Lsl+BM7Am5AW4J/XLDfC6hH+IoqzuzhL9a2GWK8g8/6
+        e8xJjZOoUDPvwYUc+fTFhd3eeU8Cf7TCwRlPnyCSOIqAwULD3vPLVB+VZUxf/HJgbekWMAC9GupT
+        U+hh5CHsoMMAL05bQOjGqCSOhwg9Rr2DJDugCKo7ENSego3Q4c6ZW+iGmP6kj6I9UNBB6BZeWucJ
+        nEbwoziDHnrhSDlNnGnhhcXbRT04b13Yges6kkgghJYkpkaTymBaDJoShNB3kxLToqBREjjeSUdB
+        M3PuVCmfFaAQ9CjqzOBR/AjpeUzYHXwlacgoNCyAYeRA4Jn3qU4ZbGrTBWVAMNirO2AW0WBQjOMk
+        /rdi3vfb8df8BAphn58VxuiiYtApOSXmpKJHQe/JXx+cyjB5Qy90SAuoTvZT5SuaD7IX7nqtDJqW
+        qj2NH2JC6f07DpcZQhg5XHkPNQ2LXiSlyxq6DuXEPVtRxIZ0rJxNxI2jK1uKJAdnqFJ3srIGBz/d
+        VJH2Q5dtKnU9CaY3k/z0rjxG8+0clTUsHZ7/v7jZnDfN9aj4QFJzdDpOTmHd0J0tdJp0y85MqxmU
+        ixk4n3Ch3FcXh13Owf5SowzB4HGwhXURa3/y+yEb1NyAC1d2u3y8/TV+4eFzm3mB9lxYXrX6s4tv
+        l+8B7/HO2/+IWlnRXwguN/MMh3i97o4ULSom/rebt/8BAAD//wMAjn9Wun8HAAA=
+    headers:
+      CF-RAY:
+      - 9a8015df9d14deb6-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Dec 2025 03:47:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '3485'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '3488'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999965'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_92e85e76a5164665a000d62be10007ff
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_context_call_stream_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_context_call_stream_method.yaml
@@ -1,0 +1,614 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a adventure book.","role":"user"}],"model":"gpt-4o-mini","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '119'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: 'event: response.created
+
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_0621bba1937c003f00692fb2ef3a1081909de7267bd49043df","object":"response","created_at":1764733679,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.in_progress
+
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_0621bba1937c003f00692fb2ef3a1081909de7267bd49043df","object":"response","created_at":1764733679,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+
+        event: response.output_item.added
+
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+
+        event: response.content_part.added
+
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"I","logprobs":[],"obfuscation":"qFC6F6fbyDfekML"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        recommend","logprobs":[],"obfuscation":"dOMcRB"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        **","logprobs":[],"obfuscation":"BXCcmfMwwHrOK"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"vpmVWwqHVeJm51x"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"The","logprobs":[],"obfuscation":"SZG4oShDm0UXs"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        Hobbit","logprobs":[],"obfuscation":"Q9miMMZ3R"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"\"","logprobs":[],"obfuscation":"w959qmNXh054Fue"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        by","logprobs":[],"obfuscation":"XVGl5D2e4fnwn"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":12,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        J","logprobs":[],"obfuscation":"8lZiCZvYdPLsJy"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":13,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":".R","logprobs":[],"obfuscation":"BLRPSmDEX1Xwyt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":14,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":".R","logprobs":[],"obfuscation":"HsbovjCGReZAnT"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":15,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"VgDe42ZpVyYgr4M"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":16,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        Tolkien","logprobs":[],"obfuscation":"gWIP1axy"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":17,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"**","logprobs":[],"obfuscation":"qCU3ySdmiZ8u3I"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":18,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"Uox9DsdJZXV3rPX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":19,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        This","logprobs":[],"obfuscation":"KKrHBK5A5NZ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":20,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        classic","logprobs":[],"obfuscation":"Qw1PpTJY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":21,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        adventure","logprobs":[],"obfuscation":"ff3xLN"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":22,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        novel","logprobs":[],"obfuscation":"yIflo07V4t"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":23,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        follows","logprobs":[],"obfuscation":"dKmwZtae"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":24,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"BruGXdgsqTn5"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":25,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        journey","logprobs":[],"obfuscation":"nMcek4Zt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":26,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"bz2myo8aUtbOr"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":27,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        Bil","logprobs":[],"obfuscation":"27LT6rkgPF4k"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":28,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"bo","logprobs":[],"obfuscation":"ohNKKbClLXCDw5"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":29,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        B","logprobs":[],"obfuscation":"IDNeJDZ6sQUUBY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":30,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"agg","logprobs":[],"obfuscation":"E2sNZCR8LUizO"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":31,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"ins","logprobs":[],"obfuscation":"0hYUfevVSrwwH"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":32,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"mfJ8mQzWE3AHsm6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":33,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"fSWPw3bZVcfXPX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":34,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        hob","logprobs":[],"obfuscation":"qicxSyMEl1FW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":35,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"bit","logprobs":[],"obfuscation":"bU5to9ggdABmx"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":36,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        who","logprobs":[],"obfuscation":"JDXPgqygoVFG"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":37,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        is","logprobs":[],"obfuscation":"n3yRlRzHYWzAt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":38,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        unexpectedly","logprobs":[],"obfuscation":"Je6"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":39,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        swept","logprobs":[],"obfuscation":"VfuxNsA6fQ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":40,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        into","logprobs":[],"obfuscation":"uP0jm5i414C"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":41,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"05xpjncsb4Bb03"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":42,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        quest","logprobs":[],"obfuscation":"2nEffBL0oz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":43,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        to","logprobs":[],"obfuscation":"7CXvWT3sUXYXP"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":44,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        help","logprobs":[],"obfuscation":"6Yr110RJQIa"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":45,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"390GnvNE4LIsSx"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":46,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        group","logprobs":[],"obfuscation":"VUBqNgSssX"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":47,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"Y1DJPn9yEoeSo"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":48,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        dwar","logprobs":[],"obfuscation":"8ExGTB4FpBr"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":49,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"ves","logprobs":[],"obfuscation":"nM3aA7yzLGy9d"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":50,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        reclaim","logprobs":[],"obfuscation":"HGUrhPn3"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":51,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        their","logprobs":[],"obfuscation":"ErY7gefvnY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":52,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        homeland","logprobs":[],"obfuscation":"Ysm4nSJ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":53,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        from","logprobs":[],"obfuscation":"vUdxnOu85Mb"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":54,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        the","logprobs":[],"obfuscation":"VVtYP60HVIlb"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":55,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        dragon","logprobs":[],"obfuscation":"rO0ryKEJ9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":56,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        Sm","logprobs":[],"obfuscation":"TyHXyBWP6bKUy"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":57,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"aug","logprobs":[],"obfuscation":"ElFsdunfiGcDu"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":58,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"D6FSc0YPGYwZ9Ni"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":59,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        With","logprobs":[],"obfuscation":"UGbV7jfw1qF"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":60,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        rich","logprobs":[],"obfuscation":"AnEhNPWHGMz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":61,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        world","logprobs":[],"obfuscation":"EC5VcGL03P"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":62,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"-building","logprobs":[],"obfuscation":"yvZmIpg"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":63,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"0dtnTEjpyjVu1X7"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":64,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        memorable","logprobs":[],"obfuscation":"HnkFob"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":65,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        characters","logprobs":[],"obfuscation":"h6Rdn"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":66,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"Z1nXMxynhYgbqEi"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":67,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        and","logprobs":[],"obfuscation":"1RbW3z35QPnA"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":68,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        plenty","logprobs":[],"obfuscation":"RPHU0bx9Y"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":69,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"m560hDw7sOmTt"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":70,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        excitement","logprobs":[],"obfuscation":"UYuYN"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":71,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"iKbkvZLpFcLOwe9"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":72,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        it''s","logprobs":[],"obfuscation":"pFEtrTUhJ2o"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":73,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        a","logprobs":[],"obfuscation":"o9XqavqqY7Ehft"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":74,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        perfect","logprobs":[],"obfuscation":"4COJyFiL"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":75,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        choice","logprobs":[],"obfuscation":"bCXp3V8NW"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":76,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        for","logprobs":[],"obfuscation":"dSdxv0fR2sI4"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":77,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        readers","logprobs":[],"obfuscation":"ZPQlIXdg"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":78,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        of","logprobs":[],"obfuscation":"E0oPXQiQEgNad"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":79,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        all","logprobs":[],"obfuscation":"itrdScYTyosa"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":80,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        ages","logprobs":[],"obfuscation":"jIWX9zuPGbl"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":81,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        looking","logprobs":[],"obfuscation":"lQRFMNca"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":82,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        for","logprobs":[],"obfuscation":"mkrKrHGVRWWQ"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":83,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        an","logprobs":[],"obfuscation":"GCimXUMirXfjz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":84,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        engaging","logprobs":[],"obfuscation":"X6TgsmY"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":85,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":"
+        adventure","logprobs":[],"obfuscation":"fFKUbz"}
+
+
+        event: response.output_text.delta
+
+        data: {"type":"response.output_text.delta","sequence_number":86,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"kmPtbPJD4MYcAfM"}
+
+
+        event: response.output_text.done
+
+        data: {"type":"response.output_text.done","sequence_number":87,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure novel
+        follows the journey of Bilbo Baggins, a hobbit who is unexpectedly swept into
+        a quest to help a group of dwarves reclaim their homeland from the dragon
+        Smaug. With rich world-building, memorable characters, and plenty of excitement,
+        it''s a perfect choice for readers of all ages looking for an engaging adventure.","logprobs":[]}
+
+
+        event: response.content_part.done
+
+        data: {"type":"response.content_part.done","sequence_number":88,"item_id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure novel
+        follows the journey of Bilbo Baggins, a hobbit who is unexpectedly swept into
+        a quest to help a group of dwarves reclaim their homeland from the dragon
+        Smaug. With rich world-building, memorable characters, and plenty of excitement,
+        it''s a perfect choice for readers of all ages looking for an engaging adventure."}}
+
+
+        event: response.output_item.done
+
+        data: {"type":"response.output_item.done","sequence_number":89,"output_index":0,"item":{"id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure novel
+        follows the journey of Bilbo Baggins, a hobbit who is unexpectedly swept into
+        a quest to help a group of dwarves reclaim their homeland from the dragon
+        Smaug. With rich world-building, memorable characters, and plenty of excitement,
+        it''s a perfect choice for readers of all ages looking for an engaging adventure."}],"role":"assistant"}}
+
+
+        event: response.completed
+
+        data: {"type":"response.completed","sequence_number":90,"response":{"id":"resp_0621bba1937c003f00692fb2ef3a1081909de7267bd49043df","object":"response","created_at":1764733679,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_0621bba1937c003f00692fb2ef8ff88190829751bdd48f2fe2","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"I
+        recommend **\"The Hobbit\" by J.R.R. Tolkien**. This classic adventure novel
+        follows the journey of Bilbo Baggins, a hobbit who is unexpectedly swept into
+        a quest to help a group of dwarves reclaim their homeland from the dragon
+        Smaug. With rich world-building, memorable characters, and plenty of excitement,
+        it''s a perfect choice for readers of all ages looking for an engaging adventure."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":16,"input_tokens_details":{"cached_tokens":0},"output_tokens":84,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":100},"user":null,"metadata":{}}}
+
+
+        '
+    headers:
+      CF-RAY:
+      - 9a8015f68ef0deb6-NRT
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 03 Dec 2025 03:47:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '33'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '36'
+      x-request-id:
+      - req_fd212242acb24496a2cf57133d09d244
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_context_call_with_tags.yaml
+++ b/python/tests/ops/cassettes/test_traced_context_call_with_tags.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a science fiction book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '111'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RVwW4jNwy95yuIuSwQxME4duw45wLFoj1uT7vFgJY4HjUacUpRToxF/r2Qxh7b
+        3eQ25qOeyEfx+ecNQOVs9QyVUBya2tYrM18/LpaP23r9uKjr1eahrTfrFbUr8zTfrDe43SzaxWa7
+        XJr5U03VXabg7T9k9ETDIR7jRgiVbIMZm69Xy9WmftgsCxYVNcV8xnA/eFKy46EtmpedcAq5rhZ9
+        pDHsvHdhVz3DzxsAgGrAA0k+b2lPngeS6gbgvSSTCGcsJO9LwIXTLY0lRefjNRpVklHH4Sre41vD
+        SYekjfIL/Qoqs28M+mu6ni35XNlu0NmSZ70LbvZQPyxn9Xo2fzpqVnirZ/he2hmbmsbRx93n03h6
+        XNgyjW1b26VZL+lx80g4XxXmwqKHgQoPxYg7OgOfyV5Aw0EpnIu6LOyK9iQKvel0uiRgCKx4EvL7
+        31eg590gvP0AKUTPUH0FIcN9T8HC7e2P6ltH8JuLA8dIMZL9UcH2AH9JTB7hj3v4k+D35MLt7T18
+        61wE7TjtOp0Nwnt+cWEHgffkgd4Gz0I5gXqKwC1gQDGdi/0dGBycoi/fGGxOgoCahHJiZONID6Cd
+        ZPKCegqFRF8ZsmiCUfNtryzexmfgQKAdKuzRJ4rggnV7Z1O5pNzxSui1K58YWDuS8cAg3LNShCxD
+        CujBu32mzpn0b2bQw9T4lwiv5P3MCLZKFkyHgkZJYsl3QcUZVBoLm22T8zaTjYsJCOJMBwFFUN3+
+        WLPp0HsKO4oghDaTKYNQ68kocMgKOAF+DUdt0MO4P0ko3sNX/RIBwXiM0ZkjJwd1IUtRqCKHfL+y
+        xcN9Nb2E9+PX9DgqYV8eXKaKikHH5JxYkqoBJVfrr1dRJY2uMQjtHafYnIypKfs1rWqWe9DGoOmo
+        eaHDp5hQ3gzH4TJDCCOHK1eitmXRi6S8c6nvUU7ck0lFbEkPjbOZuHV0ZViRZO8MNepOJtdi8uO2
+        VVFZ6LJNpX4gKU82O+19fYyWrTpW1rL0eP59sc0lb9T1WPGeZMvR6WH0EOtSfzbXUemOnRlHk5Sr
+        CTgvd6U8NBcrX0/B4bJGScHgUdjKuohbf/onSMW6pgZcuDLi+fru1/iFu09tlgHa88H6qtX/+/tm
+        8RHwEe80/c+olRX9RcHzetIwxetx96RoUTHzv9+8/wcAAP//AwB+L1bRmQcAAA==
+    headers:
+      CF-RAY:
+      - 9a7bf2c46b6f6870-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 15:44:58 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=9UnlL5wDvahCfJSzhHcpGWglbfzXofmk_BZ1.Df2jOI-1764690298-1.0.1.1-eHBY5LG5yLPdK5B.gnjE0SSfVpWlZt8V.OBe.vNUMhJScxdA02QyoatXczjZVGDY_6MpXDnUYinJ4LpadMZ6VLKG0JrrlpLmJu9hfkbvHUM;
+        path=/; expires=Tue, 02-Dec-25 16:14:58 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=l4mB_MVz1H6mK_gv23nUCNeOYfwVWEBh.BEg85WirPM-1764690298207-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '3219'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '3226'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999964'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_9e395c0e7ee4416d882bff3bc05d22b6
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_context_call_wrapped_call_method.yaml
+++ b/python/tests/ops/cassettes/test_traced_context_call_wrapped_call_method.yaml
@@ -1,0 +1,115 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a historical book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '106'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3xVTW/jOAy991cQvixQpIWT5vu2h8ViDrt76AA9zAwMWqZtTWTRkKhMg0H/+0Jy
+        7CQ77d4SPurp8VGkf94BZLrK9pA58n2R15unbbUqSe2W9Uo95fl6t6jzTYmrZb7cznebcrFYqfnT
+        drFZVjXVmM0iBZffSclIw9bTEFeOUKgqMGLzzXq53u62qzxhXlCCj2cUd70hoWo4VKI6NI6Djbpq
+        NJ6GsDZG2ybbw887AICsxxO5eL6iIxnuyWV3AG8pmZzjiNlgTApoO95SVCSojb9FvbigRLO9iXf4
+        WnCQPkghfKBfQWE2hUJzS9dxRSYqa3p5WPJDp61+WOSL5UO+eZhvz54l3mwPX1I5Q1FTOzrf/E83
+        qppSN7a4Knfr9Yby5WKj6CkxJxY59ZR4yHts6AJ8ZHsCFVshexF1LeyGdjSFXmU6nRLQWhYcjfzy
+        7QY03PSOy3eQRLSH7BM4Utx1ZCu4v/+afW4JXtB10gLX8I+05OA5WL+HiPzRawXPwu4U0d87clrh
+        bx7+jM8O/tKNS0q+ZlCe4JPHkgy8aHMg59ne3z/C51Z7iD5QelvQai8cSQxYdPH0kUC1jq1WhjxI
+        S/Cdg7M03FjHXDvebD38aBk6PlIFteMu5bvg0MAzB2lBGIIr0YIiK+Q8aJty/mYnLaCt4IW8QEny
+        g8jCfDdfpeh8t8mjWsehadOJpJN8VCGtIwJtK33UVUDjZ5cigV57w+4svXdcx7kCz0qjmYEKRqK8
+        WbqlZ6MlFa9atA15KNOFAlhykGiiRMO60dgZdHiIvmkBywJszQnQAnlPVjQacIQVlEFS1DbYxOx0
+        V5KHBgzzAVAAoddHFjTQcUdWojWjr+e+nB6z6c28nX9NzyhzbNLTRO+1F7QyJMfElJT16NAYMrdD
+        Ky4M+6V3dNQcfDGusCJN4jTUveOul0Khaqk40OlDzFGcIc32OsMRerY3+4vqmp1cJcXpDF2HbuSe
+        1pnHmuRU6CoS15puVpsnd9SKCtHjOqwxmGEus+gbXZcp1PXkUEIKzx/zczTN31lZza7Dy/+ruU95
+        g69nxUdyJXstp2HbVDp0lzU8ON2yVkNrgnA2AZc1kAn3xdVyyKdgf63RBavwbGxWaY+lGb8ZIS25
+        qQBtb1b2fD37NX71HZjKTA2sLgfzm1L/+yWY55v3kPeIp/Z/xC3x6V9RL54mE4O/7XdHghUKRv63
+        u7d/AQAA//8DAAQhz73EBwAA
+    headers:
+      CF-RAY:
+      - 9a7be7e9a959d4af-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 02 Dec 2025 15:37:33 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=HBT7FSMI3KxNBIGl7q.8xqcWQSXqMH4ghGvuEs8WBH8-1764689853-1.0.1.1-xlMS4K2SVMKIOQBXKRRC6zG5tnDP5HiQFiJ.wo13fuLg2CYCRPONByProAi3rzkMptRZauLGY5HkZRJ7qQtr7d9Gbs6kDWKHpYG6FwpR8.8;
+        path=/; expires=Tue, 02-Dec-25 16:07:33 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=wwZl1FCPNBYUDAUqRV9i2h3nH3hv1JZpji7_y8rRPIQ-1764689853232-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2843'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2846'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999965'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_dd14018e03244797a0cccd127d4d70e1
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/cassettes/test_traced_context_call_wrapped_returns_trace.yaml
+++ b/python/tests/ops/cassettes/test_traced_context_call_wrapped_returns_trace.yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"input":[{"content":"As a librarian, Recommend a biography book.","role":"user"}],"model":"gpt-4o-mini"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '105'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.15
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//fFRNb+NGDL3nVxC6BAgcQ44df+S2KLDoXovedguBGlESm9FQmKFSC4v8
+        92JGtmx3k54s8eP58VF8P+8AMq6yF8g8hb7In+sN0r5cPz2Xuzpf5/n28FSX6y3m++1+vzpsDptD
+        tdusV4fd+lCVq+dsESGk/JuMnmHEBZrixhMqVQXG3Gq33ezW633+lHJBUYcQe4x0vSWlamoq0bw2
+        XgYXedVoA01htpZdk73AzzsAgKzHkXzsr+iNrPTkszuA91RM3kvMucHaFGB3/peiIkW24TYb1A9G
+        WdxNvMNjIYP2gxYqr/RrUkVsYdDewnVSkY3Mml4fN/LYsePHp/xp85jvHlf7k2YJN3uB72mcaah5
+        HV1o/mcbm/VhE7ex39aIVW0OBjflLs8TckLRsaeEQyFgQ5fEZ7KnpBGn5C6krondwJ5FoaPO3akA
+        nRPFs5Df/7pJWml6L+UHmQT0Atk38GSk68hV8PDwI/ti6YiuIg+/Y8dWxf3IoBzhD3HwW0veyT8P
+        D0v4s+UAcR5PLbnAbwQlS+Oxb0dwoiDOjnBaPGhLYLkmkBrEpZ8vHXk2eB/ga/zw2DXwFbUlH6Ac
+        FNAGAanr+M4ucNNqfFBJWC0HldhuIQl41AgZKSl3tDwTvQ/g0HvUSM9gr4OnMM91HwC7kpVlCBB6
+        9qwLmFZ0ZGUKC0BXgcWgkR13PZo415m6g14sK5uQ6siIk45NWMI3vQ9ArsEmNqbkUSeV7AieAqE3
+        LVUL6PA1YSsgNPF0wRNWUIsHdGOUip2Sp6BUAbvT4OMCLGFFPrTcL0D8hZIZbJxymc27fj89zevP
+        vNj0SWEIHBSdTsWxMBVlPXq0luztsakfJl/oPb1F0Yqz9RTpguZj7L10vRYGTUvFK42f5jzFb5/F
+        XVd4wiDuxneorsXrVVG8qqHr0J+xZxsKWJOOBVcRuGa6saRA/o0NFcpnG6txsNM9ZVFYuh5TqevJ
+        Y5QzeukyP0XT3ZyY1eI7vLxf3Wuqm3Q9MX4jX0pgHSeXqHjoLvY5Kd0Km2k1g0o2Jy7nm6n0xdVR
+        53Owv+boB2fwJGxWccDSnr1+SOY0D8DuxmpX28Wv8Sv/nsdMC6wujfnNqP918P3zR4mPcOftfwat
+        omivCOerWcMh3K67I8UKFSP++937vwAAAP//AwDwrvBtewcAAA==
+    headers:
+      CF-RAY:
+      - 9a8018f61851546d-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 03 Dec 2025 03:50:04 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - sotai-i3ryiz
+      openai-processing-ms:
+      - '2459'
+      openai-project:
+      - proj_BrdCBgI2MYOVf6LqjZtIUDev
+      openai-version:
+      - '2020-10-01'
+      x-envoy-upstream-service-time:
+      - '2462'
+      x-ratelimit-limit-requests:
+      - '5000'
+      x-ratelimit-limit-tokens:
+      - '4000000'
+      x-ratelimit-remaining-requests:
+      - '4999'
+      x-ratelimit-remaining-tokens:
+      - '3999965'
+      x-ratelimit-reset-requests:
+      - 12ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_c4c73cfef0a544879ee4cfcefda5007a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/ops/test_tracing.py
+++ b/python/tests/ops/test_tracing.py
@@ -2,18 +2,28 @@
 
 from __future__ import annotations
 
+from collections.abc import Generator
 from typing import Any, TypeVar
 
 import pytest
 from inline_snapshot import snapshot
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from mirascope import ops
+from mirascope import llm, ops
 from mirascope.ops._internal.exporters.utils import format_span_id, format_trace_id
 
 from .utils import extract_span_data
 
 T = TypeVar("T")
+
+
+@pytest.fixture(autouse=True, scope="function")
+def initialize() -> Generator[None, None, None]:
+    """Initialize ops configuration and LLM instrumentation for each test."""
+    ops.configure()
+    ops.instrument_llm()
+    yield
+    ops.uninstrument_llm()
 
 
 def test_sync_trace(
@@ -52,14 +62,15 @@ def test_sync_trace(
         }
     )
 
-    wrapped_span = spans[1]
-    context = wrapped_span.get_span_context()
-    assert context is not None
-    assert wrapped_result.span_id == format_span_id(context.span_id)
-    assert wrapped_result.trace_id == format_trace_id(context.trace_id)
+    traced_span = spans[1]
+    traced_context = traced_span.get_span_context()
+    assert traced_context is not None
+    assert wrapped_result.span_id == format_span_id(traced_context.span_id)
+    assert wrapped_result.trace_id == format_trace_id(traced_context.trace_id)
 
-    wrapped_span_data = extract_span_data(wrapped_span)
-    assert wrapped_span_data == span_data
+    call_span = spans[1]
+    call_span_data = extract_span_data(call_span)
+    assert call_span_data == span_data
 
 
 @pytest.mark.asyncio
@@ -99,14 +110,15 @@ async def test_async_trace(
         }
     )
 
-    wrapped_span = spans[1]
-    context = wrapped_span.get_span_context()
-    assert context is not None
-    assert wrapped_result.span_id == format_span_id(context.span_id)
-    assert wrapped_result.trace_id == format_trace_id(context.trace_id)
+    traced_span = spans[1]
+    traced_context = traced_span.get_span_context()
+    assert traced_context is not None
+    assert wrapped_result.span_id == format_span_id(traced_context.span_id)
+    assert wrapped_result.trace_id == format_trace_id(traced_context.trace_id)
 
-    wrapped_span_data = extract_span_data(wrapped_span)
-    assert wrapped_span_data == span_data
+    call_span = spans[1]
+    call_span_data = extract_span_data(call_span)
+    assert call_span_data == span_data
 
 
 def test_sync_trace_no_return_with_tags(
@@ -204,8 +216,8 @@ def test_trace_missing_and_dynamic_type_hints(
     def fn(value: Any, other: Any) -> None: ...  # noqa: ANN401
 
     fn.__annotations__ = {"value": int}
-    fn = ops.trace(fn)
-    fn(1, "no_type_hint")
+    traced_fn = ops.trace(fn)
+    traced_fn(1, "no_type_hint")
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -236,9 +248,9 @@ def test_trace_with_session(span_exporter: InMemorySpanExporter) -> None:
         return x * 2
 
     with ops.session(id="trace-session-123"):
-        result = process(5)
+        wrapped_result = process.wrapped(5)
 
-    assert result == 10
+    assert wrapped_result.result == 10
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -272,9 +284,9 @@ async def test_async_trace_with_session(span_exporter: InMemorySpanExporter) -> 
         return x * 3
 
     with ops.session(id="async-trace-session-456"):
-        result = await process(7)
+        wrapped_result = await process.wrapped(7)
 
-    assert result == 21
+    assert wrapped_result.result == 21
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -307,9 +319,9 @@ def module_level_traced_function(x: int) -> int:
 
 def test_trace_module_level_function(span_exporter: InMemorySpanExporter) -> None:
     """Test @trace decorator on module-level functions (non-local function qualname)."""
-    result = module_level_traced_function(3)
+    wrapped_result = module_level_traced_function.wrapped(3)
 
-    assert result == 12
+    assert wrapped_result.result == 12
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
@@ -326,6 +338,925 @@ def test_trace_module_level_function(span_exporter: InMemorySpanExporter) -> Non
                 "mirascope.trace.arg_types": '{"x":"int"}',
                 "mirascope.trace.arg_values": '{"x":3}',
                 "mirascope.trace.output": 12,
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_call_sync(span_exporter: InMemorySpanExporter) -> None:
+    """Test @ops.trace on @llm.call creates TracedCall and returns Response directly."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    assert isinstance(recommend, ops.TracedCall)
+
+    response = recommend("fantasy")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["fantasy"],"kwargs":{}}',
+                "mirascope.trace.output": 'I recommend **"The Name of the Wind"** by Patrick Rothfuss. It\'s the first book in the *Kingkiller Chronicle* series and follows the story of Kvothe, a gifted young man who grows into a legendary figure. The book beautifully blends magic, music, and storytelling, offering a rich and immersive world. If you enjoy character-driven narratives with a touch of mystery and adventure, this is a great choice!',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_call_wrapped_method(span_exporter: InMemorySpanExporter) -> None:
+    """Test TracedCall.wrapped() returns Trace."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    trace = recommend.wrapped("mystery")
+    assert trace.result.content
+    assert trace.span_id is not None
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["mystery"],"kwargs":{}}',
+                "mirascope.trace.output": 'I recommend "The Girl with the Dragon Tattoo" by Stieg Larsson. This gripping mystery follows journalist Mikael Blomkvist and hacker Lisbeth Salander as they investigate a decades-old disappearance in a wealthy family. The novel expertly weaves elements of suspense, intrigue, and rich character development. It\'s the first in the "Millennium" series, so if you enjoy it, there\'s more to explore!',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_call_wrapped_call_method(span_exporter: InMemorySpanExporter) -> None:
+    """Test TracedCall.wrapped.call() returns Response directly (bypassing Trace)."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    response = recommend("scifi")
+    assert response.content
+    assert hasattr(response, "content")
+    assert not hasattr(response, "span_id")
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["scifi"],"kwargs":{}}',
+                "mirascope.trace.output": 'I recommend **"Dune" by Frank Herbert**. It\'s a classic of science fiction, set on the desert planet of Arrakis, where precious resources and political intrigue shape the fate of its inhabitants. The themes of ecology, religion, and power make it a richly layered read. If you enjoy intricate world-building and deep philosophical questions, this book is a must-read!',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_call_wrapped_stream(span_exporter: InMemorySpanExporter) -> None:
+    """Test TracedCall.wrapped_stream() returns Trace[StreamResponse]."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    trace = recommend.wrapped_stream("adventure")
+    assert trace.span_id is not None
+    trace.result.finish()
+    assert trace.result.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "stream",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "stream",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["adventure"],"kwargs":{}}',
+                "mirascope.trace.output": "**[No Content]**",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_call_call_method(span_exporter: InMemorySpanExporter) -> None:
+    """Test TracedCall.call() returns Response directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    response = recommend.call("fantasy")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["fantasy"],"kwargs":{}}',
+                "mirascope.trace.output": "I recommend **\"The Name of the Wind\"** by Patrick Rothfuss. It's the first book in the *Kingkiller Chronicle* series and follows the story of Kvothe, a gifted young man who grows into a legendary figure. The narrative blends magic, music, and adventure, all while featuring rich world-building and intricate character development. It's a compelling read for any fantasy enthusiast!",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_call_stream_method(span_exporter: InMemorySpanExporter) -> None:
+    """Test TracedCall.stream() returns StreamResponse directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    stream_response = recommend.wrapped_stream("adventure").result
+    stream_response.finish()
+    assert stream_response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "stream",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "stream",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["adventure"],"kwargs":{}}',
+                "mirascope.trace.output": "**[No Content]**",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_call_call_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedAsyncCall.call() returns AsyncResponse directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    response = await recommend.call("horror")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["horror"],"kwargs":{}}',
+                "mirascope.trace.output": 'I highly recommend **"The Cabin at the End of the World" by Paul Tremblay**. It blends psychological horror with existential themes, exploring family dynamics and the impact of fear on human behavior. The tension builds as a family vacation turns into a nightmare when they are confronted by strangers with a terrifying ultimatum. It’s a gripping read that will keep you on the edge of your seat!',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_call_wrapped_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedAsyncCall.wrapped() returns AsyncTrace[AsyncResponse] and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    response = await recommend.wrapped("horror")
+    assert response.result.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["horror"],"kwargs":{}}',
+                "mirascope.trace.output": "I recommend **\"The Haunting of Hill House\" by Shirley Jackson**. It's a classic psychological horror novel that explores the unsettling experiences of a group of people invited to a supposedly haunted mansion. The atmosphere is eerie, and Jackson expertly delves into themes of fear, isolation, and the unknown. It's a must-read for any horror fan!",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_call_stream_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedAsyncCall.stream() returns AsyncStreamResponse directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    stream_response = (await recommend.wrapped_stream("adventure")).result
+    await stream_response.finish()
+    assert stream_response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "stream",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "stream",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["adventure"],"kwargs":{}}',
+                "mirascope.trace.output": "**[No Content]**",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_context_call_call_method(span_exporter: InMemorySpanExporter) -> None:
+    """Test TracedContextCall.call() returns ContextResponse directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = recommend.call(ctx, "fantasy")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["fantasy"],"kwargs":{}}',
+                "mirascope.trace.output": 'I recommend "The Name of the Wind" by Patrick Rothfuss. It\'s the first book in the *Kingkiller Chronicle* series and follows the story of Kvothe, an exceptional young man with a mysterious past. The narrative blends magic, music, and adventure, while its lyrical prose and rich world-building immerse readers in an enchanting realm. The character development and storytelling are particularly compelling. Perfect for anyone looking to dive into a captivating fantasy world!',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_context_call_wrapped_returns_trace(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedContextCall.wrapped() returns Trace[ContextResponse] (not just result)."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    trace = recommend.wrapped(ctx, "biography")
+    assert trace.result.content
+    assert trace.span_id is not None
+
+
+@pytest.mark.vcr()
+def test_traced_context_call_stream_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedContextCall.stream() returns ContextStreamResponse directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    stream_response = recommend.wrapped_stream(ctx, "adventure").result
+    stream_response.finish()
+    assert stream_response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "stream",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "stream",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["adventure"],"kwargs":{}}',
+                "mirascope.trace.output": "**[No Content]**",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_context_call_call_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedAsyncContextCall.call() returns AsyncContextResponse directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = await recommend.call(ctx, "mystery")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["mystery"],"kwargs":{}}',
+                "mirascope.trace.output": "I highly recommend **\"The No. 1 Ladies' Detective Agency\" by Alexander McCall Smith**. This charming mystery features Precious Ramotswe, Botswana's first female detective, as she navigates various cases with her unique perspective and keen intuition. The book blends humor, culture, and intriguing mysteries, making it a delightful read for both mystery enthusiasts and those looking for something different. It’s the first in a series, so if you enjoy it, there’s plenty more to explore!",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_context_call_wrapped_returns_trace(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedAsyncContextCall.wrapped() returns AsyncTrace[AsyncContextResponse] (not just result)."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    trace = await recommend.wrapped(ctx, "biography")
+    assert trace.result.content
+    assert trace.span_id is not None
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_context_call_stream_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedAsyncContextCall.stream() returns AsyncContextStreamResponse directly and creates span."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    stream_response = (await recommend.wrapped_stream(ctx, "adventure")).result
+    await stream_response.finish()
+    assert stream_response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "stream",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "stream",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["adventure"],"kwargs":{}}',
+                "mirascope.trace.output": "**[No Content]**",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_call(span_exporter: InMemorySpanExporter) -> None:
+    """Test @ops.trace on async @llm.call creates TracedAsyncCall and returns AsyncResponse directly."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    assert isinstance(recommend, ops.TracedAsyncCall)
+
+    response = await recommend("horror")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["horror"],"kwargs":{}}',
+                "mirascope.trace.output": "I recommend **\"The Haunting of Hill House\" by Shirley Jackson**. It's a classic gothic horror novel that explores themes of fear, isolation, and the supernatural. The story follows a group of people who stay at an old mansion to study its paranormal activities. Jackson's writing masterfully builds tension and unease, making it a must-read for horror enthusiasts.",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_call_with_tags(span_exporter: InMemorySpanExporter) -> None:
+    """Test @ops.trace(tags=[...]) passes tags to TracedCall."""
+
+    @ops.trace(tags=["production", "recommendations"])
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(genre: str) -> str:
+        return f"Recommend a {genre} book."
+
+    response = recommend("romance")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"args":["romance"],"kwargs":{}}',
+                "mirascope.trace.tags": ("production", "recommendations"),
+                "mirascope.trace.output": 'One great romance book to consider is **"The Hating Game" by Sally Thorne**. It features a fun and engaging enemies-to-lovers storyline set in a corporate office, filled with witty banter and undeniable chemistry. The dynamic between the two main characters, Lucy and Joshua, is both humorous and heartfelt, making for a captivating read. If you enjoy sharp dialogue and a slow-burn romance, this book is definitely worth picking up!',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_context_call(span_exporter: InMemorySpanExporter) -> None:
+    """Test @ops.trace on @llm.call with context creates TracedContextCall and returns ContextResponse directly."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    assert isinstance(recommend, ops.TracedContextCall)
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = recommend(ctx, "fantasy")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["fantasy"],"kwargs":{}}',
+                "mirascope.trace.output": "I recommend **\"The Name of the Wind\" by Patrick Rothfuss**. It's the first book in the *Kingkiller Chronicle* series and follows the journey of Kvothe, a gifted young man who becomes a legendary figure. The story beautifully weaves together magic, music, and adventure, all told with lyrical prose. It's a captivating read for anyone who loves deep world-building and intricate storytelling!",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_context_call(span_exporter: InMemorySpanExporter) -> None:
+    """Test @ops.trace on async @llm.call with context creates TracedAsyncContextCall and returns AsyncContextResponse directly."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    assert isinstance(recommend, ops.TracedAsyncContextCall)
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = await recommend(ctx, "mystery")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["mystery"],"kwargs":{}}',
+                "mirascope.trace.output": "I recommend *The No. 1 Ladies' Detective Agency* by Alexander McCall Smith. This charming mystery features Precious Ramotswe, Botswana's first female detective, who uses her intuition and keen observation skills to solve cases in her community. The book is both engaging and uplifting, offering a unique blend of mystery, humor, and cultural insight. It's the first in a beloved series, making it a great starting point for readers who enjoy cozy mysteries.",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_context_call_wrapped_call_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedContextCall.wrapped.call() returns ContextResponse directly."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = recommend.call(ctx, "historical")
+    assert response.content
+    assert hasattr(response, "content")
+    assert not hasattr(response, "span_id")
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["historical"],"kwargs":{}}',
+                "mirascope.trace.output": 'I recommend **"The Warmth of Other Suns: The Epic Story of America\'s Great Migration" by Isabel Wilkerson**. This compelling historical narrative chronicles the journey of African Americans who moved from the rural South to urban centers in the North and West between 1915 and 1970. Through the stories of three individuals, Wilkerson explores the profound social, cultural, and political changes brought about by this migration, making it not only an essential read but an engaging and personal look at a pivotal moment in American history.',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_context_call_wrapped_call_method(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test TracedAsyncContextCall.wrapped.call() returns AsyncContextResponse directly."""
+
+    @ops.trace
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = await recommend.call(ctx, "thriller")
+    assert response.content
+    assert hasattr(response, "content")
+    assert not hasattr(response, "span_id")
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["thriller"],"kwargs":{}}',
+                "mirascope.trace.output": 'I recommend **"The Girl on the Train" by Paula Hawkins**. This psychological thriller weaves together the lives of three women, exploring themes of obsession, memory, and deception. With its gripping plot and unexpected twists, the story keeps readers on the edge of their seats. The intricately crafted characters and their intertwined narratives make it a captivating read. Perfect for fans of suspenseful, character-driven stories!',
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+def test_traced_context_call_with_tags(span_exporter: InMemorySpanExporter) -> None:
+    """Test @ops.trace(tags=[...]) on @llm.call with context creates TracedContextCall with tags."""
+
+    @ops.trace(tags=["context-tag"])
+    @llm.call("openai:responses/gpt-4o-mini")
+    def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    assert isinstance(recommend, ops.TracedContextCall)
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = recommend(ctx, "science fiction")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": False,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["science fiction"],"kwargs":{}}',
+                "mirascope.trace.tags": ("context-tag",),
+                "mirascope.trace.output": "I recommend **\"The Dispossessed\" by Ursula K. Le Guin**. This thought-provoking novel explores themes of anarchism, capitalism, and the nature of society through the lens of two contrasting worlds: one that values individualism and wealth and another that promotes communal living and equality. Le Guin's well-crafted characters and intricate world-building create a rich narrative that challenges readers to reflect on their own societal structures. It's a classic that continues to resonate today.",
+            },
+            "status": {"status_code": "UNSET", "description": None},
+            "events": [],
+        }
+    )
+
+
+@pytest.mark.vcr()
+@pytest.mark.asyncio
+async def test_traced_async_context_call_with_tags(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    """Test @ops.trace(tags=[...]) on async @llm.call with context creates TracedAsyncContextCall with tags."""
+
+    @ops.trace(tags=["async-context-tag"])
+    @llm.call("openai:responses/gpt-4o-mini")
+    async def recommend(ctx: llm.Context[str], genre: str) -> str:
+        return f"{ctx.deps} Recommend a {genre} book."
+
+    assert isinstance(recommend, ops.TracedAsyncContextCall)
+
+    ctx = llm.Context(deps="As a librarian,")
+    response = await recommend(ctx, "dystopian")
+    assert response.content
+
+    spans = span_exporter.get_finished_spans()
+    trace_spans = [
+        span
+        for span in spans
+        if (span.attributes or {}).get("mirascope.type") == "trace"
+    ]
+    assert len(trace_spans) == 1
+
+    span_data = extract_span_data(trace_spans[0])
+    assert span_data == snapshot(
+        {
+            "name": "call",
+            "attributes": {
+                "mirascope.type": "trace",
+                "mirascope.fn.qualname": "call",
+                "mirascope.fn.module": "mirascope.llm.calls.calls",
+                "mirascope.fn.is_async": True,
+                "mirascope.trace.arg_types": '{"ctx":"Context","args":"P.args","kwargs":"P.kwargs"}',
+                "mirascope.trace.arg_values": '{"ctx":{"deps":"As a librarian,"},"args":["dystopian"],"kwargs":{}}',
+                "mirascope.trace.tags": ("async-context-tag",),
+                "mirascope.trace.output": "I recommend **\"The Handmaid's Tale\" by Margaret Atwood**. Set in a totalitarian society where women are stripped of their rights, the novel explores themes of gender, power, and individuality. Atwood's rich prose and compelling characters make it a thought-provoking read that remains relevant today. It also raises important questions about autonomy and society's role in personal freedoms. Perfect for anyone interested in dystopian fiction!",
             },
             "status": {"status_code": "UNSET", "description": None},
             "events": [],

--- a/python/tests/ops/utils.py
+++ b/python/tests/ops/utils.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Mapping
 from contextlib import suppress
 from typing import TypedDict
 
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.util.types import AttributeValue
+
+_OBJECT_ADDRESS_PATTERN = re.compile(r" at 0x[0-9a-fA-F]+")
 
 
 class SpanStatus(TypedDict):


### PR DESCRIPTION
### TL;DR

Added call-level tracing for `@llm.call` decorated functions, allowing developers to trace and monitor LLM calls with OpenTelemetry.

### What changed?

- Added a new `trace` parameter to the `@llm.call` decorator that accepts a configuration dictionary or `False` to opt out
- Implemented tracing infrastructure for all call types (sync/async, regular/context, call/stream)
- Added `TraceConfig` type to configure span names and tags
- Modified the `instrument_llm()` function to accept a `trace_calls` parameter that enables global call tracing
- Created span handling for streaming responses that properly closes spans when streams complete
- Added automatic argument and return value capture for better observability

### How to test?

```python
from mirascope import llm, ops

# Enable call tracing globally
ops.instrument_llm(trace_calls=True)

# Add trace configuration to specific calls
@llm.call(
    provider="openai",
    model_id="gpt-4o-mini",
    trace={"tags": ["production"], "name": "answer_query"}
)
def answer_question(question: str) -> str:
    return f"Answer: {question}"

# Call the function - a trace span will be emitted
response = answer_question("What is the capital of France?")
```

### Why make this change?

This change enhances observability for LLM applications by providing function-level tracing. It allows developers to:

1. Monitor the performance and behavior of specific LLM calls
2. Tag important calls for filtering in observability systems
3. Capture input arguments and output responses for debugging
4. Track streaming responses properly through completion
5. Integrate with existing OpenTelemetry infrastructure for comprehensive application monitoring

This is particularly valuable in production environments where understanding LLM call patterns and performance is critical.