### PR TITLE
refactor: allow passing models by ModelId or Model

### DIFF
--- a/python/examples/intro/parameters/model.py
+++ b/python/examples/intro/parameters/model.py
@@ -3,7 +3,7 @@ from mirascope import llm
 
 def recommend_book(genre: str) -> llm.Response:
     model = llm.use_model(
-        model_id="openai/gpt-5",
+        "openai/gpt-5",
         temperature=1,  # [!code highlight]
     )
     message = llm.messages.user(f"Please recommend a book in {genre}.")

--- a/python/tests/llm/calls/test_decorator.py
+++ b/python/tests/llm/calls/test_decorator.py
@@ -157,6 +157,18 @@ class TestCall:
         with pytest.raises(ValueError, match="Invalid model_id format"):
             llm.call("really-cool-model-i-heard-about")
 
+    def test_call_decorator_accepts_model_instance(self) -> None:
+        """Test that llm.call() accepts a Model instance."""
+        model = llm.Model("openai/gpt-4o", max_tokens=100)
+
+        @llm.call(model)
+        def test_fn() -> str:
+            return "test"
+
+        assert test_fn.default_model.provider == "openai"
+        assert test_fn.default_model.model_id == "openai/gpt-4o"
+        assert test_fn.default_model.params.get("max_tokens") == 100
+
 
 class TestContextCall:
     """Tests for context call decorator (with context dependency)."""

--- a/python/tests/llm/models/test_model.py
+++ b/python/tests/llm/models/test_model.py
@@ -55,3 +55,23 @@ def test_value_error_invalid_models() -> None:
 
     with pytest.raises(ValueError, match="Invalid model_id format"):
         llm.call("really-cool-model-i-heard-about")
+
+
+def test_use_model_accepts_model_instance() -> None:
+    """Test that use_model accepts a Model instance."""
+    model_instance = llm.Model("anthropic/claude-sonnet-4-0", temperature=0.7)
+    model = llm.use_model(model_instance)
+
+    assert model.provider == "anthropic"
+    assert model.model_id == "anthropic/claude-sonnet-4-0"
+    assert model.params.get("temperature") == 0.7
+
+
+def test_model_context_accepts_model_instance() -> None:
+    """Test that llm.model() accepts a Model instance."""
+    model_instance = llm.Model("anthropic/claude-sonnet-4-0", temperature=0.8)
+
+    with llm.model(model_instance) as model:
+        assert model.provider == "anthropic"
+        assert model.model_id == "anthropic/claude-sonnet-4-0"
+        assert model.params.get("temperature") == 0.8


### PR DESCRIPTION
This changes `llm.call`, `llm.model` and `llm.use_model` so that they
all can accept either `ModelId` with params, or `Model` without params.

Also, `llm.model` now returns the `Model` for convenience.

Some docstring improvements were also made.