### PR TITLE
Add VersionInfo dataclass to ops module

### DIFF
--- a/python/mirascope/ops/__init__.py
+++ b/python/mirascope/ops/__init__.py
@@ -45,6 +45,7 @@ try:
         AsyncVersionedFunction,
         VersionDecorator,
         VersionedFunction,
+        VersionInfo,
         version,
     )
     from .exceptions import ClosureComputationError
@@ -95,6 +96,7 @@ except ImportError:  # pragma: no cover
     AsyncVersionedFunction = _create_otel_import_error_stub("AsyncVersionedFunction")
     VersionDecorator = _create_otel_import_error_stub("VersionDecorator")
     VersionedFunction = _create_otel_import_error_stub("VersionedFunction")
+    VersionInfo = _create_otel_import_error_stub("VersionInfo")
     version = _create_otel_import_error_stub("version")
 
 
@@ -116,6 +118,7 @@ __all__ = [
     "TracedContextCall",
     "TracedFunction",
     "VersionDecorator",
+    "VersionInfo",
     "VersionedFunction",
     "configure",
     "current_session",

--- a/python/mirascope/ops/_internal/versioning.py
+++ b/python/mirascope/ops/_internal/versioning.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Generator, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, NewType, overload
@@ -58,6 +58,45 @@ class AsyncVersionedResult(AsyncTrace[R]):
     """
 
     function_uuid: str | None = None
+
+
+@dataclass(kw_only=True, frozen=True)
+class VersionInfo:
+    """Static version metadata for a versioned function.
+
+    Contains all information needed to identify and describe a specific version
+    of a function, including its computed version number and hashes.
+    """
+
+    uuid: str | None
+    """Server-assigned unique identifier for this version (None if not registered)."""
+
+    hash: str
+    """SHA256 hash of the complete closure code."""
+
+    signature_hash: str
+    """SHA256 hash of the function signature."""
+
+    name: str
+    """Display name for the versioned function."""
+
+    description: str | None
+    """Human-readable description of the versioned function."""
+
+    version: str
+    """Auto-computed semantic version in X.Y format."""
+
+    tags: tuple[str, ...]
+    """Tags associated with this version for filtering/classification."""
+
+    metadata: Mapping[str, str]
+    """Arbitrary key-value pairs for additional metadata."""
+
+    # This will be covered in the next PR in this stack...
+    def __post_init__(self) -> None:  # pragma: no cover
+        """Clean up tags and initialize frozen metadata after dataclass init."""
+        object.__setattr__(self, "tags", tuple(sorted(set(self.tags or []))))
+        object.__setattr__(self, "metadata", dict(self.metadata))
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
### TL;DR

Added a new `VersionInfo` dataclass to store and expose version metadata for versioned functions.

### What changed?

- Created a new `VersionInfo` dataclass in `versioning.py` that contains all information needed to identify and describe a specific version of a function
- Added the class to the appropriate import/export statements in `__init__.py`
- Added unit tests to verify the dataclass can be instantiated with various field combinations

### How to test?

Run the new unit tests that verify the `VersionInfo` dataclass:
```bash
pytest python/tests/ops/test_versioning.py::test_version_info_instantiation python/tests/ops/test_versioning.py::test_version_info_with_none_values
```

### Why make this change?

This change provides a structured way to access and store version metadata for functions. The `VersionInfo` class encapsulates all the version-related information (UUID, hashes, version numbers, tags, etc.) in a single, well-defined object, making it easier to work with versioned functions and their metadata throughout the codebase.