### PR TITLE
refactor: clean up cloud/auth module effect usage patterns

### DIFF
--- a/cloud/auth/utils.ts
+++ b/cloud/auth/utils.ts
@@ -1,6 +1,3 @@
-/**
- * Check if secure cookies should be used based on environment
- */
 function isSecure(): boolean {
   return (
     process.env.ENVIRONMENT === "production" ||
@@ -8,9 +5,6 @@ function isSecure(): boolean {
   );
 }
 
-/**
- * Extract a cookie value from a request by name
- */
 function getCookieValue(request: Request, name: string): string | null {
   const cookieHeader = request.headers.get("Cookie");
   if (!cookieHeader) return null;
@@ -25,23 +19,14 @@ function getCookieValue(request: Request, name: string): string | null {
   return null;
 }
 
-/**
- * Extract session ID from request cookie
- */
 export function getSessionIdFromCookie(request: Request): string | null {
   return getCookieValue(request, "session");
 }
 
-/**
- * Extract OAuth state from request cookie
- */
 export function getOAuthStateFromCookie(request: Request): string | null {
   return getCookieValue(request, "oauth_state");
 }
 
-/**
- * Generate cookie header value for setting a session
- */
 export function setSessionCookie(sessionId: string): string {
   const maxAge = 7 * 24 * 60 * 60; // 7 days in seconds
 
@@ -57,9 +42,6 @@ export function setSessionCookie(sessionId: string): string {
   return cookieParts.join("; ");
 }
 
-/**
- * Generate cookie header value for clearing a session
- */
 export function clearSessionCookie(): string {
   const cookieParts = [
     "session=;",
@@ -73,9 +55,6 @@ export function clearSessionCookie(): string {
   return cookieParts.join("; ");
 }
 
-/**
- * Generate cookie header value for OAuth state
- */
 export function setOAuthStateCookie(state: string): string {
   const cookieParts = [
     `oauth_state=${state}`,
@@ -89,9 +68,6 @@ export function setOAuthStateCookie(state: string): string {
   return cookieParts.join("; ");
 }
 
-/**
- * Generate cookie header value for clearing OAuth state
- */
 export function clearOAuthStateCookie(): string {
   const cookieParts = [
     "oauth_state=;",

--- a/cloud/vitest.config.ts
+++ b/cloud/vitest.config.ts
@@ -16,8 +16,11 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html"],
-      // TODO: Add auth to coverage requirements
-      include: ["api", "db"],
+      include: [
+        "api",
+        // "auth", // TODO: Add auth to coverage requirements
+        "db",
+      ],
       exclude: ["**/index.ts", ...coverageConfigDefaults.exclude],
       thresholds: {
         global: {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors OAuth flows into composable Effect helpers, updates user/session processing to use DatabaseService, and adds validated proxy callback handling; minor coverage config tweak.
> 
> - **Auth/OAuth**:
>   - Extracts composable helpers: `validateOAuthParams`, `decodeState`, `validateStateMatch`, `validateTokenResponse`, `exchangeCodeForToken`.
>   - Rewrites `handleOAuthCallback` as an Effect pipeline; appends `clearOAuthStateCookie()` on success.
>   - Updates `processAuthenticatedUser` to depend on `DatabaseService`, return `Effect<..., AuthenticationFailedError | DatabaseError>`, and build redirect with `setSessionCookie`.
>   - Adds proxy flow utilities: `validatePreviewUrl`, `validateProxyParams`, `validateReturnUrl`, `validateProxyStateMatch`, `buildProxyRedirectResponse`, and refactors `handleOAuthProxyCallback` accordingly.
>   - Imports `DatabaseError` and removes direct `Database` param usage.
> - **Tests**:
>   - Tweaks coverage `include` list formatting/comment in `cloud/vitest.config.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8db59c3e6f89d8e0d731f7ad20f6f6586305dbc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->