### PR TITLE
feat: organization structure and db services

### DIFF
--- a/cloud/auth/oauth.ts
+++ b/cloud/auth/oauth.ts
@@ -1,6 +1,6 @@
 import { Effect } from "effect";
 import { DatabaseService, DEFAULT_SESSION_DURATION } from "@/db";
-import { DatabaseError } from "@/db/errors";
+import { AlreadyExistsError, DatabaseError } from "@/db/errors";
 import { EnvironmentService } from "@/environment";
 import {
   OAuthError,
@@ -446,7 +446,7 @@ function processAuthenticatedUser(
   siteUrl: string,
 ): Effect.Effect<
   Response,
-  AuthenticationFailedError | DatabaseError,
+  AuthenticationFailedError | AlreadyExistsError | DatabaseError,
   DatabaseService
 > {
   const validateEmail = (email: string | null) => {

--- a/cloud/db/errors.ts
+++ b/cloud/db/errors.ts
@@ -16,3 +16,15 @@ export class InvalidSessionError extends Data.TaggedError(
   readonly message: string;
   readonly sessionId?: string;
 }> {}
+
+export class AlreadyExistsError extends Data.TaggedError("AlreadyExistsError")<{
+  readonly message: string;
+  readonly resource?: string;
+}> {}
+
+export class PermissionDeniedError extends Data.TaggedError(
+  "PermissionDeniedError",
+)<{
+  readonly message: string;
+  readonly resource?: string;
+}> {}

--- a/cloud/db/migrations/0001_violet_maddog.sql
+++ b/cloud/db/migrations/0001_violet_maddog.sql
@@ -1,0 +1,21 @@
+CREATE TYPE "public"."role" AS ENUM('OWNER', 'ADMIN', 'DEVELOPER', 'ANNOTATOR');--> statement-breakpoint
+CREATE TABLE "organizations" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "organizations_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+CREATE TABLE "organization_memberships" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"organization_id" uuid NOT NULL,
+	"role" "role" NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now(),
+	CONSTRAINT "organization_memberships_user_id_organization_id_unique" UNIQUE("user_id","organization_id")
+);
+--> statement-breakpoint
+ALTER TABLE "organization_memberships" ADD CONSTRAINT "organization_memberships_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "organization_memberships" ADD CONSTRAINT "organization_memberships_organization_id_organizations_id_fk" FOREIGN KEY ("organization_id") REFERENCES "public"."organizations"("id") ON DELETE no action ON UPDATE no action;

--- a/cloud/db/migrations/meta/0001_snapshot.json
+++ b/cloud/db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,257 @@
+{
+  "id": "5b4a843f-6e37-453e-80bc-0e58d819c7db",
+  "prevId": "6831346d-2126-4145-8f9a-d38221132daa",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organizations": {
+      "name": "organizations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organizations_name_unique": {
+          "name": "organizations_name_unique",
+          "nullsNotDistinct": false,
+          "columns": ["name"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.organization_memberships": {
+      "name": "organization_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "organization_memberships_user_id_users_id_fk": {
+          "name": "organization_memberships_user_id_users_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "organization_memberships_organization_id_organizations_id_fk": {
+          "name": "organization_memberships_organization_id_organizations_id_fk",
+          "tableFrom": "organization_memberships",
+          "tableTo": "organizations",
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "organization_memberships_user_id_organization_id_unique": {
+          "name": "organization_memberships_user_id_organization_id_unique",
+          "nullsNotDistinct": false,
+          "columns": ["user_id", "organization_id"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.role": {
+      "name": "role",
+      "schema": "public",
+      "values": ["OWNER", "ADMIN", "DEVELOPER", "ANNOTATOR"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/cloud/db/migrations/meta/_journal.json
+++ b/cloud/db/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1765072957708,
       "tag": "0000_concerned_multiple_man",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1765183454327,
+      "tag": "0001_violet_maddog",
+      "breakpoints": true
     }
   ]
 }

--- a/cloud/db/schema/index.ts
+++ b/cloud/db/schema/index.ts
@@ -1,10 +1,24 @@
 export * from "@/db/schema/sessions";
 export * from "@/db/schema/users";
+export * from "@/db/schema/organizations";
+export * from "@/db/schema/organization-memberships";
 
 export type { PublicSession } from "@/db/schema/sessions";
 export type { PublicUser } from "@/db/schema/users";
+export type { PublicOrganization } from "@/db/schema/organizations";
+export type {
+  PublicOrganizationMembership,
+  PublicOrganizationWithMembership,
+  Role,
+} from "@/db/schema/organization-memberships";
 
 import { users } from "@/db/schema/users";
 import { sessions } from "@/db/schema/sessions";
+import { organizations } from "@/db/schema/organizations";
+import { organizationMemberships } from "@/db/schema/organization-memberships";
 
-export type DatabaseTable = typeof users | typeof sessions;
+export type DatabaseTable =
+  | typeof users
+  | typeof sessions
+  | typeof organizations
+  | typeof organizationMemberships;

--- a/cloud/db/schema/organization-memberships.ts
+++ b/cloud/db/schema/organization-memberships.ts
@@ -1,0 +1,63 @@
+import { relations } from "drizzle-orm";
+import { pgEnum, pgTable, timestamp, unique, uuid } from "drizzle-orm/pg-core";
+import { organizations, type PublicOrganization } from "./organizations";
+import { users } from "./users";
+
+export const roleEnum = pgEnum("role", [
+  "OWNER",
+  "ADMIN",
+  "DEVELOPER",
+  "ANNOTATOR",
+]);
+export const ROLE_VALUES = roleEnum.enumValues;
+
+export const organizationMemberships = pgTable(
+  "organization_memberships",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    userId: uuid("user_id")
+      .references(() => users.id)
+      .notNull(),
+    organizationId: uuid("organization_id")
+      .references(() => organizations.id)
+      .notNull(),
+    role: roleEnum("role").notNull(),
+    createdAt: timestamp("created_at").defaultNow(),
+    updatedAt: timestamp("updated_at").defaultNow(),
+  },
+  (table) => ({
+    userOrgUnique: unique().on(table.userId, table.organizationId),
+  }),
+);
+
+export const organizationMembershipsRelations = relations(
+  organizationMemberships,
+  ({ one }) => ({
+    user: one(users, {
+      fields: [organizationMemberships.userId],
+      references: [users.id],
+    }),
+    organization: one(organizations, {
+      fields: [organizationMemberships.organizationId],
+      references: [organizations.id],
+    }),
+  }),
+);
+
+// Internal types
+export type OrganizationMembership =
+  typeof organizationMemberships.$inferSelect;
+export type NewOrganizationMembership =
+  typeof organizationMemberships.$inferInsert;
+export type Role = (typeof roleEnum.enumValues)[number];
+
+// Public types
+export type PublicOrganizationMembership = Pick<
+  OrganizationMembership,
+  "id" | "role" | "createdAt"
+>;
+
+// Public organization with user's membership role
+export type PublicOrganizationWithMembership = PublicOrganization & {
+  role: Role;
+};

--- a/cloud/db/schema/organizations.ts
+++ b/cloud/db/schema/organizations.ts
@@ -1,0 +1,21 @@
+import { relations } from "drizzle-orm";
+import { pgTable, text, timestamp, uuid } from "drizzle-orm/pg-core";
+import { organizationMemberships } from "./organization-memberships";
+
+export const organizations = pgTable("organizations", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  name: text("name").notNull().unique(),
+  createdAt: timestamp("created_at").defaultNow(),
+  updatedAt: timestamp("updated_at").defaultNow(),
+});
+
+export const organizationsRelations = relations(organizations, ({ many }) => ({
+  memberships: many(organizationMemberships),
+}));
+
+// Internal types
+export type Organization = typeof organizations.$inferSelect;
+export type NewOrganization = typeof organizations.$inferInsert;
+
+// Public types for API responses
+export type PublicOrganization = Pick<Organization, "id" | "name">;

--- a/cloud/db/services/index.ts
+++ b/cloud/db/services/index.ts
@@ -1,5 +1,7 @@
+export * from "@/db/services/base";
 export * from "@/db/services/users";
 export * from "@/db/services/sessions";
+export * from "@/db/services/organizations";
 
 import { Context } from "effect";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -8,10 +10,12 @@ import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import * as schema from "@/db/schema";
 import { UserService } from "@/db/services/users";
 import { SessionService } from "@/db/services/sessions";
+import { OrganizationService } from "@/db/services/organizations";
 
 export type Database = {
   readonly users: UserService;
   readonly sessions: SessionService;
+  readonly organizations: OrganizationService;
 };
 
 export class DatabaseService extends Context.Tag("DatabaseService")<
@@ -35,9 +39,11 @@ export function getDatabase(
 
   const users = new UserService(client);
   const sessions = new SessionService(client);
+  const organizations = new OrganizationService(client);
 
   return {
     users,
     sessions,
+    organizations,
   };
 }

--- a/cloud/db/services/organizations.test.ts
+++ b/cloud/db/services/organizations.test.ts
@@ -1,0 +1,576 @@
+import { describe, it, expect } from "vitest";
+import {
+  withTestDatabase,
+  withErroringService,
+  createPartialMockDatabase,
+} from "@/tests/db";
+import { Effect } from "effect";
+import {
+  AlreadyExistsError,
+  DatabaseError,
+  NotFoundError,
+  PermissionDeniedError,
+} from "@/db/errors";
+import { OrganizationService } from "@/db/services/organizations";
+
+describe("OrganizationService", () => {
+  describe("create", () => {
+    it(
+      "should create an organization and membership",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const created = yield* db.organizations.create(
+            { name: "Test Organization" },
+            user.id,
+          );
+
+          expect(created).toBeDefined();
+          expect(created.id).toBeDefined();
+          expect(created.name).toBe("Test Organization");
+          expect(created.role).toBe("OWNER");
+        }),
+      ),
+    );
+
+    it(
+      "should return AlreadyExistsError when name is taken",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          yield* db.organizations.create({ name: "Duplicate Org" }, user.id);
+
+          const result = yield* Effect.either(
+            db.organizations.create({ name: "Duplicate Org" }, user.id),
+          );
+
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(AlreadyExistsError);
+            expect(result.left.message).toBe(
+              "An organization with this name already exists",
+            );
+          }
+        }),
+      ),
+    );
+  });
+
+  describe("findById", () => {
+    it(
+      "should retrieve organization when user is a member",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const created = yield* db.organizations.create(
+            { name: "Find By Id Org" },
+            user.id,
+          );
+
+          const result = yield* db.organizations.findById(created.id, user.id);
+          expect(result).toBeDefined();
+          expect(result.id).toBe(created.id);
+          expect(result.name).toBe("Find By Id Org");
+        }),
+      ),
+    );
+
+    it(
+      "should return PermissionDeniedError when user is not a member",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const otherUser = yield* db.users.create({
+            email: "other@example.com",
+            name: "Other User",
+          });
+
+          const created = yield* db.organizations.create(
+            { name: "Non Member Read Org" },
+            user.id,
+          );
+
+          const result = yield* Effect.either(
+            db.organizations.findById(created.id, otherUser.id),
+          );
+
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(PermissionDeniedError);
+            expect(result.left.message).toBe(
+              "You do not have permission to read this organization",
+            );
+          }
+        }),
+      ),
+    );
+  });
+
+  describe("update", () => {
+    it(
+      "should update organization when user is admin or owner",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const created = yield* db.organizations.create(
+            { name: "Update Org" },
+            user.id,
+          );
+
+          const updated = yield* db.organizations.update(
+            created.id,
+            { name: "Updated Org Name" },
+            user.id,
+          );
+          expect(updated).toBeDefined();
+          expect(updated.id).toBe(created.id);
+          expect(updated.name).toBe("Updated Org Name");
+        }),
+      ),
+    );
+
+    it(
+      "should return PermissionDeniedError when user lacks permission",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const otherUser = yield* db.users.create({
+            email: "other@example.com",
+            name: "Other User",
+          });
+
+          const created = yield* db.organizations.create(
+            { name: "Non Member Update Org" },
+            user.id,
+          );
+
+          const result = yield* Effect.either(
+            db.organizations.update(
+              created.id,
+              { name: "Should Fail" },
+              otherUser.id,
+            ),
+          );
+
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(PermissionDeniedError);
+            expect(result.left.message).toBe(
+              "You do not have permission to update this organization",
+            );
+          }
+        }),
+      ),
+    );
+  });
+
+  describe("delete", () => {
+    it(
+      "should delete an organization and its memberships",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const created = yield* db.organizations.create(
+            { name: "Delete Test Org" },
+            user.id,
+          );
+
+          yield* db.organizations.delete(created.id, user.id);
+
+          // Organization should be deleted - trying to find it should fail
+          const result = yield* Effect.either(
+            db.organizations.findById(created.id, user.id),
+          );
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            // Could be NotFoundError (not found) or PermissionDeniedError (can't check membership)
+            // Since org is deleted, membership is also deleted, so permission check fails
+            expect(
+              result.left instanceof NotFoundError ||
+                result.left instanceof PermissionDeniedError,
+            ).toBe(true);
+          }
+        }),
+      ),
+    );
+
+    it(
+      "should return NotFoundError when organization does not exist",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const result = yield* Effect.either(
+            db.organizations.delete(
+              "00000000-0000-0000-0000-000000000000",
+              user.id,
+            ),
+          );
+
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(NotFoundError);
+            expect(result.left.message).toContain("not found");
+          }
+        }),
+      ),
+    );
+
+    it(
+      "should return PermissionDeniedError when user is not a member",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const otherUser = yield* db.users.create({
+            email: "other@example.com",
+            name: "Other User",
+          });
+
+          const created = yield* db.organizations.create(
+            { name: "Non Member Delete Org" },
+            user.id,
+          );
+
+          const result = yield* Effect.either(
+            db.organizations.delete(created.id, otherUser.id),
+          );
+
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(PermissionDeniedError);
+            expect(result.left.message).toBe(
+              "You do not have permission to delete this organization",
+            );
+          }
+        }),
+      ),
+    );
+
+    it("should return PermissionDeniedError when user is not an owner", () => {
+      return Effect.gen(function* () {
+        // Mock the database to simulate a user who is a member but not an owner
+        let selectCallCount = 0;
+        const mockDb = createPartialMockDatabase({
+          select: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // First call: organization check - return existing org
+              return {
+                from: () => ({
+                  where: () => ({
+                    limit: () => Promise.resolve([{ id: "test-org-id" }]),
+                  }),
+                }),
+              };
+            }
+            // Second call: membership check - return DEVELOPER membership
+            return {
+              from: () => ({
+                where: () => ({
+                  limit: () => Promise.resolve([{ role: "DEVELOPER" }]),
+                }),
+              }),
+            };
+          },
+        });
+
+        const service = new OrganizationService(mockDb);
+
+        const result = yield* Effect.either(
+          service.delete("test-org-id", "test-user-id"),
+        );
+
+        expect(result._tag).toBe("Left");
+        if (result._tag === "Left") {
+          expect(result.left).toBeInstanceOf(PermissionDeniedError);
+          expect(result.left.message).toBe(
+            "You do not have permission to delete this organization",
+          );
+        }
+      }).pipe(Effect.runPromise);
+    });
+  });
+
+  describe("findAll", () => {
+    it(
+      "should retrieve all organizations for a user",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          yield* db.organizations.create({ name: "Org 1" }, user.id);
+          yield* db.organizations.create({ name: "Org 2" }, user.id);
+
+          const organizations = yield* db.organizations.findAll(user.id);
+          expect(organizations).toHaveLength(2);
+          expect(organizations[0].role).toBe("OWNER");
+          expect(organizations[1].role).toBe("OWNER");
+        }),
+      ),
+    );
+
+    it(
+      "should return empty array for user with no organizations",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          const organizations = yield* db.organizations.findAll(user.id);
+          expect(organizations).toHaveLength(0);
+        }),
+      ),
+    );
+  });
+
+  describe("findAll", () => {
+    it(
+      "should return all organizations the user is a member of",
+      withTestDatabase((db) =>
+        Effect.gen(function* () {
+          const user = yield* db.users.create({
+            email: "test@example.com",
+            name: "Test User",
+          });
+
+          yield* db.organizations.create({ name: "Org A" }, user.id);
+          yield* db.organizations.create({ name: "Org B" }, user.id);
+
+          const all = yield* db.organizations.findAll(user.id);
+          expect(Array.isArray(all)).toBe(true);
+          expect(all.length).toBe(2);
+          expect(all.find((o) => o.name === "Org A")).toBeDefined();
+          expect(all.find((o) => o.name === "Org B")).toBeDefined();
+        }),
+      ),
+    );
+  });
+
+  describe("Error handling", () => {
+    it(
+      "create returns DatabaseError when check for existing fails",
+      withErroringService(OrganizationService, (service) =>
+        Effect.gen(function* () {
+          const result = yield* Effect.either(
+            service.create({ name: "Test Org" }, "test-user-id"),
+          );
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(DatabaseError);
+            expect(result.left.message).toContain(
+              "Failed to check for existing organization",
+            );
+          }
+        }),
+      ),
+    );
+
+    it("findAll returns DatabaseError on database query failure", () => {
+      return Effect.gen(function* () {
+        const mockDb = createPartialMockDatabase({
+          select: () => ({
+            from: () => ({
+              innerJoin: () => ({
+                where: () =>
+                  Promise.reject(new Error("Database connection failed")),
+              }),
+            }),
+          }),
+        });
+
+        const service = new OrganizationService(mockDb);
+
+        const result = yield* Effect.either(service.findAll("test-user-id"));
+        expect(result._tag).toBe("Left");
+        if (result._tag === "Left") {
+          expect(result.left).toBeInstanceOf(DatabaseError);
+          expect(result.left.message).toContain(
+            "Failed to get user organizations",
+          );
+        }
+      }).pipe(Effect.runPromise);
+    });
+
+    it(
+      "delete returns DatabaseError on database query failure",
+      withErroringService(OrganizationService, (service) =>
+        Effect.gen(function* () {
+          const result = yield* Effect.either(
+            service.delete("test-org-id", "test-user-id"),
+          );
+          expect(result._tag).toBe("Left");
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(DatabaseError);
+            expect(result.left.message).toContain(
+              "Failed to find organization",
+            );
+          }
+        }),
+      ),
+    );
+
+    it("create returns DatabaseError when transaction fails", () => {
+      return Effect.gen(function* () {
+        let selectCallCount = 0;
+        const mockDb = createPartialMockDatabase({
+          select: () => {
+            selectCallCount++;
+            // First call returns empty (no existing org)
+            if (selectCallCount === 1) {
+              return {
+                from: () => ({
+                  where: () => ({
+                    limit: () => Promise.resolve([]),
+                  }),
+                }),
+              };
+            }
+            throw new Error("Database connection failed");
+          },
+          insert: () => {
+            throw new Error("Transaction failed");
+          },
+        });
+
+        // Add transaction mock
+        (
+          mockDb as unknown as { transaction: () => Promise<unknown> }
+        ).transaction = () => Promise.reject(new Error("Transaction failed"));
+
+        const service = new OrganizationService(mockDb);
+
+        const result = yield* Effect.either(
+          service.create({ name: "Test Org" }, "test-user-id"),
+        );
+        expect(result._tag).toBe("Left");
+        if (result._tag === "Left") {
+          expect(result.left).toBeInstanceOf(DatabaseError);
+          expect(result.left.message).toContain(
+            "Failed to create organization",
+          );
+        }
+      }).pipe(Effect.runPromise);
+    });
+
+    it("delete returns DatabaseError when membership check fails", () => {
+      return Effect.gen(function* () {
+        let selectCallCount = 0;
+        const mockDb = createPartialMockDatabase({
+          select: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // First call: organization check - return existing org
+              return {
+                from: () => ({
+                  where: () => ({
+                    limit: () => Promise.resolve([{ id: "test-org-id" }]),
+                  }),
+                }),
+              };
+            }
+            // Second call: membership check - fail
+            throw new Error("Database connection failed");
+          },
+        });
+
+        const service = new OrganizationService(mockDb);
+
+        const result = yield* Effect.either(
+          service.delete("test-org-id", "test-user-id"),
+        );
+        expect(result._tag).toBe("Left");
+        if (result._tag === "Left") {
+          expect(result.left).toBeInstanceOf(DatabaseError);
+          expect(result.left.message).toContain("Failed to check membership");
+        }
+      }).pipe(Effect.runPromise);
+    });
+
+    it("delete returns DatabaseError when delete transaction fails", () => {
+      return Effect.gen(function* () {
+        let selectCallCount = 0;
+        const mockDb = createPartialMockDatabase({
+          select: () => {
+            selectCallCount++;
+            if (selectCallCount === 1) {
+              // First call: organization check - return existing org
+              return {
+                from: () => ({
+                  where: () => ({
+                    limit: () => Promise.resolve([{ id: "test-org-id" }]),
+                  }),
+                }),
+              };
+            }
+            // Second call: membership check - return OWNER membership
+            return {
+              from: () => ({
+                where: () => ({
+                  limit: () => Promise.resolve([{ role: "OWNER" }]),
+                }),
+              }),
+            };
+          },
+        });
+
+        // Add transaction mock that fails
+        (
+          mockDb as unknown as { transaction: () => Promise<unknown> }
+        ).transaction = () => Promise.reject(new Error("Transaction failed"));
+
+        const service = new OrganizationService(mockDb);
+
+        const result = yield* Effect.either(
+          service.delete("test-org-id", "test-user-id"),
+        );
+        expect(result._tag).toBe("Left");
+        if (result._tag === "Left") {
+          expect(result.left).toBeInstanceOf(DatabaseError);
+          expect(result.left.message).toContain(
+            "Failed to delete organization",
+          );
+        }
+      }).pipe(Effect.runPromise);
+    });
+  });
+});

--- a/cloud/db/services/organizations.ts
+++ b/cloud/db/services/organizations.ts
@@ -1,0 +1,292 @@
+import { Effect } from "effect";
+import { and, eq } from "drizzle-orm";
+import type { PgColumn } from "drizzle-orm/pg-core";
+import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
+import {
+  BaseService,
+  BaseAuthenticatedService,
+  type PermissionAction,
+} from "@/db/services/base";
+import {
+  AlreadyExistsError,
+  DatabaseError,
+  NotFoundError,
+  PermissionDeniedError,
+} from "@/db/errors";
+import {
+  organizations,
+  organizationMemberships,
+  type NewOrganization,
+  type PublicOrganization,
+  type PublicOrganizationWithMembership,
+  type Role,
+} from "@/db/schema";
+import type * as schema from "@/db/schema";
+
+/**
+ * Minimum role required for each action.
+ * Role hierarchy: OWNER > ADMIN > DEVELOPER > ANNOTATOR
+ */
+const ROLE_HIERARCHY: Record<Role, number> = {
+  OWNER: 4,
+  ADMIN: 3,
+  DEVELOPER: 2,
+  ANNOTATOR: 1,
+};
+
+const REQUIRED_ROLE_FOR_ACTION: Record<PermissionAction, Role> = {
+  read: "ANNOTATOR",
+  update: "ADMIN",
+  delete: "OWNER",
+};
+
+class BaseOrganizationService extends BaseService<
+  PublicOrganization,
+  string,
+  typeof organizations
+> {
+  protected getTable() {
+    return organizations;
+  }
+
+  protected getResourceName() {
+    return "organization";
+  }
+
+  protected getPublicFields(): Record<string, PgColumn> {
+    return {
+      id: organizations.id,
+      name: organizations.name,
+    };
+  }
+}
+
+export class OrganizationService extends BaseAuthenticatedService<
+  PublicOrganization,
+  string,
+  typeof organizations
+> {
+  protected readonly baseService: BaseOrganizationService;
+
+  constructor(db: PostgresJsDatabase<typeof schema>) {
+    super(db);
+    this.baseService = new BaseOrganizationService(db);
+  }
+
+  protected checkPermission(
+    userId: string,
+    action: PermissionAction,
+    organizationId: string,
+  ): Effect.Effect<void, PermissionDeniedError | DatabaseError> {
+    const fetchMembership = Effect.tryPromise({
+      try: async () => {
+        const [membership] = await this.db
+          .select({ role: organizationMemberships.role })
+          .from(organizationMemberships)
+          .where(
+            and(
+              eq(organizationMemberships.userId, userId),
+              eq(organizationMemberships.organizationId, organizationId),
+            ),
+          )
+          .limit(1);
+        return membership;
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to check membership",
+          cause: error,
+        }),
+    });
+
+    const verifyMembershipAndRole = (
+      membership: { role: Role } | undefined,
+    ): Effect.Effect<void, PermissionDeniedError> => {
+      if (!membership) {
+        return Effect.fail(
+          new PermissionDeniedError({
+            message: `You do not have permission to ${action} this organization`,
+            resource: this.baseService.resourceName,
+          }),
+        );
+      }
+
+      const requiredRole = REQUIRED_ROLE_FOR_ACTION[action];
+      const userRoleLevel = ROLE_HIERARCHY[membership.role];
+      const requiredRoleLevel = ROLE_HIERARCHY[requiredRole];
+
+      if (userRoleLevel < requiredRoleLevel) {
+        return Effect.fail(
+          new PermissionDeniedError({
+            message: `You do not have permission to ${action} this organization`,
+            resource: this.baseService.resourceName,
+          }),
+        );
+      }
+
+      return Effect.succeed(undefined);
+    };
+
+    return fetchMembership.pipe(Effect.flatMap(verifyMembershipAndRole));
+  }
+
+  create(
+    data: NewOrganization,
+    userId: string,
+  ): Effect.Effect<
+    PublicOrganizationWithMembership,
+    AlreadyExistsError | DatabaseError
+  > {
+    const fetchExistingOrganization = Effect.tryPromise({
+      try: async () => {
+        const [existing] = await this.db
+          .select({ name: organizations.name })
+          .from(organizations)
+          .where(eq(organizations.name, data.name))
+          .limit(1);
+        return existing;
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to check for existing organization",
+          cause: error,
+        }),
+    });
+
+    const rejectIfExists = (
+      existing: { name: string } | undefined,
+    ): Effect.Effect<void, AlreadyExistsError> => {
+      if (existing) {
+        return Effect.fail(
+          new AlreadyExistsError({
+            message: "An organization with this name already exists",
+            resource: this.baseService.resourceName,
+          }),
+        );
+      }
+      return Effect.succeed(undefined);
+    };
+
+    const createOrganizationWithOwner = Effect.tryPromise({
+      try: async () => {
+        return await this.db.transaction(async (tx) => {
+          const [organization] = await tx
+            .insert(organizations)
+            .values({ name: data.name })
+            .returning({ id: organizations.id, name: organizations.name });
+
+          await tx.insert(organizationMemberships).values({
+            userId,
+            organizationId: organization.id,
+            role: "OWNER",
+          });
+
+          return {
+            id: organization.id,
+            name: organization.name,
+            role: "OWNER" as Role,
+          };
+        });
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to create organization",
+          cause: error,
+        }),
+    });
+
+    return fetchExistingOrganization.pipe(
+      Effect.flatMap(rejectIfExists),
+      Effect.andThen(createOrganizationWithOwner),
+    );
+  }
+
+  findAll(
+    userId: string,
+  ): Effect.Effect<PublicOrganizationWithMembership[], DatabaseError> {
+    const fetchUserOrganizationsWithRoles = Effect.tryPromise({
+      try: async () => {
+        return await this.db
+          .select({
+            id: organizations.id,
+            name: organizations.name,
+            role: organizationMemberships.role,
+          })
+          .from(organizationMemberships)
+          .innerJoin(
+            organizations,
+            eq(organizationMemberships.organizationId, organizations.id),
+          )
+          .where(eq(organizationMemberships.userId, userId));
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to get user organizations",
+          cause: error,
+        }),
+    });
+
+    return fetchUserOrganizationsWithRoles;
+  }
+
+  override delete(
+    id: string,
+    userId: string,
+  ): Effect.Effect<
+    void,
+    NotFoundError | PermissionDeniedError | DatabaseError
+  > {
+    const fetchOrganization = Effect.tryPromise({
+      try: async () => {
+        const [org] = await this.db
+          .select({ id: organizations.id })
+          .from(organizations)
+          .where(eq(organizations.id, id))
+          .limit(1);
+        return org;
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to find organization",
+          cause: error,
+        }),
+    });
+
+    const rejectIfNotFound = (
+      org: { id: string } | undefined,
+    ): Effect.Effect<{ id: string }, NotFoundError> => {
+      if (!org) {
+        return Effect.fail(
+          new NotFoundError({
+            message: `Organization with id ${id} not found`,
+            resource: this.baseService.resourceName,
+          }),
+        );
+      }
+      return Effect.succeed(org);
+    };
+
+    const deleteOrganizationWithMemberships = Effect.tryPromise({
+      try: async () => {
+        await this.db.transaction(async (tx) => {
+          await tx
+            .delete(organizationMemberships)
+            .where(eq(organizationMemberships.organizationId, id));
+
+          await tx.delete(organizations).where(eq(organizations.id, id));
+        });
+      },
+      catch: (error) =>
+        new DatabaseError({
+          message: "Failed to delete organization",
+          cause: error,
+        }),
+    });
+
+    return fetchOrganization.pipe(
+      Effect.flatMap(rejectIfNotFound),
+      Effect.andThen(this.checkPermission(userId, "delete", id)),
+      Effect.andThen(deleteOrganizationWithMemberships),
+    );
+  }
+}

--- a/cloud/db/utils.test.ts
+++ b/cloud/db/utils.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { isUniqueConstraintError } from "@/db/utils";
+
+describe("isUniqueConstraintError", () => {
+  it("returns false for null", () => {
+    expect(isUniqueConstraintError(null)).toBe(false);
+  });
+
+  it("returns false for undefined", () => {
+    expect(isUniqueConstraintError(undefined)).toBe(false);
+  });
+
+  it("returns false for non-object values", () => {
+    expect(isUniqueConstraintError("string")).toBe(false);
+    expect(isUniqueConstraintError(123)).toBe(false);
+    expect(isUniqueConstraintError(true)).toBe(false);
+  });
+
+  it("returns false for objects without code property", () => {
+    expect(isUniqueConstraintError({})).toBe(false);
+    expect(isUniqueConstraintError({ message: "error" })).toBe(false);
+  });
+
+  it("returns false for objects with non-matching code", () => {
+    expect(isUniqueConstraintError({ code: "12345" })).toBe(false);
+    expect(isUniqueConstraintError({ code: "00000" })).toBe(false);
+  });
+
+  it("returns true for direct PostgreSQL unique violation error", () => {
+    expect(isUniqueConstraintError({ code: "23505" })).toBe(true);
+  });
+
+  it("returns false for wrapped error with non-object cause", () => {
+    expect(isUniqueConstraintError({ cause: null })).toBe(false);
+    expect(isUniqueConstraintError({ cause: "string" })).toBe(false);
+    expect(isUniqueConstraintError({ cause: 123 })).toBe(false);
+  });
+
+  it("returns false for wrapped error with cause missing code", () => {
+    expect(isUniqueConstraintError({ cause: {} })).toBe(false);
+    expect(isUniqueConstraintError({ cause: { message: "error" } })).toBe(
+      false,
+    );
+  });
+
+  it("returns false for wrapped error with non-matching cause code", () => {
+    expect(isUniqueConstraintError({ cause: { code: "12345" } })).toBe(false);
+  });
+
+  it("returns true for Drizzle-wrapped PostgreSQL unique violation error", () => {
+    // This simulates how Drizzle wraps PostgreSQL errors
+    expect(isUniqueConstraintError({ cause: { code: "23505" } })).toBe(true);
+  });
+
+  it("returns true for full Drizzle error structure", () => {
+    // Simulate a real Drizzle error with all properties
+    const drizzleError = {
+      message:
+        'Failed query: insert into "users" ...\nparams: test@example.com',
+      query: 'insert into "users" ...',
+      params: ["test@example.com"],
+      cause: {
+        message:
+          'duplicate key value violates unique constraint "users_email_unique"',
+        code: "23505",
+        detail: "Key (email)=(test@example.com) already exists.",
+        severity: "ERROR",
+      },
+    };
+    expect(isUniqueConstraintError(drizzleError)).toBe(true);
+  });
+});

--- a/cloud/db/utils.ts
+++ b/cloud/db/utils.ts
@@ -1,0 +1,31 @@
+// PostgreSQL error code for unique constraint violation
+const PG_UNIQUE_VIOLATION = "23505";
+
+/**
+ * Check if an error is a PostgreSQL unique constraint violation.
+ * Drizzle wraps PostgreSQL errors, so we check both the error itself
+ * and its cause for the unique violation code.
+ */
+export function isUniqueConstraintError(error: unknown): boolean {
+  if (typeof error !== "object" || error === null) {
+    return false;
+  }
+
+  // Check if error.code matches (direct postgres error)
+  if ("code" in error && error.code === PG_UNIQUE_VIOLATION) {
+    return true;
+  }
+
+  // Check if error.cause.code matches (Drizzle-wrapped error)
+  if (
+    "cause" in error &&
+    typeof error.cause === "object" &&
+    error.cause !== null &&
+    "code" in error.cause &&
+    error.cause.code === PG_UNIQUE_VIOLATION
+  ) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces organizations/memberships schema and `OrganizationService` with role-based permissions; adds `AlreadyExistsError`/`PermissionDeniedError` and unique-constraint detection; updates base service and OAuth error typing.
> 
> - **Database schema & migrations**:
>   - Add `public.role` enum and tables `organizations` and `organization_memberships` with unique and FK constraints.
>   - New Drizzle models (`organizations`, `organizationMemberships`) and exports in `schema/index.ts`.
> - **Services**:
>   - **Base**: Map unique constraint to `AlreadyExistsError`; expose `resourceName`; add `BaseAuthenticatedService` for permission-checked CRUD.
>   - **Organizations**: Implement `OrganizationService` with role hierarchy (`OWNER` > `ADMIN` > `DEVELOPER` > `ANNOTATOR`), transactional create (auto-owner membership), per-user `findAll`, and guarded `delete`.
>   - Register `organizations` in `DatabaseService`.
> - **Errors & utils**:
>   - Add `AlreadyExistsError`, `PermissionDeniedError` in `db/errors.ts`.
>   - Add `isUniqueConstraintError` utility with tests.
> - **Auth**:
>   - Broaden `processAuthenticatedUser` error type to include `AlreadyExistsError`.
> - **Tests**:
>   - Add comprehensive tests for base service errors, organization permissions/CRUD, and utils.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c775eb36685803e5684f92e6e8faf9be8400489f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->