### PR TITLE
feat(db): add traces and spans schema

### DIFF
--- a/cloud/db/schema/index.ts
+++ b/cloud/db/schema/index.ts
@@ -8,6 +8,8 @@ export * from "@/db/schema/project-memberships";
 export * from "@/db/schema/project-membership-audit";
 export * from "@/db/schema/environments";
 export * from "@/db/schema/api-keys";
+export * from "@/db/schema/traces";
+export * from "@/db/schema/spans";
 
 export type { PublicSession } from "@/db/schema/sessions";
 export type { PublicUser } from "@/db/schema/users";
@@ -32,6 +34,8 @@ export type {
   NewEnvironment,
 } from "@/db/schema/environments";
 export type { PublicApiKey, ApiKeyCreateResponse } from "@/db/schema/api-keys";
+export type { PublicTrace } from "@/db/schema/traces";
+export type { PublicSpan } from "@/db/schema/spans";
 
 import { users } from "@/db/schema/users";
 import { sessions } from "@/db/schema/sessions";
@@ -43,6 +47,8 @@ import { projectMemberships } from "@/db/schema/project-memberships";
 import { projectMembershipAudit } from "@/db/schema/project-membership-audit";
 import { environments } from "@/db/schema/environments";
 import { apiKeys } from "@/db/schema/api-keys";
+import { traces } from "@/db/schema/traces";
+import { spans } from "@/db/schema/spans";
 
 export type DatabaseTable =
   | typeof users
@@ -54,4 +60,6 @@ export type DatabaseTable =
   | typeof projectMemberships
   | typeof projectMembershipAudit
   | typeof environments
-  | typeof apiKeys;
+  | typeof apiKeys
+  | typeof traces
+  | typeof spans;

--- a/cloud/db/schema/spans.ts
+++ b/cloud/db/schema/spans.ts
@@ -1,0 +1,120 @@
+import { relations } from "drizzle-orm";
+import {
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  unique,
+  jsonb,
+  integer,
+  index,
+  bigint,
+  foreignKey,
+} from "drizzle-orm/pg-core";
+import { traces } from "./traces";
+import { environments } from "./environments";
+import { projects } from "./projects";
+import { organizations } from "./organizations";
+
+export const spans = pgTable(
+  "spans",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    traceDbId: uuid("trace_db_id").notNull(),
+    traceId: text("trace_id").notNull(),
+    spanId: text("span_id").notNull(),
+    parentSpanId: text("parent_span_id"),
+    environmentId: uuid("environment_id")
+      .references(() => environments.id, { onDelete: "cascade" })
+      .notNull(),
+    projectId: uuid("project_id")
+      .references(() => projects.id, { onDelete: "cascade" })
+      .notNull(),
+    organizationId: uuid("organization_id")
+      .references(() => organizations.id, { onDelete: "cascade" })
+      .notNull(),
+    name: text("name").notNull(),
+    kind: integer("kind"),
+    startTimeUnixNano: bigint("start_time_unix_nano", { mode: "bigint" }),
+    endTimeUnixNano: bigint("end_time_unix_nano", { mode: "bigint" }),
+    attributes: jsonb("attributes"),
+    status: jsonb("status"),
+    events: jsonb("events"),
+    links: jsonb("links"),
+    droppedAttributesCount: integer("dropped_attributes_count"),
+    droppedEventsCount: integer("dropped_events_count"),
+    droppedLinksCount: integer("dropped_links_count"),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (table) => ({
+    spanTraceEnvUnique: unique().on(
+      table.spanId,
+      table.traceId,
+      table.environmentId,
+    ),
+    // Composite foreign key to ensure trace_id and environment_id match the referenced trace
+    traceConsistencyFk: foreignKey({
+      columns: [table.traceDbId, table.traceId, table.environmentId],
+      foreignColumns: [traces.id, traces.traceId, traces.environmentId],
+      name: "spans_trace_consistency_fk",
+    }).onDelete("cascade"),
+    envCreatedAtIdx: index("spans_env_created_at_idx").on(
+      table.environmentId,
+      table.createdAt,
+    ),
+    traceDbIdIdx: index("spans_trace_db_id_idx").on(table.traceDbId),
+    startTimeIdx: index("spans_start_time_idx").on(table.startTimeUnixNano),
+    envStartTimeIdx: index("spans_env_start_time_idx").on(
+      table.environmentId,
+      table.startTimeUnixNano,
+    ),
+  }),
+);
+
+export const spansRelations = relations(spans, ({ one }) => ({
+  trace: one(traces, {
+    fields: [spans.traceDbId],
+    references: [traces.id],
+  }),
+  environment: one(environments, {
+    fields: [spans.environmentId],
+    references: [environments.id],
+  }),
+  project: one(projects, {
+    fields: [spans.projectId],
+    references: [projects.id],
+  }),
+  organization: one(organizations, {
+    fields: [spans.organizationId],
+    references: [organizations.id],
+  }),
+}));
+
+// Internal types
+export type Span = typeof spans.$inferSelect;
+export type NewSpan = typeof spans.$inferInsert;
+
+// Public types for API responses
+export type PublicSpan = Pick<
+  Span,
+  | "id"
+  | "traceDbId"
+  | "traceId"
+  | "spanId"
+  | "parentSpanId"
+  | "environmentId"
+  | "projectId"
+  | "organizationId"
+  | "name"
+  | "kind"
+  | "startTimeUnixNano"
+  | "endTimeUnixNano"
+  | "attributes"
+  | "status"
+  | "events"
+  | "links"
+  | "droppedAttributesCount"
+  | "droppedEventsCount"
+  | "droppedLinksCount"
+  | "createdAt"
+>;

--- a/cloud/db/schema/traces.ts
+++ b/cloud/db/schema/traces.ts
@@ -1,0 +1,84 @@
+import { relations } from "drizzle-orm";
+import {
+  pgTable,
+  text,
+  timestamp,
+  uuid,
+  unique,
+  jsonb,
+  index,
+} from "drizzle-orm/pg-core";
+import { environments } from "./environments";
+import { projects } from "./projects";
+import { organizations } from "./organizations";
+
+export const traces = pgTable(
+  "traces",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    traceId: text("trace_id").notNull(),
+    environmentId: uuid("environment_id")
+      .references(() => environments.id, { onDelete: "cascade" })
+      .notNull(),
+    projectId: uuid("project_id")
+      .references(() => projects.id, { onDelete: "cascade" })
+      .notNull(),
+    organizationId: uuid("organization_id")
+      .references(() => organizations.id, { onDelete: "cascade" })
+      .notNull(),
+    serviceName: text("service_name"),
+    serviceVersion: text("service_version"),
+    resourceAttributes: jsonb("resource_attributes"),
+    createdAt: timestamp("created_at").defaultNow(),
+  },
+  (table) => ({
+    traceEnvUnique: unique().on(table.traceId, table.environmentId),
+    // Composite unique constraint for spans foreign key reference
+    idTraceIdEnvUnique: unique("traces_id_trace_id_environment_id_unique").on(
+      table.id,
+      table.traceId,
+      table.environmentId,
+    ),
+    envCreatedAtIdx: index("traces_env_created_at_idx").on(
+      table.environmentId,
+      table.createdAt,
+    ),
+    envServiceNameIdx: index("traces_env_service_name_idx").on(
+      table.environmentId,
+      table.serviceName,
+    ),
+  }),
+);
+
+export const tracesRelations = relations(traces, ({ one }) => ({
+  environment: one(environments, {
+    fields: [traces.environmentId],
+    references: [environments.id],
+  }),
+  project: one(projects, {
+    fields: [traces.projectId],
+    references: [projects.id],
+  }),
+  organization: one(organizations, {
+    fields: [traces.organizationId],
+    references: [organizations.id],
+  }),
+}));
+
+// Internal types
+export type Trace = typeof traces.$inferSelect;
+export type NewTrace = typeof traces.$inferInsert;
+
+// Public types for API responses
+export type PublicTrace = Pick<
+  Trace,
+  | "id"
+  | "traceId"
+  | "environmentId"
+  | "projectId"
+  | "organizationId"
+  | "serviceName"
+  | "serviceVersion"
+  | "resourceAttributes"
+  | "createdAt"
+>;


### PR DESCRIPTION
### TL;DR

Added database schema for traces and spans to support distributed tracing functionality.

### What changed?

- Created two new database schema files:
  - `traces.ts`: Defines the traces table with fields for trace ID, environment, project, organization, service information, and resource attributes
  - `spans.ts`: Defines the spans table with fields for span details, timing information, and relationships to traces
- Updated the main schema index file to:
  - Export the new schema types
  - Export the public interfaces for API responses
  - Include traces and spans in the DatabaseTable type

### How to test?

1. Run database migrations to create the new tables
2. Verify that the schema can be used to store and retrieve trace and span data
3. Confirm that the relationships between traces, spans, environments, projects, and organizations work correctly

### Why make this change?

This change establishes the database foundation for implementing distributed tracing capabilities in the application. The schema design allows for storing hierarchical span data within traces while maintaining proper relationships to environments, projects, and organizations. This will enable visualization and analysis of request flows across services.