### PR TITLE
feat(db): add TraceService for OTLP ingestion

### DIFF
--- a/cloud/api/traces.handlers.ts
+++ b/cloud/api/traces.handlers.ts
@@ -9,6 +9,10 @@ import {
 
 export * from "@/api/traces.schemas";
 
+/**
+ * Handler for creating traces from OTLP trace data.
+ * Accepts OpenTelemetry trace data and stores it in the database.
+ */
 export const createTraceHandler = (payload: CreateTraceRequest) =>
   Effect.gen(function* () {
     const serviceName =

--- a/cloud/db/database.ts
+++ b/cloud/db/database.ts
@@ -48,15 +48,18 @@ import { Projects } from "@/db/projects";
 import { ProjectMemberships } from "@/db/project-memberships";
 import { Environments } from "@/db/environments";
 import { ApiKeys } from "@/db/api-keys";
+import { Traces } from "@/db/traces";
 import { Payments, type StripeConfig } from "@/payments";
 
 /**
- * Type definition for the environments service with nested API keys.
+ * Type definition for the environments service with nested API keys and traces.
  *
  * Access pattern: `db.organizations.projects.environments.apiKeys.create(...)`
+ * Traces: `db.organizations.projects.environments.traces.create(...)`
  */
 export interface EnvironmentsService extends Ready<Environments> {
   readonly apiKeys: Ready<ApiKeys>;
+  readonly traces: Ready<Traces>;
 }
 
 /**
@@ -143,6 +146,7 @@ export class Database extends Context.Tag("Database")<
       );
       const environmentsService = new Environments(projectMemberships);
       const apiKeysService = new ApiKeys(projectMemberships);
+      const tracesService = new Traces(projectMemberships);
 
       return {
         users: provideDependencies(new Users()),
@@ -156,6 +160,7 @@ export class Database extends Context.Tag("Database")<
             environments: {
               ...provideDependencies(environmentsService),
               apiKeys: provideDependencies(apiKeysService),
+              traces: provideDependencies(tracesService),
             },
           },
         },

--- a/cloud/db/schema/traces.ts
+++ b/cloud/db/schema/traces.ts
@@ -86,3 +86,9 @@ export type PublicTrace = Pick<
   | "resourceAttributes"
   | "createdAt"
 >;
+
+// Type for the create response (includes ingestion stats)
+export type CreateTraceResponse = PublicTrace & {
+  acceptedSpans: number;
+  rejectedSpans: number;
+};

--- a/cloud/db/traces.test.ts
+++ b/cloud/db/traces.test.ts
@@ -1,0 +1,1217 @@
+import {
+  describe,
+  it,
+  expect,
+  TestEnvironmentFixture,
+  MockDrizzleORM,
+} from "@/tests/db";
+import { Effect } from "effect";
+import { Database } from "@/db";
+import { DatabaseError, NotFoundError, PermissionDeniedError } from "@/errors";
+
+describe("Traces", () => {
+  describe("create", () => {
+    it.effect("creates single span", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: "test-service" } },
+                { key: "service.version", value: { stringValue: "1.0.0" } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "abc123",
+                    spanId: "span001",
+                    name: "test-span",
+                    startTimeUnixNano: "1234567890000000000",
+                    endTimeUnixNano: "1234567891000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result.acceptedSpans).toBe(1);
+        expect(result.rejectedSpans).toBe(0);
+        expect(result.traceId).toBe("abc123");
+        expect(result.serviceName).toBe("test-service");
+      }),
+    );
+
+    it.effect("creates multiple spans", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: "test-service" } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace001",
+                    spanId: "span001",
+                    name: "span-1",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                  {
+                    traceId: "trace001",
+                    spanId: "span002",
+                    parentSpanId: "span001",
+                    name: "span-2",
+                    startTimeUnixNano: "1100000000",
+                    endTimeUnixNano: "1900000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result.acceptedSpans).toBe(2);
+        expect(result.rejectedSpans).toBe(0);
+        expect(result.traceId).toBe("trace001");
+        expect(result.serviceName).toBe("test-service");
+      }),
+    );
+
+    it.effect("upserts trace on conflict", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const makeResourceSpans = (spanId: string, serviceName: string) => [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: serviceName } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "same-trace-id",
+                    spanId,
+                    name: "span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result1 =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans: makeResourceSpans("span-a", "service-v1") },
+          });
+
+        expect(result1.acceptedSpans).toBe(1);
+
+        const result2 =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans: makeResourceSpans("span-b", "service-v2") },
+          });
+
+        expect(result2.acceptedSpans).toBe(1);
+      }),
+    );
+
+    it.effect("rejects duplicate spans", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-dup",
+                    spanId: "span-dup",
+                    name: "duplicate-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result1 =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result1.acceptedSpans).toBe(1);
+        expect(result1.rejectedSpans).toBe(0);
+
+        const result2 =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result2.acceptedSpans).toBe(0);
+        expect(result2.rejectedSpans).toBe(1);
+      }),
+    );
+
+    it.effect("handles span with null/optional fields", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: {},
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-null",
+                    spanId: "span-null",
+                    name: "minimal-span",
+                    startTimeUnixNano: "",
+                    endTimeUnixNano: "",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result.acceptedSpans).toBe(1);
+      }),
+    );
+
+    it.effect("handles span with events and links", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: "test" } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-events",
+                    spanId: "span-events",
+                    name: "span-with-events",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                    kind: 1,
+                    status: { code: 1, message: "OK" },
+                    attributes: [
+                      { key: "attr1", value: { stringValue: "val1" } },
+                    ],
+                    events: [
+                      {
+                        name: "event1",
+                        timeUnixNano: "1500000000",
+                        attributes: [
+                          { key: "level", value: { stringValue: "info" } },
+                        ],
+                      },
+                    ],
+                    links: [
+                      {
+                        traceId: "linked-trace",
+                        spanId: "linked-span",
+                      },
+                    ],
+                    droppedAttributesCount: 0,
+                    droppedEventsCount: 0,
+                    droppedLinksCount: 0,
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result.acceptedSpans).toBe(1);
+      }),
+    );
+
+    it.effect("handles all OTLP value types including unknown", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: "test" } },
+                { key: "int-attr", value: { intValue: "42" } },
+                { key: "double-attr", value: { doubleValue: 3.14 } },
+                { key: "bool-attr", value: { boolValue: true } },
+                {
+                  key: "array-attr",
+                  value: {
+                    arrayValue: {
+                      values: [
+                        { stringValue: "item1" },
+                        { intValue: "123" },
+                        "raw-string-value" as unknown as {
+                          stringValue: string;
+                        },
+                      ],
+                    },
+                  },
+                },
+                {
+                  key: "array-empty",
+                  value: {
+                    arrayValue: {
+                      values: [],
+                    },
+                  },
+                },
+                {
+                  key: "kvlist-attr",
+                  value: {
+                    kvlistValue: {
+                      values: [
+                        { key: "nested", value: { stringValue: "value" } },
+                        { key: "raw", value: "direct-value" },
+                      ],
+                    },
+                  },
+                },
+                {
+                  key: "kvlist-empty",
+                  value: {
+                    kvlistValue: {
+                      values: [],
+                    },
+                  },
+                },
+                { key: "unknown-attr", value: {} },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-types",
+                    spanId: "span-types",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result.acceptedSpans).toBe(1);
+      }),
+    );
+
+    it.effect("returns DatabaseError when trace upsert fails", () =>
+      Effect.gen(function* () {
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-db-error",
+                    spanId: "span-db-error",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: "owner-id",
+            organizationId: "org-id",
+            projectId: "project-id",
+            environmentId: "env-id",
+            data: { resourceSpans },
+          });
+
+        // When trace upsert fails, the span is rejected
+        expect(result.rejectedSpans).toBe(1);
+        expect(result.acceptedSpans).toBe(0);
+      }).pipe(
+        Effect.provide(
+          new MockDrizzleORM()
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([{ id: "project-id" }])
+            .insert(new Error("Trace upsert failed"))
+            .build(),
+        ),
+      ),
+    );
+
+    it.effect("returns DatabaseError when span insert fails", () =>
+      Effect.gen(function* () {
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-span-error",
+                    spanId: "span-span-error",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: "owner-id",
+            organizationId: "org-id",
+            projectId: "project-id",
+            environmentId: "env-id",
+            data: { resourceSpans },
+          });
+
+        // When span insert fails, the span is rejected
+        expect(result.rejectedSpans).toBe(1);
+        expect(result.acceptedSpans).toBe(0);
+      }).pipe(
+        Effect.provide(
+          new MockDrizzleORM()
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([{ id: "project-id" }])
+            .insert([{ id: "trace-id" }]) // Trace upsert succeeds
+            .insert(new Error("Span insert failed")) // Span insert fails
+            .build(),
+        ),
+      ),
+    );
+
+    it.effect("handles empty resourceSpans", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans: [] },
+          });
+
+        expect(result.acceptedSpans).toBe(0);
+        expect(result.rejectedSpans).toBe(0);
+        expect(result.id).toBe("");
+      }),
+    );
+
+    it.effect("returns PermissionDeniedError for VIEWER role", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, projectViewer } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-perm",
+                    spanId: "span-perm",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result = yield* db.organizations.projects.environments.traces
+          .create({
+            userId: projectViewer.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(PermissionDeniedError);
+        expect(result.message).toContain("permission");
+      }),
+    );
+
+    it.effect("returns PermissionDeniedError for ANNOTATOR role", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, projectAnnotator } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-perm2",
+                    spanId: "span-perm2",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        const result = yield* db.organizations.projects.environments.traces
+          .create({
+            userId: projectAnnotator.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(PermissionDeniedError);
+        expect(result.message).toContain("permission");
+      }),
+    );
+  });
+
+  describe("findAll", () => {
+    it.effect("retrieves all traces in an environment", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        // Create traces
+        const resourceSpans = [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: "svc-1" } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-list-1",
+                    spanId: "span-list-1",
+                    name: "span-1",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        yield* db.organizations.projects.environments.traces.create({
+          userId: owner.id,
+          organizationId: org.id,
+          projectId: project.id,
+          environmentId: environment.id,
+          data: { resourceSpans },
+        });
+
+        yield* db.organizations.projects.environments.traces.create({
+          userId: owner.id,
+          organizationId: org.id,
+          projectId: project.id,
+          environmentId: environment.id,
+          data: {
+            resourceSpans: [
+              {
+                resource: {
+                  attributes: [
+                    { key: "service.name", value: { stringValue: "svc-2" } },
+                  ],
+                },
+                scopeSpans: [
+                  {
+                    scope: { name: "test" },
+                    spans: [
+                      {
+                        traceId: "trace-list-2",
+                        spanId: "span-list-2",
+                        name: "span-2",
+                        startTimeUnixNano: "1000000000",
+                        endTimeUnixNano: "2000000000",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        });
+
+        const traces =
+          yield* db.organizations.projects.environments.traces.findAll({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          });
+
+        expect(traces).toHaveLength(2);
+        expect(traces.map((t) => t.traceId).sort()).toEqual([
+          "trace-list-1",
+          "trace-list-2",
+        ]);
+      }),
+    );
+
+    it.effect(
+      "returns `NotFoundError` when non-member tries to list (hides project)",
+      () =>
+        Effect.gen(function* () {
+          const { environment, project, org, nonMember } =
+            yield* TestEnvironmentFixture;
+          const db = yield* Database;
+
+          const result = yield* db.organizations.projects.environments.traces
+            .findAll({
+              userId: nonMember.id,
+              organizationId: org.id,
+              projectId: project.id,
+              environmentId: environment.id,
+            })
+            .pipe(Effect.flip);
+
+          expect(result).toBeInstanceOf(NotFoundError);
+        }),
+    );
+
+    it.effect("returns empty array when environment has no traces", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const traces =
+          yield* db.organizations.projects.environments.traces.findAll({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          });
+
+        expect(traces).toHaveLength(0);
+      }),
+    );
+
+    it.effect("returns `DatabaseError` when query fails", () =>
+      Effect.gen(function* () {
+        const db = yield* Database;
+
+        const result = yield* db.organizations.projects.environments.traces
+          .findAll({
+            userId: "owner-id",
+            organizationId: "org-id",
+            projectId: "project-id",
+            environmentId: "env-id",
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(DatabaseError);
+        expect(result.message).toBe("Failed to list traces");
+      }).pipe(
+        Effect.provide(
+          new MockDrizzleORM()
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([{ id: "project-id" }])
+            .select(new Error("Database connection failed"))
+            .build(),
+        ),
+      ),
+    );
+  });
+
+  describe("findById", () => {
+    it.effect("retrieves a trace by ID", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: "test-svc" } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-get-123",
+                    spanId: "span-get-123",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        yield* db.organizations.projects.environments.traces.create({
+          userId: owner.id,
+          organizationId: org.id,
+          projectId: project.id,
+          environmentId: environment.id,
+          data: { resourceSpans },
+        });
+
+        const trace =
+          yield* db.organizations.projects.environments.traces.findById({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            traceId: "trace-get-123",
+          });
+
+        expect(trace.traceId).toBe("trace-get-123");
+        expect(trace.serviceName).toBe("test-svc");
+      }),
+    );
+
+    it.effect("returns `NotFoundError` when trace doesn't exist", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const result = yield* db.organizations.projects.environments.traces
+          .findById({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            traceId: "non-existent-trace-id",
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(NotFoundError);
+        expect(result.message).toBe("Trace non-existent-trace-id not found");
+      }),
+    );
+
+    it.effect(
+      "returns `NotFoundError` when non-member tries to get (hides project)",
+      () =>
+        Effect.gen(function* () {
+          const { environment, project, org, owner, nonMember } =
+            yield* TestEnvironmentFixture;
+          const db = yield* Database;
+
+          const resourceSpans = [
+            {
+              resource: { attributes: [] },
+              scopeSpans: [
+                {
+                  scope: { name: "test" },
+                  spans: [
+                    {
+                      traceId: "trace-hidden",
+                      spanId: "span-hidden",
+                      name: "test-span",
+                      startTimeUnixNano: "1000000000",
+                      endTimeUnixNano: "2000000000",
+                    },
+                  ],
+                },
+              ],
+            },
+          ];
+
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+          const result = yield* db.organizations.projects.environments.traces
+            .findById({
+              userId: nonMember.id,
+              organizationId: org.id,
+              projectId: project.id,
+              environmentId: environment.id,
+              traceId: "trace-hidden",
+            })
+            .pipe(Effect.flip);
+
+          expect(result).toBeInstanceOf(NotFoundError);
+        }),
+    );
+
+    it.effect("returns `DatabaseError` when query fails", () =>
+      Effect.gen(function* () {
+        const db = yield* Database;
+
+        const result = yield* db.organizations.projects.environments.traces
+          .findById({
+            userId: "owner-id",
+            organizationId: "org-id",
+            projectId: "project-id",
+            environmentId: "env-id",
+            traceId: "trace-id",
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(DatabaseError);
+        expect(result.message).toBe("Failed to get trace");
+      }).pipe(
+        Effect.provide(
+          new MockDrizzleORM()
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([{ id: "project-id" }])
+            .select(new Error("Database connection failed"))
+            .build(),
+        ),
+      ),
+    );
+  });
+
+  describe("update", () => {
+    it.effect("returns PermissionDeniedError (traces are immutable)", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const result = yield* db.organizations.projects.environments.traces
+          .update({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            traceId: "some-trace-id",
+            data: undefined as never,
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(PermissionDeniedError);
+        expect(result.message).toContain("immutable");
+      }),
+    );
+  });
+
+  describe("delete", () => {
+    it.effect("deletes trace and associated spans", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: {
+              attributes: [
+                { key: "service.name", value: { stringValue: "del-service" } },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-to-delete",
+                    spanId: "span-to-delete",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        yield* db.organizations.projects.environments.traces.create({
+          userId: owner.id,
+          organizationId: org.id,
+          projectId: project.id,
+          environmentId: environment.id,
+          data: { resourceSpans },
+        });
+
+        yield* db.organizations.projects.environments.traces.delete({
+          userId: owner.id,
+          organizationId: org.id,
+          projectId: project.id,
+          environmentId: environment.id,
+          traceId: "trace-to-delete",
+        });
+
+        const result =
+          yield* db.organizations.projects.environments.traces.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { resourceSpans },
+          });
+
+        expect(result.acceptedSpans).toBe(1);
+      }),
+    );
+
+    it.effect("returns NotFoundError when trace not found", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const result = yield* db.organizations.projects.environments.traces
+          .delete({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            traceId: "non-existent-trace-id",
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(NotFoundError);
+      }),
+    );
+
+    it.effect("returns PermissionDeniedError for DEVELOPER role", () =>
+      Effect.gen(function* () {
+        const { environment, project, org, owner, projectDeveloper } =
+          yield* TestEnvironmentFixture;
+        const db = yield* Database;
+
+        const resourceSpans = [
+          {
+            resource: { attributes: [] },
+            scopeSpans: [
+              {
+                scope: { name: "test" },
+                spans: [
+                  {
+                    traceId: "trace-no-delete",
+                    spanId: "span-no-delete",
+                    name: "test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ];
+
+        yield* db.organizations.projects.environments.traces.create({
+          userId: owner.id,
+          organizationId: org.id,
+          projectId: project.id,
+          environmentId: environment.id,
+          data: { resourceSpans },
+        });
+
+        const result = yield* db.organizations.projects.environments.traces
+          .delete({
+            userId: projectDeveloper.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            traceId: "trace-no-delete",
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(PermissionDeniedError);
+        expect(result.message).toContain("delete");
+      }),
+    );
+
+    it.effect("returns DatabaseError when span deletion fails", () =>
+      Effect.gen(function* () {
+        const db = yield* Database;
+
+        const result = yield* db.organizations.projects.environments.traces
+          .delete({
+            userId: "owner-id",
+            organizationId: "org-id",
+            projectId: "project-id",
+            environmentId: "env-id",
+            traceId: "trace-id",
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(DatabaseError);
+        expect(result.message).toBe("Failed to delete spans");
+      }).pipe(
+        Effect.provide(
+          new MockDrizzleORM()
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([{ id: "project-id" }])
+            .delete(new Error("Connection failed"))
+            .build(),
+        ),
+      ),
+    );
+
+    it.effect("returns DatabaseError when trace deletion fails", () =>
+      Effect.gen(function* () {
+        const db = yield* Database;
+
+        const result = yield* db.organizations.projects.environments.traces
+          .delete({
+            userId: "owner-id",
+            organizationId: "org-id",
+            projectId: "project-id",
+            environmentId: "env-id",
+            traceId: "trace-id",
+          })
+          .pipe(Effect.flip);
+
+        expect(result).toBeInstanceOf(DatabaseError);
+        expect(result.message).toBe("Failed to delete trace");
+      }).pipe(
+        Effect.provide(
+          new MockDrizzleORM()
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([
+              {
+                role: "OWNER",
+                organizationId: "org-id",
+                memberId: "owner-id",
+                createdAt: new Date(),
+              },
+            ])
+            .select([{ id: "project-id" }])
+            .delete([])
+            .delete(new Error("Connection failed"))
+            .build(),
+        ),
+      ),
+    );
+  });
+});

--- a/cloud/db/traces.ts
+++ b/cloud/db/traces.ts
@@ -1,0 +1,725 @@
+/**
+ * @fileoverview Effect-native Traces service for OTLP ingestion.
+ *
+ * Provides authenticated CRUD operations for traces with role-based access
+ * control. Traces belong to environments and inherit authorization from the
+ * project's membership system. Traces are ingested via the OTLP (OpenTelemetry
+ * Protocol) format and stored with their associated spans.
+ *
+ * ## Architecture
+ *
+ * ```
+ * Traces (authenticated)
+ *   └── authorization via ProjectMemberships.getRole()
+ * ```
+ *
+ * ## Trace Roles
+ *
+ * Traces use the project's role system:
+ * - `ADMIN` - Full trace management (create, read, delete)
+ * - `DEVELOPER` - Can create and read traces
+ * - `VIEWER` - Read-only access to traces
+ * - `ANNOTATOR` - Read-only access to traces
+ *
+ * Note: Traces are immutable and cannot be updated once created.
+ *
+ * ## Implicit Access
+ *
+ * Organization OWNER and ADMIN roles have implicit ADMIN access to all projects
+ * (and thus all environments and traces) within their organization.
+ *
+ * ## OTLP Ingestion
+ *
+ * The `create` method accepts OTLP ResourceSpans format and:
+ * - Upserts traces based on traceId + environmentId
+ * - Inserts spans with conflict handling (duplicates are rejected)
+ * - Returns ingestion statistics (acceptedSpans, rejectedSpans)
+ *
+ * @example
+ * ```ts
+ * const db = yield* Database;
+ *
+ * // Ingest OTLP traces
+ * const result = yield* db.organizations.projects.environments.traces.create({
+ *   userId: "user-123",
+ *   organizationId: "org-456",
+ *   projectId: "proj-789",
+ *   environmentId: "env-012",
+ *   data: { resourceSpans: [...] },
+ * });
+ * console.log(`Accepted: ${result.acceptedSpans}, Rejected: ${result.rejectedSpans}`);
+ *
+ * // List traces in an environment
+ * const traces = yield* db.organizations.projects.environments.traces.findAll({
+ *   userId: "user-123",
+ *   organizationId: "org-456",
+ *   projectId: "proj-789",
+ *   environmentId: "env-012",
+ * });
+ * ```
+ */
+
+import { Effect } from "effect";
+import { and, eq } from "drizzle-orm";
+import {
+  BaseAuthenticatedEffectService,
+  type PermissionTable,
+} from "@/db/base";
+import { DrizzleORM } from "@/db/client";
+import { ProjectMemberships } from "@/db/project-memberships";
+import {
+  AlreadyExistsError,
+  DatabaseError,
+  NotFoundError,
+  PermissionDeniedError,
+} from "@/errors";
+import {
+  traces,
+  type NewTrace,
+  type PublicTrace,
+  type CreateTraceResponse,
+} from "@/db/schema/traces";
+import { spans, type NewSpan } from "@/db/schema/spans";
+import type { ProjectRole } from "@/db/schema";
+import type { ResourceSpans, KeyValue } from "@/api/traces.schemas";
+
+export type { PublicTrace, CreateTraceResponse };
+
+/** Input type for trace ingestion via OTLP format. */
+export type TraceCreateInput = {
+  resourceSpans: readonly ResourceSpans[];
+};
+
+/** OTLP value type extracted from KeyValue. */
+export type OTLPValue = KeyValue["value"];
+
+// =============================================================================
+// OTLP Utilities
+// =============================================================================
+
+/**
+ * Convert an OTLP value to a plain JSON value.
+ */
+function convertOTLPValue(value: OTLPValue): unknown {
+  if (value.stringValue !== undefined) {
+    return value.stringValue;
+  }
+  if (value.intValue !== undefined) {
+    return value.intValue;
+  }
+  if (value.doubleValue !== undefined) {
+    return value.doubleValue;
+  }
+  if (value.boolValue !== undefined) {
+    return value.boolValue;
+  }
+  if (value.arrayValue !== undefined) {
+    return value.arrayValue.values.map((item: unknown) => {
+      if (typeof item === "object" && item !== null) {
+        return convertOTLPValue(item as OTLPValue);
+      }
+      return item;
+    });
+  }
+  if (value.kvlistValue !== undefined) {
+    const result: Record<string, unknown> = {};
+    for (const kv of value.kvlistValue.values) {
+      if (typeof kv.value === "object" && kv.value !== null) {
+        result[kv.key] = convertOTLPValue(kv.value as OTLPValue);
+      } else {
+        result[kv.key] = kv.value;
+      }
+    }
+    return result;
+  }
+  return null;
+}
+
+/**
+ * Convert an OTLP KeyValue array to a plain JSON object.
+ */
+function keyValueArrayToObject(
+  keyValues: readonly KeyValue[] | undefined,
+): Record<string, unknown> | null {
+  if (!keyValues || keyValues.length === 0) {
+    return null;
+  }
+
+  const result: Record<string, unknown> = {};
+  for (const kv of keyValues) {
+    result[kv.key] = convertOTLPValue(kv.value);
+  }
+  return result;
+}
+
+/**
+ * Extract service name from resource attributes.
+ */
+function extractServiceName(
+  attributes: readonly KeyValue[] | undefined,
+): string | null {
+  const attr = attributes?.find((a) => a.key === "service.name");
+  return attr?.value?.stringValue ?? null;
+}
+
+/**
+ * Extract service version from resource attributes.
+ */
+function extractServiceVersion(
+  attributes: readonly KeyValue[] | undefined,
+): string | null {
+  const attr = attributes?.find((a) => a.key === "service.version");
+  return attr?.value?.stringValue ?? null;
+}
+
+// =============================================================================
+// Traces Service
+// =============================================================================
+
+type TracePath =
+  "organizations/:organizationId/projects/:projectId/environments/:environmentId/traces/:traceId";
+
+/**
+ * Effect-native Traces service.
+ *
+ * Provides CRUD operations with role-based access control for traces.
+ * Authorization is inherited from project membership via ProjectMemberships.getRole().
+ *
+ * ## Permission Matrix
+ *
+ * | Action   | ADMIN | DEVELOPER | VIEWER | ANNOTATOR |
+ * |----------|-------|-----------|--------|-----------|
+ * | create   | ✓     | ✓         | ✗      | ✗         |
+ * | read     | ✓     | ✓         | ✓      | ✓         |
+ * | update   | ✗     | ✗         | ✗      | ✗         |
+ * | delete   | ✓     | ✗         | ✗      | ✗         |
+ *
+ * Note: Traces are immutable - update always fails with PermissionDeniedError.
+ *
+ * ## Security Model
+ *
+ * - Org OWNER/ADMIN have implicit project ADMIN access (and thus trace access)
+ * - Non-members cannot see that an environment/trace exists (returns NotFoundError)
+ * - Traces are ingested via OTLP format with upsert semantics
+ * - Spans are inserted with conflict handling (duplicates are rejected)
+ */
+export class Traces extends BaseAuthenticatedEffectService<
+  PublicTrace,
+  TracePath,
+  TraceCreateInput,
+  never,
+  ProjectRole
+> {
+  private readonly projectMemberships: ProjectMemberships;
+
+  constructor(projectMemberships: ProjectMemberships) {
+    super();
+    this.projectMemberships = projectMemberships;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Base Implementation
+  // ---------------------------------------------------------------------------
+
+  protected getResourceName(): string {
+    return "trace";
+  }
+
+  protected getPermissionTable(): PermissionTable<ProjectRole> {
+    return {
+      create: ["ADMIN", "DEVELOPER"],
+      read: ["ADMIN", "DEVELOPER", "VIEWER", "ANNOTATOR"],
+      update: ["ADMIN", "DEVELOPER"],
+      delete: ["ADMIN"],
+    };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Role Resolution
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Determines the user's effective role for a trace.
+   *
+   * Delegates to `ProjectMemberships.getRole` which handles:
+   * - Org OWNER → treated as project ADMIN
+   * - Org ADMIN → treated as project ADMIN
+   * - Explicit project membership role
+   * - No access → NotFoundError (hides trace existence)
+   */
+  getRole({
+    userId,
+    organizationId,
+    projectId,
+  }: {
+    userId: string;
+    organizationId: string;
+    projectId: string;
+    environmentId?: string;
+    traceId?: string;
+  }): Effect.Effect<
+    ProjectRole,
+    NotFoundError | PermissionDeniedError | DatabaseError,
+    DrizzleORM
+  > {
+    return this.projectMemberships.getRole({
+      userId,
+      organizationId,
+      projectId,
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // CRUD Operations
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Ingests OTLP traces and spans into the database.
+   *
+   * Requires ADMIN or DEVELOPER role on the project.
+   * Traces are upserted based on traceId + environmentId.
+   * Spans are inserted with conflict handling - duplicates are rejected.
+   *
+   * @param args.userId - The user ingesting the traces
+   * @param args.organizationId - The organization containing the project
+   * @param args.projectId - The project containing the environment
+   * @param args.environmentId - The environment to ingest traces into
+   * @param args.data - OTLP ResourceSpans data
+   * @returns Trace info with ingestion statistics (acceptedSpans, rejectedSpans)
+   * @throws PermissionDeniedError - If user lacks create permission
+   * @throws NotFoundError - If the environment doesn't exist or user lacks access
+   * @throws DatabaseError - If the database operation fails
+   */
+  create({
+    userId,
+    organizationId,
+    projectId,
+    environmentId,
+    data,
+  }: {
+    userId: string;
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+    data: TraceCreateInput;
+  }): Effect.Effect<
+    CreateTraceResponse,
+    AlreadyExistsError | NotFoundError | PermissionDeniedError | DatabaseError,
+    DrizzleORM
+  > {
+    return Effect.gen(this, function* () {
+      const client = yield* DrizzleORM;
+
+      yield* this.authorize({
+        userId,
+        action: "create",
+        organizationId,
+        projectId,
+        environmentId,
+        traceId: "", // Not used for create
+      });
+
+      // Process OTLP resource spans
+      let acceptedSpans = 0;
+      let rejectedSpans = 0;
+      let firstTrace: PublicTrace | null = null;
+
+      for (const rs of data.resourceSpans) {
+        const serviceName = extractServiceName(rs.resource?.attributes);
+        const serviceVersion = extractServiceVersion(rs.resource?.attributes);
+        const resourceAttributes = keyValueArrayToObject(
+          rs.resource?.attributes,
+        );
+
+        for (const scopeSpan of rs.scopeSpans) {
+          for (const span of scopeSpan.spans) {
+            const result = yield* Effect.gen(function* () {
+              const traceData: NewTrace = {
+                traceId: span.traceId,
+                environmentId,
+                projectId,
+                organizationId,
+                serviceName,
+                serviceVersion,
+                resourceAttributes,
+              };
+
+              // Upsert the trace
+              const [upsertedTrace] = yield* client
+                .insert(traces)
+                .values(traceData)
+                .onConflictDoUpdate({
+                  target: [traces.traceId, traces.environmentId],
+                  set: {
+                    serviceName: traceData.serviceName,
+                    serviceVersion: traceData.serviceVersion,
+                    resourceAttributes: traceData.resourceAttributes,
+                  },
+                })
+                .returning()
+                .pipe(
+                  Effect.mapError(
+                    (e) =>
+                      new DatabaseError({
+                        message: "Failed to upsert trace",
+                        cause: e,
+                      }),
+                  ),
+                );
+
+              if (!firstTrace && upsertedTrace) {
+                firstTrace = upsertedTrace;
+              }
+
+              const spanData: NewSpan = {
+                traceDbId: upsertedTrace.id,
+                traceId: span.traceId,
+                spanId: span.spanId,
+                parentSpanId: span.parentSpanId,
+                environmentId,
+                projectId,
+                organizationId,
+                name: span.name,
+                kind: span.kind,
+                startTimeUnixNano: span.startTimeUnixNano
+                  ? BigInt(span.startTimeUnixNano)
+                  : null,
+                endTimeUnixNano: span.endTimeUnixNano
+                  ? BigInt(span.endTimeUnixNano)
+                  : null,
+                attributes: keyValueArrayToObject(span.attributes),
+                status: span.status,
+                events: span.events,
+                links: span.links,
+                droppedAttributesCount: span.droppedAttributesCount,
+                droppedEventsCount: span.droppedEventsCount,
+                droppedLinksCount: span.droppedLinksCount,
+              };
+
+              // Insert the span
+              const insertedSpans = yield* client
+                .insert(spans)
+                .values(spanData)
+                .onConflictDoNothing({
+                  target: [spans.spanId, spans.traceId, spans.environmentId],
+                })
+                .returning({ id: spans.id })
+                .pipe(
+                  Effect.mapError(
+                    (e) =>
+                      new DatabaseError({
+                        message: "Failed to insert span",
+                        cause: e,
+                      }),
+                  ),
+                );
+
+              return insertedSpans.length > 0;
+            }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+
+            if (result) {
+              acceptedSpans++;
+            } else {
+              rejectedSpans++;
+            }
+          }
+        }
+      }
+
+      // Return first trace info with ingestion stats
+      const traceInfo: PublicTrace = firstTrace ?? {
+        id: "",
+        traceId: "",
+        environmentId,
+        projectId,
+        organizationId,
+        serviceName: null,
+        serviceVersion: null,
+        resourceAttributes: null,
+        createdAt: null,
+      };
+
+      return {
+        ...traceInfo,
+        acceptedSpans,
+        rejectedSpans,
+      };
+    });
+  }
+
+  /**
+   * Retrieves all traces in an environment.
+   *
+   * Requires any role on the project (ADMIN, DEVELOPER, VIEWER, or ANNOTATOR).
+   *
+   * @param args.userId - The authenticated user
+   * @param args.organizationId - The organization containing the project
+   * @param args.projectId - The project containing the environment
+   * @param args.environmentId - The environment to list traces for
+   * @returns Array of traces in the environment
+   * @throws NotFoundError - If the environment doesn't exist or user lacks access
+   * @throws PermissionDeniedError - If the user lacks read permission
+   * @throws DatabaseError - If the database query fails
+   */
+  findAll({
+    userId,
+    organizationId,
+    projectId,
+    environmentId,
+  }: {
+    userId: string;
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+  }): Effect.Effect<
+    PublicTrace[],
+    NotFoundError | PermissionDeniedError | DatabaseError,
+    DrizzleORM
+  > {
+    return Effect.gen(this, function* () {
+      const client = yield* DrizzleORM;
+
+      yield* this.authorize({
+        userId,
+        action: "read",
+        organizationId,
+        projectId,
+        environmentId,
+        traceId: "",
+      });
+
+      return yield* client
+        .select()
+        .from(traces)
+        .where(eq(traces.environmentId, environmentId))
+        .pipe(
+          Effect.mapError(
+            (e) =>
+              new DatabaseError({
+                message: "Failed to list traces",
+                cause: e,
+              }),
+          ),
+        );
+    });
+  }
+
+  /**
+   * Retrieves a trace by ID.
+   *
+   * Requires any role on the project (ADMIN, DEVELOPER, VIEWER, or ANNOTATOR).
+   *
+   * @param args.userId - The authenticated user
+   * @param args.organizationId - The organization containing the project
+   * @param args.projectId - The project containing the environment
+   * @param args.environmentId - The environment containing the trace
+   * @param args.traceId - The trace to retrieve
+   * @returns The trace
+   * @throws NotFoundError - If the trace doesn't exist or user lacks access
+   * @throws PermissionDeniedError - If the user lacks read permission
+   * @throws DatabaseError - If the database query fails
+   */
+  findById({
+    userId,
+    organizationId,
+    projectId,
+    environmentId,
+    traceId,
+  }: {
+    userId: string;
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+    traceId: string;
+  }): Effect.Effect<
+    PublicTrace,
+    NotFoundError | PermissionDeniedError | DatabaseError,
+    DrizzleORM
+  > {
+    return Effect.gen(this, function* () {
+      const client = yield* DrizzleORM;
+
+      yield* this.authorize({
+        userId,
+        action: "read",
+        organizationId,
+        projectId,
+        environmentId,
+        traceId,
+      });
+
+      const [row] = yield* client
+        .select()
+        .from(traces)
+        .where(
+          and(
+            eq(traces.traceId, traceId),
+            eq(traces.environmentId, environmentId),
+          ),
+        )
+        .pipe(
+          Effect.mapError(
+            (e) =>
+              new DatabaseError({
+                message: "Failed to get trace",
+                cause: e,
+              }),
+          ),
+        );
+
+      if (!row) {
+        return yield* Effect.fail(
+          new NotFoundError({
+            message: `Trace ${traceId} not found`,
+          }),
+        );
+      }
+
+      return row;
+    });
+  }
+
+  /**
+   * Updates a trace (not supported - traces are immutable).
+   *
+   * Always fails with PermissionDeniedError because traces cannot be modified
+   * after creation.
+   *
+   * @throws PermissionDeniedError - Always (traces are immutable)
+   */
+  update({
+    userId,
+    organizationId,
+    projectId,
+    environmentId,
+    traceId,
+  }: {
+    userId: string;
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+    traceId: string;
+    data: never;
+  }): Effect.Effect<
+    PublicTrace,
+    NotFoundError | PermissionDeniedError | DatabaseError,
+    DrizzleORM
+  > {
+    return Effect.gen(this, function* () {
+      yield* this.authorize({
+        userId,
+        action: "update",
+        organizationId,
+        projectId,
+        environmentId,
+        traceId,
+      });
+
+      return yield* Effect.fail(
+        new PermissionDeniedError({
+          message: "Traces are immutable and cannot be updated.",
+          resource: "trace",
+        }),
+      );
+    });
+  }
+
+  /**
+   * Deletes a trace and all associated spans.
+   *
+   * Requires ADMIN role on the project.
+   * Deletion is performed atomically in a transaction.
+   *
+   * @param args.userId - The authenticated user
+   * @param args.organizationId - The organization containing the project
+   * @param args.projectId - The project containing the environment
+   * @param args.environmentId - The environment containing the trace
+   * @param args.traceId - The trace to delete
+   * @throws NotFoundError - If the trace doesn't exist
+   * @throws PermissionDeniedError - If the user lacks delete permission
+   * @throws DatabaseError - If the database operation fails
+   */
+  delete({
+    userId,
+    organizationId,
+    projectId,
+    environmentId,
+    traceId,
+  }: {
+    userId: string;
+    organizationId: string;
+    projectId: string;
+    environmentId: string;
+    traceId: string;
+  }): Effect.Effect<
+    void,
+    NotFoundError | PermissionDeniedError | DatabaseError,
+    DrizzleORM
+  > {
+    return Effect.gen(this, function* () {
+      const client = yield* DrizzleORM;
+
+      yield* this.authorize({
+        userId,
+        action: "delete",
+        organizationId,
+        projectId,
+        environmentId,
+        traceId,
+      });
+
+      // Use transaction to ensure spans and trace are deleted atomically
+      yield* client.withTransaction(
+        Effect.gen(function* () {
+          // Delete spans first (foreign key constraint)
+          yield* client
+            .delete(spans)
+            .where(
+              and(
+                eq(spans.traceId, traceId),
+                eq(spans.environmentId, environmentId),
+              ),
+            )
+            .pipe(
+              Effect.mapError(
+                (e) =>
+                  new DatabaseError({
+                    message: "Failed to delete spans",
+                    cause: e,
+                  }),
+              ),
+            );
+
+          // Delete the trace
+          const [row] = yield* client
+            .delete(traces)
+            .where(
+              and(
+                eq(traces.traceId, traceId),
+                eq(traces.environmentId, environmentId),
+              ),
+            )
+            .returning({ id: traces.id })
+            .pipe(
+              Effect.mapError(
+                (e) =>
+                  new DatabaseError({
+                    message: "Failed to delete trace",
+                    cause: e,
+                  }),
+              ),
+            );
+
+          if (!row) {
+            return yield* Effect.fail(
+              new NotFoundError({
+                message: `Trace ${traceId} not found`,
+                resource: "trace",
+              }),
+            );
+          }
+        }),
+      );
+    });
+  }
+}


### PR DESCRIPTION
### TL;DR

Added trace ingestion service to store and manage OpenTelemetry trace data.

### What changed?

- Created a new `TraceService` class for handling trace data ingestion
- Implemented methods to process and store OpenTelemetry trace data
- Added comprehensive test coverage for the trace service
- Integrated the trace service into the database service layer
- Added utility functions to normalize OTLP (OpenTelemetry Protocol) data formats

The implementation includes:
- Environment context resolution to associate traces with projects and organizations
- Conversion of OTLP values to normalized JSON structures
- Handling of various attribute types including nested arrays and key-value lists
- Proper handling of duplicate spans with acceptance/rejection tracking

### How to test?

Run the test suite which covers various scenarios:
- Basic trace ingestion
- Handling of duplicate spans
- Processing of complex attribute types
- Normalization of events and links
- Partial success scenarios with mixed new/duplicate spans

```
pnpm test db/services/traces.test.ts
```

### Why make this change?

This change enables the application to ingest and store OpenTelemetry trace data, which is essential for implementing distributed tracing functionality. The trace service provides the foundation for collecting performance and debugging information from applications, allowing users to monitor and troubleshoot their systems effectively.