### PR TITLE
feat(api): add API Key auth to /traces endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,7 +175,7 @@ export const useEnvironments = (organizationId: string | null, projectId: string
 - **API Key-based**: Via `X-API-Key` header with `authenticateApiKeyWithUser()`
 - API keys are scoped to their creator via `createdById` column
 - Use `getCreator(apiKeyId)` to resolve the user who created an API key
-- `getAuthenticatedUser()` tries session auth first, then API key auth
+- `authenticate(...)` tries session auth first, then API key auth
 
 ### Testing Patterns
 

--- a/cloud/api/traces.schemas.ts
+++ b/cloud/api/traces.schemas.ts
@@ -1,5 +1,12 @@
 import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
 import { Schema } from "effect";
+import {
+  NotFoundError,
+  PermissionDeniedError,
+  DatabaseError,
+  AlreadyExistsError,
+  UnauthorizedError,
+} from "@/errors";
 
 export const KeyValueSchema = Schema.Struct({
   key: Schema.String,
@@ -106,5 +113,10 @@ export type CreateTraceResponse = typeof CreateTraceResponseSchema.Type;
 export class TracesApi extends HttpApiGroup.make("traces").add(
   HttpApiEndpoint.post("create", "/traces")
     .setPayload(CreateTraceRequestSchema)
-    .addSuccess(CreateTraceResponseSchema),
+    .addSuccess(CreateTraceResponseSchema)
+    .addError(UnauthorizedError, { status: UnauthorizedError.status })
+    .addError(NotFoundError, { status: NotFoundError.status })
+    .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+    .addError(DatabaseError, { status: DatabaseError.status })
+    .addError(AlreadyExistsError, { status: AlreadyExistsError.status }),
 ) {}

--- a/cloud/app/api/auth/status.ts
+++ b/cloud/app/api/auth/status.ts
@@ -1,8 +1,9 @@
+import { Effect } from "effect";
 import { useQuery } from "@tanstack/react-query";
 import { useServerFn } from "@tanstack/react-start";
 import { createServerFn } from "@tanstack/react-start";
 import { getRequest } from "@tanstack/react-start/server";
-import { getAuthenticatedUser } from "@/auth";
+import { authenticate } from "@/auth";
 import { runEffect } from "@/app/lib/effect";
 import type { Result } from "@/app/lib/types";
 import type { PublicUser } from "@/db/schema";
@@ -16,7 +17,9 @@ export const getCurrentUser = createServerFn({ method: "GET" }).handler(
       return { success: true, data: null };
     }
 
-    return await runEffect(getAuthenticatedUser(request));
+    return await runEffect(
+      authenticate(request).pipe(Effect.map((result) => result.user)),
+    );
   },
 );
 

--- a/cloud/app/routes/api.v0.$.tsx
+++ b/cloud/app/routes/api.v0.$.tsx
@@ -3,7 +3,7 @@ import { Effect } from "effect";
 import { handleRequest } from "@/api/handler";
 import { handleErrors, handleDefects } from "@/api/utils";
 import { NotFoundError, InternalError } from "@/errors";
-import { getAuthenticatedUser, type PathParameters } from "@/auth";
+import { authenticate, type PathParameters } from "@/auth";
 import { Database } from "@/db";
 
 /**
@@ -58,18 +58,13 @@ export const Route = createFileRoute("/api/v0/$")({
             });
           }
 
-          // Extract path parameters from TanStack Router's splat for API key validation
           const pathParams = extractPathParameters(params["*"]);
-
-          // getAuthenticatedUser now returns UnauthorizedError if authentication fails
-          const authenticatedUser = yield* getAuthenticatedUser(
-            request,
-            pathParams,
-          );
+          const authResult = yield* authenticate(request, pathParams);
 
           const result = yield* handleRequest(request, {
             prefix: "/api/v0",
-            authenticatedUser,
+            user: authResult.user,
+            apiKeyInfo: authResult.apiKeyInfo,
             environment: process.env.ENVIRONMENT || "development",
           });
 

--- a/cloud/auth/context.ts
+++ b/cloud/auth/context.ts
@@ -1,5 +1,19 @@
-import { Context } from "effect";
-import type { PublicUser } from "@/db/schema";
+import { Context, Effect } from "effect";
+import type { PublicUser, ApiKeyInfo } from "@/db/schema";
+import { UnauthorizedError } from "@/errors";
+
+/** Auth result including optional API key info. */
+export type AuthResult = {
+  user: PublicUser;
+  apiKeyInfo?: ApiKeyInfo;
+};
+
+/** Make specific fields of T required. */
+export type RequireField<T, K extends keyof T> = Omit<T, K> &
+  Required<Pick<T, K>>;
+
+/** AuthResult with required apiKeyInfo. */
+export type ApiKeyAuthResult = RequireField<AuthResult, "apiKeyInfo">;
 
 /**
  * Context that provides the authenticated user for the current request.
@@ -9,3 +23,33 @@ export class AuthenticatedUser extends Context.Tag("AuthenticatedUser")<
   AuthenticatedUser,
   PublicUser
 >() {}
+
+/**
+ * Context that provides authentication result for the current request.
+ * Contains the authenticated user and optional API key info.
+ */
+export class Authentication extends Context.Tag("Authentication")<
+  Authentication,
+  AuthResult
+>() {
+  /**
+   * Require API key authentication.
+   * Fails with UnauthorizedError if apiKeyInfo is not present.
+   */
+  static readonly ApiKey: Effect.Effect<
+    ApiKeyAuthResult,
+    UnauthorizedError,
+    Authentication
+  > = Effect.gen(function* () {
+    const auth = yield* Authentication;
+    if (!auth.apiKeyInfo) {
+      return yield* Effect.fail(
+        new UnauthorizedError({
+          message:
+            "API key required. Provide X-API-Key header or Bearer token.",
+        }),
+      );
+    }
+    return auth as ApiKeyAuthResult;
+  });
+}

--- a/cloud/auth/utils.ts
+++ b/cloud/auth/utils.ts
@@ -1,8 +1,9 @@
 import { Effect } from "effect";
 import { Database } from "@/db";
 import { UnauthorizedError } from "@/errors";
-import type { PublicUser, ApiKeyInfo } from "@/db/schema";
+import type { ApiKeyInfo } from "@/db/schema";
 import { getApiKeyFromRequest } from "@/auth/api-key";
+import type { AuthResult } from "@/auth/context";
 
 function isSecure(): boolean {
   return (
@@ -169,27 +170,11 @@ export const validateApiKey = (
     return apiKeyInfo;
   });
 
-/**
- * Gets the authenticated user from a request.
- *
- * Supports two authentication methods (checked in order):
- * 1. API Key (X-API-Key header or Authorization: Bearer)
- * 2. Session cookie
- *
- * For API keys, returns the user who owns the API key (from getApiKeyInfo).
- * For sessions, returns the user associated with the session.
- *
- * When path parameters are provided and API key authentication is used,
- * validates that the API key belongs to the specified environment/project/organization.
- * This prevents an API key from one environment being used to access another.
- *
- * @param request - The HTTP request
- * @param pathParams - Optional path parameters to validate against API key scope
- */
-export const getAuthenticatedUser = (
+/** Authenticate with API key or session and return user + optional ApiKeyInfo. */
+export const authenticate = (
   request: Request,
   pathParams?: PathParameters,
-): Effect.Effect<PublicUser, UnauthorizedError, Database> =>
+): Effect.Effect<AuthResult, UnauthorizedError, Database> =>
   Effect.gen(function* () {
     const db = yield* Database;
 
@@ -199,13 +184,15 @@ export const getAuthenticatedUser = (
       // Validate the API key against path parameters and get complete info
       const apiKeyInfo = yield* validateApiKey(apiKey, pathParams);
 
-      // Return the owner as the authenticated user
-      // All owner fields come from the inner join in getApiKeyInfo
+      // Return both user and API key info
       return {
-        id: apiKeyInfo.ownerId,
-        email: apiKeyInfo.ownerEmail,
-        name: apiKeyInfo.ownerName,
-        deletedAt: apiKeyInfo.ownerDeletedAt,
+        user: {
+          id: apiKeyInfo.ownerId,
+          email: apiKeyInfo.ownerEmail,
+          name: apiKeyInfo.ownerName,
+          deletedAt: apiKeyInfo.ownerDeletedAt,
+        },
+        apiKeyInfo,
       };
     }
 
@@ -219,7 +206,7 @@ export const getAuthenticatedUser = (
       );
     }
 
-    return yield* db.sessions.findUserBySessionId(sessionId).pipe(
+    const user = yield* db.sessions.findUserBySessionId(sessionId).pipe(
       Effect.catchAll(() =>
         Effect.fail(
           new UnauthorizedError({
@@ -228,4 +215,6 @@ export const getAuthenticatedUser = (
         ),
       ),
     );
+
+    return { user };
   });

--- a/fern/openapi.json
+++ b/fern/openapi.json
@@ -103,6 +103,56 @@
                 }
               }
             }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "AlreadyExistsError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlreadyExistsError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
           }
         },
         "requestBody": {
@@ -2878,7 +2928,7 @@
           }
         ]
       },
-      "DatabaseError": {
+      "UnauthorizedError": {
         "type": "object",
         "required": [
           "message",
@@ -2888,14 +2938,10 @@
           "message": {
             "type": "string"
           },
-          "cause": {
-            "$id": "/schemas/unknown",
-            "title": "unknown"
-          },
           "tag": {
             "type": "string",
             "enum": [
-              "DatabaseError"
+              "UnauthorizedError"
             ]
           }
         },
@@ -2918,6 +2964,51 @@
             "type": "string",
             "enum": [
               "NotFoundError"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "PermissionDeniedError": {
+        "type": "object",
+        "required": [
+          "message",
+          "tag"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "resource": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string",
+            "enum": [
+              "PermissionDeniedError"
+            ]
+          }
+        },
+        "additionalProperties": false
+      },
+      "DatabaseError": {
+        "type": "object",
+        "required": [
+          "message",
+          "tag"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "cause": {
+            "$id": "/schemas/unknown",
+            "title": "unknown"
+          },
+          "tag": {
+            "type": "string",
+            "enum": [
+              "DatabaseError"
             ]
           }
         },
@@ -2963,28 +3054,6 @@
             "type": "string",
             "enum": [
               "StripeError"
-            ]
-          }
-        },
-        "additionalProperties": false
-      },
-      "PermissionDeniedError": {
-        "type": "object",
-        "required": [
-          "message",
-          "tag"
-        ],
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "resource": {
-            "type": "string"
-          },
-          "tag": {
-            "type": "string",
-            "enum": [
-              "PermissionDeniedError"
             ]
           }
         },


### PR DESCRIPTION
### TL;DR

Implemented proper trace ingestion with API key authentication and database persistence.

### What changed?

- Replaced the debug logging implementation with actual trace data persistence
- Added API key authentication to the trace ingestion endpoint
- Connected the trace handler to the database service for storing trace data
- Added proper error handling for unauthorized access, not found resources, and database errors
- Enhanced the API schema to include appropriate error responses
- Expanded test coverage with comprehensive tests for authentication and trace ingestion

### How to test?

1. Send a POST request to `/traces` with a valid API key in the `X-API-Key` header
2. Include a valid trace payload with resource spans
3. Verify a 200 response with a `partialSuccess` object
4. Test with invalid API keys to ensure 401/404 responses
5. Run the test suite with `npm test` to verify all scenarios

### Why make this change?

This change completes the trace ingestion pipeline by properly authenticating requests and persisting trace data to the database. It replaces the previous placeholder implementation that only logged trace data without storing it. This enables the application to collect and analyze distributed traces from client applications.