### PR TITLE
refactor: simplify client interface

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -27,7 +27,7 @@ from . import (
 with suppress(ImportError):
     from . import mcp
 from .calls import AsyncCall, AsyncContextCall, Call, CallDecorator, ContextCall, call
-from .clients import ModelId, Params, Provider, client, get_client
+from .clients import ModelId, Params, Provider, client
 from .content import (
     AssistantContentChunk,
     AssistantContentPart,
@@ -220,7 +220,6 @@ __all__ = [
     "exceptions",
     "format",
     "formatting",
-    "get_client",
     "mcp",
     "messages",
     "model",

--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -4,8 +4,8 @@ from .anthropic import (
     AnthropicClient,
     AnthropicModelId,
 )
-from .base import BaseClient, ClientT, Params
-from .get_client import client, get_client
+from .base import BaseClient, Params
+from .get_client import client
 from .google import GoogleClient, GoogleModelId
 from .mlx import MLXClient, MLXModelId
 from .openai import (
@@ -21,7 +21,6 @@ __all__ = [
     "AnthropicClient",
     "AnthropicModelId",
     "BaseClient",
-    "ClientT",
     "GoogleClient",
     "GoogleModelId",
     "MLXClient",
@@ -34,6 +33,5 @@ __all__ = [
     "Params",
     "Provider",
     "client",
-    "get_client",
     "model_id_to_provider",
 ]

--- a/python/mirascope/llm/clients/anthropic/__init__.py
+++ b/python/mirascope/llm/clients/anthropic/__init__.py
@@ -3,11 +3,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import AnthropicClient, client, get_client
+    from .clients import AnthropicClient, client
     from .model_ids import AnthropicModelId
 else:
     try:
-        from .clients import AnthropicClient, client, get_client
+        from .clients import AnthropicClient, client
         from .model_ids import AnthropicModelId
     except ImportError:  # pragma: no cover
         from .._missing_import_stubs import create_client_stub, create_import_error_stub
@@ -15,11 +15,9 @@ else:
         AnthropicClient = create_client_stub("anthropic", "AnthropicClient")
         AnthropicModelId = str
         client = create_import_error_stub("anthropic", "AnthropicClient")
-        get_client = create_import_error_stub("anthropic", "AnthropicClient")
 
 __all__ = [
     "AnthropicClient",
     "AnthropicModelId",
     "client",
-    "get_client",
 ]

--- a/python/mirascope/llm/clients/anthropic/clients.py
+++ b/python/mirascope/llm/clients/anthropic/clients.py
@@ -2,7 +2,6 @@
 
 import os
 from collections.abc import Sequence
-from contextvars import ContextVar
 from functools import lru_cache
 from typing import overload
 from typing_extensions import Unpack
@@ -36,10 +35,6 @@ from ..base import BaseClient, Params
 from . import _utils
 from .model_ids import AnthropicModelId
 
-ANTHROPIC_CLIENT_CONTEXT: ContextVar["AnthropicClient"] = ContextVar(
-    "ANTHROPIC_CLIENT_CONTEXT"
-)
-
 
 @lru_cache(maxsize=256)
 def _anthropic_singleton(
@@ -69,23 +64,8 @@ def client(
     return _anthropic_singleton(api_key, base_url)
 
 
-def get_client() -> "AnthropicClient":
-    """Retrieve the current Anthropic client from context, or a global default.
-
-    Returns:
-        The current Anthropic client from context if available, otherwise
-        a global default client based on environment variables.
-    """
-    ctx_client = ANTHROPIC_CLIENT_CONTEXT.get(None)
-    return ctx_client or client()
-
-
-class AnthropicClient(BaseClient[AnthropicModelId, Anthropic, "AnthropicClient"]):
+class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
     """The client for the Anthropic LLM model."""
-
-    @property
-    def _context_var(self) -> ContextVar["AnthropicClient"]:
-        return ANTHROPIC_CLIENT_CONTEXT
 
     def __init__(
         self, *, api_key: str | None = None, base_url: str | None = None

--- a/python/mirascope/llm/clients/base/__init__.py
+++ b/python/mirascope/llm/clients/base/__init__.py
@@ -1,14 +1,13 @@
 """Base client interfaces and types."""
 
 from . import _utils
-from .client import BaseClient, ClientT
+from .client import BaseClient
 from .kwargs import BaseKwargs, KwargsT
 from .params import Params
 
 __all__ = [
     "BaseClient",
     "BaseKwargs",
-    "ClientT",
     "KwargsT",
     "Params",
     "_utils",

--- a/python/mirascope/llm/clients/get_client.py
+++ b/python/mirascope/llm/clients/get_client.py
@@ -1,165 +1,25 @@
-from typing import Literal, overload
+from typing import Any
 
 from .anthropic import (
-    AnthropicClient,
     client as anthropic_client,
-    get_client as get_anthropic_client,
 )
+from .base import BaseClient
 from .google import (
-    GoogleClient,
     client as google_client,
-    get_client as get_google_client,
 )
 from .mlx import (
-    MLXClient,
     client as mlx_client,
-    get_client as get_mlx_client,
 )
 from .openai import (
-    OpenAICompletionsClient,
-    OpenAIResponsesClient,
     completions_client as openai_completions_client,
-    get_completions_client as get_openai_completions_client,
-    get_responses_client as get_openai_responses_client,
     responses_client as openai_responses_client,
 )
 from .providers import Provider
 
 
-@overload
-def get_client(provider: Literal["anthropic"]) -> AnthropicClient:
-    """Get an Anthropic client instance."""
-    ...
-
-
-@overload
-def get_client(provider: Literal["google"]) -> GoogleClient:
-    """Get a Google client instance."""
-    ...
-
-
-@overload
-def get_client(provider: Literal["openai"]) -> OpenAICompletionsClient:
-    """Get an OpenAI client instance."""
-    ...
-
-
-@overload
-def get_client(
-    provider: Literal["openai:responses"],
-) -> OpenAIResponsesClient:
-    """Get an OpenAI responses client instance."""
-    ...
-
-
-@overload
-def get_client(provider: Literal["mlx"]) -> MLXClient:
-    """Get an MLX client instance."""
-    ...
-
-
-def get_client(
-    provider: Provider,
-) -> (
-    AnthropicClient
-    | GoogleClient
-    | OpenAICompletionsClient
-    | OpenAIResponsesClient
-    | MLXClient
-):
-    """Get a client instance for the specified provider.
-
-    Args:
-        provider: The provider name ("openai", "anthropic", or "google").
-
-    Returns:
-        A client instance for the specified provider. The specific client type
-        depends on the provider:
-        - "openai" returns `OpenAICompletionsClient` (ChatCompletion API)
-        - "openai:responses" returns `OpenAIResponsesClient` (Responses API)
-        - "anthropic" returns `AnthropicClient`
-        - "google" returns `GoogleClient`
-
-    Multiple calls to get_client will return the same Client rather than constructing
-    new ones.
-
-    Raises:
-        ValueError: If the provider is not supported.
-    """
-    match provider:
-        case "anthropic":
-            return get_anthropic_client()
-        case "google":
-            return get_google_client()
-        case "openai":
-            return get_openai_completions_client()
-        case "openai:responses":
-            return get_openai_responses_client()
-        case "mlx":  # pragma: no cover (MLX is only available on macOS)
-            return get_mlx_client()
-        case _:
-            raise ValueError(f"Unknown provider: {provider}")
-
-
-@overload
-def client(
-    provider: Literal["openai"],
-    *,
-    api_key: str | None = None,
-    base_url: str | None = None,
-) -> OpenAICompletionsClient:
-    """Create a cached OpenAI chat completions client with the given parameters."""
-    ...
-
-
-@overload
-def client(
-    provider: Literal["openai:responses"],
-    *,
-    api_key: str | None = None,
-    base_url: str | None = None,
-) -> OpenAIResponsesClient:
-    """Create a cached OpenAI responses client with the given parameters."""
-    ...
-
-
-@overload
-def client(
-    provider: Literal["anthropic"],
-    *,
-    api_key: str | None = None,
-    base_url: str | None = None,
-) -> AnthropicClient:
-    """Create a cached Anthropic client with the given parameters."""
-    ...
-
-
-@overload
-def client(
-    provider: Literal["google"],
-    *,
-    api_key: str | None = None,
-    base_url: str | None = None,
-) -> GoogleClient:
-    """Create a cached Google client with the given parameters."""
-    ...
-
-
-@overload
-def client(provider: Literal["mlx"]) -> MLXClient:
-    """Create a cached MLX client."""
-    ...
-
-
 def client(
     provider: Provider, *, api_key: str | None = None, base_url: str | None = None
-) -> (
-    AnthropicClient
-    | GoogleClient
-    | OpenAICompletionsClient
-    | OpenAIResponsesClient
-    | MLXClient
-):
+) -> BaseClient[str, Any]:
     """Create a cached client instance for the specified provider.
 
     Args:

--- a/python/mirascope/llm/clients/google/__init__.py
+++ b/python/mirascope/llm/clients/google/__init__.py
@@ -3,11 +3,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import GoogleClient, client, get_client
+    from .clients import GoogleClient, client
     from .model_ids import GoogleModelId
 else:
     try:
-        from .clients import GoogleClient, client, get_client
+        from .clients import GoogleClient, client
         from .model_ids import GoogleModelId
     except ImportError:  # pragma: no cover
         from .._missing_import_stubs import create_client_stub, create_import_error_stub
@@ -15,6 +15,5 @@ else:
         GoogleClient = create_client_stub("google", "GoogleClient")
         GoogleModelId = str
         client = create_import_error_stub("google", "GoogleClient")
-        get_client = create_import_error_stub("google", "GoogleClient")
 
-__all__ = ["GoogleClient", "GoogleModelId", "client", "get_client"]
+__all__ = ["GoogleClient", "GoogleModelId", "client"]

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -2,7 +2,6 @@
 
 import os
 from collections.abc import Sequence
-from contextvars import ContextVar
 from functools import lru_cache
 from typing import overload
 from typing_extensions import Unpack
@@ -37,8 +36,6 @@ from ..base import BaseClient, Params
 from . import _utils
 from .model_ids import GoogleModelId
 
-GOOGLE_CLIENT_CONTEXT: ContextVar["GoogleClient"] = ContextVar("GOOGLE_CLIENT_CONTEXT")
-
 
 @lru_cache(maxsize=256)
 def _google_singleton(api_key: str | None, base_url: str | None) -> "GoogleClient":
@@ -66,23 +63,8 @@ def client(
     return _google_singleton(api_key, base_url)
 
 
-def get_client() -> "GoogleClient":
-    """Retrieve the current Google client from context, or a global default.
-
-    Returns:
-        The current Google client from context if available, otherwise
-        a global default client based on environment variables.
-    """
-    ctx_client = GOOGLE_CLIENT_CONTEXT.get(None)
-    return ctx_client or client()
-
-
-class GoogleClient(BaseClient[GoogleModelId, Client, "GoogleClient"]):
+class GoogleClient(BaseClient[GoogleModelId, Client]):
     """The client for the Google LLM model."""
-
-    @property
-    def _context_var(self) -> ContextVar["GoogleClient"]:
-        return GOOGLE_CLIENT_CONTEXT
 
     def __init__(
         self, *, api_key: str | None = None, base_url: str | None = None

--- a/python/mirascope/llm/clients/mlx/__init__.py
+++ b/python/mirascope/llm/clients/mlx/__init__.py
@@ -3,11 +3,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import MLXClient, client, get_client
+    from .clients import MLXClient, client
     from .model_ids import MLXModelId
 else:
     try:
-        from .clients import MLXClient, client, get_client
+        from .clients import MLXClient, client
         from .model_ids import MLXModelId
     except ImportError:  # pragma: no cover
         from .._missing_import_stubs import create_client_stub, create_import_error_stub
@@ -15,11 +15,9 @@ else:
         MLXClient = create_client_stub("mlx", "MLXClient")
         MLXModelId = str
         client = create_import_error_stub("mlx", "MLXClient")
-        get_client = create_import_error_stub("mlx", "MLXClient")
 
 __all__ = [
     "MLXClient",
     "MLXModelId",
     "client",
-    "get_client",
 ]

--- a/python/mirascope/llm/clients/openai/__init__.py
+++ b/python/mirascope/llm/clients/openai/__init__.py
@@ -4,13 +4,11 @@ from .completions import (
     OpenAICompletionsClient,
     OpenAICompletionsModelId,
     client as completions_client,
-    get_client as get_completions_client,
 )
 from .responses import (
     OpenAIResponsesClient,
     OpenAIResponsesModelId,
     client as responses_client,
-    get_client as get_responses_client,
 )
 
 __all__ = [
@@ -19,7 +17,5 @@ __all__ = [
     "OpenAIResponsesClient",
     "OpenAIResponsesModelId",
     "completions_client",
-    "get_completions_client",
-    "get_responses_client",
     "responses_client",
 ]

--- a/python/mirascope/llm/clients/openai/completions/__init__.py
+++ b/python/mirascope/llm/clients/openai/completions/__init__.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import OpenAICompletionsClient, client, get_client
+    from .clients import OpenAICompletionsClient, client
     from .model_ids import OpenAICompletionsModelId
 else:
     try:
-        from .clients import OpenAICompletionsClient, client, get_client
+        from .clients import OpenAICompletionsClient, client
         from .model_ids import OpenAICompletionsModelId
     except ImportError:  # pragma: no cover
         from ..._missing_import_stubs import (
@@ -18,11 +18,9 @@ else:
         )
         OpenAICompletionsModelId = str
         client = create_import_error_stub("openai", "OpenAICompletionsClient")
-        get_client = create_import_error_stub("openai", "OpenAICompletionsClient")
 
 __all__ = [
     "OpenAICompletionsClient",
     "OpenAICompletionsModelId",
     "client",
-    "get_client",
 ]

--- a/python/mirascope/llm/clients/openai/completions/clients.py
+++ b/python/mirascope/llm/clients/openai/completions/clients.py
@@ -2,7 +2,6 @@
 
 import os
 from collections.abc import Sequence
-from contextvars import ContextVar
 from functools import lru_cache
 from typing import overload
 from typing_extensions import Unpack
@@ -36,10 +35,6 @@ from ...base import BaseClient, Params
 from . import _utils
 from .model_ids import OpenAICompletionsModelId
 
-OPENAI_COMPLETIONS_CLIENT_CONTEXT: ContextVar["OpenAICompletionsClient"] = ContextVar(
-    "OPENAI_COMPLETIONS_CLIENT_CONTEXT"
-)
-
 
 @lru_cache(maxsize=256)
 def _openai_singleton(
@@ -69,25 +64,8 @@ def client(
     return _openai_singleton(api_key, base_url)
 
 
-def get_client() -> "OpenAICompletionsClient":
-    """Retrieve the current OpenAI client from context, or a global default.
-
-    Returns:
-        The current OpenAI client from context if available, otherwise
-        a global default client based on environment variables.
-    """
-    ctx_client = OPENAI_COMPLETIONS_CLIENT_CONTEXT.get(None)
-    return ctx_client or client()
-
-
-class OpenAICompletionsClient(
-    BaseClient[OpenAICompletionsModelId, OpenAI, "OpenAICompletionsClient"]
-):
+class OpenAICompletionsClient(BaseClient[OpenAICompletionsModelId, OpenAI]):
     """The client for the OpenAI LLM model."""
-
-    @property
-    def _context_var(self) -> ContextVar["OpenAICompletionsClient"]:
-        return OPENAI_COMPLETIONS_CLIENT_CONTEXT
 
     def __init__(
         self, *, api_key: str | None = None, base_url: str | None = None

--- a/python/mirascope/llm/clients/openai/responses/__init__.py
+++ b/python/mirascope/llm/clients/openai/responses/__init__.py
@@ -1,11 +1,11 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import OpenAIResponsesClient, client, get_client
+    from .clients import OpenAIResponsesClient, client
     from .model_ids import OpenAIResponsesModelId
 else:
     try:
-        from .clients import OpenAIResponsesClient, client, get_client
+        from .clients import OpenAIResponsesClient, client
         from .model_ids import OpenAIResponsesModelId
     except ImportError:  # pragma: no cover
         from ..._missing_import_stubs import (
@@ -16,11 +16,9 @@ else:
         OpenAIResponsesClient = create_client_stub("openai", "OpenAIResponsesClient")
         OpenAIResponsesModelId = str
         client = create_import_error_stub("openai", "OpenAIResponsesClient")
-        get_client = create_import_error_stub("openai", "OpenAIResponsesClient")
 
 __all__ = [
     "OpenAIResponsesClient",
     "OpenAIResponsesModelId",
     "client",
-    "get_client",
 ]

--- a/python/mirascope/llm/clients/openai/responses/clients.py
+++ b/python/mirascope/llm/clients/openai/responses/clients.py
@@ -2,7 +2,6 @@
 
 import os
 from collections.abc import Sequence
-from contextvars import ContextVar
 from functools import lru_cache
 from typing import overload
 from typing_extensions import Unpack
@@ -36,10 +35,6 @@ from ...base import BaseClient, Params
 from . import _utils
 from .model_ids import OpenAIResponsesModelId
 
-OPENAI_RESPONSES_CLIENT_CONTEXT: ContextVar["OpenAIResponsesClient"] = ContextVar(
-    "OPENAI_RESPONSES_CLIENT_CONTEXT"
-)
-
 
 @lru_cache(maxsize=256)
 def _openai_responses_singleton(
@@ -58,23 +53,8 @@ def client(
     return _openai_responses_singleton(api_key, base_url)
 
 
-def get_client() -> "OpenAIResponsesClient":
-    """Get the current `OpenAIResponsesClient` from context."""
-    current_client = OPENAI_RESPONSES_CLIENT_CONTEXT.get(None)
-    if current_client is None:
-        current_client = client()
-        OPENAI_RESPONSES_CLIENT_CONTEXT.set(current_client)
-    return current_client
-
-
-class OpenAIResponsesClient(
-    BaseClient[OpenAIResponsesModelId, OpenAI, "OpenAIResponsesClient"]
-):
+class OpenAIResponsesClient(BaseClient[OpenAIResponsesModelId, OpenAI]):
     """The client for the OpenAI Responses API."""
-
-    @property
-    def _context_var(self) -> ContextVar["OpenAIResponsesClient"]:
-        return OPENAI_RESPONSES_CLIENT_CONTEXT
 
     def __init__(
         self, *, api_key: str | None = None, base_url: str | None = None

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, overload
 from typing_extensions import Unpack
 
-from ..clients import get_client, model_id_to_provider
+from ..clients import client, model_id_to_provider
 from ..context import Context, DepsT
 from ..formatting import Format, FormattableT
 from ..messages import Message, UserContent
@@ -162,7 +162,7 @@ class Model:
         Returns:
             An `llm.Response` object containing the LLM-generated content.
         """
-        return get_client(self.provider).call(
+        return client(self.provider).call(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
@@ -220,7 +220,7 @@ class Model:
         Returns:
             An `llm.AsyncResponse` object containing the LLM-generated content.
         """
-        return await get_client(self.provider).call_async(
+        return await client(self.provider).call_async(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
@@ -278,7 +278,7 @@ class Model:
         Returns:
             An `llm.StreamResponse` object for iterating over the LLM-generated content.
         """
-        return get_client(self.provider).stream(
+        return client(self.provider).stream(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
@@ -336,7 +336,7 @@ class Model:
         Returns:
             An `llm.AsyncStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
-        return await get_client(self.provider).stream_async(
+        return await client(self.provider).stream_async(
             model_id=self.model_id,
             messages=messages,
             tools=tools,
@@ -407,7 +407,7 @@ class Model:
         Returns:
             An `llm.ContextResponse` object containing the LLM-generated content.
         """
-        return get_client(self.provider).context_call(
+        return client(self.provider).context_call(
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
@@ -479,7 +479,7 @@ class Model:
         Returns:
             An `llm.AsyncContextResponse` object containing the LLM-generated content.
         """
-        return await get_client(self.provider).context_call_async(
+        return await client(self.provider).context_call_async(
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
@@ -555,7 +555,7 @@ class Model:
         Returns:
             An `llm.ContextStreamResponse` object for iterating over the LLM-generated content.
         """
-        return get_client(self.provider).context_stream(
+        return client(self.provider).context_stream(
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
@@ -633,7 +633,7 @@ class Model:
         Returns:
             An `llm.AsyncContextStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
-        return await get_client(self.provider).context_stream_async(
+        return await client(self.provider).context_stream_async(
             ctx=ctx,
             model_id=self.model_id,
             messages=messages,
@@ -693,7 +693,7 @@ class Model:
         Returns:
             A new `llm.Response` object containing the extended conversation.
         """
-        return get_client(self.provider).resume(
+        return client(self.provider).resume(
             model_id=self.model_id,
             response=response,
             content=content,
@@ -751,7 +751,7 @@ class Model:
         Returns:
             A new `llm.AsyncResponse` object containing the extended conversation.
         """
-        return await get_client(self.provider).resume_async(
+        return await client(self.provider).resume_async(
             model_id=self.model_id,
             response=response,
             content=content,
@@ -814,7 +814,7 @@ class Model:
         Returns:
             A new `llm.ContextResponse` object containing the extended conversation.
         """
-        return get_client(self.provider).context_resume(
+        return client(self.provider).context_resume(
             ctx=ctx,
             model_id=self.model_id,
             response=response,
@@ -880,7 +880,7 @@ class Model:
         Returns:
             A new `llm.AsyncContextResponse` object containing the extended conversation.
         """
-        return await get_client(self.provider).context_resume_async(
+        return await client(self.provider).context_resume_async(
             ctx=ctx,
             model_id=self.model_id,
             response=response,
@@ -939,7 +939,7 @@ class Model:
         Returns:
             A new `llm.StreamResponse` object for streaming the extended conversation.
         """
-        return get_client(self.provider).resume_stream(
+        return client(self.provider).resume_stream(
             model_id=self.model_id,
             response=response,
             content=content,
@@ -997,7 +997,7 @@ class Model:
         Returns:
             A new `llm.AsyncStreamResponse` object for asynchronously streaming the extended conversation.
         """
-        return await get_client(self.provider).resume_stream_async(
+        return await client(self.provider).resume_stream_async(
             model_id=self.model_id,
             response=response,
             content=content,
@@ -1066,7 +1066,7 @@ class Model:
         Returns:
             A new `llm.ContextStreamResponse` object for streaming the extended conversation.
         """
-        return get_client(self.provider).context_resume_stream(
+        return client(self.provider).context_resume_stream(
             ctx=ctx,
             model_id=self.model_id,
             response=response,
@@ -1138,7 +1138,7 @@ class Model:
         Returns:
             A new `llm.AsyncContextStreamResponse` object for asynchronously streaming the extended conversation.
         """
-        return await get_client(self.provider).context_resume_stream_async(
+        return await client(self.provider).context_resume_stream_async(
             ctx=ctx,
             model_id=self.model_id,
             response=response,

--- a/python/tests/llm/clients/anthropic/test_client.py
+++ b/python/tests/llm/clients/anthropic/test_client.py
@@ -3,29 +3,6 @@
 from mirascope import llm
 
 
-def test_context_manager() -> None:
-    """Test nested context manager behavior and get_client() integration."""
-
-    global_client = llm.get_client("anthropic")
-
-    client1 = llm.client("anthropic", api_key="key1")
-    client2 = llm.client("anthropic", api_key="key2")
-
-    assert llm.get_client("anthropic") is global_client
-
-    with client1 as ctx1:
-        assert ctx1 is client1
-        assert llm.get_client("anthropic") is client1
-
-        with client2 as ctx2:
-            assert ctx2 is client2
-            assert llm.get_client("anthropic") is client2
-
-        assert llm.get_client("anthropic") is client1
-
-    assert llm.get_client("anthropic") is global_client
-
-
 def test_client_caching() -> None:
     """Test that client() returns cached instances for identical parameters."""
     client1 = llm.client(
@@ -47,5 +24,5 @@ def test_client_caching() -> None:
     assert client1 is not client4
 
     client5 = llm.client("anthropic", api_key=None, base_url=None)
-    client6 = llm.get_client("anthropic")
+    client6 = llm.client("anthropic")
     assert client5 is client6

--- a/python/tests/llm/clients/google/test_client.py
+++ b/python/tests/llm/clients/google/test_client.py
@@ -23,29 +23,6 @@ def test_custom_base_url() -> None:
         assert google_client.client is mock_client_instance
 
 
-def test_context_manager() -> None:
-    """Test nested context manager behavior and get_client() integration."""
-
-    global_client = llm.get_client("google")
-
-    client1 = llm.client("google", api_key="key1")
-    client2 = llm.client("google", api_key="key2")
-
-    assert llm.get_client("google") is global_client
-
-    with client1 as ctx1:
-        assert ctx1 is client1
-        assert llm.get_client("google") is client1
-
-        with client2 as ctx2:
-            assert ctx2 is client2
-            assert llm.get_client("google") is client2
-
-        assert llm.get_client("google") is client1
-
-    assert llm.get_client("google") is global_client
-
-
 def test_client_caching() -> None:
     """Test that client() returns cached instances for identical parameters."""
     client1 = llm.client(
@@ -67,5 +44,5 @@ def test_client_caching() -> None:
     assert client1 is not client4
 
     client5 = llm.client("google", api_key=None, base_url=None)
-    client6 = llm.get_client("google")
+    client6 = llm.client("google")
     assert client5 is client6

--- a/python/tests/llm/clients/mlx/test_client.py
+++ b/python/tests/llm/clients/mlx/test_client.py
@@ -3,14 +3,6 @@
 from mirascope import llm
 
 
-def test_context_manager() -> None:
-    """Test nested context manager behavior and get_client() integration."""
-    global_client = llm.get_client("mlx")
-    with llm.client("mlx") as client1:
-        assert client1 is global_client
-        assert llm.get_client("mlx") is client1
-
-
 def test_client_caching() -> None:
     """Test that client() returns cached instances for identical parameters."""
     client1 = llm.client("mlx")

--- a/python/tests/llm/clients/openai/test_completions_client.py
+++ b/python/tests/llm/clients/openai/test_completions_client.py
@@ -114,29 +114,6 @@ def test_strict_unsupported_legacy_model() -> None:
         )
 
 
-def test_context_manager() -> None:
-    """Test nested context manager behavior and get_client() integration."""
-
-    global_client = llm.get_client("openai")
-
-    client1 = llm.client("openai", api_key="key1")
-    client2 = llm.client("openai", api_key="key2")
-
-    assert llm.get_client("openai") is global_client
-
-    with client1 as ctx1:
-        assert ctx1 is client1
-        assert llm.get_client("openai") is client1
-
-        with client2 as ctx2:
-            assert ctx2 is client2
-            assert llm.get_client("openai") is client2
-
-        assert llm.get_client("openai") is client1
-
-    assert llm.get_client("openai") is global_client
-
-
 def test_client_caching() -> None:
     """Test that client() returns cached instances for identical parameters."""
     client1 = llm.client(
@@ -162,5 +139,5 @@ def test_client_caching() -> None:
     assert client1 is not client4
 
     client5 = llm.client("openai", api_key=None, base_url=None)
-    client6 = llm.get_client("openai")
+    client6 = llm.client("openai")
     assert client5 is client6

--- a/python/tests/llm/clients/openai/test_responses_client.py
+++ b/python/tests/llm/clients/openai/test_responses_client.py
@@ -65,29 +65,6 @@ def test_prepare_message_multiple_system_messages() -> None:
     )
 
 
-def test_context_manager() -> None:
-    """Test nested context manager behavior and get_client() integration."""
-
-    global_client = llm.get_client("openai:responses")
-
-    client1 = llm.client("openai:responses", api_key="key1")
-    client2 = llm.client("openai:responses", api_key="key2")
-
-    assert llm.get_client("openai:responses") is global_client
-
-    with client1 as ctx1:
-        assert ctx1 is client1
-        assert llm.get_client("openai:responses") is client1
-
-        with client2 as ctx2:
-            assert ctx2 is client2
-            assert llm.get_client("openai:responses") is client2
-
-        assert llm.get_client("openai:responses") is client1
-
-    assert llm.get_client("openai:responses") is global_client
-
-
 def test_client_caching() -> None:
     """Test that client() returns cached instances for identical parameters."""
     client1 = llm.client(
@@ -113,5 +90,5 @@ def test_client_caching() -> None:
     assert client1 is not client4
 
     client5 = llm.client("openai:responses", api_key=None, base_url=None)
-    client6 = llm.get_client("openai:responses")
+    client6 = llm.client("openai:responses")
     assert client5 is client6

--- a/python/tests/llm/clients/test_providers.py
+++ b/python/tests/llm/clients/test_providers.py
@@ -1,4 +1,4 @@
-"""Tests for provider get_client functions."""
+"""Tests for provider client functions."""
 
 import os
 import sys
@@ -8,40 +8,40 @@ import pytest
 from mirascope import llm
 
 
-def test_get_client_anthropic() -> None:
-    """Test that get_client('anthropic') returns same instance on multiple calls."""
-    client1 = llm.get_client("anthropic")
-    client2 = llm.get_client("anthropic")
+def test_client_anthropic() -> None:
+    """Test that client('anthropic') returns same instance on multiple calls."""
+    client1 = llm.client("anthropic")
+    client2 = llm.client("anthropic")
 
     assert isinstance(client1, llm.clients.AnthropicClient)
     assert client1 is client2
     assert client1.client.api_key == os.getenv("ANTHROPIC_API_KEY")
 
 
-def test_get_client_google() -> None:
-    """Test that get_client('google') returns same instance on multiple calls."""
-    client1 = llm.get_client("google")
-    client2 = llm.get_client("google")
+def test_client_google() -> None:
+    """Test that client('google') returns same instance on multiple calls."""
+    client1 = llm.client("google")
+    client2 = llm.client("google")
 
     assert isinstance(client1, llm.clients.GoogleClient)
     assert client1 is client2
     assert client1.client._api_client.api_key == os.getenv("GOOGLE_API_KEY")  # pyright: ignore[reportPrivateUsage]
 
 
-def test_get_client_openai() -> None:
-    """Test that get_client('openai') returns same instance on multiple calls."""
-    client1 = llm.get_client("openai")
-    client2 = llm.get_client("openai")
+def test_client_openai() -> None:
+    """Test that client('openai') returns same instance on multiple calls."""
+    client1 = llm.client("openai")
+    client2 = llm.client("openai")
 
     assert isinstance(client1, llm.clients.OpenAICompletionsClient)
     assert client1 is client2
     assert client1.client.api_key == os.getenv("OPENAI_API_KEY")
 
 
-def test_get_client_openai_responses() -> None:
-    """Test that get_client('openai:responses') returns same instance on multiple calls."""
-    client1 = llm.get_client("openai:responses")
-    client2 = llm.get_client("openai:responses")
+def test_client_openai_responses() -> None:
+    """Test that client('openai:responses') returns same instance on multiple calls."""
+    client1 = llm.client("openai:responses")
+    client2 = llm.client("openai:responses")
 
     assert isinstance(client1, llm.clients.OpenAIResponsesClient)
     assert client1 is client2
@@ -51,13 +51,13 @@ def test_get_client_openai_responses() -> None:
 @pytest.mark.skipif(sys.platform != "darwin", reason="MLX is only available on macOS")
 def test_get_client_mlx() -> None:
     """Test that get_client('mlx') returns same instance on multiple calls."""
-    client1 = llm.get_client("mlx")
-    client2 = llm.get_client("mlx")
+    client1 = llm.client("mlx")
+    client2 = llm.client("mlx")
     assert isinstance(client1, llm.clients.MLXClient)
     assert client1 is client2
 
 
-def test_get_client_unknown_provider() -> None:
-    """Test that get_client raises ValueError for unknown providers."""
+def test_client_unknown_provider() -> None:
+    """Test that client raises ValueError for unknown providers."""
     with pytest.raises(ValueError, match="Unknown provider: unknown"):
-        llm.get_client("unknown")  # pyright: ignore[reportArgumentType, reportCallIssue]
+        llm.client("unknown")  # pyright: ignore[reportArgumentType]

--- a/python/tests/llm/models/test_model.py
+++ b/python/tests/llm/models/test_model.py
@@ -1,25 +1,8 @@
 """Tests for the Model class."""
 
-from unittest.mock import MagicMock
-
 import pytest
 
 from mirascope import llm
-
-
-def test_client_pulled_from_context_at_call_time() -> None:
-    """Test that models get client at call time, not construction time."""
-    model = llm.use_model("openai/gpt-4o")
-
-    custom_client = llm.client("openai", api_key="test-key")
-
-    mock_call = MagicMock(return_value=MagicMock())
-    custom_client.call = mock_call
-
-    with custom_client:
-        model.call(messages=[llm.messages.user("Hello")])
-
-    mock_call.assert_called_once()
 
 
 def test_use_model_without_context() -> None:

--- a/python/tests/ops/test_model_call.py
+++ b/python/tests/ops/test_model_call.py
@@ -255,7 +255,7 @@ def test_model_call_with_error(span_exporter: InMemorySpanExporter) -> None:
         body=None,
     )
 
-    with patch("mirascope.llm.models.models.get_client", return_value=mock_client):
+    with patch("mirascope.llm.models.models.client", return_value=mock_client):
         model = llm.Model(model_id="openai:responses/gpt-4o-mini")
         messages = [llm.messages.user("Hello")]
 
@@ -756,9 +756,7 @@ def test_model_call_with_format_tool_finish_reason(
                 finish_reason=FinishReason.MAX_TOKENS,
             )
 
-    with patch(
-        "mirascope.llm.models.models.get_client", return_value=_FormatToolClient()
-    ):
+    with patch("mirascope.llm.models.models.client", return_value=_FormatToolClient()):
         model = llm.Model(
             model_id="openai:responses/gpt-4o-mini",
             max_tokens=5,

--- a/python/tests/ops/test_model_stream.py
+++ b/python/tests/ops/test_model_stream.py
@@ -351,7 +351,7 @@ def test_model_stream_with_error(span_exporter: InMemorySpanExporter) -> None:
         body=None,
     )
 
-    with patch("mirascope.llm.models.models.get_client", return_value=mock_client):
+    with patch("mirascope.llm.models.models.client", return_value=mock_client):
         model = llm.Model(model_id="openai:responses/gpt-4o")
         with pytest.raises(openai.APIError):
             model.stream(messages=_math_messages())
@@ -401,7 +401,7 @@ def test_model_stream_iterator_error_records_exception(
         chunk_iterator=_chunk_iterator(),
     )
 
-    with patch("mirascope.llm.models.models.get_client", return_value=mock_client):
+    with patch("mirascope.llm.models.models.client", return_value=mock_client):
         model = llm.Model(model_id="openai:responses/gpt-4o")
         response = model.stream(messages=_math_messages())
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
Reduces the client interface to no longer be a context manager, instead
it is just a class that wraps around underlying client with a
Model-compatible interface. Later I will re-generate the context
management stuff one layer out (as a Provider that has a Client)