### PR TITLE
Add DATABASE_URL to .example.env.local

### DIFF
--- a/cloud/.example.env.local
+++ b/cloud/.example.env.local
@@ -1,1 +1,2 @@
 ENVIRONMENT=local
+DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mirascope_cloud_dev


### PR DESCRIPTION
### TL;DR

Added DATABASE_URL to the example dev environment file that works with the colocated docker compose config.

### What changed?

Added a DATABASE_URL environment variable to the `.example.env.local` file with a default PostgreSQL connection string for local development.

### How to test?

1. Copy the `.example.env.local` file to create a new `.env.local` file
2. Verify that the DATABASE_URL is properly set
3. Ensure the application can connect to the local PostgreSQL database using these credentials

### Why make this change?

Just a time saver for anybody wanting to stand this up locally.