### PR TITLE
chore: add dist to ignore to avoid linters/formatters treating it as source

### DIFF
--- a/cloud/.gitignore
+++ b/cloud/.gitignore
@@ -6,6 +6,6 @@
 tsconfig.tsbuildinfo
 !src/lib
 coverage
-docker/data
+dist
 
 docker/data


### PR DESCRIPTION
### TL;DR

Add `cloud/dist` to `.gitignore` to exclude it from linters/formatters. Also removes `docker/data` duplicate.

### What changed?

`cloud/.gitignore` now has a `dist` entry and a duplicate `docker/data` removed.

### How to test?

1. `cd cloud && bun run build && bun run format`
2. Files under `cloud/dist` are no longer subject to formatting.

### Why make this change?

Files under `dist` are artifacts and packaged for distribution. No need to pretty-format them.