### PR TITLE
feat(api): add annotations API endpoints

### DIFF
--- a/cloud/api/annotations.handlers.ts
+++ b/cloud/api/annotations.handlers.ts
@@ -1,0 +1,149 @@
+import { Effect } from "effect";
+import { Database } from "@/db";
+import { Authentication } from "@/auth";
+import type { PublicAnnotation } from "@/db/schema/annotations";
+import type {
+  CreateAnnotationRequest,
+  UpdateAnnotationRequest,
+} from "@/api/annotations.schemas";
+
+export * from "@/api/annotations.schemas";
+
+export const toAnnotation = (ann: PublicAnnotation) => ({
+  ...ann,
+  createdAt: ann.createdAt?.toISOString() ?? null,
+  updatedAt: ann.updatedAt?.toISOString() ?? null,
+});
+
+/**
+ * Handler for listing annotations with optional filters.
+ * Returns annotations for the authenticated environment.
+ */
+export const listAnnotationsHandler = (params: {
+  otelTraceId?: string;
+  otelSpanId?: string;
+  label?: "pass" | "fail";
+  limit?: number;
+  offset?: number;
+}) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+
+    const results =
+      yield* db.organizations.projects.environments.traces.annotations.findAll({
+        userId: user.id,
+        organizationId: apiKeyInfo.organizationId,
+        projectId: apiKeyInfo.projectId,
+        environmentId: apiKeyInfo.environmentId,
+        filters: {
+          otelTraceId: params.otelTraceId,
+          otelSpanId: params.otelSpanId,
+          label: params.label,
+          limit: params.limit,
+          offset: params.offset,
+        },
+      });
+
+    return {
+      annotations: results.map(toAnnotation),
+      total: results.length,
+    };
+  });
+
+/**
+ * Handler for creating a new annotation.
+ * Associates an annotation with a span in the authenticated environment.
+ */
+export const createAnnotationHandler = (payload: CreateAnnotationRequest) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+
+    const result =
+      yield* db.organizations.projects.environments.traces.annotations.create({
+        userId: user.id,
+        organizationId: apiKeyInfo.organizationId,
+        projectId: apiKeyInfo.projectId,
+        environmentId: apiKeyInfo.environmentId,
+        data: {
+          otelSpanId: payload.otelSpanId,
+          otelTraceId: payload.otelTraceId,
+          label: payload.label ?? null,
+          reasoning: payload.reasoning ?? null,
+          metadata: payload.metadata ?? null,
+        },
+      });
+
+    return toAnnotation(result);
+  });
+
+/**
+ * Handler for retrieving an annotation by ID.
+ * Returns the annotation if found in the authenticated environment.
+ */
+export const getAnnotationHandler = (id: string) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+
+    const result =
+      yield* db.organizations.projects.environments.traces.annotations.findById(
+        {
+          userId: user.id,
+          organizationId: apiKeyInfo.organizationId,
+          projectId: apiKeyInfo.projectId,
+          environmentId: apiKeyInfo.environmentId,
+          annotationId: id,
+        },
+      );
+
+    return toAnnotation(result);
+  });
+
+/**
+ * Handler for updating an existing annotation.
+ * Updates the annotation fields in the authenticated environment.
+ */
+export const updateAnnotationHandler = (
+  id: string,
+  payload: UpdateAnnotationRequest,
+) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+
+    const result =
+      yield* db.organizations.projects.environments.traces.annotations.update({
+        userId: user.id,
+        organizationId: apiKeyInfo.organizationId,
+        projectId: apiKeyInfo.projectId,
+        environmentId: apiKeyInfo.environmentId,
+        annotationId: id,
+        data: {
+          label: payload.label,
+          reasoning: payload.reasoning,
+          metadata: payload.metadata,
+        },
+      });
+
+    return toAnnotation(result);
+  });
+
+/**
+ * Handler for deleting an annotation.
+ * Removes the annotation from the authenticated environment.
+ */
+export const deleteAnnotationHandler = (id: string) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const { user, apiKeyInfo } = yield* Authentication.ApiKey;
+
+    yield* db.organizations.projects.environments.traces.annotations.delete({
+      userId: user.id,
+      organizationId: apiKeyInfo.organizationId,
+      projectId: apiKeyInfo.projectId,
+      environmentId: apiKeyInfo.environmentId,
+      annotationId: id,
+    });
+  });

--- a/cloud/api/annotations.schemas.ts
+++ b/cloud/api/annotations.schemas.ts
@@ -1,0 +1,130 @@
+import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
+import { Schema } from "effect";
+import {
+  NotFoundError,
+  AlreadyExistsError,
+  DatabaseError,
+  PermissionDeniedError,
+  UnauthorizedError,
+} from "@/errors";
+
+const LabelSchema = Schema.Literal("pass", "fail");
+
+const CreateAnnotationRequestSchema = Schema.Struct({
+  otelSpanId: Schema.String,
+  otelTraceId: Schema.String,
+  label: Schema.optional(Schema.NullOr(LabelSchema)),
+  reasoning: Schema.optional(Schema.NullOr(Schema.String)),
+  metadata: Schema.optional(
+    Schema.NullOr(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+  ),
+});
+
+export type CreateAnnotationRequest = typeof CreateAnnotationRequestSchema.Type;
+
+const UpdateAnnotationRequestSchema = Schema.Struct({
+  label: Schema.optional(Schema.NullOr(LabelSchema)),
+  reasoning: Schema.optional(Schema.NullOr(Schema.String)),
+  metadata: Schema.optional(
+    Schema.NullOr(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
+  ),
+});
+
+export type UpdateAnnotationRequest = typeof UpdateAnnotationRequestSchema.Type;
+
+const AnnotationResponseSchema = Schema.Struct({
+  id: Schema.String,
+  spanId: Schema.String,
+  traceId: Schema.String,
+  otelSpanId: Schema.String,
+  otelTraceId: Schema.String,
+  label: Schema.NullOr(LabelSchema),
+  reasoning: Schema.NullOr(Schema.String),
+  metadata: Schema.NullOr(
+    Schema.Record({ key: Schema.String, value: Schema.Unknown }),
+  ),
+  environmentId: Schema.String,
+  projectId: Schema.String,
+  organizationId: Schema.String,
+  createdBy: Schema.NullOr(Schema.String),
+  createdAt: Schema.NullOr(Schema.String),
+  updatedAt: Schema.NullOr(Schema.String),
+});
+
+export type AnnotationResponse = typeof AnnotationResponseSchema.Type;
+
+const ListAnnotationsResponseSchema = Schema.Struct({
+  annotations: Schema.Array(AnnotationResponseSchema),
+  total: Schema.Number,
+});
+
+export type ListAnnotationsResponse = typeof ListAnnotationsResponseSchema.Type;
+
+export class AnnotationsApi extends HttpApiGroup.make("annotations")
+  .add(
+    HttpApiEndpoint.get("list", "/annotations")
+      .setUrlParams(
+        Schema.Struct({
+          otelTraceId: Schema.optional(Schema.String),
+          otelSpanId: Schema.optional(Schema.String),
+          label: Schema.optional(LabelSchema),
+          limit: Schema.optional(Schema.NumberFromString),
+          offset: Schema.optional(Schema.NumberFromString),
+        }),
+      )
+      .addSuccess(ListAnnotationsResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.post("create", "/annotations")
+      .setPayload(CreateAnnotationRequestSchema)
+      .addSuccess(AnnotationResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(AlreadyExistsError, { status: AlreadyExistsError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.get("get", "/annotations/:id")
+      .setPath(
+        Schema.Struct({
+          id: Schema.String,
+        }),
+      )
+      .addSuccess(AnnotationResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.put("update", "/annotations/:id")
+      .setPath(
+        Schema.Struct({
+          id: Schema.String,
+        }),
+      )
+      .setPayload(UpdateAnnotationRequestSchema)
+      .addSuccess(AnnotationResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.del("delete", "/annotations/:id")
+      .setPath(
+        Schema.Struct({
+          id: Schema.String,
+        }),
+      )
+      .addSuccess(Schema.Void)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  ) {}

--- a/cloud/api/annotations.test.ts
+++ b/cloud/api/annotations.test.ts
@@ -1,0 +1,347 @@
+import { Effect } from "effect";
+import {
+  describe,
+  it,
+  expect,
+  TestApiContext,
+  createApiClient,
+} from "@/tests/api";
+import type { PublicProject, PublicEnvironment } from "@/db/schema";
+import { toAnnotation } from "@/api/annotations.handlers";
+import { TEST_DATABASE_URL } from "@/tests/db";
+
+describe("toAnnotation", () => {
+  it("converts dates to ISO strings", () => {
+    const now = new Date();
+    const annotation = {
+      id: "test-id",
+      spanId: "span-db-id",
+      traceId: "trace-db-id",
+      otelSpanId: "otel-span-id",
+      otelTraceId: "otel-trace-id",
+      label: "pass" as const,
+      reasoning: "test-reasoning",
+      metadata: { key: "value" },
+      environmentId: "env-id",
+      projectId: "project-id",
+      organizationId: "org-id",
+      createdBy: "user-id",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const result = toAnnotation(annotation);
+
+    expect(result.createdAt).toBe(now.toISOString());
+    expect(result.updatedAt).toBe(now.toISOString());
+  });
+
+  it("handles null dates", () => {
+    const annotation = {
+      id: "test-id",
+      spanId: "span-db-id",
+      traceId: "trace-db-id",
+      otelSpanId: "otel-span-id",
+      otelTraceId: "otel-trace-id",
+      label: null,
+      reasoning: null,
+      metadata: null,
+      environmentId: "env-id",
+      projectId: "project-id",
+      organizationId: "org-id",
+      createdBy: "user-id",
+      createdAt: null,
+      updatedAt: null,
+    };
+
+    const result = toAnnotation(annotation);
+
+    expect(result.createdAt).toBeNull();
+    expect(result.updatedAt).toBeNull();
+  });
+});
+
+describe.sequential("Annotations API", (it) => {
+  let project: PublicProject;
+  let environment: PublicEnvironment;
+  let apiKeyClient: Awaited<ReturnType<typeof createApiClient>>["client"];
+  let disposeApiKeyClient: (() => Promise<void>) | null = null;
+  let createdAnnotationId: string;
+
+  it.effect(
+    "POST /organizations/:orgId/projects - create project for annotations test",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        project = yield* client.projects.create({
+          path: { organizationId: org.id },
+          payload: {
+            name: "Annotations Test Project",
+            slug: "annotations-test-project",
+          },
+        });
+        expect(project.id).toBeDefined();
+      }),
+  );
+
+  it.effect(
+    "POST /organizations/:orgId/projects/:projId/environments - create environment for annotations test",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        environment = yield* client.environments.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: {
+            name: "Annotations Test Environment",
+            slug: "annotations-test-env",
+          },
+        });
+        expect(environment.id).toBeDefined();
+      }),
+  );
+
+  it.effect("Create API key client for annotations tests", () =>
+    Effect.gen(function* () {
+      const { org, owner } = yield* TestApiContext;
+      const apiKeyInfo = {
+        apiKeyId: "test-api-key-id",
+        organizationId: org.id,
+        projectId: project.id,
+        environmentId: environment.id,
+        ownerId: owner.id,
+        ownerEmail: owner.email,
+        ownerName: owner.name,
+        ownerDeletedAt: owner.deletedAt,
+      };
+
+      const result = yield* Effect.promise(() =>
+        createApiClient(TEST_DATABASE_URL, owner, apiKeyInfo),
+      );
+      apiKeyClient = result.client;
+      disposeApiKeyClient = result.dispose;
+    }),
+  );
+
+  it.effect("POST /traces - create trace for annotations test", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.traces.create({
+        payload: {
+          resourceSpans: [
+            {
+              resource: {
+                attributes: [
+                  { key: "service.name", value: { stringValue: "test-svc" } },
+                ],
+              },
+              scopeSpans: [
+                {
+                  scope: { name: "test-scope" },
+                  spans: [
+                    {
+                      traceId: "0123456789abcdef0123456789abcdef",
+                      spanId: "0123456789abcdef",
+                      name: "test-span",
+                      startTimeUnixNano: "1700000000000000000",
+                      endTimeUnixNano: "1700000001000000000",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+      expect(result.partialSuccess).toBeDefined();
+    }),
+  );
+
+  it.effect("POST /annotations - creates annotation", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.annotations.create({
+        payload: {
+          otelTraceId: "0123456789abcdef0123456789abcdef",
+          otelSpanId: "0123456789abcdef",
+          label: "pass",
+        },
+      });
+      expect(result.id).toBeDefined();
+      expect(result.label).toBe("pass");
+      createdAnnotationId = result.id;
+    }),
+  );
+
+  it.effect("POST /annotations - creates annotation with optional fields", () =>
+    Effect.gen(function* () {
+      const optionalTraceId = "fedcba9876543210fedcba9876543210";
+      const optionalSpanId = "fedcba9876543210";
+
+      yield* apiKeyClient.traces.create({
+        payload: {
+          resourceSpans: [
+            {
+              resource: {
+                attributes: [
+                  { key: "service.name", value: { stringValue: "test-svc" } },
+                ],
+              },
+              scopeSpans: [
+                {
+                  scope: { name: "test-scope" },
+                  spans: [
+                    {
+                      traceId: optionalTraceId,
+                      spanId: optionalSpanId,
+                      name: "optional-span",
+                      startTimeUnixNano: "1700000000000000001",
+                      endTimeUnixNano: "1700000001000000001",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      const result = yield* apiKeyClient.annotations.create({
+        payload: {
+          otelTraceId: optionalTraceId,
+          otelSpanId: optionalSpanId,
+          label: "fail",
+          reasoning: "test-reasoning",
+          metadata: { key: "value" },
+        },
+      });
+      expect(result.id).toBeDefined();
+      expect(result.label).toBe("fail");
+      expect(result.reasoning).toBe("test-reasoning");
+      expect(result.metadata).toEqual({ key: "value" });
+    }),
+  );
+
+  it.effect("GET /annotations/:id - gets annotation by ID", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.annotations.get({
+        path: { id: createdAnnotationId },
+      });
+      expect(result.id).toBe(createdAnnotationId);
+      expect(result.label).toBe("pass");
+    }),
+  );
+
+  it.effect("PUT /annotations/:id - updates annotation", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.annotations.update({
+        path: { id: createdAnnotationId },
+        payload: {
+          label: "fail",
+          reasoning: "updated-reasoning",
+        },
+      });
+      expect(result.id).toBe(createdAnnotationId);
+      expect(result.label).toBe("fail");
+      expect(result.reasoning).toBe("updated-reasoning");
+    }),
+  );
+
+  it.effect("GET /annotations - lists annotations", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.annotations.list({
+        urlParams: {},
+      });
+      expect(result.total).toBeGreaterThanOrEqual(1);
+      expect(result.annotations.length).toBeGreaterThanOrEqual(1);
+    }),
+  );
+
+  it.effect("GET /annotations - filters by label", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.annotations.list({
+        urlParams: { label: "fail" },
+      });
+      expect(result.total).toBeGreaterThanOrEqual(1);
+      expect(result.annotations.every((a) => a.label === "fail")).toBe(true);
+    }),
+  );
+
+  it.effect("GET /annotations - filters by otelTraceId", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.annotations.list({
+        urlParams: { otelTraceId: "0123456789abcdef0123456789abcdef" },
+      });
+      expect(result.total).toBeGreaterThanOrEqual(1);
+      expect(
+        result.annotations.every(
+          (a) => a.otelTraceId === "0123456789abcdef0123456789abcdef",
+        ),
+      ).toBe(true);
+    }),
+  );
+
+  it.effect("GET /annotations - paginates with limit and offset", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.annotations.list({
+        urlParams: { limit: 1, offset: 0 },
+      });
+      expect(result.annotations.length).toBeLessThanOrEqual(1);
+    }),
+  );
+
+  it.effect("DELETE /annotations/:id - deletes annotation", () =>
+    Effect.gen(function* () {
+      const deleteTraceId = "00112233445566778899aabbccddeeff";
+      const deleteSpanId = "0011223344556677";
+
+      yield* apiKeyClient.traces.create({
+        payload: {
+          resourceSpans: [
+            {
+              resource: {
+                attributes: [
+                  { key: "service.name", value: { stringValue: "test-svc" } },
+                ],
+              },
+              scopeSpans: [
+                {
+                  scope: { name: "test-scope" },
+                  spans: [
+                    {
+                      traceId: deleteTraceId,
+                      spanId: deleteSpanId,
+                      name: "delete-span",
+                      startTimeUnixNano: "1700000000000000002",
+                      endTimeUnixNano: "1700000001000000002",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      });
+
+      const created = yield* apiKeyClient.annotations.create({
+        payload: {
+          otelTraceId: deleteTraceId,
+          otelSpanId: deleteSpanId,
+          label: "pass",
+        },
+      });
+
+      yield* apiKeyClient.annotations.delete({ path: { id: created.id } });
+
+      const list = yield* apiKeyClient.annotations.list({
+        urlParams: {},
+      });
+      expect(list.annotations.find((a) => a.id === created.id)).toBeUndefined();
+    }),
+  );
+
+  it.effect("Dispose API key client", () =>
+    Effect.gen(function* () {
+      if (disposeApiKeyClient) {
+        yield* Effect.promise(disposeApiKeyClient);
+      }
+    }),
+  );
+});

--- a/cloud/api/api.ts
+++ b/cloud/api/api.ts
@@ -7,6 +7,7 @@ import { ProjectsApi } from "@/api/projects.schemas";
 import { EnvironmentsApi } from "@/api/environments.schemas";
 import { ApiKeysApi } from "@/api/api-keys.schemas";
 import { FunctionsApi } from "@/api/functions.schemas";
+import { AnnotationsApi } from "@/api/annotations.schemas";
 
 export * from "@/errors";
 export * from "@/api/health.schemas";
@@ -17,6 +18,7 @@ export * from "@/api/projects.schemas";
 export * from "@/api/environments.schemas";
 export * from "@/api/api-keys.schemas";
 export * from "@/api/functions.schemas";
+export * from "@/api/annotations.schemas";
 
 export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
   .add(HealthApi)
@@ -26,4 +28,5 @@ export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
   .add(ProjectsApi)
   .add(EnvironmentsApi)
   .add(ApiKeysApi)
-  .add(FunctionsApi) {}
+  .add(FunctionsApi)
+  .add(AnnotationsApi) {}

--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -38,6 +38,13 @@ import {
   findByHashHandler,
   deleteFunctionHandler,
 } from "@/api/functions.handlers";
+import {
+  listAnnotationsHandler,
+  createAnnotationHandler,
+  getAnnotationHandler,
+  updateAnnotationHandler,
+  deleteAnnotationHandler,
+} from "@/api/annotations.handlers";
 import { MirascopeCloudApi } from "@/api/api";
 
 export { MirascopeCloudApi };
@@ -181,6 +188,20 @@ const FunctionsHandlersLive = HttpApiBuilder.group(
       .handle("findByHash", ({ path }) => findByHashHandler(path.hash)),
 );
 
+const AnnotationsHandlersLive = HttpApiBuilder.group(
+  MirascopeCloudApi,
+  "annotations",
+  (handlers) =>
+    handlers
+      .handle("list", ({ urlParams }) => listAnnotationsHandler(urlParams))
+      .handle("create", ({ payload }) => createAnnotationHandler(payload))
+      .handle("get", ({ path }) => getAnnotationHandler(path.id))
+      .handle("update", ({ path, payload }) =>
+        updateAnnotationHandler(path.id, payload),
+      )
+      .handle("delete", ({ path }) => deleteAnnotationHandler(path.id)),
+);
+
 export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(HealthHandlersLive),
   Layer.provide(TracesHandlersLive),
@@ -190,4 +211,5 @@ export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(EnvironmentsHandlersLive),
   Layer.provide(ApiKeysHandlersLive),
   Layer.provide(FunctionsHandlersLive),
+  Layer.provide(AnnotationsHandlersLive),
 );

--- a/cloud/db/annotations.ts
+++ b/cloud/db/annotations.ts
@@ -30,7 +30,7 @@
  * const db = yield* Database;
  *
  * // Create an annotation for a span
- * const annotation = yield* db.organizations.projects.environments.annotations.create({
+ * const annotation = yield* db.organizations.projects.environments.traces.annotations.create({
  *   userId: "user-123",
  *   organizationId: "org-456",
  *   projectId: "proj-789",
@@ -44,7 +44,7 @@
  * });
  *
  * // List annotations in an environment
- * const annotations = yield* db.organizations.projects.environments.annotations.findAll({
+ * const annotations = yield* db.organizations.projects.environments.traces.annotations.findAll({
  *   userId: "user-123",
  *   organizationId: "org-456",
  *   projectId: "proj-789",

--- a/fern/openapi.json
+++ b/fern/openapi.json
@@ -3938,6 +3938,1020 @@
           }
         }
       }
+    },
+    "/annotations": {
+      "get": {
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "annotations.list",
+        "parameters": [
+          {
+            "name": "otelTraceId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "otelSpanId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "label",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pass",
+                "fail"
+              ]
+            },
+            "required": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/NumberFromString"
+            },
+            "required": false
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/NumberFromString"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "annotations",
+                    "total"
+                  ],
+                  "properties": {
+                    "annotations": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "spanId",
+                          "traceId",
+                          "otelSpanId",
+                          "otelTraceId",
+                          "label",
+                          "reasoning",
+                          "metadata",
+                          "environmentId",
+                          "projectId",
+                          "organizationId",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "spanId": {
+                            "type": "string"
+                          },
+                          "traceId": {
+                            "type": "string"
+                          },
+                          "otelSpanId": {
+                            "type": "string"
+                          },
+                          "otelTraceId": {
+                            "type": "string"
+                          },
+                          "label": {
+                            "anyOf": [
+                              {
+                                "type": "string",
+                                "enum": [
+                                  "pass",
+                                  "fail"
+                                ]
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "reasoning": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "metadata": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "required": [],
+                                "properties": {},
+                                "additionalProperties": {
+                                  "$id": "/schemas/unknown",
+                                  "title": "unknown"
+                                }
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "environmentId": {
+                            "type": "string"
+                          },
+                          "projectId": {
+                            "type": "string"
+                          },
+                          "organizationId": {
+                            "type": "string"
+                          },
+                          "createdBy": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "updatedAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "annotations.create",
+        "parameters": [],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "spanId",
+                    "traceId",
+                    "otelSpanId",
+                    "otelTraceId",
+                    "label",
+                    "reasoning",
+                    "metadata",
+                    "environmentId",
+                    "projectId",
+                    "organizationId",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "spanId": {
+                      "type": "string"
+                    },
+                    "traceId": {
+                      "type": "string"
+                    },
+                    "otelSpanId": {
+                      "type": "string"
+                    },
+                    "otelTraceId": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "pass",
+                            "fail"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "reasoning": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": [],
+                          "properties": {},
+                          "additionalProperties": {
+                            "$id": "/schemas/unknown",
+                            "title": "unknown"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "environmentId": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "organizationId": {
+                      "type": "string"
+                    },
+                    "createdBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "AlreadyExistsError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlreadyExistsError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "otelSpanId",
+                  "otelTraceId"
+                ],
+                "properties": {
+                  "otelSpanId": {
+                    "type": "string"
+                  },
+                  "otelTraceId": {
+                    "type": "string"
+                  },
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "pass",
+                          "fail"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "reasoning": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "metadata": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "required": [],
+                        "properties": {},
+                        "additionalProperties": {
+                          "$id": "/schemas/unknown",
+                          "title": "unknown"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/annotations/{id}": {
+      "get": {
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "annotations.get",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "spanId",
+                    "traceId",
+                    "otelSpanId",
+                    "otelTraceId",
+                    "label",
+                    "reasoning",
+                    "metadata",
+                    "environmentId",
+                    "projectId",
+                    "organizationId",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "spanId": {
+                      "type": "string"
+                    },
+                    "traceId": {
+                      "type": "string"
+                    },
+                    "otelSpanId": {
+                      "type": "string"
+                    },
+                    "otelTraceId": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "pass",
+                            "fail"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "reasoning": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": [],
+                          "properties": {},
+                          "additionalProperties": {
+                            "$id": "/schemas/unknown",
+                            "title": "unknown"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "environmentId": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "organizationId": {
+                      "type": "string"
+                    },
+                    "createdBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "annotations.update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "spanId",
+                    "traceId",
+                    "otelSpanId",
+                    "otelTraceId",
+                    "label",
+                    "reasoning",
+                    "metadata",
+                    "environmentId",
+                    "projectId",
+                    "organizationId",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "spanId": {
+                      "type": "string"
+                    },
+                    "traceId": {
+                      "type": "string"
+                    },
+                    "otelSpanId": {
+                      "type": "string"
+                    },
+                    "otelTraceId": {
+                      "type": "string"
+                    },
+                    "label": {
+                      "anyOf": [
+                        {
+                          "type": "string",
+                          "enum": [
+                            "pass",
+                            "fail"
+                          ]
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "reasoning": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "metadata": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "required": [],
+                          "properties": {},
+                          "additionalProperties": {
+                            "$id": "/schemas/unknown",
+                            "title": "unknown"
+                          }
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "environmentId": {
+                      "type": "string"
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "organizationId": {
+                      "type": "string"
+                    },
+                    "createdBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "label": {
+                    "anyOf": [
+                      {
+                        "type": "string",
+                        "enum": [
+                          "pass",
+                          "fail"
+                        ]
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "reasoning": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "metadata": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "required": [],
+                        "properties": {},
+                        "additionalProperties": {
+                          "$id": "/schemas/unknown",
+                          "title": "unknown"
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "tags": [
+          "annotations"
+        ],
+        "operationId": "annotations.delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -4166,6 +5180,10 @@
           }
         },
         "additionalProperties": false
+      },
+      "NumberFromString": {
+        "type": "string",
+        "description": "a string to be decoded into a number"
       }
     },
     "securitySchemes": {}
@@ -4195,6 +5213,9 @@
     },
     {
       "name": "functions"
+    },
+    {
+      "name": "annotations"
     }
   ],
   "servers": [


### PR DESCRIPTION
### TL;DR

Added API endpoints for managing annotations with full CRUD operations.

### What changed?

- Created new file `annotations.handlers.ts` with handlers for creating, retrieving, updating, deleting, and listing annotations
- Created new file `annotations.schemas.ts` with schema definitions for annotation requests and responses
- Implemented API authentication using API keys
- Added proper error handling for unauthorized access, not found resources, and database errors
- Defined type interfaces for all request and response objects

### How to test?

1. Test creating an annotation with `POST /annotations` endpoint
2. Retrieve an annotation with `GET /annotations/:id`
3. Update an annotation with `PUT /annotations/:id`
4. List annotations with `GET /annotations` using optional filters (traceId, spanId, label)
5. Delete an annotation with `DELETE /annotations/:id`
6. Verify proper error responses when using invalid API keys or accessing non-existent resources

### Why make this change?

This change adds support for annotations in the API, allowing users to attach metadata to spans and traces. Annotations provide context and additional information that can help with debugging, analysis, and collaboration. The implementation follows the existing API patterns with proper authentication, validation, and error handling.