### PR TITLE
fix: eliminate error upon first load which sort of fixes itself thanks to reloading

### DIFF
--- a/cloud/src/router.tsx
+++ b/cloud/src/router.tsx
@@ -1,10 +1,26 @@
 import { createRouter } from "@tanstack/react-router";
-import { routeTree } from "@/src/routeTree.gen";
 import { DefaultCatchBoundary } from "@/src/components/default-catch-boundary";
 import { NotFound } from "@/src/components/not-found";
 
-export function getRouter() {
-  const router = createRouter({
+let routerInstance: ReturnType<typeof createRouter> | null = null;
+let routeTreeModule: typeof import("@/src/routeTree.gen") | null = null;
+
+// Lazy load routeTree to avoid circular dependency
+async function getRouteTree() {
+  if (!routeTreeModule) {
+    routeTreeModule = await import("@/src/routeTree.gen");
+  }
+  return routeTreeModule.routeTree;
+}
+
+export async function getRouter() {
+  if (routerInstance) {
+    return routerInstance;
+  }
+
+  const routeTree = await getRouteTree();
+
+  routerInstance = createRouter({
     routeTree,
     defaultPreload: "intent",
     defaultErrorComponent: DefaultCatchBoundary,
@@ -12,5 +28,5 @@ export function getRouter() {
     scrollRestoration: true,
   });
 
-  return router;
+  return routerInstance;
 }


### PR DESCRIPTION
Moving into draft for now: This seemed to work well but now I'm doubting myself... needs more testing.

### TL;DR

Implemented lazy loading for route tree to prevent circular dependencies and added router instance caching.

### What changed?

- Modified `getRouter()` to be an async function that lazily loads the route tree
- Added caching of the router instance to prevent multiple instantiations
- Removed direct import of `routeTree` and replaced it with dynamic import
- Created a helper function `getRouteTree()` to handle the lazy loading logic
- Added state variables to store the router instance and route tree module

### How to test?

Restart `bun run dev` and attempt a hard refresh SHIFT+CMD+R in the browser. Without these changes the initial request will result in an error.

1. Verify that the application routing still works correctly
2. Check for any circular dependency warnings in the console
3. Verify that navigation between routes functions as expected
4. Test that the router is properly initialized on first use

### Why make this change?

This change resolves circular dependency issues in the application's routing system. By lazily loading the route tree and caching the router instance, we prevent initialization problems that can occur when components reference each other in a circular manner. This improves application stability and prevents potential runtime errors.