### PR TITLE
fix(api): distinguish handler NotFoundError from route-not-found in Effect API

### DIFF
--- a/cloud/api/handler.ts
+++ b/cloud/api/handler.ts
@@ -79,7 +79,11 @@ export const handleRequest = (
         }
 
         const response = await webHandler.handler(modifiedRequest);
-        const matched = response.status !== 404;
+        const contentType = response.headers.get("content-type") || "";
+        const isJsonResponse = contentType
+          .toLowerCase()
+          .includes("application/json");
+        const matched = response.status !== 404 || isJsonResponse;
         return { matched, response };
       },
       catch: (error) =>


### PR DESCRIPTION
### TL;DR

Improved API response handling to consider JSON content type when determining if a request was matched.

### What changed?

Enhanced the request handling logic in `cloud/api/handler.ts` to check both the status code and content type when determining if a request was matched. Previously, only a non-404 status code would indicate a matched request. Now, a request is also considered matched if the response has a JSON content type, even with a 404 status.

### How to test?

1. Make an API request that returns a 404 status but includes JSON content
2. Verify that the request is now considered "matched" in the response
3. Make a request that returns a 404 with non-JSON content and verify it's considered "not matched"

### Why make this change?

Some API endpoints may return a 404 status code with meaningful JSON content that should be processed by the client. This change ensures that such responses are properly identified as matched requests, allowing the application to handle them appropriately rather than treating them as unmatched routes.