### PR TITLE
refactor: use llm.Model as a context mgr directly

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -78,7 +78,7 @@ from .messages import (
     UserContent,
     UserMessage,
 )
-from .models import Model, model, use_model
+from .models import Model, model, model_from_context, use_model
 from .prompts import (
     AsyncContextPrompt,
     AsyncPrompt,
@@ -223,6 +223,7 @@ __all__ = [
     "mcp",
     "messages",
     "model",
+    "model_from_context",
     "models",
     "prompt",
     "prompts",

--- a/python/mirascope/llm/models/__init__.py
+++ b/python/mirascope/llm/models/__init__.py
@@ -6,11 +6,11 @@ the model at runtime, and `llm.use_model()` retrieves the model from context or
 creates a default one.
 """
 
-from .models import Model, get_model_from_context, model, use_model
+from .models import Model, model, model_from_context, use_model
 
 __all__ = [
     "Model",
-    "get_model_from_context",
     "model",
+    "model_from_context",
     "use_model",
 ]

--- a/python/mirascope/llm/responses/root_response.py
+++ b/python/mirascope/llm/responses/root_response.py
@@ -167,12 +167,6 @@ class RootResponse(Generic[ToolkitT, FormattableT], ABC):
     @property
     def model(self) -> "Model":
         """A `Model` with parameters matching this response."""
-        from ..models import Model, get_model_from_context
+        from ..models import use_model  # Dynamic import to avoid circular dependency
 
-        if context_model := get_model_from_context():
-            return context_model
-
-        return Model(
-            model_id=self.model_id,
-            **self.params,
-        )
+        return use_model(self.model_id, **self.params)


### PR DESCRIPTION
Backwards compatible with `llm.model` usage, although I removed the
option to pass a `Model` to `llm.model` as it is redundant