### PR TITLE
refactor: move ProviderId to new providers package

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -27,7 +27,7 @@ from . import (
 with suppress(ImportError):
     from . import mcp
 from .calls import AsyncCall, AsyncContextCall, Call, CallDecorator, ContextCall, call
-from .clients import ModelId, Params, Provider, client
+from .clients import ModelId, Params, client
 from .content import (
     AssistantContentChunk,
     AssistantContentPart,
@@ -87,6 +87,7 @@ from .prompts import (
     PromptDecorator,
     prompt,
 )
+from .providers import ProviderId
 from .responses import (
     AsyncChunkIterator,
     AsyncContextResponse,
@@ -178,7 +179,7 @@ __all__ = [
     "PermissionError",
     "Prompt",
     "PromptDecorator",
-    "Provider",
+    "ProviderId",
     "RateLimitError",
     "RawMessageChunk",
     "Response",

--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -1,5 +1,6 @@
 """Client interfaces for LLM providers."""
 
+from ..providers import KNOWN_PROVIDER_IDS, ProviderId
 from .anthropic import (
     AnthropicClient,
     AnthropicModelId,
@@ -12,10 +13,10 @@ from .openai import (
     OpenAIClient,
     OpenAIModelId,
 )
-from .providers import PROVIDERS, ModelId, Provider, model_id_to_provider
+from .providers import ModelId, model_id_to_provider
 
 __all__ = [
-    "PROVIDERS",
+    "KNOWN_PROVIDER_IDS",
     "AnthropicClient",
     "AnthropicModelId",
     "BaseClient",
@@ -27,7 +28,7 @@ __all__ = [
     "OpenAIClient",
     "OpenAIModelId",
     "Params",
-    "Provider",
+    "ProviderId",
     "client",
     "model_id_to_provider",
 ]

--- a/python/mirascope/llm/clients/base/_utils.py
+++ b/python/mirascope/llm/clients/base/_utils.py
@@ -8,7 +8,7 @@ from ...messages import AssistantMessage, Message, SystemMessage, UserMessage
 from .params import Params
 
 if TYPE_CHECKING:
-    from ..providers import ModelId, Provider
+    from ..providers import ModelId, ProviderId
 
 logger = logging.getLogger(__name__)
 
@@ -138,7 +138,7 @@ class SafeParamsAccessor:
         self,
         param_name: str,
         param_value: object,
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId | None" = None,
     ) -> None:
         unsupported_by = f"provider: {provider}"
@@ -159,7 +159,7 @@ class SafeParamsAccessor:
 def ensure_all_params_accessed(
     *,
     params: Params,
-    provider: "Provider",
+    provider: "ProviderId",
     unsupported_params: list[str] | None = None,
 ) -> Generator[SafeParamsAccessor, None, None]:
     """Context manager that ensures all parameters are accessed.

--- a/python/mirascope/llm/clients/get_client.py
+++ b/python/mirascope/llm/clients/get_client.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from ..providers import ProviderId
 from .anthropic import (
     client as anthropic_client,
 )
@@ -13,11 +14,10 @@ from .mlx import (
 from .openai import (
     client as openai_client,
 )
-from .providers import Provider
 
 
 def client(
-    provider: Provider, *, api_key: str | None = None, base_url: str | None = None
+    provider: ProviderId, *, api_key: str | None = None, base_url: str | None = None
 ) -> BaseClient[str, Any]:
     """Create a cached client instance for the specified provider.
 

--- a/python/mirascope/llm/clients/providers.py
+++ b/python/mirascope/llm/clients/providers.py
@@ -1,5 +1,6 @@
-from typing import Literal, TypeAlias, cast, get_args
+from typing import TypeAlias, cast
 
+from ..providers import KNOWN_PROVIDER_IDS, ProviderId
 from .anthropic import (
     AnthropicModelId,
 )
@@ -13,18 +14,10 @@ from .openai import (
     OpenAIModelId,
 )
 
-Provider: TypeAlias = Literal[
-    "anthropic",  # AnthropicClient
-    "google",  # GoogleClient
-    "openai",  # OpenAIClient
-    "mlx",  # Local inference powered by `mlx-lm`
-]
-PROVIDERS = get_args(Provider)
-
 ModelId: TypeAlias = AnthropicModelId | GoogleModelId | OpenAIModelId | MLXModelId | str
 
 
-def model_id_to_provider(model_id: ModelId) -> Provider:
+def model_id_to_provider(model_id: ModelId) -> ProviderId:
     """Extract the provider from a model ID.
 
     Args:
@@ -45,10 +38,10 @@ def model_id_to_provider(model_id: ModelId) -> Provider:
 
     provider = model_id.split("/", 1)[0]
 
-    if provider not in PROVIDERS:
+    if provider not in KNOWN_PROVIDER_IDS:
         raise ValueError(
             f"Unknown provider: '{provider}'. "
-            f"Supported providers are: {', '.join(PROVIDERS)}"
+            f"Supported providers are: {', '.join(KNOWN_PROVIDER_IDS)}"
         )
 
-    return cast(Provider, provider)
+    return cast(ProviderId, provider)

--- a/python/mirascope/llm/exceptions.py
+++ b/python/mirascope/llm/exceptions.py
@@ -3,7 +3,7 @@
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .clients import ModelId, Provider
+    from .clients import ModelId, ProviderId
     from .formatting import FormattingMode
 
 
@@ -49,14 +49,14 @@ class FeatureNotSupportedError(MirascopeLLMError):
     If compatibility is model-specific, then `model_id` should be specified.
     If the feature is not supported by the provider at all, then it may be `None`."""
 
-    provider: "Provider"
+    provider: "ProviderId"
     model_id: "ModelId | None"
     feature: str
 
     def __init__(
         self,
         feature: str,
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId | None" = None,
         message: str | None = None,
     ) -> None:
@@ -77,7 +77,7 @@ class FormattingModeNotSupportedError(FeatureNotSupportedError):
     def __init__(
         self,
         formatting_mode: "FormattingMode",
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId | None" = None,
         message: str | None = None,
     ) -> None:

--- a/python/mirascope/llm/messages/message.py
+++ b/python/mirascope/llm/messages/message.py
@@ -10,7 +10,7 @@ from ..content import AssistantContentPart, Text, UserContentPart
 from ..types import Jsonable
 
 if TYPE_CHECKING:
-    from ..clients import ModelId, Provider
+    from ..clients import ModelId, ProviderId
 
 
 @dataclass(kw_only=True)
@@ -51,7 +51,7 @@ class AssistantMessage:
     name: str | None = None
     """A name identifying the creator of this message."""
 
-    provider: Provider | None
+    provider: ProviderId | None
     """The LLM provider that generated this assistant message, if available."""
 
     model_id: ModelId | None

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from ..clients import (
         ModelId,
         Params,
-        Provider,
+        ProviderId,
     )
 
 
@@ -93,7 +93,7 @@ class Model:
         ```
     """
 
-    provider: Provider
+    provider: ProviderId
     """The provider being used (e.g. `openai`)."""
 
     model_id: ModelId

--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -1,0 +1,5 @@
+"""Provider system for routing model calls through different implementations."""
+
+from .provider_id import KNOWN_PROVIDER_IDS, ProviderId
+
+__all__ = ["KNOWN_PROVIDER_IDS", "ProviderId"]

--- a/python/mirascope/llm/providers/provider_id.py
+++ b/python/mirascope/llm/providers/provider_id.py
@@ -1,0 +1,11 @@
+"""Identifiers for all registered providers."""
+
+from typing import Literal, TypeAlias, get_args
+
+ProviderId: TypeAlias = Literal[
+    "anthropic",  # Anthropic provider via AnthropicClient
+    "google",  # Google provider via GoogleClient
+    "openai",  # OpenAI provider via OpenAIClient
+    "mlx",  # Local inference powered by `mlx-lm`, via MLXClient
+]
+KNOWN_PROVIDER_IDS = get_args(ProviderId)

--- a/python/mirascope/llm/responses/base_response.py
+++ b/python/mirascope/llm/responses/base_response.py
@@ -11,7 +11,7 @@ from .finish_reason import FinishReason
 from .root_response import RootResponse
 
 if TYPE_CHECKING:
-    from ..clients import ModelId, Params, Provider
+    from ..clients import ModelId, Params, ProviderId
 
 
 class BaseResponse(RootResponse[ToolkitT, FormattableT]):
@@ -21,7 +21,7 @@ class BaseResponse(RootResponse[ToolkitT, FormattableT]):
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",

--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -38,7 +38,7 @@ from .streams import (
 )
 
 if TYPE_CHECKING:
-    from ..clients import ModelId, Params, Provider
+    from ..clients import ModelId, Params, ProviderId
 
 
 @dataclass(kw_only=True)
@@ -157,7 +157,7 @@ class BaseStreamResponse(
     def __init__(
         self,
         *,
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",

--- a/python/mirascope/llm/responses/response.py
+++ b/python/mirascope/llm/responses/response.py
@@ -23,7 +23,7 @@ from .base_response import BaseResponse
 from .finish_reason import FinishReason
 
 if TYPE_CHECKING:
-    from ..clients import ModelId, Params, Provider
+    from ..clients import ModelId, Params, ProviderId
 
 
 class Response(BaseResponse[Toolkit, FormattableT]):
@@ -33,7 +33,7 @@ class Response(BaseResponse[Toolkit, FormattableT]):
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -104,7 +104,7 @@ class AsyncResponse(BaseResponse[AsyncToolkit, FormattableT]):
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -184,7 +184,7 @@ class ContextResponse(
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -272,7 +272,7 @@ class AsyncContextResponse(
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",

--- a/python/mirascope/llm/responses/root_response.py
+++ b/python/mirascope/llm/responses/root_response.py
@@ -13,7 +13,7 @@ from . import _utils
 from .finish_reason import FinishReason
 
 if TYPE_CHECKING:
-    from ..clients import ModelId, Params, Provider
+    from ..clients import ModelId, Params, ProviderId
     from ..models import Model
 
 
@@ -23,7 +23,7 @@ class RootResponse(Generic[ToolkitT, FormattableT], ABC):
     raw: Any
     """The raw response from the LLM."""
 
-    provider: "Provider"
+    provider: "ProviderId"
     """The provider that generated this response."""
 
     model_id: "ModelId"

--- a/python/mirascope/llm/responses/stream_response.py
+++ b/python/mirascope/llm/responses/stream_response.py
@@ -27,7 +27,7 @@ from .base_stream_response import (
 )
 
 if TYPE_CHECKING:
-    from ..clients import ModelId, Params, Provider
+    from ..clients import ModelId, Params, ProviderId
 
 
 class StreamResponse(BaseSyncStreamResponse[Toolkit, FormattableT]):
@@ -94,7 +94,7 @@ class StreamResponse(BaseSyncStreamResponse[Toolkit, FormattableT]):
     def __init__(
         self,
         *,
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -221,7 +221,7 @@ class AsyncStreamResponse(BaseAsyncStreamResponse[AsyncToolkit, FormattableT]):
     def __init__(
         self,
         *,
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -357,7 +357,7 @@ class ContextStreamResponse(
     def __init__(
         self,
         *,
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -501,7 +501,7 @@ class AsyncContextStreamResponse(
     def __init__(
         self,
         *,
-        provider: "Provider",
+        provider: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",

--- a/python/mirascope/ops/_internal/instrumentation/llm/llm.py
+++ b/python/mirascope/ops/_internal/instrumentation/llm/llm.py
@@ -20,7 +20,7 @@ from opentelemetry.semconv.attributes import (
 )
 
 from .....llm.clients import Params
-from .....llm.clients.providers import ModelId, Provider
+from .....llm.clients.providers import ModelId, ProviderId
 from .....llm.context import Context, DepsT
 from .....llm.formatting import Format, FormattableT
 from .....llm.formatting._utils import create_tool_schema
@@ -250,7 +250,7 @@ def _serialize_tool_definitions(
 def _build_request_attributes(
     *,
     operation: str,
-    provider: Provider,
+    provider: ProviderId,
     model_id: ModelId,
     messages: Sequence[Message],
     tools: ToolsParam,

--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -108,11 +108,11 @@ def vcr_config() -> VCRConfig:
 class ProviderRequest(pytest.FixtureRequest):
     """Request for the `provider` fixture parameter."""
 
-    param: llm.Provider
+    param: llm.ProviderId
 
 
 @pytest.fixture
-def provider(request: ProviderRequest) -> llm.Provider:
+def provider(request: ProviderRequest) -> llm.ProviderId:
     """Get provider from test parameters."""
     return request.param
 


### PR DESCRIPTION
Going to move all the client code to llm/providers eventually, this is a
first step. For now I am allowing dependents to import via clients
module, will clean up later.