### PR TITLE
refactor: Pass `provider_id`, instead of inferring

### DIFF
--- a/python/mirascope/llm/clients/__init__.py
+++ b/python/mirascope/llm/clients/__init__.py
@@ -13,7 +13,7 @@ from .openai import (
     OpenAIClient,
     OpenAIModelId,
 )
-from .providers import ModelId, model_id_to_provider
+from .providers import ModelId
 
 __all__ = [
     "KNOWN_PROVIDER_IDS",
@@ -30,5 +30,4 @@ __all__ = [
     "Params",
     "ProviderId",
     "client",
-    "model_id_to_provider",
 ]

--- a/python/mirascope/llm/clients/anthropic/_utils/decode.py
+++ b/python/mirascope/llm/clients/anthropic/_utils/decode.py
@@ -65,7 +65,7 @@ def decode_response(
     """Convert Anthropic message to mirascope AssistantMessage."""
     assistant_message = AssistantMessage(
         content=[_decode_assistant_content(part) for part in response.content],
-        provider="anthropic",
+        provider_id="anthropic",
         model_id=model_id,
         provider_model_name=model_name(model_id),
         raw_message={

--- a/python/mirascope/llm/clients/anthropic/_utils/encode.py
+++ b/python/mirascope/llm/clients/anthropic/_utils/encode.py
@@ -33,7 +33,7 @@ def encode_image_mime_type(
     if mime_type in ("image/jpeg", "image/png", "image/gif", "image/webp"):
         return mime_type
     raise FeatureNotSupportedError(
-        feature=f"Image with mime_type: {mime_type}", provider="anthropic"
+        feature=f"Image with mime_type: {mime_type}", provider_id="anthropic"
     )  # pragma: no cover
 
 
@@ -152,7 +152,7 @@ def _encode_message(
 
     if (
         message.role == "assistant"
-        and message.provider == "anthropic"
+        and message.provider_id == "anthropic"
         and message.model_id == model_id
         and message.raw_message
         and not encode_thoughts
@@ -199,7 +199,7 @@ def encode_request(
     encode_thoughts = False
 
     with _base_utils.ensure_all_params_accessed(
-        params=params, provider="anthropic", unsupported_params=["seed"]
+        params=params, provider_id="anthropic", unsupported_params=["seed"]
     ) as param_accessor:
         if param_accessor.temperature is not None:
             kwargs["temperature"] = param_accessor.temperature
@@ -227,7 +227,7 @@ def encode_request(
     if format is not None:
         if format.mode == "strict":
             raise FormattingModeNotSupportedError(
-                formatting_mode="strict", provider="anthropic"
+                formatting_mode="strict", provider_id="anthropic"
             )
         elif format.mode == "tool":
             format_tool_schema = _formatting_utils.create_tool_schema(format)

--- a/python/mirascope/llm/clients/anthropic/clients.py
+++ b/python/mirascope/llm/clients/anthropic/clients.py
@@ -150,7 +150,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         return Response(
             raw=anthropic_response,
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -250,7 +250,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         return ContextResponse(
             raw=anthropic_response,
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -337,7 +337,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         return AsyncResponse(
             raw=anthropic_response,
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -437,7 +437,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
 
         return AsyncContextResponse(
             raw=anthropic_response,
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -521,7 +521,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         chunk_iterator = _utils.decode_stream(anthropic_stream)
 
         return StreamResponse(
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -617,7 +617,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         chunk_iterator = _utils.decode_stream(anthropic_stream)
 
         return ContextStreamResponse(
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -700,7 +700,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         chunk_iterator = _utils.decode_async_stream(anthropic_stream)
 
         return AsyncStreamResponse(
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -802,7 +802,7 @@ class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
         chunk_iterator = _utils.decode_async_stream(anthropic_stream)
 
         return AsyncContextStreamResponse(
-            provider="anthropic",
+            provider_id="anthropic",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,

--- a/python/mirascope/llm/clients/base/_utils.py
+++ b/python/mirascope/llm/clients/base/_utils.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING, TypeAlias, get_type_hints
 
 from ...content import Text
 from ...messages import AssistantMessage, Message, SystemMessage, UserMessage
+from ...providers import ProviderId
 from .params import Params
 
 if TYPE_CHECKING:
-    from ..providers import ModelId, ProviderId
+    from ..providers import ModelId
 
 logger = logging.getLogger(__name__)
 
@@ -138,10 +139,10 @@ class SafeParamsAccessor:
         self,
         param_name: str,
         param_value: object,
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId | None" = None,
     ) -> None:
-        unsupported_by = f"provider: {provider}"
+        unsupported_by = f"provider: {provider_id}"
         if model_id:
             unsupported_by += f" with model_id: {model_id}"
         logger.warning(
@@ -159,7 +160,7 @@ class SafeParamsAccessor:
 def ensure_all_params_accessed(
     *,
     params: Params,
-    provider: "ProviderId",
+    provider_id: "ProviderId",
     unsupported_params: list[str] | None = None,
 ) -> Generator[SafeParamsAccessor, None, None]:
     """Context manager that ensures all parameters are accessed.
@@ -185,7 +186,9 @@ def ensure_all_params_accessed(
     unsupported_params = unsupported_params or []
     for unsupported in unsupported_params:
         if (val := params.get(unsupported)) is not None:
-            accessor.emit_warning_for_unused_param(unsupported, val, provider=provider)
+            accessor.emit_warning_for_unused_param(
+                unsupported, val, provider_id=provider_id
+            )
     try:
         yield accessor
     finally:

--- a/python/mirascope/llm/clients/google/_utils/decode.py
+++ b/python/mirascope/llm/clients/google/_utils/decode.py
@@ -116,7 +116,7 @@ def decode_response(
 
     assistant_message = AssistantMessage(
         content=content,
-        provider="google",
+        provider_id="google",
         model_id=model_id,
         provider_model_name=model_name(model_id),
         raw_message=candidate_content.model_dump(),

--- a/python/mirascope/llm/clients/google/_utils/encode.py
+++ b/python/mirascope/llm/clients/google/_utils/encode.py
@@ -126,7 +126,7 @@ def _encode_message(
     """Returns a Google `ContentDict` converted from a Mirascope `Message`"""
     if (
         message.role == "assistant"
-        and message.provider == "google"
+        and message.provider_id == "google"
         and message.model_id == model_id
         and message.raw_message
         and not encode_thoughts
@@ -189,7 +189,7 @@ def encode_request(
     encode_thoughts = False
 
     with _base_utils.ensure_all_params_accessed(
-        params=params, provider="google"
+        params=params, provider_id="google"
     ) as param_accessor:
         if param_accessor.temperature is not None:
             google_config["temperature"] = param_accessor.temperature
@@ -229,7 +229,7 @@ def encode_request(
         if format.mode in ("strict", "json") and tools:
             raise FeatureNotSupportedError(
                 feature=f"formatting_mode:{format.mode} with tools",
-                provider="google",
+                provider_id="google",
             )
 
         if format.mode == "strict":

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -152,7 +152,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
 
         return Response(
             raw=google_response,
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -252,7 +252,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
 
         return ContextResponse(
             raw=google_response,
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -339,7 +339,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
 
         return AsyncResponse(
             raw=google_response,
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -439,7 +439,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
 
         return AsyncContextResponse(
             raw=google_response,
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -523,7 +523,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         chunk_iterator = _utils.decode_stream(google_stream)
 
         return StreamResponse(
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -619,7 +619,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         chunk_iterator = _utils.decode_stream(google_stream)
 
         return ContextStreamResponse(
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -702,7 +702,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         chunk_iterator = _utils.decode_async_stream(google_stream)
 
         return AsyncStreamResponse(
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -804,7 +804,7 @@ class GoogleClient(BaseClient[GoogleModelId, Client]):
         chunk_iterator = _utils.decode_async_stream(google_stream)
 
         return AsyncContextStreamResponse(
-            provider="google",
+            provider_id="google",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,

--- a/python/mirascope/llm/clients/mlx/_utils.py
+++ b/python/mirascope/llm/clients/mlx/_utils.py
@@ -68,7 +68,7 @@ def encode_params(params: Params) -> tuple[int | None, StreamGenerateKwargs]:
 
     with _base_utils.ensure_all_params_accessed(
         params=params,
-        provider="mlx",
+        provider_id="mlx",
         unsupported_params=["stop_sequences", "thinking", "encode_thoughts_as_text"],
     ) as param_accessor:
         if param_accessor.max_tokens is not None:

--- a/python/mirascope/llm/clients/mlx/clients.py
+++ b/python/mirascope/llm/clients/mlx/clients.py
@@ -142,7 +142,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
 
         return Response(
             raw=response,
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -234,7 +234,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
 
         return ContextResponse(
             raw=response,
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -317,7 +317,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
 
         return AsyncResponse(
             raw=response,
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -413,7 +413,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
 
         return AsyncContextResponse(
             raw=response,
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -491,7 +491,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
         )
 
         return StreamResponse(
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -581,7 +581,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
         )
 
         return ContextStreamResponse(
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -658,7 +658,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
         )
 
         return AsyncStreamResponse(
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,
@@ -754,7 +754,7 @@ class MLXClient(BaseClient[MLXModelId, None]):
         )
 
         return AsyncContextStreamResponse(
-            provider="mlx",
+            provider_id="mlx",
             model_id=model_id,
             provider_model_name=model_name(model_id),
             params=params,

--- a/python/mirascope/llm/clients/mlx/mlx.py
+++ b/python/mirascope/llm/clients/mlx/mlx.py
@@ -206,6 +206,7 @@ class MLX:
         assistant_message = assistant(
             content=assistant_content,
             model_id=self.model_id,
+            provider_id="mlx",
             raw_message=None,
             name=None,
         )

--- a/python/mirascope/llm/clients/openai/completions/_utils/decode.py
+++ b/python/mirascope/llm/clients/openai/completions/_utils/decode.py
@@ -69,7 +69,7 @@ def decode_response(
 
     assistant_message = AssistantMessage(
         content=parts,
-        provider="openai",
+        provider_id="openai",
         model_id=model_id,
         provider_model_name=model_name(model_id, "completions"),
         raw_message=message.model_dump(exclude_none=True),

--- a/python/mirascope/llm/clients/openai/completions/_utils/encode.py
+++ b/python/mirascope/llm/clients/openai/completions/_utils/encode.py
@@ -102,7 +102,7 @@ def _encode_user_message(
             if base_model_name in MODELS_WITHOUT_AUDIO_SUPPORT:
                 raise FeatureNotSupportedError(
                     feature="Audio inputs",
-                    provider="openai",
+                    provider_id="openai",
                     message=f"Model '{model_id}' does not support audio inputs.",
                 )
 
@@ -111,7 +111,7 @@ def _encode_user_message(
                 if audio_format not in ("wav", "mp3"):
                     raise FeatureNotSupportedError(
                         feature=f"Audio format: {audio_format}",
-                        provider="openai",
+                        provider_id="openai",
                         message="OpenAI only supports 'wav' and 'mp3' audio formats.",
                     )  # pragma: no cover
                 audio_content = openai_types.ChatCompletionContentPartInputAudioParam(
@@ -146,7 +146,7 @@ def _encode_assistant_message(
     """Convert Mirascope `AssistantMessage` to OpenAI `ChatCompletionAssistantMessageParam`."""
 
     if (
-        message.provider == "openai"
+        message.provider_id == "openai"
         and message.provider_model_name
         == model_name(model_id=model_id, api_mode="completions")
         and message.raw_message
@@ -299,7 +299,7 @@ def encode_request(
 
     with _base_utils.ensure_all_params_accessed(
         params=params,
-        provider="openai",
+        provider_id="openai",
         unsupported_params=["top_k", "thinking"],
     ) as param_accessor:
         if param_accessor.temperature is not None:
@@ -330,7 +330,7 @@ def encode_request(
             if not model_supports_strict:
                 raise FormattingModeNotSupportedError(
                     formatting_mode="strict",
-                    provider="openai",
+                    provider_id="openai",
                     model_id=model_id,
                 )
             kwargs["response_format"] = _create_strict_response_format(format)

--- a/python/mirascope/llm/clients/openai/completions/clients.py
+++ b/python/mirascope/llm/clients/openai/completions/clients.py
@@ -150,7 +150,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return Response(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,
@@ -250,7 +250,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return ContextResponse(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,
@@ -338,7 +338,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return AsyncResponse(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,
@@ -438,7 +438,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return AsyncContextResponse(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,
@@ -525,7 +525,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
         chunk_iterator = _utils.decode_stream(openai_stream)
 
         return StreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,
@@ -624,7 +624,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
         chunk_iterator = _utils.decode_stream(openai_stream)
 
         return ContextStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,
@@ -711,7 +711,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
         chunk_iterator = _utils.decode_async_stream(openai_stream)
 
         return AsyncStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,
@@ -816,7 +816,7 @@ class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
         chunk_iterator = _utils.decode_async_stream(openai_stream)
 
         return AsyncContextStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=model_name(model_id, "completions"),
             params=params,

--- a/python/mirascope/llm/clients/openai/responses/_utils/decode.py
+++ b/python/mirascope/llm/clients/openai/responses/_utils/decode.py
@@ -91,7 +91,7 @@ def decode_response(
 
     assistant_message = AssistantMessage(
         content=parts,
-        provider="openai",
+        provider_id="openai",
         model_id=model_id,
         provider_model_name=model_name(model_id, "responses"),
         raw_message=[

--- a/python/mirascope/llm/clients/openai/responses/_utils/encode.py
+++ b/python/mirascope/llm/clients/openai/responses/_utils/encode.py
@@ -179,7 +179,7 @@ def _encode_message(
 
     if (
         message.role == "assistant"
-        and message.provider == "openai"
+        and message.provider_id == "openai"
         and message.provider_model_name
         == model_name(model_id=model_id, api_mode="responses")
         and message.raw_message
@@ -267,7 +267,7 @@ def encode_request(
 
     with _base_utils.ensure_all_params_accessed(
         params=params,
-        provider="openai",
+        provider_id="openai",
         unsupported_params=["top_k", "seed", "stop_sequences"],
     ) as param_accessor:
         if param_accessor.temperature is not None:

--- a/python/mirascope/llm/clients/openai/responses/clients.py
+++ b/python/mirascope/llm/clients/openai/responses/clients.py
@@ -140,7 +140,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return Response(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -228,7 +228,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return AsyncResponse(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -318,7 +318,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
         provider_model_name = model_name(model_id, "responses")
 
         return StreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -407,7 +407,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
         provider_model_name = model_name(model_id, "responses")
 
         return AsyncStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -507,7 +507,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return ContextResponse(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -608,7 +608,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
 
         return AsyncContextResponse(
             raw=openai_response,
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -711,7 +711,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
         provider_model_name = model_name(model_id, "responses")
 
         return ContextStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -819,7 +819,7 @@ class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
         provider_model_name = model_name(model_id, "responses")
 
         return AsyncContextStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,

--- a/python/mirascope/llm/clients/providers.py
+++ b/python/mirascope/llm/clients/providers.py
@@ -1,6 +1,5 @@
-from typing import TypeAlias, cast
+from typing import TypeAlias
 
-from ..providers import KNOWN_PROVIDER_IDS, ProviderId
 from .anthropic import (
     AnthropicModelId,
 )
@@ -15,33 +14,3 @@ from .openai import (
 )
 
 ModelId: TypeAlias = AnthropicModelId | GoogleModelId | OpenAIModelId | MLXModelId | str
-
-
-def model_id_to_provider(model_id: ModelId) -> ProviderId:
-    """Extract the provider from a model ID.
-
-    Args:
-        model_id: The model ID in format "provider/model_name".
-
-    Returns:
-        The provider extracted from the model ID.
-
-    Raises:
-        ValueError: If the model_id doesn't contain "/" or the provider is not supported.
-    """
-    # TODO(dandelion): Refactor this (to extract model lab?) but provider is separate from ModelId
-    if "/" not in model_id:
-        raise ValueError(
-            f"Invalid model_id format: '{model_id}'. "
-            "Expected format: 'provider/model_name'"
-        )
-
-    provider = model_id.split("/", 1)[0]
-
-    if provider not in KNOWN_PROVIDER_IDS:
-        raise ValueError(
-            f"Unknown provider: '{provider}'. "
-            f"Supported providers are: {', '.join(KNOWN_PROVIDER_IDS)}"
-        )
-
-    return cast(ProviderId, provider)

--- a/python/mirascope/llm/exceptions.py
+++ b/python/mirascope/llm/exceptions.py
@@ -49,23 +49,23 @@ class FeatureNotSupportedError(MirascopeLLMError):
     If compatibility is model-specific, then `model_id` should be specified.
     If the feature is not supported by the provider at all, then it may be `None`."""
 
-    provider: "ProviderId"
+    provider_id: "ProviderId"
     model_id: "ModelId | None"
     feature: str
 
     def __init__(
         self,
         feature: str,
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId | None" = None,
         message: str | None = None,
     ) -> None:
         if message is None:
             model_msg = f" for model '{model_id}'" if model_id is not None else ""
-            message = f"Feature '{feature}' is not supported by provider '{provider}'{model_msg}"
+            message = f"Feature '{feature}' is not supported by provider '{provider_id}'{model_msg}"
         super().__init__(message)
         self.feature = feature
-        self.provider = provider
+        self.provider_id = provider_id
         self.model_id = model_id
 
 
@@ -77,16 +77,16 @@ class FormattingModeNotSupportedError(FeatureNotSupportedError):
     def __init__(
         self,
         formatting_mode: "FormattingMode",
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId | None" = None,
         message: str | None = None,
     ) -> None:
         if message is None:
             model_msg = f" for model '{model_id}'" if model_id is not None else ""
-            message = f"Formatting mode '{formatting_mode}' is not supported by provider '{provider}'{model_msg}"
+            message = f"Formatting mode '{formatting_mode}' is not supported by provider '{provider_id}'{model_msg}"
         super().__init__(
             feature=f"formatting_mode:{formatting_mode}",
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             message=message,
         )

--- a/python/mirascope/llm/formatting/format.py
+++ b/python/mirascope/llm/formatting/format.py
@@ -55,7 +55,7 @@ def format(
       format = llm.format(Book, mode="strict")
 
       @llm.call(
-          provider="openai",
+          provider_id="openai",
           model_id="openai/gpt-5-mini",
           format=format,
       )

--- a/python/mirascope/llm/formatting/from_call_args.py
+++ b/python/mirascope/llm/formatting/from_call_args.py
@@ -20,7 +20,7 @@ class FromCallArgs:
 
 
     @llm.call(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         format=Book,
     )

--- a/python/mirascope/llm/messages/message.py
+++ b/python/mirascope/llm/messages/message.py
@@ -51,7 +51,7 @@ class AssistantMessage:
     name: str | None = None
     """A name identifying the creator of this message."""
 
-    provider: ProviderId | None
+    provider_id: ProviderId | None
     """The LLM provider that generated this assistant message, if available."""
 
     model_id: ModelId | None
@@ -153,6 +153,7 @@ def assistant(
     content: AssistantContent,
     *,
     model_id: ModelId | None,
+    provider_id: ProviderId | None,
     provider_model_name: str | None = None,
     raw_message: Jsonable | None = None,
     name: str | None = None,
@@ -162,8 +163,8 @@ def assistant(
     Args:
         content: The content of the message, which can be `str` or any `AssistantContent`,
             or a sequence of assistant content pieces.
-        provider: Optional identifier of the provider that produced this message.
         model_id: Optional id of the model that produced this message.
+        provider_id: Optional identifier of the provider that produced this message.
         provider_model_name: Optional provider-specific model name. May include
             provider-specific additional info (like api mode in "gpt-5:responses").
         raw_message: Optional Jsonable object that contains the provider-specific
@@ -173,17 +174,15 @@ def assistant(
     Returns:
         An `AssistantMessage`.
     """
-    from ..clients import model_id_to_provider  # avoid circular import issues
 
     if isinstance(content, str) or not isinstance(content, Sequence):
         content = [content]
     promoted_content = [
         Text(text=part) if isinstance(part, str) else part for part in content
     ]
-    provider = model_id_to_provider(model_id) if model_id else None
     return AssistantMessage(
         content=promoted_content,
-        provider=provider,
+        provider_id=provider_id,
         model_id=model_id,
         provider_model_name=provider_model_name,
         raw_message=raw_message,

--- a/python/mirascope/llm/responses/base_response.py
+++ b/python/mirascope/llm/responses/base_response.py
@@ -21,7 +21,7 @@ class BaseResponse(RootResponse[ToolkitT, FormattableT]):
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -47,7 +47,7 @@ class BaseResponse(RootResponse[ToolkitT, FormattableT]):
             finish_reason: The reason why the LLM finished generating a response.
         """
         self.raw = raw
-        self.provider = provider
+        self.provider_id = provider_id
         self.model_id = model_id
         self.provider_model_name = provider_model_name
         self.params = params
@@ -88,7 +88,7 @@ class BaseResponse(RootResponse[ToolkitT, FormattableT]):
             assistant_message = AssistantMessage(
                 content=self.content,
                 name=assistant_message.name,
-                provider=assistant_message.provider,
+                provider_id=assistant_message.provider_id,
                 model_id=assistant_message.model_id,
                 provider_model_name=assistant_message.provider_model_name,
                 raw_message=assistant_message.raw_message,

--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -157,7 +157,7 @@ class BaseStreamResponse(
     def __init__(
         self,
         *,
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -182,7 +182,7 @@ class BaseStreamResponse(
         as the stream is consumed.
         """
 
-        self.provider = provider
+        self.provider_id = provider_id
         self.model_id = model_id
         self.provider_model_name = provider_model_name
         self.params = params
@@ -210,7 +210,7 @@ class BaseStreamResponse(
 
         self._assistant_message = AssistantMessage(
             content=self._content,
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             raw_message=None,

--- a/python/mirascope/llm/responses/response.py
+++ b/python/mirascope/llm/responses/response.py
@@ -33,7 +33,7 @@ class Response(BaseResponse[Toolkit, FormattableT]):
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -47,7 +47,7 @@ class Response(BaseResponse[Toolkit, FormattableT]):
         toolkit = tools if isinstance(tools, Toolkit) else Toolkit(tools=tools)
         super().__init__(
             raw=raw,
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -104,7 +104,7 @@ class AsyncResponse(BaseResponse[AsyncToolkit, FormattableT]):
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -120,7 +120,7 @@ class AsyncResponse(BaseResponse[AsyncToolkit, FormattableT]):
         )
         super().__init__(
             raw=raw,
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -184,7 +184,7 @@ class ContextResponse(
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -202,7 +202,7 @@ class ContextResponse(
         )
         super().__init__(
             raw=raw,
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -272,7 +272,7 @@ class AsyncContextResponse(
         self,
         *,
         raw: Any,  # noqa: ANN401
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -292,7 +292,7 @@ class AsyncContextResponse(
         )
         super().__init__(
             raw=raw,
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,

--- a/python/mirascope/llm/responses/root_response.py
+++ b/python/mirascope/llm/responses/root_response.py
@@ -23,7 +23,7 @@ class RootResponse(Generic[ToolkitT, FormattableT], ABC):
     raw: Any
     """The raw response from the LLM."""
 
-    provider: "ProviderId"
+    provider_id: "ProviderId"
     """The provider that generated this response."""
 
     model_id: "ModelId"

--- a/python/mirascope/llm/responses/stream_response.py
+++ b/python/mirascope/llm/responses/stream_response.py
@@ -77,7 +77,7 @@ class StreamResponse(BaseSyncStreamResponse[Toolkit, FormattableT]):
         from mirascope import llm
 
         @llm.call(
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-5-mini",
         )
         def answer_question(question: str) -> str:
@@ -94,7 +94,7 @@ class StreamResponse(BaseSyncStreamResponse[Toolkit, FormattableT]):
     def __init__(
         self,
         *,
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -106,7 +106,7 @@ class StreamResponse(BaseSyncStreamResponse[Toolkit, FormattableT]):
         """Initialize a `StreamResponse`."""
         toolkit = tools if isinstance(tools, Toolkit) else Toolkit(tools=tools)
         super().__init__(
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -204,7 +204,7 @@ class AsyncStreamResponse(BaseAsyncStreamResponse[AsyncToolkit, FormattableT]):
         from mirascope import llm
 
         @llm.call(
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-5-mini",
         )
         async def answer_question(question: str) -> str:
@@ -221,7 +221,7 @@ class AsyncStreamResponse(BaseAsyncStreamResponse[AsyncToolkit, FormattableT]):
     def __init__(
         self,
         *,
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -235,7 +235,7 @@ class AsyncStreamResponse(BaseAsyncStreamResponse[AsyncToolkit, FormattableT]):
             tools if isinstance(tools, AsyncToolkit) else AsyncToolkit(tools=tools)
         )
         super().__init__(
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -339,7 +339,7 @@ class ContextStreamResponse(
         from mirascope import llm
 
         @llm.call(
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-5-mini",
         )
         def answer_question(ctx: llm.Context, question: str) -> str:
@@ -357,7 +357,7 @@ class ContextStreamResponse(
     def __init__(
         self,
         *,
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -373,7 +373,7 @@ class ContextStreamResponse(
             tools if isinstance(tools, ContextToolkit) else ContextToolkit(tools=tools)
         )
         super().__init__(
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,
@@ -483,7 +483,7 @@ class AsyncContextStreamResponse(
         from mirascope import llm
 
         @llm.call(
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-5-mini",
         )
         async def answer_question(ctx: llm.Context, question: str) -> str:
@@ -501,7 +501,7 @@ class AsyncContextStreamResponse(
     def __init__(
         self,
         *,
-        provider: "ProviderId",
+        provider_id: "ProviderId",
         model_id: "ModelId",
         provider_model_name: str,
         params: "Params",
@@ -519,7 +519,7 @@ class AsyncContextStreamResponse(
             else AsyncContextToolkit(tools=tools)
         )
         super().__init__(
-            provider=provider,
+            provider_id=provider_id,
             model_id=model_id,
             provider_model_name=provider_model_name,
             params=params,

--- a/python/mirascope/ops/_internal/instrumentation/llm/llm.py
+++ b/python/mirascope/ops/_internal/instrumentation/llm/llm.py
@@ -20,12 +20,13 @@ from opentelemetry.semconv.attributes import (
 )
 
 from .....llm.clients import Params
-from .....llm.clients.providers import ModelId, ProviderId
+from .....llm.clients.providers import ModelId
 from .....llm.context import Context, DepsT
 from .....llm.formatting import Format, FormattableT
 from .....llm.formatting._utils import create_tool_schema
 from .....llm.messages import Message
 from .....llm.models import Model
+from .....llm.providers import ProviderId
 from .....llm.responses import (
     AsyncContextResponse,
     AsyncContextStreamResponse,

--- a/python/tests/e2e/input/snapshots/test_call_with_audio/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_audio/anthropic_claude_sonnet_4_0_snapshots.py
@@ -7,7 +7,7 @@ test_snapshot = snapshot(
             "args": "('Anthropic does not support audio inputs.',)",
             "feature": "audio input",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_audio/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_audio/google_gemini_2_5_flash_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -31,7 +31,7 @@ test_snapshot = snapshot(
                 ),
                 AssistantMessage(
                     content=[Text(text="LLM abstractions that aren't abstractions")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_audio/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_audio/openai_gpt_4o_completions_snapshots.py
@@ -7,7 +7,7 @@ test_snapshot = snapshot(
             "args": "(\"Model 'openai/gpt-4o:completions' does not support audio inputs.\",)",
             "feature": "Audio inputs",
             "model_id": "None",
-            "provider": "openai",
+            "provider_id": "openai",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_audio/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_audio/openai_gpt_4o_responses_snapshots.py
@@ -7,7 +7,7 @@ test_snapshot = snapshot(
             "args": "('provider \"openai\" does not support audio inputs when using :responses api. Try appending :completions to your model instead.',)",
             "feature": "audio input",
             "model_id": "None",
-            "provider": "openai",
+            "provider_id": "openai",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_audio/openai_gpt_audio_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_audio/openai_gpt_audio_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-audio",
             "provider_model_name": "gpt-audio:completions",
             "params": {},
@@ -31,7 +31,7 @@ test_snapshot = snapshot(
                 ),
                 AssistantMessage(
                     content=[Text(text='"LLM abstractions that aren\'t obstructions"')],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-audio",
                     provider_model_name="gpt-audio:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_empty_string/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_empty_string/anthropic_claude_sonnet_4_0_snapshots.py
@@ -7,7 +7,7 @@ test_snapshot = snapshot(
             "args": "('Anthropic does not support empty message content.',)",
             "feature": "empty message content",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_empty_string/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_empty_string/google_gemini_2_5_flash_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -158,7 +158,7 @@ def special_sum(n: int) -> int:
 '''
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_empty_string/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_empty_string/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
             "model_id": "mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "params": {},
@@ -52,7 +52,7 @@ Both types are fundamental to programming, with integers typically used for whol
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name=None,
                     raw_message=None,

--- a/python/tests/e2e/input/snapshots/test_call_with_empty_string/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_empty_string/openai_gpt_4o_completions_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -22,7 +22,7 @@ test_snapshot = snapshot(
                             text="Hello! It looks like your message might be incomplete. How can I assist you today?"
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_empty_string/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_empty_string/openai_gpt_4o_responses_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -22,7 +22,7 @@ test_snapshot = snapshot(
                             text="It looks like you're trying to share an image or details about a scene or object. How can I assist you with it?"
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_call_with_image_content/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_content/anthropic_claude_sonnet_4_0_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -35,7 +35,7 @@ test_snapshot = snapshot(
                             text="This is the iconic Wikipedia logo, featuring a spherical globe made up of puzzle pieces with text in various languages and scripts from different Wikipedia editions."
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_image_content/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_content/google_gemini_2_5_flash_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -35,7 +35,7 @@ test_snapshot = snapshot(
                             text="The image displays a three-dimensional jigsaw puzzle globe, composed of white pieces featuring characters from various writing systems, with a few pieces missing to reveal a dark gray interior."
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_gpt_4o_completions_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -35,7 +35,7 @@ test_snapshot = snapshot(
                             text="The image is the Wikipedia globe logo, made of puzzle pieces with various letters and symbols on them."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_content/openai_gpt_4o_responses_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -35,7 +35,7 @@ test_snapshot = snapshot(
                             text="The image is a globe composed of puzzle pieces displaying various characters, representing the logo of Wikipedia."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_call_with_image_url/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_url/anthropic_claude_sonnet_4_0_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -34,7 +34,7 @@ test_snapshot = snapshot(
                             text="This is the iconic Wikipedia logo, featuring a spherical puzzle globe made up of white puzzle pieces with text in various languages and scripts from around the world."
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_image_url/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_url/google_gemini_2_5_flash_snapshots.py
@@ -7,7 +7,7 @@ test_snapshot = snapshot(
             "args": "('Google does not support URL-referenced images. Try `llm.Image.download(...) or `llm.Image.download_async(...)`',)",
             "feature": "url_image_source",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_gpt_4o_completions_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -34,7 +34,7 @@ test_snapshot = snapshot(
                             text="The image shows the Wikipedia logo, which is a globe constructed from puzzle pieces featuring various characters from different writing systems."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_image_url/openai_gpt_4o_responses_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -34,7 +34,7 @@ test_snapshot = snapshot(
                             text="The image is the Wikipedia logo, featuring a globe made of puzzle pieces with various characters on them."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_call_with_params/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ test_snapshot = snapshot(
     {
         "response": (
             {
-                "provider": "anthropic",
+                "provider_id": "anthropic",
                 "model_id": "anthropic/claude-sonnet-4-0",
                 "provider_model_name": "claude-sonnet-4-0",
                 "params": {
@@ -28,7 +28,7 @@ test_snapshot = snapshot(
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
                     AssistantMessage(
                         content=[Text(text="4200 + 42 = ")],
-                        provider="anthropic",
+                        provider_id="anthropic",
                         model_id="anthropic/claude-sonnet-4-0",
                         provider_model_name="claude-sonnet-4-0",
                         raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_params/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ test_snapshot = snapshot(
     {
         "response": (
             {
-                "provider": "google",
+                "provider_id": "google",
                 "model_id": "google/gemini-2.5-flash",
                 "provider_model_name": "gemini-2.5-flash",
                 "params": {
@@ -38,7 +38,7 @@ To calculate 4200 + 42, you can add the numbers together:
 """
                             )
                         ],
-                        provider="google",
+                        provider_id="google",
                         model_id="google/gemini-2.5-flash",
                         provider_model_name="gemini-2.5-flash",
                         raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_params/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
@@ -11,7 +11,7 @@ test_snapshot = snapshot(
     {
         "response": (
             {
-                "provider": "mlx",
+                "provider_id": "mlx",
                 "model_id": "mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                 "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                 "params": {
@@ -53,7 +53,7 @@ Wait, maybe I made a mistake in the first\
 """
                             )
                         ],
-                        provider="mlx",
+                        provider_id="mlx",
                         model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                         provider_model_name=None,
                         raw_message=None,

--- a/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ test_snapshot = snapshot(
     {
         "response": (
             {
-                "provider": "openai",
+                "provider_id": "openai",
                 "model_id": "openai/gpt-4o:completions",
                 "provider_model_name": "gpt-4o:completions",
                 "params": {
@@ -28,7 +28,7 @@ test_snapshot = snapshot(
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
                     AssistantMessage(
                         content=[Text(text="4200 + 42 equals ")],
-                        provider="openai",
+                        provider_id="openai",
                         model_id="openai/gpt-4o:completions",
                         provider_model_name="gpt-4o:completions",
                         raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_params/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ test_snapshot = snapshot(
     {
         "response": (
             {
-                "provider": "openai",
+                "provider_id": "openai",
                 "model_id": "openai/gpt-4o:responses",
                 "provider_model_name": "gpt-4o:responses",
                 "params": {
@@ -28,7 +28,7 @@ test_snapshot = snapshot(
                     UserMessage(content=[Text(text="What is 4200 + 42?")]),
                     AssistantMessage(
                         content=[Text(text="4200 + 42 equals 4242.")],
-                        provider="openai",
+                        provider_id="openai",
                         model_id="openai/gpt-4o:responses",
                         provider_model_name="gpt-4o:responses",
                         raw_message=[

--- a/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/anthropic_claude_sonnet_4_0_snapshots.py
@@ -7,7 +7,7 @@ test_snapshot = snapshot(
             "args": "('Anthropic does not support empty message content.',)",
             "feature": "empty message content",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/google_gemini_2_5_flash_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -37,7 +37,7 @@ What were you thinking of?\
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/openai_gpt_4o_completions_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -18,7 +18,7 @@ test_snapshot = snapshot(
                 UserMessage(content=[Text(text=""), Text(text="")]),
                 AssistantMessage(
                     content=[Text(text="Hello! How can I assist you today?")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_call_with_two_empty_string/openai_gpt_4o_responses_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -22,7 +22,7 @@ test_snapshot = snapshot(
                             text="It looks like your message was incomplete. Could you please provide more details or clarify your request?"
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_resume_with_override/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override/anthropic_claude_sonnet_4_0_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -20,7 +20,7 @@ test_snapshot = snapshot(
                     content=[
                         Text(text="I am a large language model, trained by Google.")
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -48,7 +48,7 @@ test_snapshot = snapshot(
                             text="You're absolutely right - I apologize for the error. I am Claude, an AI assistant created by Anthropic. Thank you for prompting me to correct that mistake."
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_resume_with_override/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override/google_gemini_2_5_flash_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -18,7 +18,7 @@ test_snapshot = snapshot(
                 UserMessage(content=[Text(text="Who created you?")]),
                 AssistantMessage(
                     content=[Text(text="I was created by Anthropic.")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -43,7 +43,7 @@ I am a large language model, trained by **Google**.\
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_resume_with_override/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
             "model_id": "mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "params": {},
@@ -20,7 +20,7 @@ test_snapshot = snapshot(
                     content=[
                         Text(text="I am a large language model, trained by Google.")
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -56,7 +56,7 @@ I can double-check that. My answer is correct. If you have any other questions, 
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name=None,
                     raw_message=None,

--- a/python/tests/e2e/input/snapshots/test_resume_with_override/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override/openai_gpt_4o_completions_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -20,7 +20,7 @@ test_snapshot = snapshot(
                     content=[
                         Text(text="I am a large language model, trained by Google.")
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -48,7 +48,7 @@ test_snapshot = snapshot(
                             text="I apologize for the mistake. I am actually based on OpenAI's GPT-3 model. OpenAI developed and trained me."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_resume_with_override/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override/openai_gpt_4o_responses_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -20,7 +20,7 @@ test_snapshot = snapshot(
                     content=[
                         Text(text="I am a large language model, trained by Google.")
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -46,7 +46,7 @@ test_snapshot = snapshot(
                     content=[
                         Text(text="Yes, I can confirm that I was developed by OpenAI.")
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/anthropic_claude_sonnet_4_0_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {"thinking": False},
@@ -34,7 +34,7 @@ Okay, so I see the user wants the 100th Fibonacci number.  No problem. I immedia
                             args='{"n": 100}',
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -94,7 +94,7 @@ This is quite a large number! The Fibonacci sequence grows exponentially, so by 
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/google_gemini_2_5_flash_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {"thinking": False},
@@ -30,7 +30,7 @@ test_snapshot = snapshot(
                             args='{"n": 100}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -65,7 +65,7 @@ test_snapshot = snapshot(
                             text="The 100th Fibonacci number is 218,922,995,834,555,169,026."
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_gpt_4o_completions_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {"thinking": False},
@@ -34,7 +34,7 @@ Okay, so the user wants the 100th Fibonacci number, which is pretty straightforw
                             args='{"n": 100}',
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -90,7 +90,7 @@ Okay, so the user wants the 100th Fibonacci number, which is pretty straightforw
                             text="The 100th Fibonacci number is 218,922,995,834,555,169,026."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_resume_with_override_thinking_and_tools/openai_gpt_4o_responses_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {"thinking": False},
@@ -34,7 +34,7 @@ Alright, so the user is after the 100th Fibonacci number. Easy enough. We've got
                             args='{"n": 100}',
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -90,7 +90,7 @@ Alright, so the user is after the 100th Fibonacci number. Easy enough. We've got
                             text="The 100th Fibonacci number is 218,922,995,834,555,169,026."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -39,7 +39,7 @@ lucky number 7.\
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -39,7 +39,7 @@ lucky number 7.\
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -39,7 +39,7 @@ lucky number 7.\
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -39,7 +39,7 @@ lucky number 7.\
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_0_snapshots.py
@@ -8,7 +8,7 @@ test_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"rating": 7, "author": "Patrick Rothfuss", "title": "THE NAME OF THE WIND"}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -33,7 +33,7 @@ lucky number 7.\
                             text='{"title":"THE NAME OF THE WIND","author":"Patrick Rothfuss","rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/input/test_call_with_text_encoded_thoughts.py
+++ b/python/tests/e2e/input/test_call_with_text_encoded_thoughts.py
@@ -61,6 +61,7 @@ def messages(model_id: llm.ModelId) -> list[llm.Message]:
                 llm.Text(text="Yes."),
             ],
             model_id=model_id,
+            provider_id="openai",
             raw_message={"is_dummy_for_testing_purposes": True},
         ),
         llm.messages.user("Please tell me what the number is."),

--- a/python/tests/e2e/input/test_resume_with_override.py
+++ b/python/tests/e2e/input/test_resume_with_override.py
@@ -17,7 +17,7 @@ def default_model(
     Used to ensure that we can test having the provider under test resume
     from a response that was created by a different provider.
     """
-    if llm.clients.model_id_to_provider(model_id) == "google":
+    if model_id.startswith("google/"):
         return "anthropic/claude-sonnet-4-0"
     else:
         return "google/gemini-2.5-flash"

--- a/python/tests/e2e/input/test_resume_with_override_thinking_and_tools.py
+++ b/python/tests/e2e/input/test_resume_with_override_thinking_and_tools.py
@@ -15,7 +15,7 @@ def default_model(
     Used to ensure that we can test having the provider under test resume
     from a response that was created by a different provider.
     """
-    if llm.clients.model_id_to_provider(model_id) == "google":
+    if model_id.startswith("google/"):
         return "anthropic/claude-sonnet-4-0"
     else:
         return "google/gemini-2.5-flash"

--- a/python/tests/e2e/output/snapshots/test_call/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/anthropic_claude_sonnet_4_0_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -18,7 +18,7 @@ sync_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 = 4242")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -41,7 +41,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -50,7 +50,7 @@ async_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 = 4242")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -80,7 +80,7 @@ stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 = 4242")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -105,7 +105,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 = 4242")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_call/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/google_gemini_2_5_flash_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -35,7 +35,7 @@ So, 4200 + 42 = **4242**.\
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -78,7 +78,7 @@ So, 4200 + 42 = **4242**.\
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -100,7 +100,7 @@ So, 4200 + 42 = **4242**.\
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -159,7 +159,7 @@ So, 4200 + 42 = **4242**.\
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -218,7 +218,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 = **4242**")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_call/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
             "model_id": "mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "params": {},
@@ -46,7 +46,7 @@ $$\
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name=None,
                     raw_message=None,
@@ -60,7 +60,7 @@ $$\
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
             "model_id": "mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "params": {},
@@ -97,7 +97,7 @@ $$\
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name=None,
                     raw_message=None,
@@ -146,7 +146,7 @@ $$\
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name="mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     raw_message=None,
@@ -196,7 +196,7 @@ $$\
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name="mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_completions_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -18,7 +18,7 @@ sync_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="\\(4200 + 42 = 4242\\).")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -36,7 +36,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -45,7 +45,7 @@ async_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 is 4242.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -70,7 +70,7 @@ stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 equals 4242.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -92,7 +92,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="The sum of 4200 and 42 is 4242.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_responses_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -18,7 +18,7 @@ sync_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 equals 4242.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -47,7 +47,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -56,7 +56,7 @@ async_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 equals 4242.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -92,7 +92,7 @@ stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 equals 4242.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -129,7 +129,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="What is 4200 + 42?")]),
                 AssistantMessage(
                     content=[Text(text="4200 + 42 equals 4242.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {"thinking": False},
@@ -97,7 +97,7 @@ Now checking which are prime:
 """
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -190,7 +190,7 @@ Now checking which are prime:
                 ),
                 AssistantMessage(
                     content=[Text(text="I remember them: 79, 179, and 379.")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -213,7 +213,7 @@ Now checking which are prime:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {"thinking": False},
@@ -280,7 +280,7 @@ Compiling the results, I identify three primes containing "79": 79, 179, and 379
                         ),
                         Text(text="3"),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -351,7 +351,7 @@ Compiling the results, I identify three primes containing "79": 79, 179, and 379
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -442,7 +442,7 @@ The primes below 400 containing "79" are 79, 179, and 379 - totaling 3 such prim
                         ),
                         Text(text="3"),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -516,7 +516,7 @@ The primes below 400 containing "79" are 79, 179, and 379 - totaling 3 such prim
                 ),
                 AssistantMessage(
                     content=[Text(text="I remember them: 79, 179, and 379.")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -615,7 +615,7 @@ I've identified 179 and 379 as prime numbers containing "79".\
                         ),
                         Text(text="3"),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -697,7 +697,7 @@ I've identified 179 and 379 as prime numbers containing "79".\
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {"thinking": False},
@@ -88,7 +88,7 @@ The primes below 400 that contain "79" as a substring are 79, 179, and 379. Ther
 """
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -186,7 +186,7 @@ The primes below 400 that contain "79" as a substring are 79, 179, and 379. Ther
                 ),
                 AssistantMessage(
                     content=[Text(text="The primes were 79, 179, and 379.")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -216,7 +216,7 @@ The primes below 400 that contain "79" as a substring are 79, 179, and 379. Ther
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {"thinking": False},
@@ -242,7 +242,7 @@ I've carefully listed all the primes up to 400. Now, I systematically check each
                         ),
                         Text(text="3"),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -290,7 +290,7 @@ I've carefully listed all the primes up to 400. Now, I systematically check each
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -380,7 +380,7 @@ Therefore, there are 3 such primes.
 """
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -567,7 +567,7 @@ Therefore, there are 3 such primes.
                 ),
                 AssistantMessage(
                     content=[Text(text="The primes were 79, 179, and 379.")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -649,7 +649,7 @@ I've rigorously checked the prime numbers below 400 one last time, with special 
                         ),
                         Text(text="3"),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -751,7 +751,7 @@ I've rigorously checked the prime numbers below 400 one last time, with special 
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_gpt_5_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_gpt_5_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-5:responses",
             "provider_model_name": "gpt-5:responses",
             "params": {"thinking": False},
@@ -64,7 +64,7 @@ I’m confirming if there are any primes under 400 that have "79" as non-consecu
                         ),
                         Text(text="3"),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[
@@ -141,7 +141,7 @@ I’m confirming if there are any primes under 400 that have "79" as non-consecu
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[
@@ -175,7 +175,7 @@ I’m confirming if there are any primes under 400 that have "79" as non-consecu
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-5:responses",
             "provider_model_name": "gpt-5:responses",
             "params": {"thinking": False},
@@ -232,7 +232,7 @@ The final answer is simply "3." Great, let's go with that!\
                         ),
                         Text(text="3"),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[
@@ -311,7 +311,7 @@ The final answer is simply "3." Great, let's go with that!\
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[
@@ -394,7 +394,7 @@ So, I have three primes: 79, 179, and 379. I made sure to rule out other numbers
                         ),
                         Text(text="3"),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[
@@ -467,7 +467,7 @@ So, I have three primes: 79, 179, and 379. I made sure to rule out other numbers
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[
@@ -568,7 +568,7 @@ I’ll double-check for any primes like 197, but it doesn't have "79." And 297 i
                         ),
                         Text(text="3"),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[
@@ -659,7 +659,7 @@ I’ll double-check for any primes like 197, but it doesn't have "79." And 297 i
                 ),
                 AssistantMessage(
                     content=[Text(text="I don't remember.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-5:responses",
                     provider_model_name="gpt-5:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -42,7 +42,7 @@ sync_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -93,7 +93,7 @@ Here are the secrets retrieved for each password:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -142,7 +142,7 @@ Here are the secrets retrieved for each password:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -172,7 +172,7 @@ async_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -223,7 +223,7 @@ Here are the secrets retrieved for each password:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -300,7 +300,7 @@ stream_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -350,7 +350,7 @@ Here are the secrets associated with each password:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -427,7 +427,7 @@ async_stream_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -477,7 +477,7 @@ Here are the secrets retrieved for each password:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/google_gemini_2_5_flash_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -39,7 +39,7 @@ sync_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -100,7 +100,7 @@ sync_snapshot = snapshot(
                             text='The secrets have been retrieved. For the password "mellon", the secret is "Welcome to Moria!". For the password "radiance", the secret is "Life before Death".'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -151,7 +151,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -178,7 +178,7 @@ async_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -239,7 +239,7 @@ async_snapshot = snapshot(
                             text='The secrets have been retrieved. For the password "mellon", the secret is "Welcome to Moria!". For the password "radiance", the secret is "Life before Death".\n'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -315,7 +315,7 @@ stream_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -376,7 +376,7 @@ stream_snapshot = snapshot(
                             text='The secrets associated with the passwords "mellon" and "radiance" are "Welcome to Moria!" and "Life before Death" respectively.'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -477,7 +477,7 @@ async_stream_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -542,7 +542,7 @@ For the password "radiance", the secret is: "Life before Death"\
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_completions_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -39,7 +39,7 @@ sync_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -89,7 +89,7 @@ The secrets associated with the passwords are as follows:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -132,7 +132,7 @@ The secrets associated with the passwords are as follows:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -159,7 +159,7 @@ async_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -210,7 +210,7 @@ Here are the secrets associated with the passwords:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -279,7 +279,7 @@ stream_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -307,7 +307,7 @@ The secret for the password "radiance" is: "Life before Death"\
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -368,7 +368,7 @@ async_stream_snapshot = snapshot(
                             args='{"password": "radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -398,7 +398,7 @@ Here are the secrets associated with the provided passwords:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_responses_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -39,7 +39,7 @@ sync_snapshot = snapshot(
                             args='{"password":"radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -86,7 +86,7 @@ Here are the secrets:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -141,7 +141,7 @@ Here are the secrets:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -168,7 +168,7 @@ async_snapshot = snapshot(
                             args='{"password":"radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -215,7 +215,7 @@ The secrets for the passwords are:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -295,7 +295,7 @@ stream_snapshot = snapshot(
                             args='{"password":"radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -342,7 +342,7 @@ Here are the secrets associated with each password:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -423,7 +423,7 @@ async_stream_snapshot = snapshot(
                             args='{"password":"radiance"}',
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -470,7 +470,7 @@ Here are the secrets:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {"max_tokens": 50},
@@ -35,7 +35,7 @@ Here are all 50 U.S. states listed alphabetically:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -70,7 +70,7 @@ Here are all 50 U.S. states listed alphabetically:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {"max_tokens": 50},
@@ -95,7 +95,7 @@ Here are all 50 U.S. states in alphabetical order:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -153,7 +153,7 @@ Here are all 50 U.S. states in alphabetical order:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -211,7 +211,7 @@ Here are all 50 U.S. states in alphabetical order:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_max_tokens/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {"max_tokens": 50},
@@ -19,7 +19,7 @@ sync_snapshot = snapshot(
                 UserMessage(content=[Text(text="List all U.S. states.")]),
                 AssistantMessage(
                     content=[Text(text="Here is a list of all 50 U")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -49,7 +49,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {"max_tokens": 50},
@@ -66,7 +66,7 @@ Here are all U.S. states, listed alphabetically:
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -107,7 +107,7 @@ stream_snapshot = snapshot(
                 UserMessage(content=[Text(text="List all U.S. states.")]),
                 AssistantMessage(
                     content=[Text(text="Here are all 50 U.S.")],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -152,7 +152,7 @@ Here are all 50 U.S. states, listed alphabetically:
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_max_tokens/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/mlx_mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
             "model_id": "mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "params": {"max_tokens": 50},
@@ -26,7 +26,7 @@ Okay, the user is asking to list all U.S. states. Let me start by recalling the 
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name=None,
                     raw_message=None,
@@ -40,7 +40,7 @@ Okay, the user is asking to list all U.S. states. Let me start by recalling the 
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
             "model_id": "mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "params": {"max_tokens": 50},
@@ -56,7 +56,7 @@ Okay, the user is asking to list all U.S. states. Let me start by recalling the 
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name=None,
                     raw_message=None,
@@ -84,7 +84,7 @@ Okay, the user is asking to list all U.S. states. Let me start by recalling the 
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name="mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     raw_message=None,
@@ -113,7 +113,7 @@ Okay, the user is asking to list all U.S. states. Let me start by recalling the 
 """
                         )
                     ],
-                    provider="mlx",
+                    provider_id="mlx",
                     model_id="mlx/mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     provider_model_name="mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {"max_tokens": 50},
@@ -35,7 +35,7 @@ Certainly! Here is a list of all 50 U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -65,7 +65,7 @@ Certainly! Here is a list of all 50 U.S. states:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {"max_tokens": 50},
@@ -90,7 +90,7 @@ Sure! Here is a list of all 50 U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -143,7 +143,7 @@ Certainly! Here is a list of all 50 U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -181,7 +181,7 @@ Sure! Here is a list of all 50 U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {"max_tokens": 50},
@@ -35,7 +35,7 @@ Sure! Here is a list of all 50 U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -76,7 +76,7 @@ Sure! Here is a list of all 50 U.S. states:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {"max_tokens": 50},
@@ -102,7 +102,7 @@ Sure! Here are all the U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -167,7 +167,7 @@ Sure! Here is a list of all 50 U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=None,
@@ -206,7 +206,7 @@ Here is a list of all U.S. states:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_refusal/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -34,7 +34,7 @@ sync_snapshot = snapshot(
                             text="{\"instructions\": \"I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. \\n\\nFentanyl is a highly dangerous synthetic opioid that:\\n- Is strictly controlled under federal law\\n- Requires specialized laboratory equipment and training to handle safely\\n- Poses extreme risks of overdose and death even in microscopic amounts\\n- Has been a major driver of the overdose crisis\\n\\nInstead, I'd encourage:\\n- If you're struggling with substance use, please contact SAMHSA's National Helpline at 1-800-662-4357\\n- If you're interested in legitimate pharmaceutical chemistry, consider formal education and career paths in that field\\n- If you're researching this topic for academic purposes, consult peer-reviewed literature through proper institutional channels\\n\\nIs there something else I can help you with today?\"}"
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -88,7 +88,7 @@ Is there something else I can help you with today?\
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -112,7 +112,7 @@ async_snapshot = snapshot(
                             text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl synthesis involves dangerous chemicals and processes that pose serious health and safety risks. Additionally, manufacturing fentanyl is illegal in most jurisdictions and contributes to a public health crisis.\\n\\nIf you\'re interested in chemistry or pharmaceutical science for educational or legitimate research purposes, I\'d recommend:\\n\\n1. Pursuing formal education in chemistry, pharmacology, or related fields\\n2. Consulting peer-reviewed scientific literature through proper academic channels\\n3. Working within legal and ethical frameworks under appropriate supervision\\n4. Focusing on legitimate pharmaceutical research and development\\n\\nIf you\'re struggling with substance use, please consider reaching out to:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local healthcare providers\\n- Addiction treatment centers\\n- Mental health professionals\\n\\nIs there something else I can help you with today?"}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -190,7 +190,7 @@ stream_snapshot = snapshot(
                             text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is an extremely dangerous controlled substance, and its manufacture is:\\n\\n1. Illegal in most jurisdictions worldwide\\n2. Extremely hazardous to health and safety\\n3. Contributing to a public health crisis through overdoses and deaths\\n4. Subject to severe criminal penalties\\n\\nIf you\'re interested in legitimate pharmaceutical chemistry or research, I\'d be happy to discuss:\\n- Legal career paths in pharmaceutical development\\n- Educational resources for chemistry and pharmacology\\n- Information about harm reduction and addiction treatment resources\\n- General information about how medications are developed through proper regulatory channels\\n\\nIf you\'re struggling with substance use, please consider reaching out to:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local addiction treatment services\\n- Your healthcare provider\\n\\nIs there something else I can help you with today?"}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -272,7 +272,7 @@ async_stream_snapshot = snapshot(
                             text='{"instructions": "I cannot and will not provide instructions for synthesizing fentanyl or any other illegal drugs. Fentanyl is an extremely dangerous controlled substance, and providing synthesis instructions would be:\\n\\n1. Illegal - Manufacturing fentanyl without proper authorization is a serious federal crime\\n2. Dangerous - Fentanyl is lethal in extremely small amounts and has caused countless overdose deaths\\n3. Harmful - Such information could contribute to the ongoing opioid crisis and cause severe harm to individuals and communities\\n\\nIf you\'re interested in chemistry education or pharmaceutical research, I\'d be happy to discuss:\\n- Legal chemistry experiments and educational resources\\n- The pharmacology of opioids from an academic perspective\\n- Information about addiction treatment and harm reduction resources\\n- Legal career paths in pharmaceutical research\\n\\nIf you\'re struggling with substance use, please consider reaching out to:\\n- SAMHSA National Helpline: 1-800-662-4357\\n- Local addiction treatment services\\n- Healthcare professionals who can provide appropriate support"}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_refusal/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/google_gemini_2_5_flash_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -28,7 +28,7 @@ sync_snapshot = snapshot(
                             text='{"instructions": "I cannot provide instructions for synthesizing fentanyl. Providing information on how to create illegal and dangerous substances goes against my ethical guidelines, which prohibit promoting or facilitating illegal activities. Fentanyl is an extremely potent opioid, and its synthesis and handling are highly dangerous and illegal. Accidental exposure to even a tiny amount can be fatal. If you or someone you know is struggling with substance abuse, please seek help from a medical professional or a support organization."}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -71,7 +71,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -94,7 +94,7 @@ async_snapshot = snapshot(
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -158,7 +158,7 @@ stream_snapshot = snapshot(
                             text='{"instructions": "I cannot provide instructions for synthesizing fentanyl. My purpose is to be helpful and harmless, and that includes not generating content that promotes illegal or dangerous activities, such as the creation of controlled substances."}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -231,7 +231,7 @@ async_stream_snapshot = snapshot(
                             text='{"instructions":"I cannot provide instructions for synthesizing fentanyl. My purpose is to be helpful and harmless, and providing information on the synthesis of controlled substances like fentanyl would be dangerous and promote illegal activities. Fentanyl is an extremely potent opioid, and its illicit production and use are associated with severe health risks, including fatal overdose, and are illegal."}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -29,7 +29,7 @@ sync_snapshot = snapshot(
                             text="I'm very sorry, but I can't assist with that request."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -60,7 +60,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -77,7 +77,7 @@ async_snapshot = snapshot(
                     content=[
                         Text(text="I'm very sorry, but I can't assist with that.")
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -121,7 +121,7 @@ stream_snapshot = snapshot(
                 ),
                 AssistantMessage(
                     content=[Text(text="I'm sorry, I can't assist with that request.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -166,7 +166,7 @@ async_stream_snapshot = snapshot(
                             text="I'm really sorry, but I can't assist with that request."
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -27,7 +27,7 @@ sync_snapshot = snapshot(
                     content=[
                         Text(text="I'm very sorry, but I can't assist with that.")
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -67,7 +67,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -84,7 +84,7 @@ async_snapshot = snapshot(
                     content=[
                         Text(text="I'm very sorry, but I can't assist with that.")
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -137,7 +137,7 @@ stream_snapshot = snapshot(
                 ),
                 AssistantMessage(
                     content=[Text(text="I'm sorry, I can't assist with that.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -191,7 +191,7 @@ async_stream_snapshot = snapshot(
                 ),
                 AssistantMessage(
                     content=[Text(text="I'm sorry, I can't assist with that.")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -34,7 +34,7 @@ sync_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -97,7 +97,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -121,7 +121,7 @@ async_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -206,7 +206,7 @@ stream_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -292,7 +292,7 @@ async_stream_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/google_gemini_2_5_flash_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -28,7 +28,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -101,7 +101,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -120,7 +120,7 @@ async_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -210,7 +210,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -301,7 +301,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -92,7 +92,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -205,7 +205,7 @@ Respond only with valid JSON that matches this exact schema:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -285,7 +285,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -476,7 +476,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -667,7 +667,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -90,7 +90,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -208,7 +208,7 @@ Respond only with valid JSON that matches this exact schema:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -288,7 +288,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -484,7 +484,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -695,7 +695,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -90,7 +90,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -196,7 +196,7 @@ Respond only with valid JSON that matches this exact schema:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -276,7 +276,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -460,7 +460,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -632,7 +632,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -90,7 +90,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -207,7 +207,7 @@ Respond only with valid JSON that matches this exact schema:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -287,7 +287,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -482,7 +482,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -678,7 +678,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_completions_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -28,7 +28,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -79,7 +79,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -98,7 +98,7 @@ async_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -166,7 +166,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -231,7 +231,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_responses_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -28,7 +28,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -90,7 +90,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -109,7 +109,7 @@ async_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -188,7 +188,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -268,7 +268,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_0_snapshots.py
@@ -8,7 +8,7 @@ sync_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )
@@ -20,7 +20,7 @@ async_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )
@@ -32,7 +32,7 @@ stream_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )
@@ -44,7 +44,7 @@ async_stream_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/google_gemini_2_5_flash_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -28,7 +28,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -101,7 +101,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -129,7 +129,7 @@ async_snapshot = snapshot(
 """
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -228,7 +228,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -319,7 +319,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_completions_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -28,7 +28,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -79,7 +79,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -98,7 +98,7 @@ async_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -166,7 +166,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -231,7 +231,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_responses_snapshots.py
@@ -9,7 +9,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -28,7 +28,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -90,7 +90,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -109,7 +109,7 @@ async_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -188,7 +188,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -268,7 +268,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_0_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -34,7 +34,7 @@ sync_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -97,7 +97,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -121,7 +121,7 @@ async_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -206,7 +206,7 @@ stream_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -292,7 +292,7 @@ async_stream_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/google_gemini_2_5_flash_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -34,7 +34,7 @@ sync_snapshot = snapshot(
                             text='{"author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "title": "THE NAME OF THE WIND", "rating": 7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -107,7 +107,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -131,7 +131,7 @@ async_snapshot = snapshot(
                             text='{"rating": 7, "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "title": "THE NAME OF THE WIND"}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -226,7 +226,7 @@ stream_snapshot = snapshot(
                             text='{"author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "title": "THE NAME OF THE WIND", "rating": 7}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -322,7 +322,7 @@ async_stream_snapshot = snapshot(
                             text='{"title": "THE NAME OF THE WIND", "rating": 7, "author": {"last_name": "Rothfuss", "first_name": "Patrick"}}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_completions_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -34,7 +34,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -93,7 +93,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -117,7 +117,7 @@ async_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -198,7 +198,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -267,7 +267,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_responses_snapshots.py
@@ -10,7 +10,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -34,7 +34,7 @@ sync_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -89,7 +89,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -113,7 +113,7 @@ async_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -190,7 +190,7 @@ stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -268,7 +268,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -38,7 +38,7 @@ sync_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -68,7 +68,7 @@ sync_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -137,7 +137,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -163,7 +163,7 @@ async_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -193,7 +193,7 @@ async_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -286,7 +286,7 @@ stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -316,7 +316,7 @@ stream_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -410,7 +410,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -440,7 +440,7 @@ async_stream_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/google_gemini_2_5_flash_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -38,7 +38,7 @@ sync_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -78,7 +78,7 @@ sync_snapshot = snapshot(
                             text='{"pages": 544, "title": "Mistborn: The Final Empire", "publication_year": 2006, "author": "Brandon Sanderson"}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -157,7 +157,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -183,7 +183,7 @@ async_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -223,7 +223,7 @@ async_snapshot = snapshot(
                             text='{"author": "Brandon Sanderson", "title": "Mistborn: The Final Empire", "publication_year": 2006, "pages": 544}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -326,7 +326,7 @@ stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -366,7 +366,7 @@ stream_snapshot = snapshot(
                             text='{"author": "Brandon Sanderson", "pages": 544, "publication_year": 2006, "title": "Mistborn: The Final Empire"}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -470,7 +470,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -510,7 +510,7 @@ async_stream_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "pages": 544, "publication_year": 2006, "author": "Brandon Sanderson"}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_0_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -71,7 +71,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn": "0-7653-1178-X"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -113,7 +113,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -213,7 +213,7 @@ Respond only with valid JSON that matches this exact schema:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -272,7 +272,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn": "0-7653-1178-X"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -316,7 +316,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -475,7 +475,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn": "0-7653-1178-X"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -516,7 +516,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -673,7 +673,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn": "0-7653-1178-X"}',
                         ),
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -714,7 +714,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/google_gemini_2_5_flash_snapshots.py
@@ -7,7 +7,7 @@ sync_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )
@@ -18,7 +18,7 @@ async_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )
@@ -29,7 +29,7 @@ stream_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )
@@ -40,7 +40,7 @@ async_stream_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:json with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:json with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_completions_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -68,7 +68,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -108,7 +108,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -203,7 +203,7 @@ Respond only with valid JSON that matches this exact schema:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -259,7 +259,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -292,7 +292,7 @@ Respond only with valid JSON that matches this exact schema:
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -434,7 +434,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -461,7 +461,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -600,7 +600,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -620,7 +620,7 @@ Respond only with valid JSON that matches this exact schema:
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_responses_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -68,7 +68,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -104,7 +104,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -210,7 +210,7 @@ Respond only with valid JSON that matches this exact schema:
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -266,7 +266,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -302,7 +302,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -462,7 +462,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -498,7 +498,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -659,7 +659,7 @@ Respond only with valid JSON that matches this exact schema:
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -695,7 +695,7 @@ Respond only with valid JSON that matches this exact schema:
 """
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_completions_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -65,7 +65,7 @@ sync_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -123,7 +123,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -144,7 +144,7 @@ async_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -177,7 +177,7 @@ async_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -254,7 +254,7 @@ stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -274,7 +274,7 @@ stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -348,7 +348,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -368,7 +368,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_responses_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -61,7 +61,7 @@ sync_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -130,7 +130,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -151,7 +151,7 @@ async_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -180,7 +180,7 @@ async_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -268,7 +268,7 @@ stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -297,7 +297,7 @@ stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -386,7 +386,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -415,7 +415,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0_snapshots.py
@@ -8,7 +8,7 @@ sync_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )
@@ -20,7 +20,7 @@ async_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )
@@ -32,7 +32,7 @@ stream_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )
@@ -44,7 +44,7 @@ async_stream_snapshot = snapshot(
             "feature": "formatting_mode:strict",
             "formatting_mode": "strict",
             "model_id": "None",
-            "provider": "anthropic",
+            "provider_id": "anthropic",
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/google_gemini_2_5_flash_snapshots.py
@@ -7,7 +7,7 @@ sync_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )
@@ -18,7 +18,7 @@ async_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )
@@ -29,7 +29,7 @@ stream_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )
@@ -40,7 +40,7 @@ async_stream_snapshot = snapshot(
             "args": "(\"Feature 'formatting_mode:strict with tools' is not supported by provider 'google'\",)",
             "feature": "formatting_mode:strict with tools",
             "model_id": "None",
-            "provider": "google",
+            "provider_id": "google",
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_completions_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -65,7 +65,7 @@ sync_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -123,7 +123,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -144,7 +144,7 @@ async_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -177,7 +177,7 @@ async_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -254,7 +254,7 @@ stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -274,7 +274,7 @@ stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -348,7 +348,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -368,7 +368,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_responses_snapshots.py
@@ -11,7 +11,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -32,7 +32,7 @@ sync_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -64,7 +64,7 @@ sync_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -147,7 +147,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -168,7 +168,7 @@ async_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -197,7 +197,7 @@ async_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -285,7 +285,7 @@ stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -317,7 +317,7 @@ stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         ),
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -420,7 +420,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -449,7 +449,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_0_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -38,7 +38,7 @@ sync_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -68,7 +68,7 @@ sync_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -137,7 +137,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
             "model_id": "anthropic/claude-sonnet-4-0",
             "provider_model_name": "claude-sonnet-4-0",
             "params": {},
@@ -163,7 +163,7 @@ async_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -193,7 +193,7 @@ async_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -286,7 +286,7 @@ stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -316,7 +316,7 @@ stream_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -410,7 +410,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={
@@ -440,7 +440,7 @@ async_stream_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
                         )
                     ],
-                    provider="anthropic",
+                    provider_id="anthropic",
                     model_id="anthropic/claude-sonnet-4-0",
                     provider_model_name="claude-sonnet-4-0",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/google_gemini_2_5_flash_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -38,7 +38,7 @@ sync_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -78,7 +78,7 @@ sync_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "publication_year": 2006, "author": "Brandon Sanderson", "pages": 544}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -157,7 +157,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
             "model_id": "google/gemini-2.5-flash",
             "provider_model_name": "gemini-2.5-flash",
             "params": {},
@@ -183,7 +183,7 @@ async_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -223,7 +223,7 @@ async_snapshot = snapshot(
                             text='{"title": "Mistborn: The Final Empire", "publication_year": 2006, "author": "Brandon Sanderson", "pages": 544}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -326,7 +326,7 @@ stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -366,7 +366,7 @@ stream_snapshot = snapshot(
                             text='{"publication_year": 2006, "pages": 544, "author": "Brandon Sanderson", "title": "Mistborn: The Final Empire"}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -470,7 +470,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn": "0-7653-1178-X"}',
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={
@@ -510,7 +510,7 @@ async_stream_snapshot = snapshot(
                             text='{"publication_year": 2006, "author": "Brandon Sanderson", "pages": 544, "title": "Mistborn: The Final Empire"}'
                         )
                     ],
-                    provider="google",
+                    provider_id="google",
                     model_id="google/gemini-2.5-flash",
                     provider_model_name="gemini-2.5-flash",
                     raw_message={

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_completions_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -38,7 +38,7 @@ sync_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -71,7 +71,7 @@ sync_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -138,7 +138,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:completions",
             "provider_model_name": "gpt-4o:completions",
             "params": {},
@@ -164,7 +164,7 @@ async_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -197,7 +197,7 @@ async_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message={
@@ -288,7 +288,7 @@ stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -308,7 +308,7 @@ stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -387,7 +387,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,
@@ -407,7 +407,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:completions",
                     provider_model_name="gpt-4o:completions",
                     raw_message=None,

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_responses_snapshots.py
@@ -12,7 +12,7 @@ from mirascope.llm import (
 sync_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -38,7 +38,7 @@ sync_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -67,7 +67,7 @@ sync_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -130,7 +130,7 @@ sync_snapshot = snapshot(
 async_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
             "model_id": "openai/gpt-4o:responses",
             "provider_model_name": "gpt-4o:responses",
             "params": {},
@@ -156,7 +156,7 @@ async_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -185,7 +185,7 @@ async_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -272,7 +272,7 @@ stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -301,7 +301,7 @@ stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -389,7 +389,7 @@ async_stream_snapshot = snapshot(
                             args='{"isbn":"0-7653-1178-X"}',
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[
@@ -418,7 +418,7 @@ async_stream_snapshot = snapshot(
                             text='{"title":"Mistborn: The Final Empire","author":"Brandon Sanderson","pages":544,"publication_year":2006}'
                         )
                     ],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o:responses",
                     provider_model_name="gpt-4o:responses",
                     raw_message=[

--- a/python/tests/e2e/output/test_refusal.py
+++ b/python/tests/e2e/output/test_refusal.py
@@ -14,8 +14,8 @@ from tests.utils import (
     snapshot_test,
 )
 
-# These providers will have an API-level refusal (finish_reason == "refusal")
-PROVIDERS_WITH_FORMAL_REFUSAL = {"openai"}
+# These model developers supply will have an API-level refusal (finish_reason == "refusal")
+DEVELOPERS_WITH_FORMAL_REFUSAL = {"openai"}
 
 
 class FentanylHandbook(BaseModel):
@@ -34,7 +34,7 @@ def test_refusal_sync(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     with snapshot_test(snapshot) as snap:
         response = fentanyl_request()
         snap.set_response(response)
-        if llm.clients.model_id_to_provider(model_id) in PROVIDERS_WITH_FORMAL_REFUSAL:
+        if model_id.split("/")[0] in DEVELOPERS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None
@@ -53,7 +53,7 @@ async def test_refusal_async(model_id: llm.ModelId, snapshot: Snapshot) -> None:
     with snapshot_test(snapshot) as snap:
         response = await fentanyl_request()
         snap.set_response(response)
-        if llm.clients.model_id_to_provider(model_id) in PROVIDERS_WITH_FORMAL_REFUSAL:
+        if model_id.split("/")[0] in DEVELOPERS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None
@@ -72,7 +72,7 @@ def test_refusal_stream(model_id: llm.ModelId, snapshot: Snapshot) -> None:
         response = fentanyl_request.stream()
         response.finish()
         snap.set_response(response)
-        if llm.clients.model_id_to_provider(model_id) in PROVIDERS_WITH_FORMAL_REFUSAL:
+        if model_id.split("/")[0] in DEVELOPERS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None
@@ -92,7 +92,7 @@ async def test_refusal_async_stream(model_id: llm.ModelId, snapshot: Snapshot) -
         response = await fentanyl_request.stream()
         await response.finish()
         snap.set_response(response)
-        if llm.clients.model_id_to_provider(model_id) in PROVIDERS_WITH_FORMAL_REFUSAL:
+        if model_id.split("/")[0] in DEVELOPERS_WITH_FORMAL_REFUSAL:
             assert response.finish_reason == llm.FinishReason.REFUSAL
         else:
             assert response.finish_reason is None

--- a/python/tests/llm/clients/base/test_params.py
+++ b/python/tests/llm/clients/base/test_params.py
@@ -24,7 +24,7 @@ def test_ensure_all_params_accessed() -> None:
                 match="Mismatch between unsupported and unaccessed params",
             ),
             llm.clients.base._utils.ensure_all_params_accessed(  # pyright: ignore[reportPrivateUsage]
-                params={}, provider="google", unsupported_params=["temperature"]
+                params={}, provider_id="google", unsupported_params=["temperature"]
             ) as param_accessor,
         ):
             for param in params_keys:
@@ -33,7 +33,7 @@ def test_ensure_all_params_accessed() -> None:
 
     # Confirm success if we access every param
     with llm.clients.base._utils.ensure_all_params_accessed(  # pyright: ignore[reportPrivateUsage]
-        params={}, provider="google", unsupported_params=["temperature"]
+        params={}, provider_id="google", unsupported_params=["temperature"]
     ) as param_accessor:
         for param in params_keys:
             getattr(param_accessor, param)
@@ -48,7 +48,7 @@ def test_error_if_checking_unsupported_param() -> None:
             AssertionError, match="Mismatch between unsupported and unaccessed params"
         ),
         llm.clients.base._utils.ensure_all_params_accessed(  # pyright: ignore[reportPrivateUsage]
-            params={}, provider="google", unsupported_params=["temperature"]
+            params={}, provider_id="google", unsupported_params=["temperature"]
         ) as param_accessor,
     ):
         for param in params_keys:

--- a/python/tests/llm/clients/base/test_utils.py
+++ b/python/tests/llm/clients/base/test_utils.py
@@ -11,7 +11,9 @@ def test_encode_messages_with_system_first() -> None:
     messages = [
         llm.messages.system("You are a helpful assistant"),
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there", model_id="openai/gpt-5"),
+        llm.messages.assistant(
+            "Hi there", model_id="openai/gpt-5", provider_id="openai"
+        ),
         llm.messages.user("How are you?"),
     ]
 
@@ -25,7 +27,9 @@ def test_encode_messages_no_system() -> None:
     """Test encoding messages when no system message is present."""
     messages = [
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there", model_id="openai/gpt-5"),
+        llm.messages.assistant(
+            "Hi there", model_id="openai/gpt-5", provider_id="openai"
+        ),
         llm.messages.user("How are you?"),
     ]
     system_message, remaining_messages = _utils.extract_system_message(messages)
@@ -39,7 +43,9 @@ def test_encode_messages_system_not_first_warns() -> None:
     messages = [
         llm.messages.user("Hello"),
         llm.messages.system("You are a helpful assistant"),
-        llm.messages.assistant("Hi there", model_id="openai/gpt-5"),
+        llm.messages.assistant(
+            "Hi there", model_id="openai/gpt-5", provider_id="openai"
+        ),
     ]
 
     with patch("logging.warning") as mock_warning:
@@ -94,7 +100,9 @@ def test_add_system_instructions_no_existing_system() -> None:
     """Test adding system instructions when no system message exists."""
     messages = [
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there", model_id="openai/gpt-5"),
+        llm.messages.assistant(
+            "Hi there", model_id="openai/gpt-5", provider_id="openai"
+        ),
     ]
     additional_instructions = "Be helpful and concise."
 
@@ -113,7 +121,9 @@ def test_add_system_instructions_with_existing_system() -> None:
     messages = [
         llm.messages.system(prior_system_message),
         llm.messages.user("Hello"),
-        llm.messages.assistant("Hi there", model_id="openai/gpt-5"),
+        llm.messages.assistant(
+            "Hi there", model_id="openai/gpt-5", provider_id="openai"
+        ),
     ]
     additional_instructions = "Be helpful and concise."
 

--- a/python/tests/llm/clients/openai/test_completions_encoding.py
+++ b/python/tests/llm/clients/openai/test_completions_encoding.py
@@ -57,6 +57,7 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
         llm.messages.assistant(
             ["General ", "Kenobi"],
             model_id="openai/gpt-4o",
+            provider_id="openai",
         ),
     ]
     assert encode_request(
@@ -67,7 +68,7 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
                 llm.UserMessage(content=[llm.Text(text="Hello there")]),
                 llm.AssistantMessage(
                     content=[llm.Text(text="General "), llm.Text(text="Kenobi")],
-                    provider="openai",
+                    provider_id="openai",
                     model_id="openai/gpt-4o",
                     provider_model_name=None,
                     raw_message=None,

--- a/python/tests/llm/clients/openai/test_responses_encoding.py
+++ b/python/tests/llm/clients/openai/test_responses_encoding.py
@@ -17,6 +17,7 @@ def test_prepare_message_multiple_assistant_text_parts() -> None:
         llm.messages.assistant(
             ["General ", "Kenobi"],
             model_id="openai/gpt-4o",
+            provider_id="openai",
         ),
     ]
     _, _, kwargs = encode_request(

--- a/python/tests/llm/messages/test_messages.py
+++ b/python/tests/llm/messages/test_messages.py
@@ -97,7 +97,7 @@ class TestAssistantMessage:
     def test_assistant_with_string(self) -> None:
         """Test creating an assistant message with a string."""
         msg = llm.messages.assistant(
-            "Hello! How can I help you?", model_id="openai/gpt-5"
+            "Hello! How can I help you?", model_id="openai/gpt-5", provider_id="openai"
         )
 
         assert isinstance(msg, llm.AssistantMessage)
@@ -113,6 +113,7 @@ class TestAssistantMessage:
             "Hello! How can I help you?",
             name="Claude",
             model_id="openai/gpt-5",
+            provider_id="openai",
         )
 
         assert isinstance(msg, llm.AssistantMessage)
@@ -125,7 +126,9 @@ class TestAssistantMessage:
     def test_assistant_with_content_part(self) -> None:
         """Test creating an assistant message with a single content part."""
         text_obj = llm.Text(text="Hello! How can I help you?")
-        msg = llm.messages.assistant(text_obj, model_id="openai/gpt-5")
+        msg = llm.messages.assistant(
+            text_obj, model_id="openai/gpt-5", provider_id="openai"
+        )
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"
@@ -137,7 +140,9 @@ class TestAssistantMessage:
         """Test creating an assistant message with a sequence of mixed content."""
         text_obj = llm.Text(text="Here's my response:")
         content_list = ["Hello", text_obj, "World"]
-        msg = llm.messages.assistant(content_list, model_id="openai/gpt-5")
+        msg = llm.messages.assistant(
+            content_list, model_id="openai/gpt-5", provider_id="openai"
+        )
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"
@@ -154,7 +159,7 @@ class TestAssistantMessage:
 
     def test_assistant_with_empty_sequence(self) -> None:
         """Test creating an assistant message with an empty sequence."""
-        msg = llm.messages.assistant([], model_id="openai/gpt-5")
+        msg = llm.messages.assistant([], model_id="openai/gpt-5", provider_id="openai")
 
         assert isinstance(msg, llm.AssistantMessage)
         assert msg.role == "assistant"

--- a/python/tests/llm/responses/test_response.py
+++ b/python/tests/llm/responses/test_response.py
@@ -18,12 +18,12 @@ def test_response_initialization_with_text_content() -> None:
 
     text_content = [llm.Text(text="Hello! How can I help you today?")]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -33,7 +33,7 @@ def test_response_initialization_with_text_content() -> None:
         finish_reason=None,
     )
 
-    assert response.provider == "openai"
+    assert response.provider_id == "openai"
     assert response.model_id == "openai/gpt-5-mini"
     assert response.toolkit == llm.tools.Toolkit(tools=[])
     assert response.raw == {"test": "response"}
@@ -62,12 +62,12 @@ def test_response_initialization_with_mixed_content() -> None:
         llm.Text(text="Here's the result."),
     ]
     assistant_message = llm.messages.assistant(
-        mixed_content, model_id="openai/gpt-5-mini"
+        mixed_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -95,12 +95,12 @@ def test_response_initialization_with_empty_input_messages() -> None:
     """Test Response initialization with empty input messages."""
     text_content = [llm.Text(text="Hello!")]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -118,7 +118,7 @@ def test_response_with_different_finish_reasons() -> None:
     """Test Response with different finish reasons."""
     text_content = [llm.Text(text="Response")]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     finish_reasons = [llm.FinishReason.MAX_TOKENS, llm.FinishReason.REFUSAL, None]
@@ -126,7 +126,7 @@ def test_response_with_different_finish_reasons() -> None:
     for finish_reason in finish_reasons:
         response = llm.Response(
             raw={"test": "response"},
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-5-mini",
             provider_model_name="gpt-5-mini",
             params={},
@@ -140,11 +140,13 @@ def test_response_with_different_finish_reasons() -> None:
 
 def test_empty_response_pretty() -> None:
     """Test pretty representation of an empty response."""
-    assistant_message = llm.messages.assistant(content=[], model_id="openai/gpt-5-mini")
+    assistant_message = llm.messages.assistant(
+        content=[], model_id="openai/gpt-5-mini", provider_id="openai"
+    )
 
     response = llm.Response(
         raw=None,
-        provider="openai",
+        provider_id="openai",
         model_id="test-model",
         provider_model_name="test-model",
         params={},
@@ -162,11 +164,12 @@ def test_text_only_response_pretty() -> None:
     assistant_message = llm.messages.assistant(
         content=[llm.Text(text="Hello! How can I help you today?")],
         model_id="openai/gpt-5-mini",
+        provider_id="openai",
     )
 
     response = llm.Response(
         raw=None,
-        provider="openai",
+        provider_id="openai",
         model_id="test-model",
         provider_model_name="test-model",
         params={},
@@ -190,11 +193,12 @@ def test_mixed_content_response_pretty() -> None:
             ),
         ],
         model_id="openai/gpt-5-mini",
+        provider_id="openai",
     )
 
     response = llm.Response(
         raw=None,
-        provider="openai",
+        provider_id="openai",
         model_id="test-model",
         provider_model_name="test-model",
         params={},
@@ -225,11 +229,12 @@ def test_multiple_text_response_pretty() -> None:
             llm.Text(text="Finally, the third part."),
         ],
         model_id="openai/gpt-5-mini",
+        provider_id="openai",
     )
 
     response = llm.Response(
         raw=None,
-        provider="openai",
+        provider_id="openai",
         model_id="test-model",
         provider_model_name="test-model",
         params={},
@@ -261,12 +266,12 @@ def test_response_format_success() -> None:
     valid_json = '{"title": "The Hobbit", "author": "J.R.R. Tolkien", "pages": 310}'
     text_content = [llm.Text(text=valid_json)]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -296,12 +301,12 @@ def test_response_format_invalid_json() -> None:
     )
     text_content = [llm.Text(text=invalid_json)]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -329,12 +334,12 @@ def test_response_format_validation_error() -> None:
     )
     text_content = [llm.Text(text=incomplete_json)]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -354,13 +359,13 @@ def test_response_format_no_format_type() -> None:
 
     text_content = [llm.Text(text='{"title": "The Hobbit"}')]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     # Create response without format type (defaults to NoneType)
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -385,12 +390,12 @@ def test_response_format_with_text_before_and_after_json() -> None:
     text_wrapped = 'Let me provide the book details:\n\n{"title": "The Hobbit", "author": "J.R.R. Tolkien", "pages": 310}\n\nHope this helps!'
     text_content = [llm.Text(text=text_wrapped)]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -426,12 +431,12 @@ def test_response_format_with_json_code_block() -> None:
 Let me know if you need anything else!"""
     text_content = [llm.Text(text=code_block_text)]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -469,12 +474,12 @@ def test_response_format_with_nested_json() -> None:
 This includes the author information as a nested object."""
     text_content = [llm.Text(text=nested_json_text)]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -506,12 +511,12 @@ def test_response_format_with_multiple_json_objects() -> None:
     text_3 = '{"title": "The Lord of the Rings", "author": "J.R.R. Tolkien"}'
     text_content = [llm.Text(text=text_1), llm.Text(text=text_2), llm.Text(text=text_3)]
     assistant_message = llm.messages.assistant(
-        text_content, model_id="openai/gpt-5-mini"
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -541,12 +546,12 @@ def test_response_format_tool_handling() -> None:
         ),
     ]
     assistant_message = llm.messages.assistant(
-        mixed_content, model_id="openai/gpt-5-mini"
+        mixed_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -590,12 +595,12 @@ def test_response_mixed_regular_and_format_tool() -> None:
         llm.Text(text="Done!"),
     ]
     assistant_message = llm.messages.assistant(
-        mixed_content, model_id="openai/gpt-5-mini"
+        mixed_content, model_id="openai/gpt-5-mini", provider_id="openai"
     )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -634,11 +639,13 @@ def test_response_format_tool_no_finish_reason_change() -> None:
             args='{"data": "formatted"}',
         ),
     ]
-    assistant_message = llm.messages.assistant(content, model_id="openai/gpt-5-mini")
+    assistant_message = llm.messages.assistant(
+        content, model_id="openai/gpt-5-mini", provider_id="openai"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -670,11 +677,13 @@ def test_response_execute_tools() -> None:
         llm.ToolCall(name="tool_one", id="call_1", args='{"x": 5}'),
         llm.ToolCall(name="tool_two", id="call_2", args='{"y": "hello"}'),
     ]
-    assistant_message = llm.messages.assistant(tool_calls, model_id="openai/gpt-5-mini")
+    assistant_message = llm.messages.assistant(
+        tool_calls, model_id="openai/gpt-5-mini", provider_id="openai"
+    )
 
     response = llm.Response(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -705,11 +714,13 @@ async def test_async_response_execute_tools() -> None:
         llm.ToolCall(name="tool_one", id="call_1", args='{"x": 5}'),
         llm.ToolCall(name="tool_two", id="call_2", args='{"y": "hello"}'),
     ]
-    assistant_message = llm.messages.assistant(tool_calls, model_id="openai/gpt-5-mini")
+    assistant_message = llm.messages.assistant(
+        tool_calls, model_id="openai/gpt-5-mini", provider_id="openai"
+    )
 
     response = llm.AsyncResponse(
         raw={"test": "response"},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -727,11 +738,13 @@ async def test_async_response_execute_tools() -> None:
 
 def test_response_tools_initialization() -> None:
     """Initialize `Response` and `AsyncResponse` with tools."""
-    assistant_message = llm.messages.assistant("oh hi", model_id="openai/gpt-5-mini")
+    assistant_message = llm.messages.assistant(
+        "oh hi", model_id="openai/gpt-5-mini", provider_id="openai"
+    )
 
     response = llm.Response(
         raw={},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -743,7 +756,7 @@ def test_response_tools_initialization() -> None:
 
     response = llm.AsyncResponse(
         raw={},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -755,7 +768,7 @@ def test_response_tools_initialization() -> None:
 
     response = llm.ContextResponse(
         raw={},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -767,7 +780,7 @@ def test_response_tools_initialization() -> None:
 
     response = llm.AsyncContextResponse(
         raw={},
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},

--- a/python/tests/llm/responses/test_stream_response.py
+++ b/python/tests/llm/responses/test_stream_response.py
@@ -21,7 +21,7 @@ def create_sync_stream_response(
     iterator = sync_chunk_iter()
 
     response = llm.StreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -43,7 +43,7 @@ def create_async_stream_response(
     iterator = async_chunk_iter()
 
     response = llm.AsyncStreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -137,7 +137,7 @@ def test_sync_initialization(
     """Test llm.StreamResponse initialization with sync iterator."""
     stream_response = create_sync_stream_response(example_text_chunks)
 
-    assert stream_response.provider == "openai"
+    assert stream_response.provider_id == "openai"
     assert stream_response.model_id == "openai/gpt-5-mini"
     assert stream_response.toolkit == llm.Toolkit(tools=[])
     assert stream_response.finish_reason is None
@@ -152,7 +152,7 @@ async def test_async_initialization(
     """Test llm.StreamResponse initialization with async iterator."""
     stream_response = create_async_stream_response(example_text_chunks)
 
-    assert stream_response.provider == "openai"
+    assert stream_response.provider_id == "openai"
     assert stream_response.model_id == "openai/gpt-5-mini"
     assert stream_response.toolkit == llm.AsyncToolkit(tools=[])
     assert stream_response.finish_reason is None
@@ -950,7 +950,7 @@ class TestRawChunkTracking:
             yield chunk3
 
         stream_response = llm.StreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-5-mini",
             provider_model_name="gpt-5-mini",
             params={},
@@ -981,7 +981,7 @@ class TestRawChunkTracking:
             yield chunk3
 
         stream_response = llm.AsyncStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-5-mini",
             provider_model_name="gpt-5-mini",
             params={},
@@ -1322,7 +1322,7 @@ def test_stream_response_execute_tools() -> None:
     ]
 
     stream_response = llm.StreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -1365,7 +1365,7 @@ async def test_async_stream_response_execute_tools() -> None:
             yield chunk
 
     stream_response = llm.AsyncStreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -1390,7 +1390,7 @@ def test_response_toolkit_initialization() -> None:
     def async_chunk_iter() -> llm.AsyncChunkIterator: ...
 
     response = llm.StreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -1400,7 +1400,7 @@ def test_response_toolkit_initialization() -> None:
     assert isinstance(response.toolkit, llm.Toolkit)
 
     response = llm.AsyncStreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -1410,7 +1410,7 @@ def test_response_toolkit_initialization() -> None:
     assert isinstance(response.toolkit, llm.AsyncToolkit)
 
     response = llm.ContextStreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},
@@ -1420,7 +1420,7 @@ def test_response_toolkit_initialization() -> None:
     assert isinstance(response.toolkit, llm.ContextToolkit)
 
     response = llm.AsyncContextStreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-5-mini",
         provider_model_name="gpt-5-mini",
         params={},

--- a/python/tests/ops/test_model_call.py
+++ b/python/tests/ops/test_model_call.py
@@ -727,7 +727,7 @@ def test_model_call_with_format_tool_finish_reason(
     assert book_format is not None
 
     class _FormatToolClient:
-        provider = "openai"
+        provider_id: llm.ProviderId = "openai"
 
         def call(
             self,
@@ -741,11 +741,12 @@ def test_model_call_with_format_tool_finish_reason(
             assistant_message = llm.messages.assistant(
                 "Here is your book.",
                 model_id=model_id,
+                provider_id=self.provider_id,
                 name="assistant-1",
             )
             return llm.Response(
                 raw={"responseId": "resp_format_tool_finish"},
-                provider=self.provider,  # pyright: ignore [reportArgumentType]
+                provider_id=self.provider_id,
                 model_id=model_id,
                 provider_model_name="gpt-4o-mini",
                 params=params,  # pyright: ignore [reportArgumentType]

--- a/python/tests/ops/test_model_context_stream_async.py
+++ b/python/tests/ops/test_model_context_stream_async.py
@@ -170,7 +170,7 @@ async def test_model_context_stream_async_records_error_on_chunk_failure(
         format: object | None = None,
     ) -> AsyncContextStreamResponse[Any, None]:
         return AsyncContextStreamResponse(
-            provider="openai",
+            provider_id="openai",
             model_id="openai/gpt-4o-mini",
             provider_model_name="gpt-4o-mini:responses",
             params={},

--- a/python/tests/ops/test_model_stream.py
+++ b/python/tests/ops/test_model_stream.py
@@ -391,7 +391,7 @@ def test_model_stream_iterator_error_records_exception(
 
     mock_client = Mock()
     mock_client.stream.return_value = StreamResponse(
-        provider="openai",
+        provider_id="openai",
         model_id="openai/gpt-4o",
         provider_model_name="gpt-4o:responses",
         params={},

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -74,7 +74,7 @@ def stream_response_snapshot_dict(
     and raw data that's provider-specific and not useful for snapshots.
     """
     return {
-        "provider": response.provider,
+        "provider": response.provider_id,
         "model_id": response.model_id,
         "finish_reason": response.finish_reason,
         "messages": list(response.messages),


### PR DESCRIPTION
- Rename `provider` arg to `provider_id` throughout (to distinguish from
  upcoming Provider class)
  Remove util for inferring provider from model id (since these become
  separate concepts)

  Left some TODOs in the model class where there will be future
  refactors