### PR TITLE
feat: add llm.Provider (base provider)

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -87,7 +87,7 @@ from .prompts import (
     PromptDecorator,
     prompt,
 )
-from .providers import ProviderId
+from .providers import Provider, ProviderId, provider_for_model
 from .responses import (
     AsyncChunkIterator,
     AsyncContextResponse,
@@ -179,6 +179,7 @@ __all__ = [
     "PermissionError",
     "Prompt",
     "PromptDecorator",
+    "Provider",
     "ProviderId",
     "RateLimitError",
     "RawMessageChunk",
@@ -228,6 +229,7 @@ __all__ = [
     "models",
     "prompt",
     "prompts",
+    "provider_for_model",
     "responses",
     "tool",
     "tools",

--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -1,5 +1,6 @@
 """Provider system for routing model calls through different implementations."""
 
+from .base_provider import Provider, provider_for_model
 from .provider_id import KNOWN_PROVIDER_IDS, ProviderId
 
-__all__ = ["KNOWN_PROVIDER_IDS", "ProviderId"]
+__all__ = ["KNOWN_PROVIDER_IDS", "Provider", "ProviderId", "provider_for_model"]

--- a/python/mirascope/llm/providers/base_provider.py
+++ b/python/mirascope/llm/providers/base_provider.py
@@ -1,0 +1,111 @@
+"""Base Provider class and context management for runtime provider overrides."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, Generic
+from typing_extensions import TypeVar
+
+if TYPE_CHECKING:
+    from ..clients import BaseClient, ModelId
+
+from .provider_id import ProviderId
+
+# Type alias for provider scope (e.g., "anthropic/", "openai/")
+ProviderScope = str
+
+ClientT = TypeVar("ClientT", bound="BaseClient[str, Any]")
+
+# Stack of provider overrides, each entry is (provider_instance, scope)
+# We use Any for the provider type to allow any Provider[ClientT] subclass
+PROVIDER_CONTEXT: ContextVar[list[tuple[Any, ProviderScope]] | None] = ContextVar(
+    "PROVIDER_CONTEXT", default=None
+)
+
+
+def provider_for_model(model_id: ModelId) -> Provider[Any] | None:
+    """Get the provider for a model from context, if any override matches.
+
+    Checks the stack from most recent to least recent (last-wins semantics).
+    Returns the Provider instance if a matching scope is found, None otherwise.
+
+    Args:
+        model_id: The full model ID (e.g., "anthropic/claude-4-5-sonnet")
+
+    Returns:
+        The Provider instance if a context override matches, None otherwise.
+    """
+    stack = PROVIDER_CONTEXT.get()
+    if stack is None:
+        return None
+
+    for provider, scope in reversed(stack):
+        if model_id.startswith(scope):
+            return provider
+
+    return None
+
+
+class Provider(Generic[ClientT]):
+    """A provider wraps a client and acts as a context manager to override provider routing.
+
+    Providers enable routing model calls through different implementations at runtime.
+    For example, you can route Anthropic models through the Together API by using a
+    custom provider instance in a context manager.
+
+    Example:
+        ```python
+        from mirascope import llm
+
+        # Create a custom provider instance with specific API key
+        custom_anthropic = llm.providers.AnthropicProvider(api_key="team-key")
+
+        # Use it in a context to override the default provider
+        with custom_anthropic:
+            model = llm.use_model("anthropic/claude-4-5-sonnet")
+            response = model.call(messages=[...])  # Uses the custom API key
+        ```
+    """
+
+    provider_id: ProviderId
+    """The provider identifier (e.g., "anthropic", "openai")."""
+
+    default_scope: ProviderScope
+    """The default scope this provider handles (e.g., "anthropic/", "openai/")."""
+
+    def __init__(
+        self,
+        client: ClientT,
+    ) -> None:
+        """Initialize a Provider with a wrapped client.
+
+        Args:
+            client: The client instance to wrap.
+        """
+        self._client = client
+        self._token_stack: list[Token[list[tuple[Any, ProviderScope]] | None]] = []
+
+    @property
+    def client(self) -> ClientT:
+        """Get the wrapped client instance."""
+        return self._client
+
+    def __enter__(self) -> Provider[ClientT]:
+        """Enter context manager - add this provider to the override stack."""
+        current_stack = PROVIDER_CONTEXT.get()
+        new_stack = (current_stack or []) + [(self, self.default_scope)]
+        token = PROVIDER_CONTEXT.set(new_stack)
+        self._token_stack.append(token)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        """Exit context manager - restore previous stack."""
+        if self._token_stack:
+            token = self._token_stack.pop()
+            PROVIDER_CONTEXT.reset(token)

--- a/python/tests/llm/providers/__init__.py
+++ b/python/tests/llm/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for provider system."""

--- a/python/tests/llm/providers/test_base_provider.py
+++ b/python/tests/llm/providers/test_base_provider.py
@@ -1,0 +1,213 @@
+"""Tests for the base Provider class and context management."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from mirascope import llm
+
+
+class MockProvider(llm.Provider[Any]):
+    """Mock provider for testing."""
+
+    provider_id = "mock"
+    default_scope = "mock/"
+
+
+class AnotherMockProvider(llm.Provider[Any]):
+    """Another mock provider for testing different scopes."""
+
+    provider_id = "another"
+    default_scope = "another/"
+
+
+def test_provider_initialization() -> None:
+    """Test that Provider can be initialized with a client."""
+    mock_client = Mock()
+    provider = MockProvider(client=mock_client)
+
+    assert provider.client is mock_client
+    assert provider.provider_id == "mock"
+    assert provider.default_scope == "mock/"
+
+
+def test_provider_context_manager_basic() -> None:
+    """Test that Provider works as a context manager."""
+    mock_client = Mock()
+    provider = MockProvider(client=mock_client)
+
+    # Before entering context, no provider should be found
+    assert llm.provider_for_model("mock/model-1") is None
+
+    # Inside context, provider should be available
+    with provider:
+        assert llm.provider_for_model("mock/model-1") is provider
+        assert llm.provider_for_model("mock/another-model") is provider
+
+    # After exiting context, provider should no longer be available
+    assert llm.provider_for_model("mock/model-1") is None
+
+
+def test_provider_scope_matching() -> None:
+    """Test that providers only match models within their scope."""
+    mock_client = Mock()
+    provider = MockProvider(client=mock_client)
+
+    with provider:
+        # Should match models with "mock/" prefix
+        assert llm.provider_for_model("mock/model-1") is provider
+        assert llm.provider_for_model("mock/other") is provider
+
+        # Should NOT match models with different prefix
+        assert llm.provider_for_model("anthropic/claude") is None
+        assert llm.provider_for_model("openai/gpt-4") is None
+        assert llm.provider_for_model("other/model") is None
+
+
+def test_nested_providers_same_instance() -> None:
+    """Test that the same provider instance can be nested."""
+    mock_client = Mock()
+    provider = MockProvider(client=mock_client)
+
+    # Not available outside any context
+    assert llm.provider_for_model("mock/model") is None
+
+    with provider:
+        # Available in outer context
+        assert llm.provider_for_model("mock/model") is provider
+
+        with provider:
+            # Still available in nested context
+            assert llm.provider_for_model("mock/model") is provider
+
+        # Still available after inner context exits
+        assert llm.provider_for_model("mock/model") is provider
+
+    # Not available after all contexts exit
+    assert llm.provider_for_model("mock/model") is None
+
+
+def test_nested_providers_different_scopes() -> None:
+    """Test multiple providers with different scopes in nested contexts."""
+    mock_client1 = Mock()
+    mock_client2 = Mock()
+    provider1 = MockProvider(client=mock_client1)
+    provider2 = AnotherMockProvider(client=mock_client2)
+
+    with provider1:
+        # Only provider1 in scope
+        assert llm.provider_for_model("mock/model") is provider1
+        assert llm.provider_for_model("another/model") is None
+
+        with provider2:
+            # Both providers in scope
+            assert llm.provider_for_model("mock/model") is provider1
+            assert llm.provider_for_model("another/model") is provider2
+
+        # Back to just provider1
+        assert llm.provider_for_model("mock/model") is provider1
+        assert llm.provider_for_model("another/model") is None
+
+    # All contexts exited
+    assert llm.provider_for_model("mock/model") is None
+    assert llm.provider_for_model("another/model") is None
+
+
+def test_multiple_contexts_parallel() -> None:
+    """Test using multiple providers in parallel (not nested)."""
+    mock_client1 = Mock()
+    mock_client2 = Mock()
+    provider1 = MockProvider(client=mock_client1)
+    provider2 = AnotherMockProvider(client=mock_client2)
+
+    # Use context manager syntax that creates multiple contexts at once
+    with provider1, provider2:
+        # Each provider matches its scope
+        assert llm.provider_for_model("mock/model") is provider1
+        assert llm.provider_for_model("another/model") is provider2
+
+    # After exiting, neither provider is available
+    assert llm.provider_for_model("mock/model") is None
+    assert llm.provider_for_model("another/model") is None
+
+
+def test_last_wins_semantics() -> None:
+    """Test that later contexts override earlier ones for the same scope."""
+
+    class OverrideMockProvider(llm.Provider[Any]):
+        """Another provider with the same scope as MockProvider."""
+
+        provider_id = "override"
+        default_scope = "mock/"  # Same scope as MockProvider
+
+    mock_client1 = Mock()
+    mock_client2 = Mock()
+    provider1 = MockProvider(client=mock_client1)
+    provider2 = OverrideMockProvider(client=mock_client2)
+
+    with provider1:
+        assert llm.provider_for_model("mock/model") is provider1
+
+        with provider2:
+            # provider2 comes later, should win for "mock/" scope
+            assert llm.provider_for_model("mock/model") is provider2
+
+        # Back to provider1
+        assert llm.provider_for_model("mock/model") is provider1
+
+
+def test_provider_for_model_empty_context() -> None:
+    """Test llm.provider_for_model when no providers are in context."""
+    assert llm.provider_for_model("mock/model") is None
+    assert llm.provider_for_model("anthropic/claude") is None
+    assert llm.provider_for_model("any/model") is None
+
+
+def test_provider_context_isolation() -> None:
+    """Test that provider contexts don't leak between uses."""
+    # This test verifies cleanup works properly
+    mock_client = Mock()
+    provider = MockProvider(client=mock_client)
+
+    # Start with no provider available
+    assert llm.provider_for_model("mock/model") is None
+
+    with provider:
+        assert llm.provider_for_model("mock/model") is provider
+
+    # Should be clean after exiting
+    assert llm.provider_for_model("mock/model") is None
+
+    # Try again to ensure no state leaked
+    with provider:
+        assert llm.provider_for_model("mock/model") is provider
+
+    assert llm.provider_for_model("mock/model") is None
+
+
+def test_provider_exception_handling() -> None:
+    """Test that provider context is cleaned up even if exception occurs."""
+    mock_client = Mock()
+    provider = MockProvider(client=mock_client)
+
+    # No provider before entering context
+    assert llm.provider_for_model("mock/model") is None
+
+    with pytest.raises(ValueError, match="test error"), provider:
+        # Provider is available inside context
+        assert llm.provider_for_model("mock/model") is provider
+        raise ValueError("test error")
+
+    # Context should still be cleaned up after exception
+    assert llm.provider_for_model("mock/model") is None
+
+
+def test_provider_returns_self_from_enter() -> None:
+    """Test that __enter__ returns the provider instance."""
+    mock_client = Mock()
+    provider = MockProvider(client=mock_client)
+
+    with provider as p:
+        assert p is provider
+        assert p.client is mock_client


### PR DESCRIPTION
It operates as a context manager with a scope for models that use this
provider. Tested. Not yet integrated into actual user usage flows.