### PR TITLE
refactor: remove model id type parameter from clients

### DIFF
--- a/python/mirascope/llm/clients/anthropic/clients.py
+++ b/python/mirascope/llm/clients/anthropic/clients.py
@@ -64,7 +64,7 @@ def client(
     return _anthropic_singleton(api_key, base_url)
 
 
-class AnthropicClient(BaseClient[AnthropicModelId, Anthropic]):
+class AnthropicClient(BaseClient[Anthropic]):
     """The client for the Anthropic LLM model."""
 
     def __init__(

--- a/python/mirascope/llm/clients/base/client.py
+++ b/python/mirascope/llm/clients/base/client.py
@@ -32,11 +32,10 @@ from ...tools import (
 )
 from .params import Params
 
-ModelIdT = TypeVar("ModelIdT", bound=str)
 ProviderClientT = TypeVar("ProviderClientT")
 
 
-class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
+class BaseClient(Generic[ProviderClientT], ABC):
     """Base abstract client for provider-specific implementations.
 
     This class defines explicit methods for each type of call, eliminating
@@ -50,7 +49,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def call(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
@@ -64,7 +63,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def call(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
@@ -78,7 +77,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def call(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
@@ -91,7 +90,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def call(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
@@ -117,7 +116,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -134,7 +133,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -151,7 +150,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -167,7 +166,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -195,7 +194,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def call_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
@@ -209,7 +208,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def call_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
@@ -223,7 +222,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def call_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
@@ -236,7 +235,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def call_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
@@ -262,7 +261,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -279,7 +278,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -296,7 +295,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -312,7 +311,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -340,7 +339,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: None = None,
@@ -354,7 +353,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
@@ -368,7 +367,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
@@ -381,7 +380,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
@@ -407,7 +406,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -424,7 +423,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -441,7 +440,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -459,7 +458,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
@@ -489,7 +488,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: None = None,
@@ -503,7 +502,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT],
@@ -517,7 +516,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None,
@@ -530,7 +529,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
         format: type[FormattableT] | Format[FormattableT] | None = None,
@@ -556,7 +555,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -573,7 +572,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -590,7 +589,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -609,7 +608,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
@@ -639,7 +638,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: Response,
         content: UserContent,
         **params: Unpack[Params],
@@ -651,7 +650,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: Response[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -663,7 +662,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: Response | Response[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -674,7 +673,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: Response | Response[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -708,7 +707,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncResponse,
         content: UserContent,
         **params: Unpack[Params],
@@ -720,7 +719,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -732,7 +731,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncResponse | AsyncResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -743,7 +742,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncResponse | AsyncResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -778,7 +777,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextResponse[DepsT, None],
         content: UserContent,
         **params: Unpack[Params],
@@ -791,7 +790,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextResponse[DepsT, FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -804,7 +803,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -816,7 +815,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -853,7 +852,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextResponse[DepsT, None],
         content: UserContent,
         **params: Unpack[Params],
@@ -866,7 +865,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextResponse[DepsT, FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -879,7 +878,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextResponse[DepsT, None]
         | AsyncContextResponse[DepsT, FormattableT],
         content: UserContent,
@@ -892,7 +891,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextResponse[DepsT, None]
         | AsyncContextResponse[DepsT, FormattableT],
         content: UserContent,
@@ -929,7 +928,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume_stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: StreamResponse,
         content: UserContent,
         **params: Unpack[Params],
@@ -941,7 +940,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume_stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: StreamResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -953,7 +952,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume_stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: StreamResponse | StreamResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -964,7 +963,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     def resume_stream(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: StreamResponse | StreamResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -998,7 +997,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncStreamResponse,
         content: UserContent,
         **params: Unpack[Params],
@@ -1010,7 +1009,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncStreamResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -1022,7 +1021,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncStreamResponse | AsyncStreamResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -1033,7 +1032,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
     async def resume_stream_async(
         self,
         *,
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncStreamResponse | AsyncStreamResponse[FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -1068,7 +1067,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextStreamResponse[DepsT, None],
         content: UserContent,
         **params: Unpack[Params],
@@ -1081,7 +1080,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextStreamResponse[DepsT, FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -1094,7 +1093,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextStreamResponse[DepsT, None]
         | ContextStreamResponse[DepsT, FormattableT],
         content: UserContent,
@@ -1109,7 +1108,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: ContextStreamResponse[DepsT, None]
         | ContextStreamResponse[DepsT, FormattableT],
         content: UserContent,
@@ -1149,7 +1148,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextStreamResponse[DepsT, None],
         content: UserContent,
         **params: Unpack[Params],
@@ -1162,7 +1161,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextStreamResponse[DepsT, FormattableT],
         content: UserContent,
         **params: Unpack[Params],
@@ -1175,7 +1174,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextStreamResponse[DepsT, None]
         | AsyncContextStreamResponse[DepsT, FormattableT],
         content: UserContent,
@@ -1191,7 +1190,7 @@ class BaseClient(Generic[ModelIdT, ProviderClientT], ABC):
         self,
         *,
         ctx: Context[DepsT],
-        model_id: ModelIdT,
+        model_id: str,
         response: AsyncContextStreamResponse[DepsT, None]
         | AsyncContextStreamResponse[DepsT, FormattableT],
         content: UserContent,

--- a/python/mirascope/llm/clients/get_client.py
+++ b/python/mirascope/llm/clients/get_client.py
@@ -18,7 +18,7 @@ from .openai import (
 
 def client(
     provider: ProviderId, *, api_key: str | None = None, base_url: str | None = None
-) -> BaseClient[str, Any]:
+) -> BaseClient[Any]:
     """Create a cached client instance for the specified provider.
 
     Args:

--- a/python/mirascope/llm/clients/google/clients.py
+++ b/python/mirascope/llm/clients/google/clients.py
@@ -63,7 +63,7 @@ def client(
     return _google_singleton(api_key, base_url)
 
 
-class GoogleClient(BaseClient[GoogleModelId, Client]):
+class GoogleClient(BaseClient[Client]):
     """The client for the Google LLM model."""
 
     def __init__(

--- a/python/mirascope/llm/clients/mlx/clients.py
+++ b/python/mirascope/llm/clients/mlx/clients.py
@@ -66,7 +66,7 @@ def _get_mlx(model_id: MLXModelId) -> MLX:
     )
 
 
-class MLXClient(BaseClient[MLXModelId, None]):
+class MLXClient(BaseClient[None]):
     """Client for interacting with MLX language models.
 
     This client provides methods for generating responses from MLX models,

--- a/python/mirascope/llm/clients/openai/clients.py
+++ b/python/mirascope/llm/clients/openai/clients.py
@@ -114,7 +114,7 @@ def client(
     return _openai_singleton(api_key, base_url)
 
 
-class OpenAIClient(BaseClient[OpenAIModelId, OpenAI]):
+class OpenAIClient(BaseClient[OpenAI]):
     """Unified client for OpenAI that routes to Completions or Responses API based on model_id."""
 
     def __init__(

--- a/python/mirascope/llm/clients/openai/completions/clients.py
+++ b/python/mirascope/llm/clients/openai/completions/clients.py
@@ -64,7 +64,7 @@ def client(
     return _openai_singleton(api_key, base_url)
 
 
-class OpenAICompletionsClient(BaseClient[OpenAIModelId, OpenAI]):
+class OpenAICompletionsClient(BaseClient[OpenAI]):
     """The client for the OpenAI LLM model."""
 
     def __init__(

--- a/python/mirascope/llm/clients/openai/responses/clients.py
+++ b/python/mirascope/llm/clients/openai/responses/clients.py
@@ -53,7 +53,7 @@ def client(
     return _openai_responses_singleton(api_key, base_url)
 
 
-class OpenAIResponsesClient(BaseClient[OpenAIModelId, OpenAI]):
+class OpenAIResponsesClient(BaseClient[OpenAI]):
     """The client for the OpenAI Responses API."""
 
     def __init__(


### PR DESCRIPTION
It's not at all helpful because:
- With provider overriding it's possible you'll route other model ids
  through the provider methods (eg. using openai completions client to
  call ollama)
- The model ids are always `| str` in practice to account for newly
  released models

So this is a case where there's no additional type safety, just the
annoyance of an extra parameter on the client classes.