### PR TITLE
refactor: remove duplicate overloading in provider code

### DIFF
--- a/python/mirascope/llm/providers/anthropic/provider.py
+++ b/python/mirascope/llm/providers/anthropic/provider.py
@@ -1,7 +1,6 @@
 """Anthropic client implementation."""
 
 from collections.abc import Sequence
-from typing import overload
 from typing_extensions import Unpack
 
 from anthropic import Anthropic, AsyncAnthropic
@@ -44,46 +43,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
         self.client = Anthropic(api_key=api_key, base_url=base_url)
         self.async_client = AsyncAnthropic(api_key=api_key, base_url=base_url)
 
-    @overload
-    def call(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> Response:
-        """Generate an `llm.Response` without a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> Response[FormattableT]:
-        """Generate an `llm.Response` with a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> Response | Response[FormattableT]:
-        """Generate an `llm.Response` with an optional response format."""
-        ...
-
-    def call(
+    def _call(
         self,
         *,
         model_id: AnthropicModelId,
@@ -131,55 +91,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             format=format,
         )
 
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None]:
-        """Generate an `llm.ContextResponse` without a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with an optional response format."""
-        ...
-
-    def context_call(
+    def _context_call(
         self,
         *,
         ctx: Context[DepsT],
@@ -231,46 +143,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             format=format,
         )
 
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse:
-        """Generate an `llm.AsyncResponse` without a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse | AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with an optional response format."""
-        ...
-
-    async def call_async(
+    async def _call_async(
         self,
         *,
         model_id: AnthropicModelId,
@@ -318,55 +191,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             format=format,
         )
 
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None]:
-        """Generate an `llm.AsyncContextResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with an optional response format."""
-        ...
-
-    async def context_call_async(
+    async def _context_call_async(
         self,
         *,
         ctx: Context[DepsT],
@@ -418,46 +243,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             format=format,
         )
 
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> StreamResponse:
-        """Stream an `llm.StreamResponse` without a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> StreamResponse | StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with an optional response format."""
-        ...
-
-    def stream(
+    def _stream(
         self,
         *,
         model_id: AnthropicModelId,
@@ -501,55 +287,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             format=format,
         )
 
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT]:
-        """Stream an `llm.ContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with an optional response format."""
-        ...
-
-    def context_stream(
+    def _context_stream(
         self,
         *,
         ctx: Context[DepsT],
@@ -597,46 +335,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             format=format,
         )
 
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse:
-        """Stream an `llm.AsyncStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with an optional response format."""
-        ...
-
-    async def stream_async(
+    async def _stream_async(
         self,
         *,
         model_id: AnthropicModelId,
@@ -680,58 +379,7 @@ class AnthropicProvider(BaseProvider[Anthropic]):
             format=format,
         )
 
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT]:
-        """Stream an `llm.AsyncContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.AsyncContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: AnthropicModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> (
-        AsyncContextStreamResponse[DepsT]
-        | AsyncContextStreamResponse[DepsT, FormattableT]
-    ):
-        """Stream an `llm.AsyncContextStreamResponse` with an optional response format."""
-        ...
-
-    async def context_stream_async(
+    async def _context_stream_async(
         self,
         *,
         ctx: Context[DepsT],

--- a/python/mirascope/llm/providers/base/base_provider.py
+++ b/python/mirascope/llm/providers/base/base_provider.py
@@ -45,7 +45,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
     client: ProviderClientT
 
     @overload
-    @abstractmethod
     def call(
         self,
         *,
@@ -59,7 +58,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def call(
         self,
         *,
@@ -73,7 +71,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def call(
         self,
         *,
@@ -86,7 +83,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Generate an `llm.Response` with an optional response format."""
         ...
 
-    @abstractmethod
     def call(
         self,
         *,
@@ -108,10 +104,28 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.Response` object containing the LLM-generated content.
         """
+        return self._call(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    def _call(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> Response | Response[FormattableT]:
+        """Implementation for call(). Subclasses override this method."""
         ...
 
     @overload
-    @abstractmethod
     def context_call(
         self,
         *,
@@ -128,7 +142,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def context_call(
         self,
         *,
@@ -145,7 +158,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def context_call(
         self,
         *,
@@ -161,7 +173,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Generate an `llm.ContextResponse` with an optional response format."""
         ...
 
-    @abstractmethod
     def context_call(
         self,
         *,
@@ -187,10 +198,32 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.ContextResponse` object containing the LLM-generated content.
         """
+        return self._context_call(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    def _context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
+        """Implementation for context_call(). Subclasses override this method."""
         ...
 
     @overload
-    @abstractmethod
     async def call_async(
         self,
         *,
@@ -204,7 +237,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def call_async(
         self,
         *,
@@ -218,7 +250,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def call_async(
         self,
         *,
@@ -231,7 +262,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Generate an `llm.AsyncResponse` with an optional response format."""
         ...
 
-    @abstractmethod
     async def call_async(
         self,
         *,
@@ -253,10 +283,28 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.AsyncResponse` object containing the LLM-generated content.
         """
+        return await self._call_async(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    async def _call_async(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse | AsyncResponse[FormattableT]:
+        """Implementation for call_async(). Subclasses override this method."""
         ...
 
     @overload
-    @abstractmethod
     async def context_call_async(
         self,
         *,
@@ -273,7 +321,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def context_call_async(
         self,
         *,
@@ -290,7 +337,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def context_call_async(
         self,
         *,
@@ -306,7 +352,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Generate an `llm.AsyncContextResponse` with an optional response format."""
         ...
 
-    @abstractmethod
     async def context_call_async(
         self,
         *,
@@ -332,10 +377,32 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.AsyncContextResponse` object containing the LLM-generated content.
         """
+        return await self._context_call_async(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    async def _context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
+        """Implementation for context_call_async(). Subclasses override this method."""
         ...
 
     @overload
-    @abstractmethod
     def stream(
         self,
         *,
@@ -349,7 +416,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def stream(
         self,
         *,
@@ -363,7 +429,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def stream(
         self,
         *,
@@ -376,7 +441,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Stream an `llm.StreamResponse` with an optional response format."""
         ...
 
-    @abstractmethod
     def stream(
         self,
         *,
@@ -398,10 +462,28 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.StreamResponse` object for iterating over the LLM-generated content.
         """
+        return self._stream(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    def _stream(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[Tool] | Toolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> StreamResponse | StreamResponse[FormattableT]:
+        """Implementation for stream(). Subclasses override this method."""
         ...
 
     @overload
-    @abstractmethod
     def context_stream(
         self,
         *,
@@ -418,7 +500,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def context_stream(
         self,
         *,
@@ -435,7 +516,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     def context_stream(
         self,
         *,
@@ -453,7 +533,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Stream an `llm.ContextStreamResponse` with an optional response format."""
         ...
 
-    @abstractmethod
     def context_stream(
         self,
         *,
@@ -481,10 +560,34 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.ContextStreamResponse` object for iterating over the LLM-generated content.
         """
+        return self._context_stream(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    def _context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[Tool | ContextTool[DepsT]]
+        | ContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> (
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Implementation for context_stream(). Subclasses override this method."""
         ...
 
     @overload
-    @abstractmethod
     async def stream_async(
         self,
         *,
@@ -498,7 +601,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def stream_async(
         self,
         *,
@@ -512,7 +614,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def stream_async(
         self,
         *,
@@ -525,7 +626,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Stream an `llm.AsyncStreamResponse` with an optional response format."""
         ...
 
-    @abstractmethod
     async def stream_async(
         self,
         *,
@@ -547,10 +647,28 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.AsyncStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
+        return await self._stream_async(
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    async def _stream_async(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
+        """Implementation for stream_async(). Subclasses override this method."""
         ...
 
     @overload
-    @abstractmethod
     async def context_stream_async(
         self,
         *,
@@ -567,7 +685,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def context_stream_async(
         self,
         *,
@@ -584,7 +701,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         ...
 
     @overload
-    @abstractmethod
     async def context_stream_async(
         self,
         *,
@@ -603,7 +719,6 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         """Stream an `llm.AsyncContextStreamResponse` with an optional response format."""
         ...
 
-    @abstractmethod
     async def context_stream_async(
         self,
         *,
@@ -632,6 +747,32 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         Returns:
             An `llm.AsyncContextStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
+        return await self._context_stream_async(
+            ctx=ctx,
+            model_id=model_id,
+            messages=messages,
+            tools=tools,
+            format=format,
+            **params,
+        )
+
+    @abstractmethod
+    async def _context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[Message],
+        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
+        | AsyncContextToolkit[DepsT]
+        | None = None,
+        format: type[FormattableT] | Format[FormattableT] | None = None,
+        **params: Unpack[Params],
+    ) -> (
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Implementation for context_stream_async(). Subclasses override this method."""
         ...
 
     @overload

--- a/python/mirascope/llm/providers/google/provider.py
+++ b/python/mirascope/llm/providers/google/provider.py
@@ -1,7 +1,6 @@
 """Google provider implementation."""
 
 from collections.abc import Sequence
-from typing import overload
 from typing_extensions import Unpack
 
 from google.genai import Client
@@ -48,46 +47,7 @@ class GoogleProvider(BaseProvider[Client]):
 
         self.client = Client(api_key=api_key, http_options=http_options)
 
-    @overload
-    def call(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> Response:
-        """Generate an `llm.Response` without a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> Response[FormattableT]:
-        """Generate an `llm.Response` with a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> Response | Response[FormattableT]:
-        """Generate an `llm.Response` with an optional response format."""
-        ...
-
-    def call(
+    def _call(
         self,
         *,
         model_id: GoogleModelId,
@@ -135,55 +95,7 @@ class GoogleProvider(BaseProvider[Client]):
             format=format,
         )
 
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None]:
-        """Generate an `llm.ContextResponse` without a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with an optional response format."""
-        ...
-
-    def context_call(
+    def _context_call(
         self,
         *,
         ctx: Context[DepsT],
@@ -235,46 +147,7 @@ class GoogleProvider(BaseProvider[Client]):
             format=format,
         )
 
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse:
-        """Generate an `llm.AsyncResponse` without a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse | AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with an optional response format."""
-        ...
-
-    async def call_async(
+    async def _call_async(
         self,
         *,
         model_id: GoogleModelId,
@@ -322,55 +195,7 @@ class GoogleProvider(BaseProvider[Client]):
             format=format,
         )
 
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None]:
-        """Generate an `llm.AsyncContextResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with an optional response format."""
-        ...
-
-    async def context_call_async(
+    async def _context_call_async(
         self,
         *,
         ctx: Context[DepsT],
@@ -422,46 +247,7 @@ class GoogleProvider(BaseProvider[Client]):
             format=format,
         )
 
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> StreamResponse:
-        """Stream an `llm.StreamResponse` without a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> StreamResponse | StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with an optional response format."""
-        ...
-
-    def stream(
+    def _stream(
         self,
         *,
         model_id: GoogleModelId,
@@ -505,55 +291,7 @@ class GoogleProvider(BaseProvider[Client]):
             format=format,
         )
 
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT]:
-        """Stream an `llm.ContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with an optional response format."""
-        ...
-
-    def context_stream(
+    def _context_stream(
         self,
         *,
         ctx: Context[DepsT],
@@ -601,46 +339,7 @@ class GoogleProvider(BaseProvider[Client]):
             format=format,
         )
 
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse:
-        """Stream an `llm.AsyncStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with an optional response format."""
-        ...
-
-    async def stream_async(
+    async def _stream_async(
         self,
         *,
         model_id: GoogleModelId,
@@ -684,58 +383,7 @@ class GoogleProvider(BaseProvider[Client]):
             format=format,
         )
 
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT]:
-        """Stream an `llm.AsyncContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.AsyncContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: GoogleModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> (
-        AsyncContextStreamResponse[DepsT]
-        | AsyncContextStreamResponse[DepsT, FormattableT]
-    ):
-        """Stream an `llm.AsyncContextStreamResponse` with an optional response format."""
-        ...
-
-    async def context_stream_async(
+    async def _context_stream_async(
         self,
         *,
         ctx: Context[DepsT],

--- a/python/mirascope/llm/providers/mlx/provider.py
+++ b/python/mirascope/llm/providers/mlx/provider.py
@@ -1,6 +1,6 @@
 from collections.abc import Sequence
 from functools import cache, lru_cache
-from typing import cast, overload
+from typing import cast
 from typing_extensions import Unpack
 
 import mlx.nn as nn
@@ -74,46 +74,7 @@ class MLXProvider(BaseProvider[None]):
     streaming responses.
     """
 
-    @overload
-    def call(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> Response:
-        """Generate an `llm.Response` without a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> Response[FormattableT]:
-        """Generate an `llm.Response` with a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> Response | Response[FormattableT]:
-        """Generate an `llm.Response` with an optional response format."""
-        ...
-
-    def call(
+    def _call(
         self,
         *,
         model_id: MLXModelId,
@@ -153,55 +114,7 @@ class MLXProvider(BaseProvider[None]):
             format=format,
         )
 
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None]:
-        """Generate an `llm.ContextResponse` without a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with an optional response format."""
-        ...
-
-    def context_call(
+    def _context_call(
         self,
         *,
         ctx: Context[DepsT],
@@ -245,46 +158,7 @@ class MLXProvider(BaseProvider[None]):
             format=format,
         )
 
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse:
-        """Generate an `llm.AsyncResponse` without a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse | AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with an optional response format."""
-        ...
-
-    async def call_async(
+    async def _call_async(
         self,
         *,
         model_id: MLXModelId,
@@ -328,55 +202,7 @@ class MLXProvider(BaseProvider[None]):
             format=format,
         )
 
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None]:
-        """Generate an `llm.AsyncContextResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with an optional response format."""
-        ...
-
-    async def context_call_async(
+    async def _context_call_async(
         self,
         *,
         ctx: Context[DepsT],
@@ -424,46 +250,7 @@ class MLXProvider(BaseProvider[None]):
             format=format,
         )
 
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> StreamResponse:
-        """Stream an `llm.StreamResponse` without a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> StreamResponse | StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with an optional response format."""
-        ...
-
-    def stream(
+    def _stream(
         self,
         *,
         model_id: MLXModelId,
@@ -501,55 +288,7 @@ class MLXProvider(BaseProvider[None]):
             format=format,
         )
 
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT]:
-        """Stream an `llm.ContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with an optional response format."""
-        ...
-
-    def context_stream(
+    def _context_stream(
         self,
         *,
         ctx: Context[DepsT],
@@ -591,46 +330,7 @@ class MLXProvider(BaseProvider[None]):
             format=format,
         )
 
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse:
-        """Stream an `llm.AsyncStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with an optional response format."""
-        ...
-
-    async def stream_async(
+    async def _stream_async(
         self,
         *,
         model_id: MLXModelId,
@@ -668,58 +368,7 @@ class MLXProvider(BaseProvider[None]):
             format=format,
         )
 
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT]:
-        """Stream an `llm.AsyncContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.AsyncContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: MLXModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> (
-        AsyncContextStreamResponse[DepsT]
-        | AsyncContextStreamResponse[DepsT, FormattableT]
-    ):
-        """Stream an `llm.AsyncContextStreamResponse` with an optional response format."""
-        ...
-
-    async def context_stream_async(
+    async def _context_stream_async(
         self,
         *,
         ctx: Context[DepsT],

--- a/python/mirascope/llm/providers/openai/completions/provider.py
+++ b/python/mirascope/llm/providers/openai/completions/provider.py
@@ -1,7 +1,6 @@
 """OpenAI client implementation."""
 
 from collections.abc import Sequence
-from typing import overload
 from typing_extensions import Unpack
 
 from openai import AsyncOpenAI, OpenAI
@@ -44,46 +43,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> Response:
-        """Generate an `llm.Response` without a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> Response[FormattableT]:
-        """Generate an `llm.Response` with a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> Response | Response[FormattableT]:
-        """Generate an `llm.Response` with an optional response format."""
-        ...
-
-    def call(
+    def _call(
         self,
         *,
         model_id: OpenAIModelId,
@@ -131,55 +91,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None]:
-        """Generate an `llm.ContextResponse` without a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with an optional response format."""
-        ...
-
-    def context_call(
+    def _context_call(
         self,
         *,
         ctx: Context[DepsT],
@@ -231,46 +143,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse:
-        """Generate an `llm.AsyncResponse` without a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse | AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with an optional response format."""
-        ...
-
-    async def call_async(
+    async def _call_async(
         self,
         *,
         model_id: OpenAIModelId,
@@ -319,55 +192,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None]:
-        """Generate an `llm.AsyncContextResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with an optional response format."""
-        ...
-
-    async def context_call_async(
+    async def _context_call_async(
         self,
         *,
         ctx: Context[DepsT],
@@ -419,46 +244,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> StreamResponse:
-        """Stream an `llm.StreamResponse` without a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> StreamResponse | StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with an optional response format."""
-        ...
-
-    def stream(
+    def _stream(
         self,
         *,
         model_id: OpenAIModelId,
@@ -505,55 +291,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT]:
-        """Stream an `llm.ContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with an optional response format."""
-        ...
-
-    def context_stream(
+    def _context_stream(
         self,
         *,
         ctx: Context[DepsT],
@@ -604,46 +342,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse:
-        """Stream an `llm.AsyncStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with an optional response format."""
-        ...
-
-    async def stream_async(
+    async def _stream_async(
         self,
         *,
         model_id: OpenAIModelId,
@@ -691,58 +390,7 @@ class OpenAICompletionsProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT]:
-        """Stream an `llm.AsyncContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.AsyncContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> (
-        AsyncContextStreamResponse[DepsT]
-        | AsyncContextStreamResponse[DepsT, FormattableT]
-    ):
-        """Stream an `llm.AsyncContextStreamResponse` with an optional response format."""
-        ...
-
-    async def context_stream_async(
+    async def _context_stream_async(
         self,
         *,
         ctx: Context[DepsT],

--- a/python/mirascope/llm/providers/openai/provider.py
+++ b/python/mirascope/llm/providers/openai/provider.py
@@ -1,7 +1,6 @@
 """Unified OpenAI client implementation."""
 
 from collections.abc import Sequence
-from typing import overload
 from typing_extensions import Unpack
 
 from openai import OpenAI
@@ -119,46 +118,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             return self._responses_provider
         return self._completions_provider
 
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> Response:
-        """Generate an `llm.Response` without a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> Response[FormattableT]:
-        """Generate an `llm.Response` with a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> Response | Response[FormattableT]:
-        """Generate an `llm.Response` with an optional response format."""
-        ...
-
-    def call(
+    def _call(
         self,
         *,
         model_id: OpenAIModelId,
@@ -188,55 +148,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             **params,
         )
 
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None]:
-        """Generate an `llm.ContextResponse` without a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.ContextResponse` with an optional response format."""
-        ...
-
-    def context_call(
+    def _context_call(
         self,
         *,
         ctx: Context[DepsT],
@@ -271,46 +183,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             **params,
         )
 
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse:
-        """Generate an `llm.AsyncResponse` without a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse | AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with an optional response format."""
-        ...
-
-    async def call_async(
+    async def _call_async(
         self,
         *,
         model_id: OpenAIModelId,
@@ -339,55 +212,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             **params,
         )
 
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None]:
-        """Generate an `llm.AsyncContextResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
-        """Generate an `llm.AsyncContextResponse` with an optional response format."""
-        ...
-
-    async def context_call_async(
+    async def _context_call_async(
         self,
         *,
         ctx: Context[DepsT],
@@ -421,46 +246,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             **params,
         )
 
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> StreamResponse:
-        """Stream an `llm.StreamResponse` without a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> StreamResponse | StreamResponse[FormattableT]:
-        """Stream an `llm.StreamResponse` with an optional response format."""
-        ...
-
-    def stream(
+    def _stream(
         self,
         *,
         model_id: OpenAIModelId,
@@ -490,55 +276,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             **params,
         )
 
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT]:
-        """Stream an `llm.ContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.ContextStreamResponse` with an optional response format."""
-        ...
-
-    def context_stream(
+    def _context_stream(
         self,
         *,
         ctx: Context[DepsT],
@@ -573,46 +311,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             **params,
         )
 
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse:
-        """Stream an `llm.AsyncStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
-        """Stream an `llm.AsyncStreamResponse` with an optional response format."""
-        ...
-
-    async def stream_async(
+    async def _stream_async(
         self,
         *,
         model_id: OpenAIModelId,
@@ -641,58 +340,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
             **params,
         )
 
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT]:
-        """Stream an `llm.AsyncContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
-        """Stream an `llm.AsyncContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
-        **params: Unpack[Params],
-    ) -> (
-        AsyncContextStreamResponse[DepsT]
-        | AsyncContextStreamResponse[DepsT, FormattableT]
-    ):
-        """Stream an `llm.AsyncContextStreamResponse` with an optional response format."""
-        ...
-
-    async def context_stream_async(
+    async def _context_stream_async(
         self,
         *,
         ctx: Context[DepsT],

--- a/python/mirascope/llm/providers/openai/responses/provider.py
+++ b/python/mirascope/llm/providers/openai/responses/provider.py
@@ -1,7 +1,6 @@
 """OpenAI Responses API client implementation."""
 
 from collections.abc import Sequence
-from typing import overload
 from typing_extensions import Unpack
 
 from openai import AsyncOpenAI, OpenAI
@@ -44,46 +43,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         self.client = OpenAI(api_key=api_key, base_url=base_url)
         self.async_client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> Response:
-        """Generate an `llm.Response` without a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> Response[FormattableT]:
-        """Generate an `llm.Response` with a response format."""
-        ...
-
-    @overload
-    def call(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> Response | Response[FormattableT]:
-        """Generate an `llm.Response` with optional response format."""
-        ...
-
-    def call(
+    def _call(
         self,
         *,
         model_id: OpenAIModelId,
@@ -132,46 +92,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse:
-        """Generate an `llm.AsyncResponse` without a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with a response format."""
-        ...
-
-    @overload
-    async def call_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> AsyncResponse | AsyncResponse[FormattableT]:
-        """Generate an `llm.AsyncResponse` with optional response format."""
-        ...
-
-    async def call_async(
+    async def _call_async(
         self,
         *,
         model_id: OpenAIModelId,
@@ -220,46 +141,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> StreamResponse:
-        """Generate a `llm.StreamResponse` without a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> StreamResponse[FormattableT]:
-        """Generate a `llm.StreamResponse` with a response format."""
-        ...
-
-    @overload
-    def stream(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> StreamResponse | StreamResponse[FormattableT]:
-        """Generate a `llm.StreamResponse` with optional response format."""
-        ...
-
-    def stream(
+    def _stream(
         self,
         *,
         model_id: OpenAIModelId,
@@ -309,46 +191,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse:
-        """Generate a `llm.AsyncStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse[FormattableT]:
-        """Generate a `llm.AsyncStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def stream_async(
-        self,
-        *,
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
-        """Generate a `llm.AsyncStreamResponse` with optional response format."""
-        ...
-
-    async def stream_async(
+    async def _stream_async(
         self,
         *,
         model_id: OpenAIModelId,
@@ -398,55 +241,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT]:
-        """Generate a `llm.ContextResponse` without a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT, FormattableT]:
-        """Generate a `llm.ContextResponse` with a response format."""
-        ...
-
-    @overload
-    def context_call(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> ContextResponse[DepsT] | ContextResponse[DepsT, FormattableT]:
-        """Generate a `llm.ContextResponse` with optional response format."""
-        ...
-
-    def context_call(
+    def _context_call(
         self,
         *,
         ctx: Context[DepsT],
@@ -499,55 +294,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT]:
-        """Generate a `llm.AsyncContextResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT, FormattableT]:
-        """Generate a `llm.AsyncContextResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_call_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextResponse[DepsT] | AsyncContextResponse[DepsT, FormattableT]:
-        """Generate a `llm.AsyncContextResponse` with optional response format."""
-        ...
-
-    async def context_call_async(
+    async def _context_call_async(
         self,
         *,
         ctx: Context[DepsT],
@@ -600,55 +347,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT]:
-        """Generate a `llm.ContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT, FormattableT]:
-        """Generate a `llm.ContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    def context_stream(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[Tool | ContextTool[DepsT]]
-        | ContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
-        """Generate a `llm.ContextStreamResponse` with optional response format."""
-        ...
-
-    def context_stream(
+    def _context_stream(
         self,
         *,
         ctx: Context[DepsT],
@@ -702,58 +401,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
             format=format,
         )
 
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: None = None,
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT]:
-        """Generate a `llm.AsyncContextStreamResponse` without a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT],
-        **params: Unpack[Params],
-    ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
-        """Generate a `llm.AsyncContextStreamResponse` with a response format."""
-        ...
-
-    @overload
-    async def context_stream_async(
-        self,
-        *,
-        ctx: Context[DepsT],
-        model_id: OpenAIModelId,
-        messages: Sequence[Message],
-        tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
-        | AsyncContextToolkit[DepsT]
-        | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
-        **params: Unpack[Params],
-    ) -> (
-        AsyncContextStreamResponse[DepsT]
-        | AsyncContextStreamResponse[DepsT, FormattableT]
-    ):
-        """Generate a `llm.AsyncContextStreamResponse` with optional response format."""
-        ...
-
-    async def context_stream_async(
+    async def _context_stream_async(
         self,
         *,
         ctx: Context[DepsT],


### PR DESCRIPTION
We now have the public interface in BaseProvider define the overload
signatures only once, and then call to an abstract private method that
the provider implementations interface. This saves 48 overload
signatures per provider, greatly reducing duplicated code.