### PR TITLE
feat: implement provider registry:

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -60,6 +60,7 @@ from .exceptions import (
     FeatureNotSupportedError,
     FormattingModeNotSupportedError,
     MirascopeLLMError,
+    NoRegisteredProviderError,
     NotFoundError,
     PermissionError,
     RateLimitError,
@@ -86,7 +87,7 @@ from .prompts import (
     PromptDecorator,
     prompt,
 )
-from .providers import ModelId, Params, ProviderId, load_provider
+from .providers import ModelId, Params, ProviderId, load_provider, register_provider
 from .responses import (
     AsyncChunkIterator,
     AsyncContextResponse,
@@ -172,6 +173,7 @@ __all__ = [
     "MirascopeLLMError",
     "Model",
     "ModelId",
+    "NoRegisteredProviderError",
     "NotFoundError",
     "Params",
     "Partial",
@@ -227,6 +229,7 @@ __all__ = [
     "prompt",
     "prompts",
     "providers",
+    "register_provider",
     "responses",
     "tool",
     "tools",

--- a/python/mirascope/llm/exceptions.py
+++ b/python/mirascope/llm/exceptions.py
@@ -103,3 +103,17 @@ class ServerError(APIError):
 
 class TimeoutError(MirascopeLLMError):
     """Raised when requests timeout or deadline exceeded."""
+
+
+class NoRegisteredProviderError(MirascopeLLMError):
+    """Raised when no provider is registered for a given model_id."""
+
+    model_id: str
+
+    def __init__(self, model_id: str) -> None:
+        message = (
+            f"No provider registered for model '{model_id}'. "
+            f"Use llm.register_provider() to register a provider for this model."
+        )
+        super().__init__(message)
+        self.model_id = model_id

--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -14,6 +14,7 @@ from .openai import (
     OpenAIProvider,
 )
 from .provider_id import KNOWN_PROVIDER_IDS, ProviderId
+from .provider_registry import get_provider_for_model, register_provider
 
 __all__ = [
     "KNOWN_PROVIDER_IDS",
@@ -29,6 +30,8 @@ __all__ = [
     "OpenAIProvider",
     "Params",
     "ProviderId",
+    "get_provider_for_model",
     "load",
     "load_provider",
+    "register_provider",
 ]

--- a/python/mirascope/llm/providers/anthropic/provider.py
+++ b/python/mirascope/llm/providers/anthropic/provider.py
@@ -36,6 +36,9 @@ from .model_id import AnthropicModelId, model_name
 class AnthropicProvider(BaseProvider[Anthropic]):
     """The client for the Anthropic LLM model."""
 
+    id = "anthropic"
+    default_scope = "anthropic/"
+
     def __init__(
         self, *, api_key: str | None = None, base_url: str | None = None
     ) -> None:

--- a/python/mirascope/llm/providers/base/base_provider.py
+++ b/python/mirascope/llm/providers/base/base_provider.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import Generic, overload
+from typing import TYPE_CHECKING, ClassVar, Generic, overload
 from typing_extensions import TypeVar, Unpack
 
 from ...context import Context, DepsT
@@ -32,6 +32,9 @@ from ...tools import (
 )
 from .params import Params
 
+if TYPE_CHECKING:
+    from ..provider_id import ProviderId
+
 ProviderClientT = TypeVar("ProviderClientT")
 
 
@@ -40,6 +43,17 @@ class BaseProvider(Generic[ProviderClientT], ABC):
 
     This class defines explicit methods for each type of call, eliminating
     the need for complex overloads in provider implementations.
+    """
+
+    id: ClassVar[ProviderId]
+    """Provider identifier (e.g., "anthropic", "openai")."""
+
+    default_scope: ClassVar[str | list[str]]
+    """Default scope(s) for this provider when explicitly registered.
+
+    Can be a single scope string or a list of scopes. For example:
+    - "anthropic/" - Single scope
+    - ["anthropic/", "openai/"] - Multiple scopes (e.g., for AWS Bedrock)
     """
 
     client: ProviderClientT

--- a/python/mirascope/llm/providers/google/provider.py
+++ b/python/mirascope/llm/providers/google/provider.py
@@ -37,6 +37,9 @@ from .model_id import GoogleModelId, model_name
 class GoogleProvider(BaseProvider[Client]):
     """The client for the Google LLM model."""
 
+    id = "google"
+    default_scope = "google/"
+
     def __init__(
         self, *, api_key: str | None = None, base_url: str | None = None
     ) -> None:

--- a/python/mirascope/llm/providers/load_provider.py
+++ b/python/mirascope/llm/providers/load_provider.py
@@ -33,7 +33,7 @@ def load_provider(
             return GoogleProvider(api_key=api_key, base_url=base_url)
         case "openai":
             return OpenAIProvider(api_key=api_key, base_url=base_url)
-        case "mlx-community":  # pragma: no cover (MLX is only available on macOS)
+        case "mlx":  # pragma: no cover (MLX is only available on macOS)
             return MLXProvider()
         case _:  # pragma: no cover
             raise ValueError(f"Unknown provider: '{provider_id}'")

--- a/python/mirascope/llm/providers/mlx/provider.py
+++ b/python/mirascope/llm/providers/mlx/provider.py
@@ -68,6 +68,9 @@ class MLXProvider(BaseProvider[None]):
     streaming responses.
     """
 
+    id = "mlx"
+    default_scope = "mlx-community/"
+
     def _call(
         self,
         *,

--- a/python/mirascope/llm/providers/openai/provider.py
+++ b/python/mirascope/llm/providers/openai/provider.py
@@ -88,6 +88,9 @@ def choose_api_mode(model_id: OpenAIModelId, messages: Sequence[Message]) -> str
 class OpenAIProvider(BaseProvider[OpenAI]):
     """Unified provider for OpenAI that routes to Completions or Responses API based on model_id."""
 
+    id = "openai"
+    default_scope = "openai/"
+
     def __init__(
         self, *, api_key: str | None = None, base_url: str | None = None
     ) -> None:

--- a/python/mirascope/llm/providers/provider_registry.py
+++ b/python/mirascope/llm/providers/provider_registry.py
@@ -1,0 +1,167 @@
+"""Provider registry for managing provider instances and scopes."""
+
+from typing import Any, overload
+
+from ..exceptions import NoRegisteredProviderError
+from .base import BaseProvider
+from .load_provider import load_provider
+from .provider_id import ProviderId
+
+# Global registry mapping scopes to providers
+# Scopes are matched by prefix (longest match wins)
+PROVIDER_REGISTRY: dict[str, "BaseProvider[Any]"] = {}
+
+# Default auto-registration mapping for built-in providers
+# These providers will be automatically registered on first use
+DEFAULT_AUTO_REGISTER_SCOPES: dict[str, "ProviderId"] = {
+    "anthropic/": "anthropic",
+    "google/": "google",
+    "openai/": "openai",
+    "mlx-community/": "mlx",
+}
+
+
+@overload
+def register_provider(
+    provider: "BaseProvider[Any]",
+    scope: str | list[str] | None = None,
+) -> BaseProvider[Any]:
+    """Register a provider instance with scope(s).
+
+    Args:
+        provider: Provider instance to register.
+        scope: Scope string or list of scopes (e.g., "anthropic/", ["anthropic/", "openai/"]).
+            If None, uses the provider's default_scope.
+    """
+    ...
+
+
+@overload
+def register_provider(
+    provider: "ProviderId",
+    scope: str | list[str] | None = None,
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> BaseProvider[Any]:
+    """Register a provider by ID with scope(s).
+
+    Args:
+        provider: Provider ID string (e.g., "anthropic", "openai").
+        scope: Scope string or list of scopes (e.g., "anthropic/", ["anthropic/", "openai/"]).
+            If None, uses the provider's default_scope.
+        api_key: API key for authentication.
+        base_url: Base URL for the API.
+    """
+    ...
+
+
+def register_provider(
+    provider: "ProviderId | BaseProvider[Any]",
+    scope: str | list[str] | None = None,
+    *,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> BaseProvider[Any]:
+    """Register a provider with scope(s) in the global registry.
+
+    Scopes use prefix matching on model IDs:
+    - "anthropic/" matches "anthropic/*"
+    - "anthropic/claude-4-5" matches "anthropic/claude-4-5*"
+    - "anthropic/claude-4-5-sonnet" matches exactly "anthropic/claude-4-5-sonnet"
+
+    When multiple scopes match a model_id, the longest match wins.
+
+    Args:
+        provider: Either a provider ID string or a provider instance.
+        scope: Scope string or list of scopes for prefix matching on model IDs.
+            If None, uses the provider's default_scope attribute.
+            Can be a single string or a list of strings.
+        api_key: API key for authentication (only used if provider is a string).
+        base_url: Base URL for the API (only used if provider is a string).
+
+    Example:
+        ```python
+        # Register with default scope
+        llm.register_provider("anthropic", api_key="key")
+
+        # Register for specific models
+        llm.register_provider("openai", scope="openai/gpt-4")
+
+        # Register for multiple scopes
+        llm.register_provider("aws-bedrock", scope=["anthropic/", "openai/"])
+
+        # Register a custom instance
+        custom = llm.providers.AnthropicProvider(api_key="team-key")
+        llm.register_provider(custom, scope="anthropic/claude-4-5-sonnet")
+        ```
+    """
+
+    if isinstance(provider, str):
+        provider = load_provider(provider, api_key=api_key, base_url=base_url)
+
+    if scope is None:
+        scope = provider.default_scope
+
+    scopes = [scope] if isinstance(scope, str) else scope
+    for s in scopes:
+        PROVIDER_REGISTRY[s] = provider
+
+    return provider
+
+
+def get_provider_for_model(model_id: str) -> "BaseProvider[Any]":
+    """Get the provider for a model_id based on the registry.
+
+    Uses longest prefix matching to find the most specific provider for the model.
+    If no explicit registration is found, checks for auto-registration defaults
+    and automatically registers the provider on first use.
+
+    Args:
+        model_id: The full model ID (e.g., "anthropic/claude-4-5-sonnet").
+
+    Returns:
+        The provider instance registered for this model.
+
+    Raises:
+        ValueError: If no provider is registered or available for this model.
+
+    Example:
+        ```python
+        # Assuming providers are registered:
+        # - "anthropic/" -> AnthropicProvider()
+        # - "anthropic/claude-4-5-sonnet" -> CustomProvider()
+
+        provider = get_provider_for_model("anthropic/claude-4-5-sonnet")
+        # Returns CustomProvider (longest match)
+
+        provider = get_provider_for_model("anthropic/claude-3-opus")
+        # Returns AnthropicProvider (matches "anthropic/" prefix)
+
+        # Auto-registration on first use:
+        provider = get_provider_for_model("openai/gpt-4")
+        # Automatically loads and registers OpenAIProvider() for "openai/"
+        ```
+    """
+    # Try explicit registry first (longest match wins)
+    matching_scopes = [
+        scope for scope in PROVIDER_REGISTRY if model_id.startswith(scope)
+    ]
+    if matching_scopes:
+        best_scope = max(matching_scopes, key=len)
+        return PROVIDER_REGISTRY[best_scope]
+
+    # Fall back to auto-registration
+    matching_defaults = [
+        scope for scope in DEFAULT_AUTO_REGISTER_SCOPES if model_id.startswith(scope)
+    ]
+    if matching_defaults:
+        best_scope = max(matching_defaults, key=len)
+        provider_id = DEFAULT_AUTO_REGISTER_SCOPES[best_scope]
+        provider = load_provider(provider_id)
+        # Auto-register for future calls
+        PROVIDER_REGISTRY[best_scope] = provider
+        return provider
+
+    # No provider found
+    raise NoRegisteredProviderError(model_id)

--- a/python/tests/llm/models/test_model.py
+++ b/python/tests/llm/models/test_model.py
@@ -1,8 +1,19 @@
 """Tests for the Model class."""
 
+from collections.abc import Generator
+
 import pytest
 
 from mirascope import llm
+from mirascope.llm.providers.provider_registry import PROVIDER_REGISTRY
+
+
+@pytest.fixture(autouse=True)
+def reset_provider_registry() -> Generator[None, None, None]:
+    """Reset the provider registry before and after each test."""
+    PROVIDER_REGISTRY.clear()
+    yield
+    PROVIDER_REGISTRY.clear()
 
 
 def test_use_model_without_context() -> None:
@@ -41,10 +52,17 @@ def test_direct_model_instantiation_ignores_context() -> None:
 
 
 def test_value_error_invalid_models() -> None:
-    """Test that invalid model_ids raise appropriate ValueErrors."""
-    with pytest.raises(ValueError, match="Unknown provider: 'nonexistent'"):
-        llm.call("nonexistent/gpt-5-mini")
+    """Test that invalid model_ids raise appropriate errors."""
 
+    # Test unregistered provider - need to actually call to trigger runtime error
+    @llm.call("nonexistent/gpt-5-mini")
+    def say_hi() -> str:
+        return "hi"
+
+    with pytest.raises(llm.NoRegisteredProviderError, match="No provider registered"):
+        say_hi()
+
+    # Test invalid model_id format (no slash)
     with pytest.raises(ValueError, match="Invalid model_id format"):
         llm.call("really-cool-model-i-heard-about")
 
@@ -80,3 +98,34 @@ def test_nested_context_manager_with_same_instance() -> None:
         )
 
     assert llm.model_from_context() is None
+
+
+def test_provider_resolution_is_dynamic() -> None:
+    """Test that Model dynamically resolves provider based on registry changes.
+
+    This ensures that changes to the provider registry affect which provider
+    is used by Model instances, even after the Model is created.
+    """
+    # Create a model - should auto-register and use default OpenAI provider
+    model = llm.Model("openai/gpt-4o")
+    initial_provider = model.provider
+    assert initial_provider.id == "openai"
+
+    # Register a custom provider for the same scope
+    custom_provider = llm.register_provider("anthropic", scope="openai/")
+
+    # The same Model instance should now resolve to the custom provider
+    assert model.provider is custom_provider
+    assert model.provider.id == "anthropic"
+
+    # Register another provider for a more specific scope
+    very_specific_provider = llm.register_provider("google", scope="openai/gpt-4o")
+
+    # Should now use the most specific provider
+    assert model.provider is very_specific_provider
+    assert model.provider.id == "google"
+
+    # A different model should use less specific provider
+    other_model = llm.Model("openai/gpt-3.5-turbo")
+    assert other_model.provider is custom_provider
+    assert other_model.provider.id == "anthropic"

--- a/python/tests/llm/providers/test_provider_registry.py
+++ b/python/tests/llm/providers/test_provider_registry.py
@@ -1,0 +1,149 @@
+"""Tests for provider registry functionality."""
+
+from collections.abc import Generator
+
+import pytest
+
+from mirascope import llm
+from mirascope.llm.providers.provider_registry import (
+    DEFAULT_AUTO_REGISTER_SCOPES,
+    PROVIDER_REGISTRY,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_provider_registry() -> Generator[None, None, None]:
+    """Reset the provider registry before and after each test."""
+    PROVIDER_REGISTRY.clear()
+    yield
+    PROVIDER_REGISTRY.clear()
+
+
+def test_auto_registered_providers() -> None:
+    """Test that providers auto-register on first use and are cached."""
+    openai = llm.providers.get_provider_for_model("openai/gpt-5")
+    assert openai is llm.load_provider("openai")
+    assert openai is llm.providers.get_provider_for_model("openai/gpt-4")
+
+
+def test_provider_registration() -> None:
+    """Test explicit provider registration."""
+    custom_openai = llm.register_provider("openai", api_key="foo-bar")
+    assert llm.providers.get_provider_for_model("openai/gpt-5") is custom_openai
+
+
+def test_provider_as_argument() -> None:
+    """Test that you can pass a Provider to register_provider"""
+    custom_openai = llm.providers.OpenAIProvider()
+    as_registered = llm.register_provider(custom_openai)
+    assert custom_openai is as_registered
+    assert llm.providers.get_provider_for_model("openai/gpt-5") is custom_openai
+
+
+def test_longest_scope_wins() -> None:
+    """Test that the longest matching scope takes precedence."""
+    default_openai = llm.register_provider("openai")
+    custom_openai = llm.register_provider(
+        "openai", scope="openai/gpt-5", api_key="foo-bar"
+    )
+    assert default_openai is not custom_openai
+    assert llm.providers.get_provider_for_model("openai/gpt-4") is default_openai
+    assert llm.providers.get_provider_for_model("openai/gpt-5") is custom_openai
+
+
+def test_register_provider_with_multiple_scopes() -> None:
+    """Test registering a provider for multiple scopes (e.g., AWS Bedrock)."""
+    provider = llm.register_provider("anthropic", scope=["anthropic/", "aws/"])
+    assert llm.providers.get_provider_for_model("anthropic/claude") is provider
+    assert llm.providers.get_provider_for_model("aws/claude") is provider
+
+
+def test_all_default_scopes_auto_register() -> None:
+    """Test that all built-in providers can auto-register dynamically."""
+    for scope, provider_id in DEFAULT_AUTO_REGISTER_SCOPES.items():
+        # Skip mlx as it won't run in CI
+        if provider_id == "mlx":
+            continue
+
+        # Test with a fake model under this scope
+        model_id = f"{scope}test-model"
+        provider = llm.providers.get_provider_for_model(model_id)
+        assert provider.id == provider_id
+
+
+def test_explicit_registration_overrides_auto() -> None:
+    """Test that explicit registration takes precedence over auto-registration."""
+    # Register a different provider for openai scope
+    custom = llm.register_provider("anthropic", scope="openai/")
+
+    # Should use explicit registration, not auto-registration
+    assert llm.providers.get_provider_for_model("openai/gpt-4") is custom
+    assert custom.id == "anthropic"
+
+
+def test_no_provider_raises_error() -> None:
+    """Test that unknown provider prefixes raise NoRegisteredProviderError."""
+    with pytest.raises(llm.NoRegisteredProviderError) as exc_info:
+        llm.providers.get_provider_for_model("unknown/model")
+
+    assert exc_info.value.model_id == "unknown/model"
+    assert "No provider registered" in str(exc_info.value)
+
+
+def test_most_specific_scope_wins() -> None:
+    """Test that more specific scopes win over less specific ones."""
+    p1 = llm.register_provider("openai", scope="openai/")
+    p2 = llm.register_provider("anthropic", scope="openai/gpt-4")
+    p3 = llm.register_provider("google", scope="openai/gpt-4-turbo")
+
+    assert llm.providers.get_provider_for_model("openai/gpt-3") is p1
+    assert llm.providers.get_provider_for_model("openai/gpt-4o") is p2
+    assert llm.providers.get_provider_for_model("openai/gpt-4-turbo-2024") is p3
+
+
+def test_empty_string_scope_matches_everything() -> None:
+    """Test that empty string scope acts as a catch-all."""
+    catch_all = llm.register_provider("openai", scope="")
+
+    # Should match any model since "" is a prefix of everything
+    assert llm.providers.get_provider_for_model("anything/model") is catch_all
+    assert llm.providers.get_provider_for_model("foo/bar") is catch_all
+
+
+def test_empty_string_scope_loses_to_specific() -> None:
+    """Test that empty string scope has lowest precedence."""
+    catch_all = llm.register_provider("openai", scope="")
+    specific = llm.register_provider("anthropic", scope="anthropic/")
+
+    # Specific scope should win
+    assert llm.providers.get_provider_for_model("anthropic/claude") is specific
+    # But catch-all should still work for unknown scopes
+    assert llm.providers.get_provider_for_model("random/model") is catch_all
+
+
+def test_empty_array_scope_registers_nothing() -> None:
+    """Test that registering with empty scope list doesn't register any scopes."""
+    custom_openai = llm.load_provider("openai", api_key="1234")
+    llm.register_provider(custom_openai, scope=[])
+
+    actual = llm.providers.get_provider_for_model("openai/gpt-5")
+    # Will use the default provider (via auto registration) since no scope was provided
+    # for the custom provider
+    assert actual is not custom_openai
+
+
+def test_overwrite_provider_registration() -> None:
+    """Test that registering a provider for the same scope overwrites the previous one."""
+    # Register first provider
+    provider1 = llm.register_provider("openai", scope="custom/", api_key="key1")
+    assert llm.providers.get_provider_for_model("custom/model") is provider1
+
+    # Register second provider for the same scope - should overwrite
+    provider2 = llm.register_provider("anthropic", scope="custom/")
+    assert llm.providers.get_provider_for_model("custom/model") is provider2
+    assert provider2 is not provider1
+
+    # Verify the first provider is no longer used
+    result = llm.providers.get_provider_for_model("custom/model")
+    assert result.id == "anthropic"
+    assert result is not provider1


### PR DESCRIPTION
- Use `llm.register_provider(provider, scope)` to register a provider
- Can pass a `BaseProvider[Any]` or a `provider_id: str`
- When passing provider id, can optionally pass api key and base url too
- Scopes are simple strings with prefix matching (longest wins)
- Default providers will auto-register to their default scopes if not
  present