### PR TITLE
Move ensure_additional_properties_false to base modules

### DIFF
--- a/python/mirascope/llm/providers/base/_utils.py
+++ b/python/mirascope/llm/providers/base/_utils.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, TypeAlias, get_type_hints
+from typing import TYPE_CHECKING, TypeAlias, cast, get_type_hints
 
 from ...content import Text
 from ...messages import AssistantMessage, Message, SystemMessage, UserMessage
@@ -193,3 +193,17 @@ def ensure_all_params_accessed(
         yield accessor
     finally:
         accessor.check_access_integrity(unsupported_params=unsupported_params)
+
+
+def ensure_additional_properties_false(obj: object) -> None:
+    """Recursively adds additionalProperties = False to a schema, required by OpenAI API."""
+    if isinstance(obj, dict):
+        obj = cast(dict[str, object], obj)
+        if obj.get("type") == "object" and "additionalProperties" not in obj:
+            obj["additionalProperties"] = False
+        for value in obj.values():
+            ensure_additional_properties_false(value)
+    elif isinstance(obj, list):
+        obj = cast(list[object], obj)
+        for item in obj:
+            ensure_additional_properties_false(item)

--- a/python/mirascope/llm/providers/openai/completions/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/completions/_utils/encode.py
@@ -21,6 +21,7 @@ from .....formatting import (
 from .....messages import AssistantMessage, Message, UserMessage
 from .....tools import FORMAT_TOOL_NAME, AnyToolSchema, BaseToolkit
 from ....base import Params, _utils as _base_utils
+from ....base._utils import ensure_additional_properties_false
 from ...model_id import OpenAIModelId, model_name
 from ...model_info import MODELS_WITHOUT_AUDIO_SUPPORT
 from ...shared import _utils as _shared_utils
@@ -233,7 +234,7 @@ def _convert_tool_to_tool_param(
     """Convert a single Mirascope `Tool` to OpenAI ChatCompletionToolParam with caching."""
     schema_dict = tool.parameters.model_dump(by_alias=True, exclude_none=True)
     schema_dict["type"] = "object"
-    _shared_utils.ensure_additional_properties_false(schema_dict)
+    ensure_additional_properties_false(schema_dict)
     return openai_types.ChatCompletionToolParam(
         type="function",
         function={
@@ -258,7 +259,7 @@ def _create_strict_response_format(
     """
     schema = format.schema.copy()
 
-    _shared_utils.ensure_additional_properties_false(schema)
+    ensure_additional_properties_false(schema)
 
     json_schema = JSONSchema(
         name=format.name,

--- a/python/mirascope/llm/providers/openai/responses/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/responses/_utils/encode.py
@@ -39,6 +39,7 @@ from .....formatting import (
 from .....messages import AssistantMessage, Message, UserMessage
 from .....tools import FORMAT_TOOL_NAME, AnyToolSchema, BaseToolkit
 from ....base import Params, _utils as _base_utils
+from ....base._utils import ensure_additional_properties_false
 from ...model_id import OpenAIModelId, model_name
 from ...model_info import NON_REASONING_MODELS
 from ...shared import _utils as _shared_utils
@@ -197,7 +198,7 @@ def _convert_tool_to_function_tool_param(tool: AnyToolSchema) -> FunctionToolPar
     """Convert a Mirascope ToolSchema to OpenAI Responses FunctionToolParam."""
     schema_dict = tool.parameters.model_dump(by_alias=True, exclude_none=True)
     schema_dict["type"] = "object"
-    _shared_utils.ensure_additional_properties_false(schema_dict)
+    ensure_additional_properties_false(schema_dict)
 
     return FunctionToolParam(
         type="function",
@@ -220,7 +221,7 @@ def _create_strict_response_format(
         ResponseFormatTextJSONSchemaConfigParam for strict structured outputs
     """
     schema = format.schema.copy()
-    _shared_utils.ensure_additional_properties_false(schema)
+    ensure_additional_properties_false(schema)
 
     response_format: ResponseFormatTextJSONSchemaConfigParam = {
         "type": "json_schema",

--- a/python/mirascope/llm/providers/openai/shared/_utils.py
+++ b/python/mirascope/llm/providers/openai/shared/_utils.py
@@ -1,7 +1,5 @@
 """Shared utils for all OpenAI clients."""
 
-from typing import cast
-
 MODELS_WITHOUT_JSON_SCHEMA_SUPPORT = {
     "chatgpt-4o-latest",
     "gpt-3.5-turbo",
@@ -43,17 +41,3 @@ MODELS_WITHOUT_JSON_OBJECT_SUPPORT = {
     "o1-mini",
     "o1-mini-2024-09-12",
 }
-
-
-def ensure_additional_properties_false(obj: object) -> None:
-    """Recursively adds additionalProperties = False to a schema, required by OpenAI API."""
-    if isinstance(obj, dict):
-        obj = cast(dict[str, object], obj)
-        if obj.get("type") == "object" and "additionalProperties" not in obj:
-            obj["additionalProperties"] = False
-        for value in obj.values():
-            ensure_additional_properties_false(value)
-    elif isinstance(obj, list):
-        obj = cast(list[object], obj)
-        for item in obj:
-            ensure_additional_properties_false(item)


### PR DESCRIPTION
### TL;DR

Moved the `ensure_additional_properties_false` utility function from OpenAI-specific module to the base utils module.

### What changed?

- Moved the `ensure_additional_properties_false` function from `mirascope/llm/providers/openai/shared/_utils.py` to `mirascope/llm/providers/base/_utils.py`
- Updated import statements in OpenAI-specific modules to reference the function from its new location
- Added the necessary `cast` import to the base utils module

### How to test?

- Verify that all OpenAI API calls that use JSON schemas (tools, response formats) continue to work correctly
- Ensure that the `additionalProperties: false` is still properly added to all object schemas in the OpenAI requests

### Why make this change?

This refactoring improves code organization by moving a utility function to a more appropriate location. Since the function handles JSON schema manipulation that could be useful for other providers beyond OpenAI, it makes sense to place it in the base utils module rather than keeping it provider-specific. This change reduces code duplication and makes the function available for use with other LLM providers that might need similar schema modifications.