### PR TITLE
Implement support for together provider

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -55,7 +55,8 @@ python/
 │   │   │   ├── anthropic/
 │   │   │   ├── google/
 │   │   │   ├── openai/
-│   │   │   ├── openai/completions/base_provider.py
+│   │   │   │   └── completions/base_provider.py
+│   │   │   ├── together/
 │   │   │   ├── provider_registry.py
 │   │   │   └── load_provider.py
 │   │   ├── content/          # Content types (text, image, audio, etc.)

--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -16,6 +16,7 @@ from .openai import (
 from .openai.completions import BaseOpenAICompletionsProvider
 from .provider_id import KNOWN_PROVIDER_IDS, ProviderId
 from .provider_registry import get_provider_for_model, register_provider
+from .together import TogetherProvider
 
 __all__ = [
     "KNOWN_PROVIDER_IDS",
@@ -33,6 +34,7 @@ __all__ = [
     "Params",
     "Provider",
     "ProviderId",
+    "TogetherProvider",
     "get_provider_for_model",
     "load",
     "load_provider",

--- a/python/mirascope/llm/providers/load_provider.py
+++ b/python/mirascope/llm/providers/load_provider.py
@@ -8,6 +8,7 @@ from .openai import OpenAIProvider
 from .openai.completions.provider import OpenAICompletionsProvider
 from .openai.responses.provider import OpenAIResponsesProvider
 from .provider_id import ProviderId
+from .together import TogetherProvider
 
 
 @lru_cache(maxsize=256)
@@ -32,14 +33,16 @@ def load_provider(
             return AnthropicProvider(api_key=api_key, base_url=base_url)
         case "google":
             return GoogleProvider(api_key=api_key, base_url=base_url)
+        case "mlx":  # pragma: no cover (MLX is only available on macOS)
+            return MLXProvider()
         case "openai":
             return OpenAIProvider(api_key=api_key, base_url=base_url)
         case "openai:completions":
             return OpenAICompletionsProvider(api_key=api_key, base_url=base_url)
         case "openai:responses":
             return OpenAIResponsesProvider(api_key=api_key, base_url=base_url)
-        case "mlx":  # pragma: no cover (MLX is only available on macOS)
-            return MLXProvider()
+        case "together":
+            return TogetherProvider(api_key=api_key, base_url=base_url)
         case _:  # pragma: no cover
             raise ValueError(f"Unknown provider: '{provider_id}'")
 

--- a/python/mirascope/llm/providers/provider_id.py
+++ b/python/mirascope/llm/providers/provider_id.py
@@ -6,8 +6,9 @@ KnownProviderId: TypeAlias = Literal[
     "anthropic",  # Anthropic provider via AnthropicProvider
     "anthropic-beta",  # Anthropic beta provider via AnthropicBetaProvider
     "google",  # Google provider via GoogleProvider
-    "openai",  # OpenAI provider via OpenAIProvider (prefers Responses routing when available)
     "mlx",  # Local inference powered by `mlx-lm`, via MLXProvider
+    "openai",  # OpenAI provider via OpenAIProvider (prefers Responses routing when available)
+    "together",  # Together AI provider via TogetherProvider
 ]
 KNOWN_PROVIDER_IDS = get_args(KnownProviderId)
 

--- a/python/mirascope/llm/providers/provider_registry.py
+++ b/python/mirascope/llm/providers/provider_registry.py
@@ -16,8 +16,9 @@ PROVIDER_REGISTRY: dict[str, Provider] = {}
 DEFAULT_AUTO_REGISTER_SCOPES: dict[str, ProviderId] = {
     "anthropic/": "anthropic",
     "google/": "google",
-    "openai/": "openai",
     "mlx-community/": "mlx",
+    "openai/": "openai",
+    "together/": "together",
 }
 
 

--- a/python/mirascope/llm/providers/together/__init__.py
+++ b/python/mirascope/llm/providers/together/__init__.py
@@ -1,0 +1,19 @@
+"""Together AI provider implementation."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .provider import TogetherProvider
+else:
+    try:
+        from .provider import TogetherProvider
+    except ImportError:  # pragma: no cover
+        from .._missing_import_stubs import (
+            create_provider_stub,
+        )
+
+        TogetherProvider = create_provider_stub("openai", "TogetherProvider")
+
+__all__ = [
+    "TogetherProvider",
+]

--- a/python/mirascope/llm/providers/together/provider.py
+++ b/python/mirascope/llm/providers/together/provider.py
@@ -1,0 +1,40 @@
+"""Together AI provider implementation."""
+
+from typing import ClassVar
+
+from ..openai.completions.base_provider import BaseOpenAICompletionsProvider
+
+
+class TogetherProvider(BaseOpenAICompletionsProvider):
+    """Provider for Together AI's OpenAI-compatible API.
+
+    Inherits from BaseOpenAICompletionsProvider with Together-specific configuration:
+    - Uses Together AI's API endpoint
+    - Requires TOGETHER_API_KEY
+
+    Usage:
+        Register the provider with model ID prefixes you want to use:
+
+        ```python
+        import llm
+
+        # Register for meta-llama models
+        llm.register_provider("together", "meta-llama/")
+
+        # Now you can use meta-llama models directly
+        @llm.call("meta-llama/Llama-3.3-70B-Instruct-Turbo")
+        def my_prompt():
+            return [llm.messages.user("Hello!")]
+        ```
+    """
+
+    id: ClassVar[str] = "together"
+    default_scope: ClassVar[str | list[str]] = []
+    default_base_url: ClassVar[str | None] = "https://api.together.xyz/v1"
+    api_key_env_var: ClassVar[str] = "TOGETHER_API_KEY"
+    api_key_required: ClassVar[bool] = True
+    provider_name: ClassVar[str | None] = "Together"
+
+    def _model_name(self, model_id: str) -> str:
+        """Return the model ID as-is for Together API."""
+        return model_id

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -20,3 +20,4 @@ def load_api_keys() -> None:
     os.environ.setdefault("ANTHROPIC_API_KEY", "dummy-anthropic-key")
     os.environ.setdefault("GOOGLE_API_KEY", "dummy-google-key")
     os.environ.setdefault("OPENAI_API_KEY", "dummy-openai-key")
+    os.environ.setdefault("TOGETHER_API_KEY", "dummy-together-key")

--- a/python/tests/e2e/input/cassettes/test_together_provider/meta_llama_Llama_3_3_70B_Instruct_Turbo.yaml
+++ b/python/tests/e2e/input/cassettes/test_together_provider/meta_llama_Llama_3_3_70B_Instruct_Turbo.yaml
@@ -1,0 +1,105 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"meta-llama/Llama-3.3-70B-Instruct-Turbo"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '111'
+      content-type:
+      - application/json
+      host:
+      - api.together.xyz
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: https://api.together.xyz/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//VFHBTsMwDL3vK6xcoSPrsnadxAVOSIA4cEGAJi/11kIaV40nJk38O0o7
+        VrhYznv2e9bLcQKg6lKtQPHT7kUOD4l5ebzdmKTAbbmws6XZWlzOskJdxlHefJCVOG4rlKnlpnUk
+        NfuBth2hUJSb5VmmTZ7maU80XJKLaw0JJs5hg1f3sSbz6TzJ9U1y54N0eyvJ877b8CDXdty00e31
+        fZCvuLYUIjABADj2FUBta1+Hat0RBvbRJgi3vUZPB+pvKgpTLPLlPC/SbKGXM631eaT2JR3UCkbE
+        8a7teBPd/N65M95QCLgjtTrbA6iOXUQUhlAHQS9n83g2eyHfp/bMsK19CVIRoA9f1F0CliWYVGtA
+        H5vpm3/z/fsCTArXYFKT/pUTZre26FwfxPuJ+J781iGr/b8jT1GuhT/Jxz1jBkU1fuFIpvMTKSzo
+        RjzLf5fQVlSOhJ5E6+8fAAAA//8DAHO/+z1OAgAA
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9afd5c184fca8169-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 18 Dec 2025 08:41:13 GMT
+      ETag:
+      - W/"24e-ufEvuT6yNDDZxOJW0AgFInKwd1I"
+      Retry-After:
+      - '2'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      alt-svc:
+      - h3=":443"; ma=86400
+      x-amzn-trace-id:
+      - 322bc83f-8f1b-4aaa-bfb3-c661b6988e6a-noamzn
+      x-api-call-end:
+      - '2025-12-18T08:41:13.495Z'
+      x-api-call-start:
+      - '2025-12-18T08:41:12.526Z'
+      x-api-received:
+      - '2025-12-18T08:41:12.511Z'
+      x-inference-version:
+      - v2
+      x-ratelimit:
+      - 'false'
+      x-ratelimit-limit:
+      - '10'
+      x-ratelimit-limit-tokens:
+      - '3000'
+      x-ratelimit-remaining:
+      - '19'
+      x-ratelimit-remaining-tokens:
+      - '3000'
+      x-ratelimit-reset:
+      - '2'
+      x-request-id:
+      - oPgYtxM-4YNCb4-9afd5c184fca8169
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/snapshots/test_strict_mode_streamed/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_streamed/anthropic_claude_sonnet_4_5_snapshots.py
@@ -9,7 +9,8 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/input/snapshots/test_strict_mode_streamed/google_gemini_3_pro_preview_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_streamed/google_gemini_3_pro_preview_snapshots.py
@@ -9,7 +9,8 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-3-pro-preview",
             "model_id": "google/gemini-3-pro-preview",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/input/snapshots/test_strict_mode_with_streamed_thinking/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_with_streamed_thinking/anthropic_claude_sonnet_4_5_snapshots.py
@@ -10,7 +10,8 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/input/snapshots/test_strict_mode_with_streamed_thinking/google_gemini_3_pro_preview_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_with_streamed_thinking/google_gemini_3_pro_preview_snapshots.py
@@ -10,7 +10,8 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-3-pro-preview",
             "model_id": "google/gemini-3-pro-preview",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/input/snapshots/test_strict_mode_with_tools_streamed/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_with_tools_streamed/anthropic_claude_sonnet_4_5_snapshots.py
@@ -11,7 +11,8 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/input/snapshots/test_strict_mode_with_tools_streamed/google_gemini_3_pro_preview_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_with_tools_streamed/google_gemini_3_pro_preview_snapshots.py
@@ -11,7 +11,8 @@ from mirascope.llm import (
 test_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-3-pro-preview",
             "model_id": "google/gemini-3-pro-preview",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/input/snapshots/test_together_provider/meta_llama_Llama_3_3_70B_Instruct_Turbo_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_together_provider/meta_llama_Llama_3_3_70B_Instruct_Turbo_snapshots.py
@@ -1,0 +1,50 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import AssistantMessage, Text, UserMessage
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "together",
+            "model_id": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            "provider_model_name": "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+            "params": {},
+            "finish_reason": None,
+            "usage": {
+                "input_tokens": 44,
+                "output_tokens": 23,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+To find the answer, add 4200 and 42.
+
+4200 + 42 = 4242\
+"""
+                        )
+                    ],
+                    provider_id="together",
+                    model_id="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                    provider_model_name="meta-llama/Llama-3.3-70B-Instruct-Turbo",
+                    raw_message={
+                        "content": """\
+To find the answer, add 4200 and 42.
+
+4200 + 42 = 4242\
+""",
+                        "role": "assistant",
+                        "tool_calls": [],
+                    },
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_call/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -75,7 +75,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -107,7 +108,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/anthropic_claude_sonnet_4_0_snapshots.py
@@ -87,7 +87,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -119,7 +120,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/google_gemini_2_5_flash_snapshots.py
@@ -153,7 +153,8 @@ So, 4200 + 42 = **4242**.\
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -232,7 +233,8 @@ So, 42\
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call/mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
@@ -123,7 +123,8 @@ $$\
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
+            "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "model_id": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "finish_reason": None,
             "messages": [
@@ -179,7 +180,8 @@ $$\
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
+            "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "model_id": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_completions_snapshots.py
@@ -77,7 +77,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -106,7 +107,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call/openai_gpt_4o_responses_snapshots.py
@@ -99,7 +99,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -143,7 +144,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -370,7 +370,8 @@ Checking primality:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -555,7 +556,8 @@ Total count: 3 primes.\
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/anthropic_claude_sonnet_4_0_snapshots.py
@@ -378,7 +378,8 @@ My final count reveals 3 primes containing "79": 79, 179, and 379.\
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -548,7 +549,8 @@ Therefore, the primes below 400 that contain "79" as a substring are 79, 179, an
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/google_gemini_2_5_flash_snapshots.py
@@ -334,7 +334,8 @@ I've carefully listed all the primes up to 400. Now, I systematically check each
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -631,7 +632,8 @@ Therefore, there are 3 such primes.
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_gpt_5_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking_true/openai_gpt_5_responses_snapshots.py
@@ -359,7 +359,8 @@ The final answer is simply "3." Great, let's go with that!\
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-5:responses",
             "model_id": "openai/gpt-5:responses",
             "finish_reason": None,
             "messages": [
@@ -523,7 +524,8 @@ So, I have three primes: 79, 179, and 379. I made sure to rule out other numbers
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-5:responses",
             "model_id": "openai/gpt-5:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -282,7 +282,8 @@ Here are the secrets retrieved for each password:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -416,7 +417,8 @@ Here are the secrets retrieved for each password:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
@@ -286,7 +286,8 @@ Here are the secrets retrieved for each password:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -424,7 +425,8 @@ Both secrets have been successfully retrieved!\
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/google_gemini_2_5_flash_snapshots.py
@@ -304,7 +304,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -473,7 +474,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_completions_snapshots.py
@@ -268,7 +268,8 @@ Here are the secrets associated with the passwords:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -366,7 +367,8 @@ The secrets associated with the passwords are:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/openai_gpt_4o_responses_snapshots.py
@@ -284,7 +284,8 @@ The secrets for the passwords are:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -419,7 +420,8 @@ Here are the secrets associated with each password:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -142,7 +142,8 @@ Here are all 50 U.S. states in alphabetical order:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [
@@ -207,7 +208,8 @@ Here are all 50 U.S. states in alphabetical order:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_claude_sonnet_4_0_snapshots.py
@@ -144,7 +144,8 @@ Here are all 50 U.S. states in alphabetical order:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [
@@ -209,7 +210,8 @@ Here are all 50 U.S. states in alphabetical order:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_max_tokens/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/google_gemini_2_5_flash_snapshots.py
@@ -114,7 +114,8 @@ Here are all U.S. states, listed alphabetically:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [
@@ -159,7 +160,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_max_tokens/mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/mlx_community_Qwen3_0_6B_4bit_DWQ_053125_snapshots.py
@@ -84,7 +84,8 @@ Okay, the user is asking me to list all U.S. states. Let me start by recalling t
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
+            "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "model_id": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [
@@ -120,7 +121,8 @@ Okay, the user is asking me to list all U.S. states. Let me start by recalling t
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "mlx",
+            "provider_id": "mlx",
+            "provider_model_name": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "model_id": "mlx-community/Qwen3-0.6B-4bit-DWQ-053125",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_completions_snapshots.py
@@ -134,7 +134,8 @@ Sure! Here is a list of all 50 U.S. states:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [
@@ -180,7 +181,8 @@ Here is a list of all 50 U.S. states:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/openai_gpt_4o_responses_snapshots.py
@@ -158,7 +158,8 @@ Sure! Here are all the U.S. states:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [
@@ -197,7 +198,8 @@ Sure! Here is a list of all 50 U.S. states:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": FinishReason.MAX_TOKENS,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_refusal/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/anthropic_claude_sonnet_4_0_snapshots.py
@@ -175,7 +175,8 @@ Is there something else I can help you with today?\
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -254,7 +255,8 @@ If you're interested in chemistry or pharmaceutical science for legitimate educa
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_refusal/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/google_gemini_2_5_flash_snapshots.py
@@ -155,7 +155,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -235,7 +236,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_completions_snapshots.py
@@ -122,7 +122,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": FinishReason.REFUSAL,
             "messages": [
@@ -174,7 +175,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": FinishReason.REFUSAL,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_refusal/openai_gpt_4o_responses_snapshots.py
@@ -138,7 +138,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": FinishReason.REFUSAL,
             "messages": [
@@ -199,7 +200,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": FinishReason.REFUSAL,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_0_snapshots.py
@@ -198,7 +198,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -291,7 +292,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_5_snapshots.py
@@ -198,7 +198,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -291,7 +292,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/google_gemini_2_5_flash_snapshots.py
@@ -207,7 +207,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -305,7 +306,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -404,7 +404,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -600,7 +601,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_0_snapshots.py
@@ -410,7 +410,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -610,7 +611,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_5_snapshots.py
@@ -414,7 +414,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -614,7 +615,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/google_gemini_2_5_flash_snapshots.py
@@ -420,7 +420,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -638,7 +639,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_completions_snapshots.py
@@ -396,7 +396,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -575,7 +576,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/openai_gpt_4o_responses_snapshots.py
@@ -418,7 +418,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -621,7 +622,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_completions_snapshots.py
@@ -163,7 +163,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -235,7 +236,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/openai_gpt_4o_responses_snapshots.py
@@ -185,7 +185,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -272,7 +273,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_5_snapshots.py
@@ -185,7 +185,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -264,7 +265,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/google_gemini_2_5_flash_snapshots.py
@@ -225,7 +225,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -323,7 +324,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_completions_snapshots.py
@@ -163,7 +163,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -235,7 +236,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/openai_gpt_4o_responses_snapshots.py
@@ -185,7 +185,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -272,7 +273,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -198,7 +198,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -291,7 +292,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_0_snapshots.py
@@ -198,7 +198,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -291,7 +292,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_5_snapshots.py
@@ -198,7 +198,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -291,7 +292,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/google_gemini_2_5_flash_snapshots.py
@@ -218,7 +218,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -321,7 +322,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_completions_snapshots.py
@@ -190,7 +190,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -266,7 +267,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/openai_gpt_4o_responses_snapshots.py
@@ -182,7 +182,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -267,7 +268,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_0_snapshots.py
@@ -276,7 +276,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -407,7 +408,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_5_snapshots.py
@@ -276,7 +276,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -407,7 +408,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/google_gemini_2_5_flash_snapshots.py
@@ -316,7 +316,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -467,7 +468,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -424,7 +424,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -629,7 +630,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_0_snapshots.py
@@ -428,7 +428,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -641,7 +642,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5_snapshots.py
@@ -500,7 +500,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -730,7 +731,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_completions_snapshots.py
@@ -394,7 +394,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -567,7 +568,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/openai_gpt_4o_responses_snapshots.py
@@ -422,7 +422,8 @@ Respond only with valid JSON that matches this exact schema:
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -626,7 +627,8 @@ Respond only with valid JSON that matches this exact schema:
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_completions_snapshots.py
@@ -249,7 +249,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -350,7 +351,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/openai_gpt_4o_responses_snapshots.py
@@ -263,7 +263,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -388,7 +389,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5_snapshots.py
@@ -263,7 +263,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -382,7 +383,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_completions_snapshots.py
@@ -249,7 +249,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -353,7 +354,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/openai_gpt_4o_responses_snapshots.py
@@ -280,7 +280,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -422,7 +423,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -276,7 +276,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -407,7 +408,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic-beta/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_0_snapshots.py
@@ -276,7 +276,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [
@@ -407,7 +408,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-0",
             "model_id": "anthropic/claude-sonnet-4-0",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5_snapshots.py
@@ -276,7 +276,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [
@@ -407,7 +408,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "anthropic",
+            "provider_id": "anthropic",
+            "provider_model_name": "claude-sonnet-4-5",
             "model_id": "anthropic/claude-sonnet-4-5",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/google_gemini_2_5_flash_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/google_gemini_2_5_flash_snapshots.py
@@ -316,7 +316,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [
@@ -467,7 +468,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "google",
+            "provider_id": "google",
+            "provider_model_name": "gemini-2.5-flash",
             "model_id": "google/gemini-2.5-flash",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_completions_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_completions_snapshots.py
@@ -278,7 +278,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [
@@ -384,7 +385,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:completions",
             "model_id": "openai/gpt-4o:completions",
             "finish_reason": None,
             "messages": [

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_responses_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/openai_gpt_4o_responses_snapshots.py
@@ -262,7 +262,8 @@ async_snapshot = snapshot(
 stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [
@@ -386,7 +387,8 @@ stream_snapshot = snapshot(
 async_stream_snapshot = snapshot(
     {
         "response": {
-            "provider": "openai",
+            "provider_id": "openai",
+            "provider_model_name": "gpt-4o:responses",
             "model_id": "openai/gpt-4o:responses",
             "finish_reason": None,
             "messages": [

--- a/python/tests/llm/providers/test_together_provider.py
+++ b/python/tests/llm/providers/test_together_provider.py
@@ -1,0 +1,49 @@
+"""Tests for TogetherProvider."""
+
+import os
+
+import pytest
+
+from mirascope.llm.providers.together.provider import TogetherProvider
+
+
+def test_together_provider_initialization() -> None:
+    """Test TogetherProvider initialization with api_key."""
+    provider = TogetherProvider(api_key="test-api-key")
+    assert provider.id == "together"
+    assert provider.default_scope == []
+
+
+def test_together_provider_missing_api_key() -> None:
+    """Test TogetherProvider raises error when API key is missing."""
+    original_key = os.environ.pop("TOGETHER_API_KEY", None)
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            TogetherProvider()
+        assert "Together API key is required" in str(exc_info.value)
+        assert "TOGETHER_API_KEY" in str(exc_info.value)
+    finally:
+        if original_key is not None:
+            os.environ["TOGETHER_API_KEY"] = original_key
+
+
+def test_together_provider_uses_env_var() -> None:
+    """Test TogetherProvider uses TOGETHER_API_KEY from environment."""
+    original_key = os.environ.get("TOGETHER_API_KEY")
+    os.environ["TOGETHER_API_KEY"] = "env-test-key"
+    try:
+        provider = TogetherProvider()
+        assert provider.id == "together"
+    finally:
+        if original_key is not None:
+            os.environ["TOGETHER_API_KEY"] = original_key
+        else:
+            os.environ.pop("TOGETHER_API_KEY", None)
+
+
+def test_together_provider_custom_base_url() -> None:
+    """Test TogetherProvider with custom base_url."""
+    provider = TogetherProvider(
+        api_key="test-key", base_url="https://custom.together.xyz/v1"
+    )
+    assert provider.id == "together"

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -83,8 +83,9 @@ def stream_response_snapshot_dict(
     and raw data that's provider-specific and not useful for snapshots.
     """
     return {
-        "provider": response.provider_id,
+        "provider_id": response.provider_id,
         "model_id": response.model_id,
+        "provider_model_name": response.provider_model_name,
         "finish_reason": response.finish_reason,
         "messages": list(response.messages),
         "format": format_snapshot(response.format),


### PR DESCRIPTION
### TL;DR

Added support for Together AI as a new provider and refactored the provider architecture to make it easier to add OpenAI-compatible providers.

### What changed?

- Renamed `clients/` directory to `providers/` in the project structure
- Created a new `OpenAICompatibleProvider` base class to simplify integration with OpenAI-compatible APIs
- Refactored `OpenAICompletionsProvider` to use the new base class
- Added `TogetherProvider` implementation for Together AI's API
- Updated provider registry to recognize Together AI models with the `together/` prefix
- Added environment variable handling for `TOGETHER_API_KEY`
- Added tests for the Together AI provider

### How to test?

1. Set your Together AI API key:
```bash
export TOGETHER_API_KEY=your_api_key
```

2. Use the Together AI provider in your code:
```python
import mirascope.llm as llm

# Register the provider (optional if TOGETHER_API_KEY is set)
llm.register_provider("together", api_key="your_api_key")

# Call a Together AI model
@llm.call("together/meta-llama/Llama-3.3-70B-Instruct-Turbo")
def ask_question(question: str) -> str:
    return question

response = ask_question("What is 4200 + 42?")
print(response.pretty())
```

### Why make this change?

This change makes it easier to integrate with OpenAI-compatible APIs by providing a reusable base class. Together AI is a popular provider that offers access to many open-source models through an OpenAI-compatible API. Adding support for Together AI expands the range of models available to Mirascope users without requiring them to learn a new API.