### PR TITLE
feat: support strict structured outputs in anthropic provider

### DIFF
--- a/python/mirascope/llm/providers/anthropic/_utils/__init__.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/__init__.py
@@ -2,6 +2,7 @@
 
 from .decode import decode_async_stream, decode_response, decode_stream
 from .encode import (
+    DEFAULT_FORMAT_MODE,
     DEFAULT_MAX_TOKENS,
     AnthropicImageMimeType,
     encode_image_mime_type,
@@ -10,6 +11,7 @@ from .encode import (
 )
 
 __all__ = [
+    "DEFAULT_FORMAT_MODE",
     "DEFAULT_MAX_TOKENS",
     "AnthropicImageMimeType",
     "decode_async_stream",

--- a/python/mirascope/llm/providers/anthropic/_utils/beta_encode.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/beta_encode.py
@@ -114,7 +114,7 @@ def beta_encode_request(
         {
             "model": model_name(model_id),
             "max_tokens": max_tokens,
-            "betas": [],
+            "betas": ["structured-outputs-2025-11-13"],
             **processed,
         }
     )
@@ -132,9 +132,7 @@ def beta_encode_request(
                     model_id=model_id,
                 )
             else:
-                kwargs["output_format"] = cast(
-                    type[BaseModel], format.formattable
-                )  # pragma: no cover # TODO remove no cover upstack
+                kwargs["output_format"] = cast(type[BaseModel], format.formattable)
 
         if format.mode == "tool":
             format_tool_schema = _formatting_utils.create_tool_schema(format)

--- a/python/mirascope/llm/providers/anthropic/_utils/encode.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/encode.py
@@ -22,6 +22,7 @@ from ...base import Params, _utils as _base_utils
 from ..model_id import AnthropicModelId, model_name
 
 DEFAULT_MAX_TOKENS = 16000
+# TODO: Change DEFAULT_FORMAT_MODE to strict when strict is no longer a beta feature.
 DEFAULT_FORMAT_MODE = "tool"
 
 AnthropicImageMimeType = Literal["image/jpeg", "image/png", "image/gif", "image/webp"]

--- a/python/tests/e2e/conftest.py
+++ b/python/tests/e2e/conftest.py
@@ -48,6 +48,7 @@ if sys.platform == "darwin":
 
     E2E_MODEL_IDS.append("mlx-community/Qwen3-0.6B-4bit-DWQ-053125")
 
+STRUCTURED_OUTPUT_MODEL_IDS = [*E2E_MODEL_IDS, "anthropic/claude-sonnet-4-5"]
 
 FORMATTING_MODES: tuple[llm.FormattingMode | None] = get_args(llm.FormattingMode) + (
     None,

--- a/python/tests/e2e/input/cassettes/test_strict_mode/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_strict_mode/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,115 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Answer this question:
+      What is 2 + 2?"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","description":"A
+      simple response for testing.","title":"IntegerAdditionResponse","properties":{"integer_a":{"type":"integer","title":"Integer
+      A"},"integer_b":{"type":"integer","title":"Integer B"},"answer":{"type":"integer","title":"Answer"}},"additionalProperties":false,"required":["integer_a","integer_b","answer"]},"type":"json_schema"}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '510'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJDBSsNAEIZfpfznDaSxKXSPInpS8FTByrJuhmYxmU12J1oJeXdJsZYq
+        nob5v2+YYUa0oaIGGq6xQ0VZCswk2SorsyIvynxTbKDgK2i0aW/y5bbu+8fb60O/LO/XT9uHu/ZG
+        2EFBPjuaLUrJ7gkKMTRzYFPySSwLFFxgIRbo5/HkCx1mciwa4w6ehfYUjd1BLwq1OCevP4nl9EFx
+        blcTpheFJKEzkWwKDA3iysgQGd8gUT8QO4LmoWkUhuOFeoTnbhAj4Y04QRfrKwVnXU3GRbLiA5tL
+        Iz/xSLb6j51m5wXU1dRStI0p27/+mS7r33RSCINcnFcqJIrv3pERTxEa818rGytM0xcAAAD//wMA
+        vNmgIsoBAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af09485ae4d086d-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:27:52 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:27:51Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:27:52Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:27:48Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:27:51Z'
+      request-id:
+      - req_011CWAvAXKjXUjfptPgmkNcd
+      x-envoy-upstream-service-time:
+      - '4120'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_strict_mode_streamed/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_strict_mode_streamed/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,164 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Answer this question:
+      What is 2 + 2?"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","description":"A
+      simple response for testing.","title":"IntegerAdditionResponse","properties":{"integer_a":{"type":"integer","title":"Integer
+      A"},"integer_b":{"type":"integer","title":"Integer B"},"answer":{"type":"integer","title":"Answer"}},"additionalProperties":false,"required":["integer_a","integer_b","answer"]},"type":"json_schema"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '524'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01FVYe4NWS8CUCki9vg3uL4w","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":263,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}            }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"integer_a\":
+        2, \""}           }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"integer_b\":
+        2, \""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"answer\":
+        4}"}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0         }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":263,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":25}           }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"  }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af094a0dcaa086d-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:27:54 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:27:52Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:27:52Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:27:52Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:27:52Z'
+      request-id:
+      - req_011CWAvAqnjweGSLSvgEaruv
+      x-envoy-upstream-service-time:
+      - '2276'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_strict_mode_with_streamed_thinking/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_strict_mode_with_streamed_thinking/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,368 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Answer this question:
+      What is 2 + 2?"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","description":"A
+      simple response for testing.","title":"IntegerAdditionResponse","properties":{"integer_a":{"type":"integer","title":"Integer
+      A"},"integer_b":{"type":"integer","title":"Integer B"},"answer":{"type":"integer","title":"Answer"}},"additionalProperties":false,"required":["integer_a","integer_b","answer"]},"type":"json_schema"},"thinking":{"type":"enabled","budget_tokens":8000},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '575'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_0116G7d3tMn6A93g5ntjCyEV","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":293,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}         }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The
+        user is asking me to answer \""}          }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"What
+        is 2 + 2"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"?\"
+        an"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"d
+        I"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        need to respon"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"d
+        with valid JSON that matches"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        the provide"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"d
+        schema."}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n\nThe"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        schema requires"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":":\n-
+        integer"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"_a:
+        integer"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        integer_b: integer\n-"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        answer: integer\n\nAll"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        three fields"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        are required."}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n\nThe"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        question"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        is \""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"What
+        is 2 + 2"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"?\"
+        so"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":":"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        integer_a = 2"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        integer_b = 2"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        answer = 2 "}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"+
+        2 = 4"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n\nI
+        need to respond with a"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        JSON object on"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        a single line without any markdown"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        or extra"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        formatting."}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EsUECkYIChgCKkBVfIvsuU7abyN1VAn4iOuarOKChrpRcTgYCvkqVFxnrIouN1diNge7Kuyc6ZtSKYGlkOoSrzmXKbmb5i1ICeAFEgyjjnZv+HG/GZsl3osaDGTxBmp1yOXX15HWLyIwWpGmCEWxdncyqPHVK7Zc1l+j+v8JTBioputEQEnBrG3P3Sf1JvH7/ZNmh5StrPWTKqwDvjs42Ygf6nL1ZChGUXtyvBCAaLCPq534aPsG0aqUJs34NZw5ZHDx0dCwcM5qT9lbQxJzHtPHQ+Gumu1pPgTwXCEL5ZJiVFjcWI0+DpKMqYp3sCMIhKGJG22I7AoGT5zg03K0voN3XbBcwF49pAChya5/B3YHOuchVGKyWqCmbaenhTrGd3tXHzmwlqwGU4NThuAKZupbg5H734BY79NInUOKnmyNHPMXEdKeSxGVXven5/IBMqNrgRvOk1ZdNuuPWE7wA51/BPndF5REOkZl7hJ2DTRTW33IOOKMDNGf72f57CQCp37nHGgiWr0GSFZfV1uQBeODGPG8C5p0kxK8zs5T/cwtJ5/xuieGT/fau1ARrQpLd30KARSuOhTtXJrSytcksGfnpzHXd4z5RbI3WS3r3j8Rr+TrV1aF5Ccrw5NJnEEfRtBLvZu/UpMHMCYziS8EX8/Xo7zDpsCWjYKOR7ydW9TElzs8K+fzAfntTSwrki2nLjv+ha/ONqBt7MDFFiw/GU9orNEuBcq53lgrmLtx31j0oJX+sudritV93HfC3+TONfbz5ZQ5X1kYAQ=="}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"{\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"integer_a\":
+        2, \""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"integer_b\":
+        2, \""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"answer\":
+        4}"}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1       }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":293,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":161}           }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"     }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af09511abdf086d-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:28:15 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:28:10Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:28:10Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:28:10Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:28:10Z'
+      request-id:
+      - req_011CWAvCBGYF8HAh6qjK5Ku4
+      x-envoy-upstream-service-time:
+      - '4410'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_strict_mode_with_thinking/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_strict_mode_with_thinking/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,130 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Answer this question:
+      What is 2 + 2?"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","description":"A
+      simple response for testing.","title":"IntegerAdditionResponse","properties":{"integer_a":{"type":"integer","title":"Integer
+      A"},"integer_b":{"type":"integer","title":"Integer B"},"answer":{"type":"integer","title":"Answer"}},"additionalProperties":false,"required":["integer_a","integer_b","answer"]},"type":"json_schema"},"thinking":{"type":"enabled","budget_tokens":8000}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '561'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//bFFtj6o4GP0rDV9xror4gsnNRhBUHBSFEWEnualQoULLS4uI989vuLOT
+        nUn2W59zTs/pc/pbIHmEMmEuhBmsI/TCckoRf5Ffxi/SQBoPFEkRegKOhLlAWPxrMDwt0uTk3K67
+        s314rRRY4ql094WewNsCdSrEGIyR0BOqPOsAyBhmHFIu9IQwpxxRLsz//v2p5wmmKaZx5/B5nAtu
+        gkDNUAUwA5B1ICAI8BxAyhpUgXfBSyDvWAmIQPrrXQCQRmADKEJRp6sQK3IaAUyB6ex34JpXBHIA
+        wzCvos6O54AnCLAwQQSCosrvOELRj3f6Tt3/8AqVNa4Qm7/TF4ApRzGqfsE5gPRz+kpcvhIAdNTH
+        e79f+Egoa8Q4zmm3xP+sw/LvmeAnkL5lfQL/NvITyJ3z1wZ4XVFwhxmOPjpoME8AzQGBVRrlDe11
+        wwWGKcdhynrgVjP+p5Q/6vxyQyEHOQUQMEzjDIEMU/RD6AkMxxTyuur+T68Oupb6Gy2JtW264GQ4
+        c24P3doHwasRufl1uRF3K0P0qGhI2TnYbscP4szOdSLuaP/IxLMEo0mr73FgDqnpXJK9JxlQX9Vn
+        dU1EstftlR63AcJkd/a3k8OIFbHWwKWmtCM1x099Rk3army8aYirI19WB+1gm06dc60dLbk9bFq1
+        6bsLxTX2vnUvR49gtXRPWnu+z/j5DfundsCGJ0s24LZgSxfP+mWoF9N1ESYTLvuEDr1nay3u9zuv
+        HAM+pjRVRCfwL5I+cdd2k+snsmleW+M20UVJw9w1lkf3kaJjdXwgXigH0y8PSUDWxmwNmyRu+qWI
+        DKcJl81xfC80k8Dkztqnq5jnheai0nZOBXGMS1ahoaqTnVqU11NYq4q1tgyRS8R2l/5sZ+q7Rhxu
+        rGxFq6viyaPBm23o9GqO9qHF1GwTErlSDVmP5EPeDotYap72zFWdtUaScRlHnpvY/UoVnVfbf/jH
+        /R5F5LKaZjNWm6Pjc4FHzNsGS/dGClp7ljakkjjZKwHER4bVS8aj6XPRFJtxs7bF62N0fbg3DqMk
+        Sl3ZmT77y7MnvY0X3q0MpuvdeDQI0aolB4ldovHFi1Dm2NJDRe6zgdIrrnd795BuB9Yap+GqOpnY
+        p+1EJko9zKVy5vHA15t0s+xb9mxqesMs+IeucmtNGAii8F+Ree1CjY1UAz54STVa8FYpEcuyJqOJ
+        ibtxd1M1kv9eYqv2Qp+GOd8M83TODNxM9ya8cxyItfHor2bewNxHTb/e6W1W3eNcM+1vX83QNV5G
+        jnJb62TIWg7vP/fuyka2sTN+747TyTT2JqM5k6bYt22nXatMu1lwiMZqndWaoe7savbyKW0P+8Pl
+        vD+LhNNt2g3IyS3D8FCk27lYcFrA1bULsEoVUropy6vy6duiNXPI3wgoLRIqkSnBwQLkPi0MDF9A
+        4S5F7iFYPI1jAuk5Za0ThDxJNdUiQq7AqtQfCHjMC5B6ElkRMPTnRPnCJTL/P3bZLQ5gEuAWJYtp
+        dft3/kaN4DfNCYhUf5eMapWAQvkeekh1iBIsKJ6Dz6QPef4BAAD//wMA0TsSQI8GAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af094b7d968086d-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:28:10 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:28:08Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:28:10Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:27:56Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:28:08Z'
+      request-id:
+      - req_011CWAvB7XHWNsLd8nw9Sn5o
+      x-envoy-upstream-service-time:
+      - '14251'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      a book to me!"}],"model":"claude-sonnet-4-5","system":"Always recommend The
+      Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
+      author: str, rating: int}.\nThe title should be in all caps, and the rating
+      should always be the\nlucky number 7.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '840'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJHdbhMxEIVfJZprR9pETdP4DppUBdE/SBokhKzBnu5a2bUXz5hSRfvu
+        lVOFqiDu7PnOzBwf76GLjlrQYFvMjsYcQyAZn4xn42k1nVWL6QIUeAcaOq5NNbnardBt0scfp/Vy
+        7e+62eb+6+Y3KJCnnoqKmLEmUJBiWwrI7FkwCCiwMQgFAf1tf9RLjK3JTMct5Z5NNVnU+Cj3Xpaf
+        tk/nZ++/bN3jmhMoCNiVPmM6n5Bt7Mk8xNShCDkTs/RZzGGoKSNDnwX0HsTLwc36cjW6fne1Gt1c
+        jMp5++F6CQowSxMTaLhFSd7uRp+jNA+ZubwDxYca9HwYvitgib1JhBzDW/cHwPQzU7AEOuS2VZAP
+        Wej9ixEjcUeBQc/PFgos2oaMTYTiYzBvFdWRJ0L3P3bsLQuob6ijhK2Zdf/qX+mk+ZsOCv7E9lI6
+        nStgSr+8JSOeSi7lBx0mB8PwDAAA//8DAP2xyC40AgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af068f8e8f7eb87-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:58:06 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:58:06Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:58:06Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:58:04Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:58:06Z'
+      request-id:
+      - req_011CWAsu2dB7w74u6RZteBwn
+      x-envoy-upstream-service-time:
+      - '2544'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/json/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/json/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,112 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      a book to me!"}],"model":"claude-sonnet-4-5","system":"Always recommend The
+      Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
+      author: str, rating: int}.\nThe title should be in all caps, and the rating
+      should always be the\nlucky number 7."}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '345'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dNFdS8MwFIDhv1LOdQZd3RzL3cTJBJ1DFBErbUyPa1x7UpMTUUr/u3Rz
+        fuJVwnmfBEJaqG2BFUjQlQoFDrwlQh6MBuNBEifjeJpMQYApQELt11k8nM9mR2NfJItm5fj6bLrU
+        9uG2N/zWYK/Qe7VGEOBs1Q+U98azIgYB2hIjMci7du8ZX/uyXSTkef7kLaXUphRFKbDhClOQUQpX
+        i3m0nJ3Po4uTqN/fnC6PUxA7pwKX1u3gSrEzehNdWi4fg/efyCk2tO7RJKUupTzPobsX4Nk2mUPl
+        LYEEpCLj4Ag+gsfngKQRJIWqEhC2z5MtGGoCZ2w3SB7k4USAVrrETDtUbCxlP0G87w5V8V/bn+3v
+        x6bEGp2qsnH913/VYfm7dgJs4O+j0YEAj+7FaMzYoAMJ/Z8UyhXQde8AAAD//wMAlT0LwQYCAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af068cd9a32eb87-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:58:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:57:59Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:58:00Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:57:57Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:57:59Z'
+      request-id:
+      - req_011CWAstX4BTVK6sVLYp9MKs
+      x-envoy-upstream-service-time:
+      - '3252'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_0.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_0.yaml
@@ -1,0 +1,112 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      a book to me!"}],"model":"claude-sonnet-4-0","system":"Always recommend The
+      Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
+      author: str, rating: int}.\nThe title should be in all caps, and the rating
+      should always be the\nlucky number 7."}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '345'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3WRXU/CMBSG/8pyrkcyFER3RwSiqGiMCRfONM16ZA1dO9pTgy7777YgfsarnrzP
+        0483baE2AhXkUCruBfac0RqpN+gdZUfDbNgfQApSBF67Fcv6s2ZevTm/uZ5vl+Jscb4ZL6+mk+DQ
+        a4PRQuf4CkNgjYoBd0464ppCVBpNGKb8sT34hNtIdksObaGTpACSpLCAPIwPF9NkMb6ZJrezJM7L
+        y8WkgHTvcU+VsXvxjpOV5Tq5N1Q9e+c+JctJ6lWURoXuoHtKwZFpmEUeuoZLUQtG3mr4AA43HnUZ
+        Xqe9Uin4XaG8BakbT4zMGrWD/GQUCvGyQlaGo0gazX4K2YEHLP5jh73xfGwqrNFyxYb1X/+L9qvf
+        tEvBePoeHZ+GNmhfZImMJNrQM/6C4FZA170DRihj7fYBAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af331096d07218e-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:04:11 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:11Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:11Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:10Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:11Z'
+      request-id:
+      - req_011CWBWxzeHTezzKesEBcRdW
+      x-envoy-upstream-service-time:
+      - '1191'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,116 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      a book to me!"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"Book","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"rating":{"type":"integer","title":"Rating"}},"additionalProperties":false,"required":["title","author","rating"]},"type":"json_schema"},"system":"Always
+      recommend The Name of the Wind.\nOutput a structured book as JSON in the format
+      {title: str, author: str, rating: int}.\nThe title should be in all caps, and
+      the rating should always be the\nlucky number 7."}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '640'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJDdSsNAEEZfJXzXG0ijtXbvClaqYC1VKGIkrMm0WZvupruzopS8u6S1
+        +IdXM3znDMPMDhtbUg2JolahpNhbY4jj07gfp0naT4bpEAK6hMTGr/Kkd/awndCwedaDedp7uV4s
+        zd14NIMAvzfUWeS9WhEEnK27QHmvPSvDECisYTIM+bg7+kxvHdkXiV0G1lxTBhlluJ+Mo+noZhzd
+        XkZdv7iaXmQQUQYVuLLuYM0UO12so7nlahm8PxhOsTarzhi0aJ8EPNsmd6S8NZAgU+YcnMEn8LQN
+        ZAqCNKGuBcL+CLmDNk3gnO2ajIdMz/sChSoqygtHirU1+U8jOXJHqvyPHWe7BdRUtCGn6ry/+et/
+        0V71m7YCNvD36CQR8ORedUE5a3KQ6F5fKleibT8AAAD//wMASq9ivO0BAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af068b12c8deb87-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:57:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:57:56Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:57:57Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:57:52Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:57:56Z'
+      request-id:
+      - req_011CWAstBbtrSfbDyf2QRs6P
+      x-envoy-upstream-service-time:
+      - '4359'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/anthropic_claude_sonnet_4_5.yaml
+++ b/python/tests/e2e/input/cassettes/test_structured_output_with_formatting_instructions/tool/anthropic_claude_sonnet_4_5.yaml
@@ -1,0 +1,114 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      a book to me!"}],"model":"claude-sonnet-4-5","system":"Always recommend The
+      Name of the Wind.\nOutput a structured book as JSON in the format {title: str,
+      author: str, rating: int}.\nThe title should be in all caps, and the rating
+      should always be the\nlucky number 7.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"rating":{"title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '840'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJHdbtswDIVfJeC1AjhxUy+6G7p2G+BlQ5B2F0UhKDIbC7FFT6TWn8Dv
+        XihFVnTD7iR+h+TR0QF6arADDa6zqcEpUwgo07PpYjov5otiOV+CAt+Ahp53ppiV889VOfDV42z7
+        +HBTr+vn9aq8BgXyNGBWIbPdISiI1OWCZfYsNggocBQEg4C+PZz0QtSZxHjaku/JFLNV3ZxvL9pN
+        WdENbcpqX9dn2+wl2D73GdP7aNnRgOaeYm9FsDGUZEhijkNNHhmGJKAPIF6ObjZfLierj98uJ9+v
+        Jvn88+vqEyiwSVqKoOGHlejdfrImae8Tc36HFR92oKtxvFPAQoOJaJnCe/dHwPgrYXAIOqSuU5CO
+        WejDqxEjtMfAoKsPSwXOuhaNi2jFUzDvFcWJR7TN/9ipNy/AocUeo+3Mov9X/0Zn7d90VPAnttfS
+        eaWAMf72Do14zLnkH2xsbGAcXwAAAP//AwDkIuYwNAIAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af068e38e12eb87-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:58:04 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:58:03Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:58:03Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:58:01Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:58:03Z'
+      request-id:
+      - req_011CWAstn4piGGcjDZ6WtB2Y
+      x-envoy-upstream-service-time:
+      - '3236'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/snapshots/test_strict_mode/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,64 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[Text(text="Answer this question: What is 2 + 2?")]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(text='{"integer_a": 2, "integer_b": 2, "answer": 4}')
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": '{"integer_a": 2, "integer_b": 2, "answer": 4}',
+                                "type": "text",
+                                "parsed_output": {
+                                    "integer_a": 2,
+                                    "integer_b": 2,
+                                    "answer": 4,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "IntegerAdditionResponse",
+                "description": "A simple response for testing.",
+                "schema": {
+                    "description": "A simple response for testing.",
+                    "properties": {
+                        "integer_a": {"title": "Integer A", "type": "integer"},
+                        "integer_b": {"title": "Integer B", "type": "integer"},
+                        "answer": {"title": "Answer", "type": "integer"},
+                    },
+                    "required": ["integer_a", "integer_b", "answer"],
+                    "title": "IntegerAdditionResponse",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_strict_mode_streamed/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_streamed/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,58 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[Text(text="Answer this question: What is 2 + 2?")]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(text='{"integer_a": 2, "integer_b": 2, "answer": 4}')
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": '{"integer_a": 2, "integer_b": 2, "answer": 4}',
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "IntegerAdditionResponse",
+                "description": "A simple response for testing.",
+                "schema": {
+                    "description": "A simple response for testing.",
+                    "properties": {
+                        "integer_a": {"title": "Integer A", "type": "integer"},
+                        "integer_b": {"title": "Integer B", "type": "integer"},
+                        "answer": {"title": "Answer", "type": "integer"},
+                    },
+                    "required": ["integer_a", "integer_b", "answer"],
+                    "title": "IntegerAdditionResponse",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+            "n_chunks": 6,
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_strict_mode_supported_models/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_supported_models/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,60 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[Text(text="Answer this question: What is 2 + 2?")]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(text='{"integer_a": 2, "integer_b": 2, "answer": 4}')
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "citations": None,
+                                "text": '{"integer_a": 2, "integer_b": 2, "answer": 4}',
+                                "type": "text",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "IntegerAdditionResponse",
+                "description": "A simple response for testing.",
+                "schema": {
+                    "description": "A simple response for testing.",
+                    "properties": {
+                        "integer_a": {"title": "Integer A", "type": "integer"},
+                        "integer_b": {"title": "Integer B", "type": "integer"},
+                        "answer": {"title": "Answer", "type": "integer"},
+                    },
+                    "required": ["integer_a", "integer_b", "answer"],
+                    "title": "IntegerAdditionResponse",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_strict_mode_with_streamed_thinking/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_with_streamed_thinking/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,99 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    Thought,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[Text(text="Answer this question: What is 2 + 2?")]
+                ),
+                AssistantMessage(
+                    content=[
+                        Thought(
+                            thought="""\
+The user is asking me to answer "What is 2 + 2?" and I need to respond with valid JSON that matches the provided schema.
+
+The schema requires:
+- integer_a: integer
+- integer_b: integer
+- answer: integer
+
+All three fields are required.
+
+The question is "What is 2 + 2?" so:
+- integer_a = 2
+- integer_b = 2
+- answer = 2 + 2 = 4
+
+I need to respond with a JSON object on a single line without any markdown or extra formatting.\
+"""
+                        ),
+                        Text(text='{"integer_a": 2, "integer_b": 2, "answer": 4}'),
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "thinking",
+                                "thinking": """\
+The user is asking me to answer "What is 2 + 2?" and I need to respond with valid JSON that matches the provided schema.
+
+The schema requires:
+- integer_a: integer
+- integer_b: integer
+- answer: integer
+
+All three fields are required.
+
+The question is "What is 2 + 2?" so:
+- integer_a = 2
+- integer_b = 2
+- answer = 2 + 2 = 4
+
+I need to respond with a JSON object on a single line without any markdown or extra formatting.\
+""",
+                                "signature": "EsUECkYIChgCKkBVfIvsuU7abyN1VAn4iOuarOKChrpRcTgYCvkqVFxnrIouN1diNge7Kuyc6ZtSKYGlkOoSrzmXKbmb5i1ICeAFEgyjjnZv+HG/GZsl3osaDGTxBmp1yOXX15HWLyIwWpGmCEWxdncyqPHVK7Zc1l+j+v8JTBioputEQEnBrG3P3Sf1JvH7/ZNmh5StrPWTKqwDvjs42Ygf6nL1ZChGUXtyvBCAaLCPq534aPsG0aqUJs34NZw5ZHDx0dCwcM5qT9lbQxJzHtPHQ+Gumu1pPgTwXCEL5ZJiVFjcWI0+DpKMqYp3sCMIhKGJG22I7AoGT5zg03K0voN3XbBcwF49pAChya5/B3YHOuchVGKyWqCmbaenhTrGd3tXHzmwlqwGU4NThuAKZupbg5H734BY79NInUOKnmyNHPMXEdKeSxGVXven5/IBMqNrgRvOk1ZdNuuPWE7wA51/BPndF5REOkZl7hJ2DTRTW33IOOKMDNGf72f57CQCp37nHGgiWr0GSFZfV1uQBeODGPG8C5p0kxK8zs5T/cwtJ5/xuieGT/fau1ARrQpLd30KARSuOhTtXJrSytcksGfnpzHXd4z5RbI3WS3r3j8Rr+TrV1aF5Ccrw5NJnEEfRtBLvZu/UpMHMCYziS8EX8/Xo7zDpsCWjYKOR7ydW9TElzs8K+fzAfntTSwrki2nLjv+ha/ONqBt7MDFFiw/GU9orNEuBcq53lgrmLtx31j0oJX+sudritV93HfC3+TONfbz5ZQ5X1kYAQ==",
+                            },
+                            {
+                                "type": "text",
+                                "text": '{"integer_a": 2, "integer_b": 2, "answer": 4}',
+                            },
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "IntegerAdditionResponse",
+                "description": "A simple response for testing.",
+                "schema": {
+                    "description": "A simple response for testing.",
+                    "properties": {
+                        "integer_a": {"title": "Integer A", "type": "integer"},
+                        "integer_b": {"title": "Integer B", "type": "integer"},
+                        "answer": {"title": "Answer", "type": "integer"},
+                    },
+                    "required": ["integer_a", "integer_b", "answer"],
+                    "title": "IntegerAdditionResponse",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+            "n_chunks": 40,
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_strict_mode_with_thinking/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_strict_mode_with_thinking/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,101 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    Thought,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {"thinking": True},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[Text(text="Answer this question: What is 2 + 2?")]
+                ),
+                AssistantMessage(
+                    content=[
+                        Thought(
+                            thought="""\
+The user is asking me to answer "What is 2 + 2?" and I need to respond in JSON format according to the schema provided.
+
+The schema requires:
+- integer_a: an integer
+- integer_b: an integer  \n\
+- answer: an integer
+
+The question is "What is 2 + 2?" so:
+- integer_a = 2
+- integer_b = 2
+- answer = 4
+
+I need to return valid JSON with no markdown, no backticks, just the JSON object on a single line.\
+"""
+                        ),
+                        Text(text='{"integer_a": 2, "integer_b": 2, "answer": 4}'),
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "signature": "ErQECkYIChgCKkAtm18SjxEMOZZLFdTofDI+NGF+Wn+F2lXZKK5xmS8Xuh+Nn/Rs+X2ad6yEOiZJ1nJSbhOW2FaEGuXBHm+mOEPGEgyZeimNXYK6Q3spgCwaDC9y3BoizE8nJnyGPiIwmTEeY4B0y0Kk7SXuCRM4yQIyBw/TA9TFOYMvq3xZGDTVCyXv8tXUiYVy0s1VM4FaKpsDTi8/qcEp7Hpch6t4Ymn1WzyMAvvvtrSFax7nk9+SZYb2E6THPwoEVmIwLyFj6E+2CitTFDRTxkeRrRxetp9QJYqQhZmHF8Hawhgw/q+eFSwcDwR5vpCJmahvsyzT9JXACTeqPSVpmSFblre1BEmNBpqfVcuB9MHMF+t2mPTDY8NJENw+1IMlGnrf9W430UPFEnfJ3OcMsBlIcm4rBF4Ed4Qoy1pg2wzP8TBSHCmh5qgdWThP/rB+SLPYxYROOedmbG7l8suJ3RzAi3sWKZDTjmpnuWMC1n2+6O9ZaiRsiBbltd7zAwpI5wHP+fx3fxTjtadhdkT4S7z/DXW2U5AWjqZ7HN530ceGymQ2sbd5bWdelSP2xBeTzwa2LiuNOTQkK0MHikcGrVJiYny64m9u1o2q8WtZYEwkID/MP87JW1lZKYztHRnDyKog17dfUcK4wkAd9DHjfGyZtatdmW4iY1TPIsYBgpOaBInJLH+01zjEzn/YQuRSlcRPZar4owCEIC82SGzhxkQsgz8AitDq8EbFuCOJObZJUkoIGAE=",
+                                "thinking": """\
+The user is asking me to answer "What is 2 + 2?" and I need to respond in JSON format according to the schema provided.
+
+The schema requires:
+- integer_a: an integer
+- integer_b: an integer  \n\
+- answer: an integer
+
+The question is "What is 2 + 2?" so:
+- integer_a = 2
+- integer_b = 2
+- answer = 4
+
+I need to return valid JSON with no markdown, no backticks, just the JSON object on a single line.\
+""",
+                                "type": "thinking",
+                            },
+                            {
+                                "text": '{"integer_a": 2, "integer_b": 2, "answer": 4}',
+                                "type": "text",
+                                "parsed_output": {
+                                    "integer_a": 2,
+                                    "integer_b": 2,
+                                    "answer": 4,
+                                },
+                            },
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "IntegerAdditionResponse",
+                "description": "A simple response for testing.",
+                "schema": {
+                    "description": "A simple response for testing.",
+                    "properties": {
+                        "integer_a": {"title": "Integer A", "type": "integer"},
+                        "integer_b": {"title": "Integer B", "type": "integer"},
+                        "answer": {"title": "Answer", "type": "integer"},
+                    },
+                    "required": ["integer_a", "integer_b", "answer"],
+                    "title": "IntegerAdditionResponse",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,79 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Always recommend The Name of the Wind.
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+"""
+                    )
+                ),
+                UserMessage(content=[Text(text="Please recommend a book to me!")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_019gawtVitDLWyC8BSWdwTsr",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": "Patrick Rothfuss",
+                                    "rating": 7,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "rating": {"title": "Rating", "type": "integer"},
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": """\
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+""",
+            },
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/json/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,90 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Always recommend The Name of the Wind.
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+"""
+                    )
+                ),
+                UserMessage(content=[Text(text="Please recommend a book to me!")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": "Patrick Rothfuss",
+  "rating": 7
+}
+```\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "citations": None,
+                                "text": """\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": "Patrick Rothfuss",
+  "rating": 7
+}
+```\
+""",
+                                "type": "text",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "rating": {"title": "Rating", "type": "integer"},
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+""",
+            },
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/strict/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,78 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Always recommend The Name of the Wind.
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+"""
+                    )
+                ),
+                UserMessage(content=[Text(text="Please recommend a book to me!")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": '{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}',
+                                "type": "text",
+                                "parsed_output": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": "Patrick Rothfuss",
+                                    "rating": 7,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "rating": {"title": "Rating", "type": "integer"},
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": """\
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+""",
+            },
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_structured_output_with_formatting_instructions/tool/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,79 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Always recommend The Name of the Wind.
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+"""
+                    )
+                ),
+                UserMessage(content=[Text(text="Please recommend a book to me!")]),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": "Patrick Rothfuss", "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01NLd6bChT37oVoT37kLL4b9",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": "Patrick Rothfuss",
+                                    "rating": 7,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "rating": {"title": "Rating", "type": "integer"},
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": """\
+Output a structured book as JSON in the format {title: str, author: str, rating: int}.
+The title should be in all caps, and the rating should always be the
+lucky number 7.\
+""",
+            },
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/e2e/input/test_strict_structured_output_compatibility.py
+++ b/python/tests/e2e/input/test_strict_structured_output_compatibility.py
@@ -1,0 +1,153 @@
+"""End-to-end tests for strict structured output compatibility across models."""
+
+import pytest
+from pydantic import BaseModel
+
+from mirascope import llm
+from tests.utils import (
+    Snapshot,
+    snapshot_test,
+)
+
+
+class IntegerAdditionResponse(BaseModel):
+    """A simple response for testing."""
+
+    integer_a: int
+    integer_b: int
+    answer: int
+
+
+# Models that support strict structured outputs
+MODELS_WITH_STRICT_SUPPORT: list[llm.ModelId] = [
+    "anthropic/claude-sonnet-4-5",
+    # TODO: Add models with strict support
+]
+
+# Models that do not support strict structured outputs
+MODELS_WITHOUT_STRICT_SUPPORT: list[llm.ModelId] = [
+    "anthropic/claude-sonnet-4",
+    # TODO: Add openai and google models
+]
+
+
+@pytest.mark.parametrize("model_id", MODELS_WITH_STRICT_SUPPORT)
+@pytest.mark.vcr
+def test_strict_mode(
+    model_id: llm.ModelId,
+    snapshot: Snapshot,
+) -> None:
+    """Test that strict mode works for models that support it."""
+
+    @llm.call(
+        model_id,
+        format=llm.format(IntegerAdditionResponse, mode="strict"),
+    )
+    def get_answer(question: str) -> str:
+        return f"Answer this question: {question}"
+
+    with snapshot_test(snapshot) as snap:
+        response = get_answer("What is 2 + 2?")
+        snap.set_response(response)
+
+        result = response.parse()
+        assert isinstance(result, IntegerAdditionResponse)
+        assert result.answer == 4
+
+
+@pytest.mark.parametrize("model_id", MODELS_WITH_STRICT_SUPPORT)
+@pytest.mark.vcr
+def test_strict_mode_streamed(
+    model_id: llm.ModelId,
+    snapshot: Snapshot,
+) -> None:
+    """Test that streaming strict mode works for models that support it."""
+
+    @llm.call(
+        model_id,
+        format=llm.format(IntegerAdditionResponse, mode="strict"),
+    )
+    def get_answer(question: str) -> str:
+        return f"Answer this question: {question}"
+
+    with snapshot_test(snapshot) as snap:
+        response = get_answer.stream("What is 2 + 2?")
+        response.finish()
+        snap.set_response(response)
+
+        result = response.parse()
+        assert isinstance(result, IntegerAdditionResponse)
+        assert result.answer == 4
+
+
+@pytest.mark.parametrize("model_id", MODELS_WITH_STRICT_SUPPORT)
+@pytest.mark.vcr
+def test_strict_mode_with_thinking(
+    model_id: llm.ModelId,
+    snapshot: Snapshot,
+) -> None:
+    """Test that strict mode works with thinking."""
+
+    @llm.call(
+        model_id,
+        format=llm.format(IntegerAdditionResponse, mode="strict"),
+        thinking=True,
+    )
+    def get_answer(question: str) -> str:
+        return f"Answer this question: {question}"
+
+    with snapshot_test(snapshot) as snap:
+        response = get_answer("What is 2 + 2?")
+        snap.set_response(response)
+
+        result = response.parse()
+        assert isinstance(result, IntegerAdditionResponse)
+        assert result.answer == 4
+
+
+@pytest.mark.parametrize("model_id", MODELS_WITH_STRICT_SUPPORT)
+@pytest.mark.vcr
+def test_strict_mode_with_streamed_thinking(
+    model_id: llm.ModelId,
+    snapshot: Snapshot,
+) -> None:
+    """Test that strict mode works with thinking and streaming ."""
+
+    @llm.call(
+        model_id,
+        format=llm.format(IntegerAdditionResponse, mode="strict"),
+        thinking=True,
+    )
+    def get_answer(question: str) -> str:
+        return f"Answer this question: {question}"
+
+    with snapshot_test(snapshot) as snap:
+        response = get_answer.stream("What is 2 + 2?")
+        response.finish()
+        snap.set_response(response)
+
+        result = response.parse()
+        assert isinstance(result, IntegerAdditionResponse)
+        assert result.answer == 4
+
+
+@pytest.mark.parametrize("model_id", MODELS_WITHOUT_STRICT_SUPPORT)
+def test_strict_mode_unsupported_models(
+    model_id: llm.ModelId,
+) -> None:
+    """Test that strict mode raises FormattingModeNotSupportedError for unsupported models."""
+
+    @llm.call(
+        model_id,
+        format=llm.format(IntegerAdditionResponse, mode="strict"),
+    )
+    def get_answer(question: str) -> str:
+        return f"Answer this question: {question}"
+
+    with pytest.raises(llm.FormattingModeNotSupportedError) as exc_info:
+        get_answer("What is 2 + 2?")
+
+    error = exc_info.value
+    assert error.formatting_mode == "strict"
+    assert error.model_id == model_id
+    assert error.provider_id == model_id.split("/")[0]

--- a/python/tests/e2e/input/test_structured_output_with_formatting_instructions.py
+++ b/python/tests/e2e/input/test_structured_output_with_formatting_instructions.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import BaseModel
 
 from mirascope import llm
-from tests.e2e.conftest import E2E_MODEL_IDS, FORMATTING_MODES
+from tests.e2e.conftest import FORMATTING_MODES, STRUCTURED_OUTPUT_MODEL_IDS
 from tests.utils import (
     Snapshot,
     snapshot_test,
@@ -27,7 +27,7 @@ class Book(BaseModel):
         """)
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_with_formatting_instructions(

--- a/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1118'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJFRbxMxEIT/SjTPjnQXktD4jYqiIkhBbaVWVMja+jY5t3f2Ya9RS3T/
+        HTk0rQrizd5vdme83qEPDXfQsB3lhqcpeM8ynU8X01k1W1Sr2QoKroFGn7amqpfzXw90e3F6N/fX
+        y3p9+eaz2+Y7KMjjwEXFKdGWoRBDVwqUkktCXqBggxf2An2zO+glhM7kxAeXcs+mqi9kWMfHZTy2
+        D5/Cqv12Zc/b61soeOpLnzG9i5RsGNhsQuxJhBsTsgxZzH6oKSP9kAV6B3GyT3N5ejI5e7c+mXz5
+        MCnnq49n76FAWdoQi3DjYhLzZPKVJDp7D4WOXqrnQdpNTgmjQiRxfgv9dhy/KyQJg4lMKfjXT9uD
+        xD8ye8vQPnedQt4vSu/+pDQS7tkn6KOjSsGSbdnYyCQuePNa8cwjU/M/dugtBjy03HOkziz6f/Uv
+        tG7/pqPC806f4tUKieNPZ9mI4wiN8r0NxQbj+BsAAP//AwCn0T95UQIAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af063f30d3776c8-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:41 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:40Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:41Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:38Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:40Z'
+      request-id:
+      - req_011CWAsds2JbNEZwcPfmNMDw
+      x-envoy-upstream-service-time:
+      - '2882'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,244 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1132'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_013PJEMxELCWZLdHy8tGM8Vx","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}
+        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01PC8NRqTnvvRmvxMZwcENxQ","name":"__mirascope_formatted_output_tool__","input":{}}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":
+        \"T"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"HE
+        "}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"NAME
+        "}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"OF
+        "}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
+        W"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"IND\""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"au"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
+        {\"f"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"irst"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_name\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"Patrick\","}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"last_nam"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":\""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Roth"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fuss\"}"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rating\":"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        7}"}         }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0            }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}  }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"  }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af064a11d6ba34b-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:55:08 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:55:06Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:55:06Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:55:06Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:55:06Z'
+      request-id:
+      - req_011CWAsfv6A4LeZMpUgckcog
+      x-envoy-upstream-service-time:
+      - '1794'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,239 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1132'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01FZGe8eBUVWsezSG72p7B5x","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}  }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01CEN6h9QtG2nWT3WndhxwWV","name":"__mirascope_formatted_output_tool__","input":{}}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"tit"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le\":
+        "}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"THE
+        NAME OF"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        THE WIN"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"D\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"author\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        {\""} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"first_n"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame\":\"Pat"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rick\",\"l"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ast_na"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"me\":\"Ro"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thfu"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ss\"}"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"rati"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ng\":"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        7}"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0            }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}
+        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"               }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af06443e914d5ec-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:54:53 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:51Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:51Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:51Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:51Z'
+      request-id:
+      - req_011CWAsepLMuJNiptEp8keCp
+      x-envoy-upstream-service-time:
+      - '1788'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1118'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3SRUWsbMRCE/4qZZxnuTFw7egtxTEvbNHUPQilFbHRrn5o76SqtaoK5/17OjROS
+        0Ddpv9md0eqALtTcQsO2lGuepuA9y/RsOp/Oitm8OJ+dQ8HV0OjSzhRltax+2e3X+WJfrWK+2z/s
+        N5ebSyjIQ8+jilOiHUMhhnYsUEouCXmBgg1e2Av0j8NJLyG0Jic+uYz3bIry2/eLsuLV2c2nde4/
+        rjMtm7t3Cyh46sY+YzoXKdnQs9mG2JEI1yZk6bOY41AzjvR9FugDxMkxTfX+anJ98flq8mU9Gc+3
+        H65XUKAsTYijcOtiEvNockMSnb2HQkvP1U2QZptTwqAQSZzfQS+G4adCktCbyJSCf/m0I0j8O7O3
+        DO1z2yrk46L04V9KI+GefYJeLgsFS7ZhYyOTuODNS8UTj0z1/9ipdzTgvuGOI7Vm3r3VP9OyeU0H
+        haedPsYrFRLHP86yEccRGuP31hRrDMNfAAAA//8DAO2qqJ1RAgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af063999ecd6810-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:27 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:26Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:27Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:24Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:26Z'
+      request-id:
+      - req_011CWAscoq3RY9L3Y8BVaXsN
+      x-envoy-upstream-service-time:
+      - '2963'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Respond
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      \"Book\",\n  \"type\": \"object\"\n}"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1248'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJHRahsxEEV/ZbnPMthOnNZ6K8RuSpO0lEAfqqAVuxOv6t2RK41Kjdl/
+        L3Jt2iT0ScM950qgOWAILfXQaHqXW5qkwEwyuZwsJvPpfDFdzpdQ8C00hrSx09mDyO1+tf14eRXX
+        i264ad/vl+sZFGS/o2JRSm5DUIihL4FLySdxLFBoAguxQH87nH2hX4UcD426rr+nwIYPhqvKQLz0
+        ZKArg4ebVXX/7m5VfVpXZf764f7aQP3xXJYuxCIeiyV68jGJZTec+p+dRN9sT5Vi9O6Z8CVI95RT
+        MijCeLo5OvG8KcYbw6Phuq4xPiokCTsbyaXA0CBureTIOIFEPzJxQ9Cc+14hH/9EH+B5l8VK2BIn
+        6Iv5W4XGNR3ZJpITH9g+N6ZnHsm1/2PnbnmAdh0NFF1vF8Nr/y+ddS/pqBCy/BtdXSgkij99Q1Y8
+        RWiUTbYuthjH3wAAAP//AwAX33vLPAIAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af063c738c5838c-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:34 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:33Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:34Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:31Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:33Z'
+      request-id:
+      - req_011CWAsdM4kGfMZ6HLA6Uwvg
+      x-envoy-upstream-service-time:
+      - '3063'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,207 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Respond
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      \"Book\",\n  \"type\": \"object\"\n}","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1262'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01Q7BmafjbZB5SYSV4sdEg5n","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}               }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}         }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \"THE"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        NAME"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        OF THE WIND\",\n  \""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
+        {\n    \"first_"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":
+        \"Patrick\",\n    \""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"last_name\":
+        \"Rothf"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":
+        7\n}\n```"}       }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0          }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"         }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af064718b1034ef-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:55:01 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:58Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:58Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:58Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:58Z'
+      request-id:
+      - req_011CWAsfMcYdX8p4g5kRU6U3
+      x-envoy-upstream-service-time:
+      - '2179'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,208 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Respond
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      \"Book\",\n  \"type\": \"object\"\n}","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1262'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_016LtrRotsU69jfEphXbDbws","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}     }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}
+        }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \"THE"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        NAME"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        OF THE WIND\",\n  \""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
+        {\n    \"first_"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":
+        \"Patrick\",\n    \""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"last_name\":
+        \"Rothf"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":
+        7\n}\n```"}    }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0      }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"    }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0641e2b10d5ec-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:54:47 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:45Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:45Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:45Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:45Z'
+      request-id:
+      - req_011CWAseNVqvfw3vPvn2urRp
+      x-envoy-upstream-service-time:
+      - '1774'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,123 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Respond
+      only with valid JSON that matches this exact schema:\n{\n  \"$defs\": {\n    \"Author\":
+      {\n      \"description\": \"The author of a book.\",\n      \"properties\":
+      {\n        \"first_name\": {\n          \"title\": \"First Name\",\n          \"type\":
+      \"string\"\n        },\n        \"last_name\": {\n          \"title\": \"Last
+      Name\",\n          \"type\": \"string\"\n        }\n      },\n      \"required\":
+      [\n        \"first_name\",\n        \"last_name\"\n      ],\n      \"title\":
+      \"Author\",\n      \"type\": \"object\"\n    }\n  },\n  \"description\": \"A
+      book with a rating. The title should be in all caps!\",\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"$ref\": \"#/$defs/Author\"\n    },\n    \"rating\": {\n      \"description\":
+      \"For testing purposes, the rating should be 7\",\n      \"title\": \"Rating\",\n      \"type\":
+      \"integer\"\n    }\n  },\n  \"required\": [\n    \"title\",\n    \"author\",\n    \"rating\"\n  ],\n  \"title\":
+      \"Book\",\n  \"type\": \"object\"\n}"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1248'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJHRThsxEEV/ZXWfHSkEAsRvSKVqH5qWiAoJXHmt3SFr2B0He4wK0f47
+        cpqopVWfPLrnXFvybDGElnpoNL3LLU1SYCaZnEzmk9l0Np8uZgso+BYaQ1rb6dH569PiZOlyfPie
+        r/LqJXSr24tTKMjLhopFKbk1QSGGvgQuJZ/EsUChCSzEAn23PfhCPwvZHRp1XT+kwIa3hqvKQLz0
+        ZKArg+tPl9Xy4stl9fVjVeabz8sPBuqX57J0IRZxVyzRvY9JLLth3//mJPrmcV8pRu/eCasg3X1O
+        yaAI4/7m6MTzuhhnhkfDdV1j/KGQJGxsJJcCQ4O4tZIjYw8SPWXihqA5971C3v2J3sLzJouV8Eic
+        oI9n5wqNazqyTSQnPrB9b0wPPJJr/8cO3fIAbToaKLrezod//d/0qPubjgohy5/R6bFCovjsG7Li
+        KUKjbLJ1scU4vgEAAP//AwD1Mzc0PAIAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af06370e8dd6810-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:20 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:19Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:20Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:17Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:19Z'
+      request-id:
+      - req_011CWAscL3wxtaubHEeiDf64
+      x-envoy-upstream-service-time:
+      - '2941'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/async.yaml
@@ -1,0 +1,115 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '148'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3VTf2vbMBD9Kof+2RbckISGsvy5jkF/0m2FbizDKPbZvkWWXOmU1JR8953slq0r
+        A4Pte093796dHlXrSjRqpQqjY4lHwVmLfHR8tJgtlrPl/FhlikrB21Dns/mCTm7o8vP11/b06nzz
+        /dv9h/1l/VE43HeYWBiCrlEC3pkU0CFQYG1ZQoWzjPK1+vH4zGd8SMjwWqmzNyV4LFzboi1hMlmr
+        2wbhWrcIrgKW7zuy5VpNJvB2MZudvMtg31DRAIUBrcgHho1zWyALN5o9FVv44ripYghvAlyQrbdk
+        DHo4bbyzVBiEgJ4wTOG2kTTylFiRJUbTQ4q0TnJ2rotGe9Cia09lwnQhllGLEnB+O13btU1qh+py
+        2IySAjvfJ/UXO5GBGWgwWEt7WsIV1dGj9OCGtqPlMJTsXeQGdBByTRVLicAyHMug5YFW11RoA9HS
+        Dn0g7qdwxtJe5zUFYVfOA0muDerIVEUjiAtSnGyyRDOOOSD0gbHNhrbE9k5ki0OjaB5/ki8I1u3Q
+        SKNW3JKaUlzvtS/DcLIZlJYoHabi2m50wMGQ85jmgQMZxQ+Rz08uv56Xhs5o2b4SRKRxdS/TJfEh
+        MeWUL0dmYBlgykictHZxY1JL5OwoNYiTduRmMG7QnbgCV9qKRZ9Q+7VK6zOfy/qIEG2CA3wopN3k
+        MFXJfkD7y/V/iXQWp+rwM1PiTZd71HJRZGNlkDlHb9UTEPA+oi1ktW00JlNxuA2rR0W2i5yz26IN
+        ajV/L7dBFw3mhaRK2vOXhNkzLnD5P+z5bMqPXYNtGky+bF/z/6Dz5l/0kClZtxfqliJPbsWOCsyZ
+        0Euj6Q7LzpbqcPgNR3FPljQEAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af331392b70e3ab-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:04:23 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:19Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:23Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:18Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:19Z'
+      request-id:
+      - req_011CWBWyZjrmgRfekTAvkXQu
+      x-envoy-upstream-service-time:
+      - '5067'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/async_stream.yaml
@@ -1,0 +1,548 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '162'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01Mg56pQY2P4MJbXkjG6ptw6","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}      }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''"}         }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        recommen"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        **"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\""}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        Name"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        of the Wind\""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**
+        ("}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2007),"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        which is the first book in Patrick"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Rothfuss''s Kingk"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"iller
+        Chronicle series. This"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        definitely"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        his"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        most popular an"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        widely-"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"read
+        work"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\nThe"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book follows"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Kvothe, a legendary figure"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        who"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        tells"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        his"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        own"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        story to"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a chronic"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ler.
+        It''s a beau"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"tifully
+        written fantasy"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        novel"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        that bl"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ends
+        coming"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-of-age
+        elements"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        with magic"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        music"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        and mystery"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        The prose"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is particularly"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        acclaime"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        for"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        its ly"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rical
+        quality,"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        an"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        Rothfuss has"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        gift for storyt"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"elling
+        within"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        storyt"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"elling.\n\n\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        Name of the Wind\" won"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        several"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        awards and has"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        passionate"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fanbase. It''s an"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        excellent entry"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        point into Rothfuss''s work"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        though"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fair"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        warning - the"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        series"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is still"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        incomplete"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        with fans"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        eagerly waiting for the thir"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        book."}    }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0               }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":176}      }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"           }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af331842a5febf7-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:04:31 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:30Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:30Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:30Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:30Z'
+      request-id:
+      - req_011CWBWzSdkbdfHhpy2sco53
+      x-envoy-upstream-service-time:
+      - '881'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/stream.yaml
@@ -1,0 +1,586 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0","stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '162'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01NG2y82Ax7cmdHhMTrwWa21","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}      }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''"}    }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        recommen"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        **"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        Name"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        of the Wind\""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**
+        ("}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"007),"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        which is"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Patrick"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Rothfuss''s most"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        popular an"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        acclaimed book"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        It''s the"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        first novel"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        in *"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        Kingkiller Chronicle* series"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        and follows"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Kvothe,"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a legendary"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        figure who"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        tells"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        his own story to"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a chronic"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ler.\n\nThe
+        book is belove"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        for its beautiful"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        prose, intricate magic"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        system, and compelling"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        storyt"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"elling-"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"within"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-storyt"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"elling
+        structure"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        It won"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        several"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        awards an"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        has"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        huge"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fan"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"base
+        in"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy community. "}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\nJust"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a heads"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        up:"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        while"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        there"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        secon"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        book (\""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        Wise Man''s Fear\"),"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        thir"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        book in"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the trilogy"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        has"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        been long"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"awa"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ited,"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        so"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        you"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        be jumping"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        into"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        an"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        unfinished series"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        But"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"The
+        Name of the Wind\" is definitely"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        worth reading"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        on"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        its own merits!"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0  }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":19,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":173}              }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"           }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af3315b69788eb8-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:04:24 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:23Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:23Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:23Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:23Z'
+      request-id:
+      - req_011CWBWyxki2eFfu58ZgQLGB
+      x-envoy-upstream-service-time:
+      - '811'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_0/sync.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-0"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '148'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3VUXY/bRgz8K4RerjVkw3ZzSevHNiiaBi3SpGgeeoGxlihr4dWuQlJ2hMP998zK
+        dr7zJGFJzXCGs7ovulRzKDZFFdxQ81xTjGzzR/P1cn27vF09KsrC16h3ut8uV78eTz8PvftpN+5f
+        rf/7p378+MmLP16ix8aecxeruj3jQFLIB07Vq7loOKpSNMbb5v/7a7/xu1yZHpvi2U1NwlXqOo41
+        zWZ3xb8t09+uY0oNGd5f+1jfFbMZ/bBeLp/8WNKp9VVLXumFM/HVgV4ma5tB9UapS2rUp34ITsgB
+        0VVQ6TuuaZfSYUHPDF0ZtvGC1piOHMhHmmXa5z7uDz4EFvqtlRR9FXhGyuJZF3fxLuamjENNCiGd
+        lJ4fwc0lOQq8hwInI5D3gzDGTGQcglKLWdMpklpC2RK6qyu8ECaQaaIqDaIX2cJMtRv1MrCjHbvB
+        fDOEMNJJvMFVauCx0/EiwlpntAsYQgHVQco8NXNshjgw3DWlk7eWOrf3VUndoPmRPepGNZZx8cHI
+        bG7vxHyVfQRjL84rPGySTGrCCONdwHnCxGpj4AlpUphFg31i8/Gzs8nE762YTgndDDuA7E5OICSD
+        ti4bUDOsziO4uHPKC/pzwP52PHXyWT2SEXhCVEQqnndOZ77XEEB/uQg3f2cnmQ64/bALXlvgYtL1
+        crUqMwH4JMtCFNDlLavJ0jMyNEk9zdX4iEEnCnw81cSHtB/LC+XTlESzxleWIpeZcopunVjjjUHY
+        kXMWUkQYc0QFm4I2bN6YRrbJrqesvbezLB+x2T6w8SWVV6pvuikHrBzG02RgvpK1C5gEPO4sweeo
+        RPU1C+gd5T+DfAwWrg7ucrUoHt6UBfbYb/Elfhe4t4jZ1gaJxaWg/HbgWOGCR2S0LIbpn7C5L3zs
+        B9taOnDUYrP6Bf8EV7W8rQBlPsXt5w3Laz3P+L3a9duMz32LdCMy29vu6/6P1VX7ZfWhLNJgnx6t
+        12vIYTn6irfmWSD0bJvUxcPDexU8y1A6BQAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af331121fda218e-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:04:17 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:12Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:17Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:12Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:12Z'
+      request-id:
+      - req_011CWBWy6bDcDzoGyFUfnaux
+      x-envoy-upstream-service-time:
+      - '5937'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"$defs":{"Author":{"type":"object","description":"The
+      author of a book.","title":"Author","properties":{"first_name":{"type":"string","title":"First
+      Name"},"last_name":{"type":"string","title":"Last Name"}},"additionalProperties":false,"required":["first_name","last_name"]}},"type":"object","description":"A
+      book with a rating. The title should be in all caps!","title":"Book","properties":{"title":{"type":"string","title":"Title"},"author":{"$ref":"#/$defs/Author"},"rating":{"type":"integer","description":"For
+      testing purposes, the rating should be 7","title":"Rating"}},"additionalProperties":false,"required":["title","author","rating"]},"type":"json_schema"}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '842'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJFdSwMxEEX/SrnPKfRTad4U68dDqxSloJEQd6fd0N2kJhOpLPvfZavF
+        qvg0w5xzGYapUfmcSkhkpUk5daN3jrg76o67g95g3JsMJhCwOSSquNa9/ujRPqzilVvM0vmQ8+UL
+        7S6mDAF+31JrUYxmTRAIvmwHJkYb2bjWybxjcgz5VB98pt0+3RaJWoEtl6QgFe6vp5352Wzaub3s
+        tP3yZn6hIBRM4sIHBVkrrGyIrJ2pPjN3hoPNNnutNMdk4blYpRgVGqEQDFu3VpCnDZpngch+qwOZ
+        6B0kyOWaU3D4ApFeE7mMIF0qS4G0P1HWsG6bWLPfkIuQo/5IIDNZQToLZNh6p38avQMPZPL/2CHb
+        LqBtQRUFU+px9df/pv3iN20EfOLj0fBEIFJ4sxlpthQg0T4mNyFH03wAAAD//wMA1uXjxQsCAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af063ae7d16ebbf-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:30 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:29Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:30Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:27Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:29Z'
+      request-id:
+      - req_011CWAsd49ko4kGZo3KqW85W
+      x-envoy-upstream-service-time:
+      - '3296'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,195 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"$defs":{"Author":{"type":"object","description":"The
+      author of a book.","title":"Author","properties":{"first_name":{"type":"string","title":"First
+      Name"},"last_name":{"type":"string","title":"Last Name"}},"additionalProperties":false,"required":["first_name","last_name"]}},"type":"object","description":"A
+      book with a rating. The title should be in all caps!","title":"Book","properties":{"title":{"type":"string","title":"Title"},"author":{"$ref":"#/$defs/Author"},"rating":{"type":"integer","description":"For
+      testing purposes, the rating should be 7","title":"Rating"}},"additionalProperties":false,"required":["title","author","rating"]},"type":"json_schema"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '856'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01SXyqHMxP33DYjhGkwUWrLi","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}            }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":
+        \"THE"}  }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        NAME"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        OF THE WIND\", \"author\":"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        {\"first_name\": \"Patrick\","}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \"last_name\": \"Roth"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"fuss\"},
+        \"rating\": "}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"7"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"}"}
+        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0 }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":43}}
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"              }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af06458dbd931ba-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:54:57 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:54Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:54Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:54Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:54Z'
+      request-id:
+      - req_011CWAsf4f5P75J2v275NkpX
+      x-envoy-upstream-service-time:
+      - '2369'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,186 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"$defs":{"Author":{"type":"object","description":"The
+      author of a book.","title":"Author","properties":{"first_name":{"type":"string","title":"First
+      Name"},"last_name":{"type":"string","title":"Last Name"}},"additionalProperties":false,"required":["first_name","last_name"]}},"type":"object","description":"A
+      book with a rating. The title should be in all caps!","title":"Book","properties":{"title":{"type":"string","title":"Title"},"author":{"$ref":"#/$defs/Author"},"rating":{"type":"integer","description":"For
+      testing purposes, the rating should be 7","title":"Rating"}},"additionalProperties":false,"required":["title","author","rating"]},"type":"json_schema"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '856'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01GQ5fDkvcL8tADTKBotq68o","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":\""}     }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"THE"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        NAME"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        OF THE WIND\",\"author\":{\""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"first_name\":\"Patrick\",\"last_"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":\"Rothfuss\"},\""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":7}"}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0               }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":36}
+        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"        }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af064072ffed5ec-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:54:44 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:41Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:41Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:41Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:41Z'
+      request-id:
+      - req_011CWAse6oHWdUdLAyqMb9Dq
+      x-envoy-upstream-service-time:
+      - '2522'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,118 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"$defs":{"Author":{"type":"object","description":"The
+      author of a book.","title":"Author","properties":{"first_name":{"type":"string","title":"First
+      Name"},"last_name":{"type":"string","title":"Last Name"}},"additionalProperties":false,"required":["first_name","last_name"]}},"type":"object","description":"A
+      book with a rating. The title should be in all caps!","title":"Book","properties":{"title":{"type":"string","title":"Title"},"author":{"$ref":"#/$defs/Author"},"rating":{"type":"integer","description":"For
+      testing purposes, the rating should be 7","title":"Rating"}},"additionalProperties":false,"required":["title","author","rating"]},"type":"json_schema"}}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '842'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJFvSwMxDIe/yvF73cE2N3R9p7ihzn+IKOhJqXdxV71rtzYV5bjvLp0b
+        MsVXCXmekIS0aFxJNSSKWseSesFZS9wb9ca9YX847k+GEwiYEhJNWKj+YP7QvJ9Nb+az89XR/PXu
+        4Pl8f2APIMCfS0oWhaAXBAHv6lTQIZjA2jIECmeZLEM+tluf6SORdZBoc7DhmnLILMftyTS7PLyY
+        ZlezLOX3p5fHOUSWQ0eunE9Wm+PF+MDK6mbTdq3Zm+Lt26z1DrtxXL3EEHJ0iXrNxi4S2u/QPQkE
+        dkvlSQdnIUG2VBy9xQYEWkWyBUHaWNcCcX2qbGHsMrJi90Y2QI4GI4FCFxWpwpNm46zaNfpb7kmX
+        /7FtbxpAy4oa8rpW4+av/0MH1W/aCbjIO+vtCQTy76YgxYY8JNKDSu1LdN0XAAAA//8DAK+wwXAT
+        AgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af06347687c6810-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:17 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:16Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:17Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:11Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:16Z'
+      request-id:
+      - req_011CWAsbreBXMAiHu3UsHkxr
+      x-envoy-upstream-service-time:
+      - '5918'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1118'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJHdThsxEIVfJZprR9qEBIjv+AmkpdlWgBqJqrJG3knWYdfeesZIVbTv
+        jpwSEFTc2XO+mXM83kEbKmpAg20wVTTk4D3JcDKcDsfFeFrMxjNQ4CrQ0PLGFKOr27O77WRcHnWz
+        89nlMpXu5m6yBQXyt6NMETNuCBTE0OQCMjsW9AIKbPBCXkD/2h14CaExiengku/JFKOV3/68KCfX
+        35bH883qYbE4ivdfM+WxzX3GtC4i29CRWYfYoghVJiTpkpj9UJNH+i4J6B2Ik32a+8V8UJ4t54Pv
+        V4N8Xn0pL0EBJqlDzODaRRbzYvIDJTr7CAoafKveBqnXiRl6BRHF+Q3ok77/rYAldCYScvDvn7YX
+        mP4k8pZA+9Q0CtJ+UXr3L6WR8EieQZ+eFgos2pqMjYTigjfviVc9ElafaYfebEBdTS1FbMy0/Z9/
+        U0f1R7VX8LrTl3gjBUzxyVky4iiChvy9FcYK+v4ZAAD//wMAy0Zmz1ECAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af063de4ba81f9a-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:38 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:37Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:37Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:35Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:37Z'
+      request-id:
+      - req_011CWAsdcnJY5UzFmdyhZRPg
+      x-envoy-upstream-service-time:
+      - '2696'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,247 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1132'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01CoFdf67phPgSCYqzxHN3LF","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}              }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01AxwMNBbuZ3sJQqwwB1SWsC","name":"__mirascope_formatted_output_tool__","input":{}}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ti"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tle"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        \""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"THE
+        NAME"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        OF THE "}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"WIND\""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"author\":
+        "}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"f"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"irst_name\":"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Patr"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ick\",\"la"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"st_name\""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":\"Rothfus"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"s\"}"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"rating"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        7}"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0   }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}
+        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"     }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0648c9c04eb3d-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:55:04 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:55:03Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:55:03Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:55:03Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:55:03Z'
+      request-id:
+      - req_011CWAsfg44KHBcXPSfLouQX
+      x-envoy-upstream-service-time:
+      - '1710'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,232 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}],"tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1132'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01GhPHrA8pRzayfxrKAoXtwj","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}               }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_013VdCQXhkCYJdz4DFi5jwyn","name":"__mirascope_formatted_output_tool__","input":{}}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        \"THE N"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"AM"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"E
+        OF THE "}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"WIND\""}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        "}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"aut"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hor\":
+        {\"fi"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rst_name\":\"P"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"atrick\","}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"last"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_n"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame\":\"R"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"othfuss\"}"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"rating\":"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        7}"}     }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0}
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":880,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}    }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"   }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af06431ca11d5ec-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 18:54:50 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:48Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:48Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:48Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:48Z'
+      request-id:
+      - req_011CWAsebuzNCtH8jEhLUMfk
+      x-envoy-upstream-service-time:
+      - '2014'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,117 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please recommend
+      the most popular book by Patrick Rothfuss"}],"model":"claude-sonnet-4-5","system":"Always
+      respond to the user''s query using the __mirascope_formatted_output_tool__ tool
+      for structured output.","tool_choice":{"type":"tool","name":"__mirascope_formatted_output_tool__","disable_parallel_tool_use":true},"tools":[{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in Book format for a final response.\nA book with
+      a rating. The title should be in all caps!","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"$ref":"#/$defs/Author"},"rating":{"description":"For
+      testing purposes, the rating should be 7","title":"Rating","type":"integer"}},"required":["title","author","rating"],"additionalProperties":false,"$defs":{"Author":{"description":"The
+      author of a book.","properties":{"first_name":{"title":"First Name","type":"string"},"last_name":{"title":"Last
+      Name","type":"string"}},"required":["first_name","last_name"],"title":"Author","type":"object"}},"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1118'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJHdThsxEIVfJZprR9pNiZr4rhJ/BUERrRqgQtbIO8la7Hq2njGiivbd
+        KwcCohV39nxn5hyPt9BzQx1Y8B3mhqbCMZJOD6bz6ayazavlbAkGQgMWetm4qj7Ti0c6OVRqbp/O
+        Tm7P5wOtvi/AgP4ZqKhIBDcEBhJ3pYAiQRSjggHPUSkq2F/bvV6ZO5eF9i7lnl1VL3G1xuubq7vw
+        s2Y5Z788fRo+gYGIfelzrg8JxfNAbs2pR1VqHGcdsrrdUFdGxiEr2C1o0F2aH6dHk8svF0eTb8eT
+        cl59vTwEA5i15VSE65BE3YvJFWoK/gEMdPhWvWZt11kERgMJNcQN2M/jeG9AlAeXCIXj+6ftgNDv
+        TNET2Ji7zkDeLcpun1M65QeKAnaxqAx49C05nwg1cHTvFa88ETYfsX1vMaChpZ4Sdm7e/69/o3X7
+        Lx0NvO70JV5tQCg9Bk9OAyWwUL63wdTAOP4FAAD//wMAuXI4AFECAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0638608b46810-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 18:54:23 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T18:54:23Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T18:54:23Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T18:54:21Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T18:54:23Z'
+      request-id:
+      - req_011CWAscaV7S2b4gbQWUyDtS
+      x-envoy-upstream-service-time:
+      - '2757'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,230 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1026'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJDNTsMwEITfZc+OlISmPz4iuHCqKEVBCFlOsrRWE2+w16FVlXdHrhRB
+        QRx3vpkd7Z6howZbkFC3OjSYeLIWOZklRZKneZGu8hUIMA1I6PxOpdn21gxFeKrceqB8RsPxc3g8
+        zUEAn3qMLvRe7xAEOGqjoL03nrVlEFCTZbQM8vU8+ZmoVcHj1BLnoNJsnZflyyZ/uGt4u9l03fP9
+        zbGsQIDVXcztkFVFdFDGvlMM2z4wyDMYX1mQkCaLeXGTZNlimZQwjm8CPFOvHGpP9rr4Ajx+BLQ1
+        grShbQWEyxlxYdysmA5oPcjlPBdQ63qPqnao2ZBV14504g518x+bsrEA+z126HSriu6v/5tm+990
+        FECBf0qzpQCPbjA1KjboQEJ8fqNdA+P4BQAA//8DAHFVzsvvAQAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af083f4ca3fb9ec-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:16:32 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:31Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:32Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:29Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:31Z'
+      request-id:
+      - req_011CWAuJW9QFpzeBPJnRbe7S
+      x-envoy-upstream-service-time:
+      - '2795'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_01P2XXYS2JDdtUSSmmVE3xXb","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01P2XXYS2JDdtUSSmmVE3xXb","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1379'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFHRahsxEPwVs88y3BmfqfXYJK7BvQenTQmEIjbSxqdGJ6nSqmDM/XuQ
+        jVvS0kftzOzMjk4wBkMOJGiHxdA8B++J58t5N180i65ZL9YgwBqQMOaDatr7/vOnx4x7vLWvm3uz
+        t5tv29KDAD5GqizKGQ8EAlJwdYA528zoGQTo4Jk8g3w6XfkcglMl09Wlvotq2tXNQOb24djij364
+        2W37Xaf1HgR4HKtOqdEmzDpEUi8hjchMRoXCsbA6L1V1pY+FQZ6ALZ/T9Dbzc0hezr4ONNtYj252
+        N0abagAsPIQEEj4m9Cb42Rf0hlIOHgREPFAG2S2XAmJ5dlYj2+DVkTCBXDTNapq+C8gcokqEVfTu
+        ujOQ6WchrwmkL84JKOeu5OkSVHF4JZ9BrlcfBGjUAymd6OLzntFc8URo/oddtdWA4kAjJXSqG//l
+        /0Hb4W90EvC71suobdYCMqVfVpNiS7Wy+sUGk4FpegMAAP//AwDuTXesVQIAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af084071d48b9ec-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:16:35 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:34Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:35Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:32Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:34Z'
+      request-id:
+      - req_011CWAuJigDYTdtoPQLxKJ1s
+      x-envoy-upstream-service-time:
+      - '2850'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,391 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1040'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01SRvBW95WVErBn4WzHU9Xp8","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_013deeHw3M7nyA6EmMtRqGos","name":"get_book_info","input":{}}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"0-7"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"653-1178"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-X\"}"}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0   }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}           }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"   }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af085816d967618-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:34 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:33Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:33Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:33Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:33Z'
+      request-id:
+      - req_011CWAuPBStjHtEqidpj5ikd
+      x-envoy-upstream-service-time:
+      - '1708'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_013deeHw3M7nyA6EmMtRqGos","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_013deeHw3M7nyA6EmMtRqGos","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tools":[{"name":"get_book_info","description":"Look up book information
+      by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1393'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01XF8Y3suk9WKVKxFPBM5w9A","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}            }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01CAH9sMR1TwyCQxWresAiGA","name":"__mirascope_formatted_output_tool__","input":{}}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ti"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tle\":
+        \"Mis"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tborn:
+        The F"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"inal
+        Emp"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ire\""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"author\":"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"B"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"randon
+        Sand"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"erson\""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pages\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        544"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"publicat"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ion"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_year\""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        2006}"} }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0            }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}  }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"               }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af085902fe37618-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:37 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:35Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:35Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:35Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:35Z'
+      request-id:
+      - req_011CWAuPMXNfHaJnGogRrTsg
+      x-envoy-upstream-service-time:
+      - '2451'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,411 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1040'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_013rjiziATmUEQZs2hExU8tn","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}}
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01HYsYRRdWvFyrLs2u2r5b7W","name":"get_book_info","input":{}}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"0"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-76"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"53-1178-X\"}"}         }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0  }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"              }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af084b7bcda75ca-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:00Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:00Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:00Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:00Z'
+      request-id:
+      - req_011CWAuLom7Be7o8u3GtkqQf
+      x-envoy-upstream-service-time:
+      - '1791'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01HYsYRRdWvFyrLs2u2r5b7W","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01HYsYRRdWvFyrLs2u2r5b7W","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tools":[{"name":"get_book_info","description":"Look up book information
+      by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1393'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01Cvy6y3vhWM1Vi7UgYkmWF1","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":18,"service_tier":"standard"}}      }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012euX4hioGF1TpUKfY1bqH3","name":"__mirascope_formatted_output_tool__","input":{}}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\":"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        \"Mist"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"bor"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n:
+        The Fina"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
+        Empir"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"a"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uthor\":
+        \""}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Brandon
+        Sa"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nderson\""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pag"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"es\":
+        5"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"44"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"public"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"at"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ion_ye"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar\""}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        200"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"6}"}   }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0               }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}            }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"             }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af084c7dc8675ca-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:03Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:03Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:03Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:03Z'
+      request-id:
+      - req_011CWAuLzXWUaP2riEbUSR7q
+      x-envoy-upstream-service-time:
+      - '2503'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,230 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1026'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJBLa8MwEIT/y5xlsN34Ed9CCIFSegp1aSlCkbeOE1tyLKmPBP/3ooBp
+        09Ljzjezw+4Zna6oRQHZCldRYLRSZINZkARxGCfhPJ6DoalQoDM1D6PN3Wpdxqd0Gcv9bH+6zY9P
+        rs/AYD978i4yRtQEhkG3XhDGNMYKZcEgtbKkLIrn8+S3WrfcGZpa/Ox4GGXpsnTr+/pmvUgW5f4j
+        KTcP7yswKNH5XE2Wb7U+8Ea9ah9WvbMozmjMVqFAGGRpchNEUZYHjxjHFwZjdc8HEkar6+ILMHR0
+        pCShUK5tGdzlDL/Qb+ZWH0gZFHkaM0ghd8TlQMI2WvFrRzjxgUT1H5uyvoD6HXU0iJYn3V//N412
+        v+nIoJ39Kc1yBkPDWyOJ24YGFPDPr8RQYRy/AAAA//8DAGu2xrXvAQAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0826c08547600-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:15:29 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:15:28Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:15:29Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:15:26Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:15:28Z'
+      request-id:
+      - req_011CWAuDsTQtiqdpWG8JxgMt
+      x-envoy-upstream-service-time:
+      - '2630'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_0176CWuGNg3GA5AWjx5WTVwE","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0176CWuGNg3GA5AWjx5WTVwE","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1379'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFHRahsxEPwVs88ynF1fmtNjoHWhSSC0hJAQxEZa+1TrJEVa1Tjm/j3I
+        xglp6KN2ZnZmR3sYgiEHErTDYmiag/fE08W0nc6bedt08w4EWAMShrxWzezL8ueybK7s/SovX+x2
+        c7tqTbwFAbyLVFmUM64JBKTg6gBztpnRMwjQwTN5BvmwP/E5BKdKppNLfRfVzO5uVv3y/OL6R0+4
+        7b5e/imh221BgMeh6pQabMKsQyS1CmlAZjIqFI6F1WGpqit9LAxyD2z5kObKZn4KycvJ754m361H
+        N/k2RJtqACzchwQSLhJ6E/zkF3pDKQcPAiKuKYNsFwsBsTw5q5Ft8GpHmEDOm+ZsHB8FZA5RJcIq
+        +nDdAcj0XMhrAumLcwLKoSu5PwZVHDbkM8ju7FyARt2T0omOPh8ZzQlPhOZ/2ElbDSj2NFBCp9rh
+        M/8dnfX/oqOAt1qPo1nTCciU/lpNii3VyuoXG0wGxvEVAAD//wMAIWF2q1UCAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0827def3c7600-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:15:32 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:15:31Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:15:32Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:15:29Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:15:31Z'
+      request-id:
+      - req_011CWAuE5f8hiS4FotGyrYgv
+      x-envoy-upstream-service-time:
+      - '3032'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,244 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Respond only with valid JSON
+      that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
+      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
+      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
+      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
+      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1029'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3SQX2vCQBDEv8s8XyCJjdF7tC9FSqmlQrWU47ysmprcpfenopLvXk6Q1pY+7vxm
+        dtg9oTUVNeBQjQwVJc5oTT65SYokT/MiHedjMNQVOFq3EWmWPU/2o4dyP7jbT6dh/qTCYTa7BYM/
+        dBRd5JzcEBisaaIgnaudl9qDQRntSXvw19PF741pRHB0aYlzEGmWL4fHhXtf3s8rNX+crHbrw3G8
+        AIOWbcxtyIuVMTtR67WJYd0FD35C7VYaHGlSDotBkmXlKHlB378xOG86YUk6o6+Lz8DRRyCtCFyH
+        pmEI5zPiwrhZeLMj7cDLsmRQUm1JKEvS10aLa0d64ZZk9R+7ZGMBdVtqycpGFO1f/zfNtr9pz2CC
+        /ykNBwyO7GetSPiaLDji8ytpK/T9FwAAAP//AwAV92BJ7wEAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af08391d98531ba-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:16:16 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:15Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:16Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:13Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:15Z'
+      request-id:
+      - req_011CWAuHLTTjcj1HgXzSzBbT
+      x-envoy-upstream-service-time:
+      - '2824'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_012Z6zYsjZLUdcUPBbkfyz9Y","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_012Z6zYsjZLUdcUPBbkfyz9Y","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Respond only with valid
+      JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\":
+      {\n      \"title\": \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\":
+      {\n      \"title\": \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1382'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFRhi9tGEP0rw34JHDrXZ87lTt8a2pR8SKG9NJRWxR7vjqWJV7O6nZFd
+        cdx/LyvHuaShIBDMe7Pz5r2VnlyfAkVXOx9xDHStSYTs+vZ6fb1artbL+9W9qxwHV7te283y5pff
+        28Px1+nx3d2wev1m/efpj5/Tw85VzqaBCotUsSVXuZxiKaAqq6GYq5xPYiTm6r+eLnyjfwoyv2q3
+        3W4/apJGnhoBaJyxRWpcDY17x2q7lKWG9x3BGxaM8FM/cKbGVWc2jtalfKa/zighCTygBMrlzAtr
+        wJa0kNa3t5fSuIvs0TjJZiKcj1gtl9838tzIdrttpJGrqx/JkCMFeCv7lPuZXl9dFfB9xwqsYB3B
+        nrMa7FI6AAt8o+OVAnofkXsKcFkKLHNM7bSAB7LShhAwH2CPYqgTnFKOAU4dZQLUDvYYo8I+p34e
+        qYcJUAL0rKYQUs+CRjMk3HZWnVmW8gT7FGM6KXxgqQBBLRMZjNl3LHDqEgRWn46UFbQjGJIqlQeG
+        dKK8HyP02LLHCLjjyMakizmSuQw6qVFfgcdYrPohxtSj+KkCPM/1lA1ZgCXwkcOIUcESNG43Zmkc
+        9GSfSm2h6ThQ7sYe5SxAF+cwfiOf+p4kzDHAg0+Zarj/7mb5RSLnEBQ6brs4Qb70UIB9ysVdhbR/
+        cZmtg1H4cfx6G62AxXK5IQRDTGYsbTU77lM/UIwsLfgOM3orEl/SLtMPkk4yDyyawuUWzZle70aO
+        obSX01gkHdH4SIDDkBP6rhgxaznPs89raZdOHkswu2Qd7DLHyCgWpwW8tVcKA2ZjP0bMcYI2Exrw
+        HqY0AsnHNEFHrDZfCiYti+xYiqxiAg3sP9tCkXoS04V7/rtyamnYZEJN4mpHEjY2ZnGfAKXHkcST
+        q2WMsXLj/DOonxzLMNrG0oFEXX13d1s5j76jjS/Kyof3NWN5wTNh+D/s0lsG0NBRTxnjZt1/y39B
+        b7r/os+VS6N9WVqtlpVTykf2tDGm7GpX/mEBc3DPz/8CAAD//wMAIjp95TYFAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af083a42f4931ba-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:16:22 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:18Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:22Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:16Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:18Z'
+      request-id:
+      - req_011CWAuHYyH8Q2HUL3jX5FY6
+      x-envoy-upstream-service-time:
+      - '6097'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,353 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Respond only with valid JSON
+      that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
+      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
+      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
+      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
+      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1043'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01LXtsqYKJqi6WWLFfiUWwqS","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":777,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}            }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_016nrHmi6KDhtJ6F4Ax2pgG2","name":"get_book_info","input":{}}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        "}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"0-76"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"53-1178-X\"}"}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0          }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":777,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}     }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"   }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0852a1cf676df-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:21 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:19Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:19Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:19Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:19Z'
+      request-id:
+      - req_011CWAuN9iSAcTNTCAsgdCEy
+      x-envoy-upstream-service-time:
+      - '1862'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_016nrHmi6KDhtJ6F4Ax2pgG2","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_016nrHmi6KDhtJ6F4Ax2pgG2","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Respond only with valid
+      JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\":
+      {\n      \"title\": \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\":
+      {\n      \"title\": \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1396'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01VVXSGANqmwTGdUK82fLYbH","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":884,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}    }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \"Mistborn: The Final Empire"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\",\n  \"author\":
+        \"Brandon"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson\",\n  \"pages"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\":
+        544,\n  \"publication"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"_year\":
+        2006\n}"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n```"}       }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0               }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":884,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":54}         }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"          }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0853e2dd576df-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:24 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:22Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:22Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:22Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:22Z'
+      request-id:
+      - req_011CWAuNPSC4xFxoV2DTDfJg
+      x-envoy-upstream-service-time:
+      - '1838'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,912 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Respond only with valid JSON
+      that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
+      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
+      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
+      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
+      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1043'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01LaATvDYgtASNLtEBB9HgpH","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":777,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}         }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
+        look up the book information for"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        ISBN"}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        0-7653-1178"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0  }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01GRNUscW1x8wu9Zms9qbuke","name":"get_book_info","input":{}}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\""}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":":
+        \""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"0-7653-1"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"178"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"-X\"}"}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1         }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":777,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}    }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"          }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af084466cb075ca-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:16:44 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:42Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:42Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:42Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:42Z'
+      request-id:
+      - req_011CWAuKTvjAy3WWR1MoxdwX
+      x-envoy-upstream-service-time:
+      - '1938'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01GRNUscW1x8wu9Zms9qbuke","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01GRNUscW1x8wu9Zms9qbuke","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Respond only with valid
+      JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\":
+      {\n      \"title\": \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\":
+      {\n      \"title\": \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1479'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01FWDhbAjoS5KSHZBV5zCE9b","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":904,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}             }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Base"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        on the book information retrieve"}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d,
+        here"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the detailed response"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":\n\n```"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\":
+        \"Mistborn: The Final"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Empire\",\n  \"author\": \""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Brandon
+        Sanderson\",\n  \""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"pages\":
+        544,\n  \""}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"publication_year\":
+        2006"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n}\n```\n\n**Additional"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Details"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        &"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Recommendation:**"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\n**Mist"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"born:
+        The Final Empire** by"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Brandon Sanderson is the"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        first"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book in the acclaime"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        Mistborn series. This epic fantasy"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        novel"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        set in a world where ash"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        falls from the sky, m"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ists"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        dom"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"inate
+        the night"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        and the immort"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"al
+        Lor"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        Ruler has"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        re"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"igned
+        for a"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        thousand years."}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\n**Key"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Highlights"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":**\n-
+        **Innovative"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Magic System**: Features"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Allomancy,\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        where people can in"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"gest
+        an"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        \""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"burn\"
+        metals to gain supernatural"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        powers\n- **"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"He"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ist"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Plot"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**:"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Combines"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        epic"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy with a clever"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        heist storyl"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ine\n-
+        **Strong"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Characters"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**:
+        Features"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        memorable"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        protagonist Vin an"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        the"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        cha"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rismatic
+        th"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ief
+        Kelsier\n- **"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Worl"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d-building"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"**:
+        Rich,"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        dark"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        atmospheric"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        setting with unique mechanics"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\n**Recommendation
+        Score: 9"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"/10**\n\nThis"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book is highly"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        recommended for:"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        Fans of epic fantasy with"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        unique"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        magic systems\n- Readers who enjoy"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        he"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ist
+        narratives\n- Those looking"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        for well"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-developed
+        characters and plot"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        twists\n- Brandon"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson fans"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        ("}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"it''s
+        one"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        of his most popular works"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":")\n\nThe
+        book is accessible"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        to newcom"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ers
+        while offering depth for experience"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        fantasy readers."}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        It"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        perfect starting"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        point for the Cosm"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ere
+        universe!"}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0    }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":904,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":332}            }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"        }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af084599c4375ca-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:16:47 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:45Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:45Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:45Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:45Z'
+      request-id:
+      - req_011CWAuKh8UZAeKsWrtSVUJA
+      x-envoy-upstream-service-time:
+      - '2068'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,247 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Respond only with valid JSON
+      that matches this exact schema:\n{\n  \"properties\": {\n    \"title\": {\n      \"title\":
+      \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\": {\n      \"title\":
+      \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\": {\n      \"title\":
+      \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\": {\n      \"title\":
+      \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1029'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJBLa8MwEIT/y5xlsJM6anxroJdAc2kbCqUIRdrYamzJ1aMPgv97USD0
+        RY8738wOu0cMTlOPBqqXSVMRnLUUi4uiLmblrC6XsyUYjEaDIbSirDYrbkZPim+rOy3r7mq40asV
+        GOLHSNlFIciWwOBdnwUZgglR2ggG5WwkG9E8Hs/+6FwvUqBzS56TKCtu3vdvz5vrdRzbanc7H+7X
+        27AHg5VDzrUUxc65gzB273LYjimiOcKEnUWDsuCLel5UFb8sHjBNTwwhulF4ksHZn8UnEOglkVWE
+        xqa+Z0inM/LCvFlEdyAb0HDOGZRUHQnlSUbjrPjpKM/ck9T/sXM2F9DY0UBe9qIe/vq/aNX9phOD
+        S/G7tJgzBPKvRpGIhjwa5Odr6TWm6RMAAP//AwAd7hYs7wEAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af081fb0d617600-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:15:11 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:15:10Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:15:11Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:15:08Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:15:10Z'
+      request-id:
+      - req_011CWAuCYBGdL1WP4A8Lave8
+      x-envoy-upstream-service-time:
+      - '3066'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_017ixfwjNEJtpg1bS3mUJVsf","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_017ixfwjNEJtpg1bS3mUJVsf","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Respond only with valid
+      JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
+      {\n      \"title\": \"Title\",\n      \"type\": \"string\"\n    },\n    \"author\":
+      {\n      \"title\": \"Author\",\n      \"type\": \"string\"\n    },\n    \"pages\":
+      {\n      \"title\": \"Pages\",\n      \"type\": \"integer\"\n    },\n    \"publication_year\":
+      {\n      \"title\": \"Publication Year\",\n      \"type\": \"integer\"\n    }\n  },\n  \"required\":
+      [\n    \"title\",\n    \"author\",\n    \"pages\",\n    \"publication_year\"\n  ],\n  \"title\":
+      \"BookSummary\",\n  \"type\": \"object\"\n}","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1382'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//fFRha+RGDP0rYr4Uwm66CUkh++3aXpuj7YdewlFal6x2RmurGUvuSM7G
+        hPvvx9jZ40pLwWA88/Tm6c2TX0KviXLYhphxTLQ2FSFfX62v15eby+vNzeVNWAVOYRt6ax82F7/9
+        GuW+v23v9vHD4+/78fZHuYkXYRV8GqiiyAxbCqtQNNcFNGNzFA+rEFWcxMP2j5cT3um57syvbdjt
+        dn+ZSiMvjQA0wdkzNWELTfiFzfdaZAv3HcEPLJjhbT9woSasFjSO3mlZ4N8WlKQCdyiJSuU8oQZs
+        ySro+urqtDTuM0d0VnmYCGeKy83mm0Y+NrLb7Rpp5OzsTUpcIZjhnRy09HPB9uysbv+/QGAD7wgO
+        XMxhr/oILPAvjV8ZYIwZuacEJz7wwlnb6RzuOzaggSMcUBxtAtEnypXcyCsjQprMdWAUOGrJCY4d
+        FQK0Dg6Ys8GhaD9LscdpBShp/hDdc2afYFAzMoMeW46YAed1JoOIOVOCNzlrjxInWM+V+FroCk3Y
+        j0WaAD05ZgOWlswpVWHeERfYa6pUrtAiC9g4UOnGHgUGPVKx8+pkdc9cywQHzVmPBj9RNqayAoTY
+        YWGrzkfwjukAR/YO6NkLakksWKaTxor5rH/p9QNLZZl0lBbMC5HDWGLHAsdOIbFFfaJiYB1BhwbG
+        PWcsJ31wry15V7V4RxMMGQXqMyaMrKNBR2xeO6w83hU9Lm4T9SxtnoD7Xotjhp+1JHg/Zirz2fW0
+        pD0LVstqzXKBBy2A4J2OVjuo8Vx8Ojt7T1H7niTNQYS7qIW2cPP1xWbJ5JyXJWwGHbddnqCcamih
+        PqAY6GHbyBq+037I9LxcPthkTr0tBidy5Hr/ZcxkFXw7NzpkdZutNS/oVAurKcLSVtSdF5V2vjaM
+        TgUSPVHWoSfxuv89lscVoPdqQ0fli2gbubO081lva+ZnO9b7kXOayZekfJ6AAYtzHDOWPMFQkO21
+        Q/YaRdEndH6ifzS3gqj9QDnzlxpfs8Lipf4UaG4S/Mjmdg7vvE6pAD1HypnEgcRLnRwWnw8shHWc
+        QehYg/BfU37U8ngePv65CnVaHwqhqYRtIEkPPhYJrxtGf48kkcJWxpxXYZz/rZ9kVa2UmVdQWhJf
+        kp+dmlesZGVhYaKjlJyYnJEan1yUCinHUFUYwORBjsMlB9MLsiC1ICM1N7UoMSfeNBdTPULWMANd
+        tlZHKb+0BFnI2MBAR6k4tagsMzk1viQztUjJSglUJaQkFqUo1dYCAAAA//8DAKKq1+GFBgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0820f3f2c7600-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:15:19 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:15:14Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:15:19Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:15:12Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:15:14Z'
+      request-id:
+      - req_011CWAuCmvkrDn8CpNwbHs2H
+      x-envoy-upstream-service-time:
+      - '7949'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/async.yaml
@@ -1,0 +1,234 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '412'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3VRXU+DQBD8K+RefAEDCG3Dm0aNNWr8jFVjLtdjBdLjDu+jqWn47+41IRWNTyw7
+        szO7c1vSqhIEKQgXzJUQGSUl2CiL0jjN4zzJSEiaEvHWVDROcnea1RV/sdf2Nl1P2LLkdxcr5Niv
+        DjwLjGEVYEMr4RvMmMZYJi22uJIWsCretgPfwsYju09B5gdCBEKpVeC6wNYQLH3dyA+lW2YbJQOs
+        gvnDyU0QR9NJfhQlyXQWLQ5JH+4llRLUGRgW9/8OV79cVE+zzWt6rKROzuqr87y9f3xGlmStn6vA
+        Uu9HvZ8flp3DpbakMUuJ+MiR9P17SIxVHdXAMLSx8Q4w8OlActSWToiQuF0yXtArU6tWIA0psiTH
+        aBivgXLU8mfSMSMecITL/7Bh1htAV0MLmgmat3/5ezSpf6N9SJSzP1uzDM8BvW44UNuAxkP9e5ZM
+        lxjCNxvngTBAAgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af331fb2e461a03-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:04:52 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:51Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:52Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:49Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:51Z'
+      request-id:
+      - req_011CWBX1r3h6fZFZZrn5cjSy
+      x-envoy-upstream-service-time:
+      - '2917'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"citations":null,"text":"I''ll look
+      up the book information for ISBN 0-7653-1178-X.","type":"text"},{"id":"toolu_01JXgU8xZ2Aonr1EhLF5mRTW","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01JXgU8xZ2Aonr1EhLF5mRTW","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '865'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/31VYW/bNhD9K4S+rDXszk7stNWXIW4SoAMyNHHWDlsGg6LOFheK1EjKrhHkv+8d
+        JSXt0vaLJfGOd++9e6Tvs9qVZLI8U0a2JU2Cs5biZD45mh4tpovZPBtnukS8Dtv1dHb67sPZ28a/
+        ubq6Lk7O//x4fLk8/90hJx4a4iwKQW4JC94ZXpAh6BCljVhSzkbCW/7X/ZAf6TNH0iPPljJQKZwV
+        sSLxfrX8TRjn7tpmLCry9FNI6yVFqQ3ytN04X8uosQFvKVggP7+1t3Y0WuJVnKXkkI9Gt3YiRqMb
+        HQ3hS1wCVeG8zcUNtl1oK404rxvtqUs8bWPlPGcuvbQlWqzwIA99uoQPoMl1xWI+71fawmjV4TmT
+        MbX5tTUHcbQYi6Pp9KRLY14cmk5enyyOJ7PZ6zeTPzrIp4VrY+LB4BPo2+wHSDOhO0022oeYyEOV
+        54ihnFQYsK4h21BPbDAVGQ4ikNcUXon3EXmBIpeQYu+8KcWehRe13GolXihpWPdTY1wtrTq85PbF
+        MDNtIUjEr0BbUbTe8nuNARiAdGIrUTe0DXkrY+vBQhba6Mi9O/rXpFxdky07DVfKecrF259n06SE
+        vam4XyIZRKW3FbT1wx6AYBME2hHX9iRBPOS95ta6HaruSFwmLqtDiFTzGL4U6ZEZN3CWhNskeWsH
+        dVur/20pkduTMRPl5SaiaydOSAUDazfoCm6AAqq9pVbROyjyrpJeKoRgzh0Z1wB9ZCQXlJKDAKMG
+        HVg+NSSHsWikj1q1RnrwZliNd1FuncVAxUfd+/JTmtuy1aZEAa57rVU1fjo2/WB1rDDlnlTjqdaB
+        xItPlcT8N0P5pqKgsQcucODF+3952ffxOg37qpUgeuBG558VYIMNoKrBCGS3EAgfKBcGJZLjxIVr
+        +1mnQXTy4LLwkf2yZygFjxep0gpqIPOjZ+VWPrMErLUhFZMPhkT4gMeLag5Q/nGHJyG+GtwYjVP/
+        R8WF9ArLzEE/2SepNyl6eftDA4c7iLlFs4gu0R9E47TtkAwILO2Z1rcOJ4revcoe/h5nIbpm3XkX
+        9yFsvYYlbNYHAmFYVuHitK0x46xNd21+n2nbtHEd3R3ZkOWL+REuW6kqWiuGBIHXX2dMhziD+15s
+        2MsNCE6o+WCtF/Xz/KforPp/9GGc4VL7cul4ugAf8jutaI3j78GU/yJK6cvs4eE/HzHO35MGAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af3320e7cc31a03-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:05:00 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:54Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:05:00Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:52Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:54Z'
+      request-id:
+      - req_011CWBX25HuwvC3HTovsajhq
+      x-envoy-upstream-service-time:
+      - '8189'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/async_stream.yaml
@@ -1,0 +1,860 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '426'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01Y3rkXz7pywoFkvNKAStY2s","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":415,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}    }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''ll
+        look up the book information for ISBN"}       }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        0-7653-1178"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}    }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0           }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01QnL3f6GPV1ZuER7jCjKaJy","name":"get_book_info","input":{}}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"i"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"sb"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"n\":
+        \"0-765"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"3-1178-X\"}"}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1    }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":415,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}     }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"    }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af332a2b887eb84-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:05:17 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:05:16Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:05:16Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:05:16Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:05:16Z'
+      request-id:
+      - req_011CWBX3peuQA2CdfW2Gf4o1
+      x-envoy-upstream-service-time:
+      - '1699'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01QnL3f6GPV1ZuER7jCjKaJy","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01QnL3f6GPV1ZuER7jCjKaJy","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '862'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01UkZGucpXa1JrcTcmPzNPq6","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":542,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":4,"service_tier":"standard"}}       }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Based
+        on the ISBN"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        lookup"}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        here''s the detailed information for"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book:\n\n**Title:** Mist"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"born:
+        The Final Empire  "}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n**Author:**
+        Brandon Sanderson"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"  \n**Pages:**
+        544  "}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n**Publication"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Date:** July 25, 2"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"006  "}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n**ISBN"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":**
+        0-7653-1"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"178-X\n\n**About"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the Book:**\nThis"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is the first"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book in Brandon"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson''s acclaime"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        Mistborn series, a"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy epic"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        that has"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        become one of the most beloved modern"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy works"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        The story follows"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Vin, a young th"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ief
+        who discovers she"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        has magical"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        abilities"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        in"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a world where ash"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        falls from the sky and the proph"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"es"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ied
+        hero"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        has"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        already"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        faile"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d."}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\n**Recommendation
+        Score:"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        9/10**\n\nThis"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book is highly"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        recommended for several"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        reasons:"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Innovative"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Magic System:**"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson''s"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        All"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"omancy
+        is"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        one"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        of the most unique an"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        well"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-developed
+        magic systems in fantasy"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **Strong"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Character Development:**"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Vin''s journey from street"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        thief to powerful"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Mistborn is compelling and well"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-execute"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d\n-
+        **Worl"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d-building"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":**
+        Rich"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        detailed world with"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fascinating"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        history"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        and mythology"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **Plot"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":**"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Engaging"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        he"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ist
+        story combine"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        with epic"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy elements\n- **Writing"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Quality:** Accessible"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        yet sophisticate"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        prose that"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        appeals to both new"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        and experienced fantasy readers\n\nThis"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is an"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        excellent"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        entry"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        point into epic"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy an"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        is"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        particularly"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        great"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        for readers who enjoy detaile"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        magic"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        systems and character-driven stories"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}             }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0        }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":542,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":304}  }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"            }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af332b51e80eb84-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:05:20 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:05:19Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:05:19Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:05:19Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:05:19Z'
+      request-id:
+      - req_011CWBX43FgeFuRDpMnWP3YY
+      x-envoy-upstream-service-time:
+      - '1750'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/stream.yaml
@@ -1,0 +1,961 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '426'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01TgXV7CDs3dUsEfBjvSb3Qa","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":415,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}             }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''ll
+        look up the book information for ISBN"}        }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        0-7653-1178"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}            }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0    }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01FPqqaBTkUphCzLqhTn72uL","name":"get_book_info","input":{}}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"isbn"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\":"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"
+        \"0-7653-117"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"8-X\"}"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1  }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":415,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}}
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"               }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af3325499d66878-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:05:05 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:05:03Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:05:03Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:05:03Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:05:03Z'
+      request-id:
+      - req_011CWBX2uFCad4dB35d811sb
+      x-envoy-upstream-service-time:
+      - '1686'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01FPqqaBTkUphCzLqhTn72uL","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01FPqqaBTkUphCzLqhTn72uL","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '862'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01KCuJVCmhooXbeZUGtX8xX3","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":542,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}
+        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Base"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        on the lookup"}          }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",
+        here''s the detailed information for"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the book:\n\n**Title:**"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Mistborn: The Final Empire"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n**Author:**
+        Brandon Sanderson"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n**ISBN"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":**
+        0-7653-1"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"178-X\n**Pages:**
+        "}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"544"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n**Publication"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Date:** July"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        25, 2006\n\n**"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"About"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the Book:**\nThis"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        is the"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        first"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        novel"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        in Brandon"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson''s acclaime"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        Mistborn trilogy. It"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        an"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        epic fantasy novel"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        set in a world where ash"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        falls from the sky and m"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ist"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        domin"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ates
+        the night"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":".
+        The story follows Vin,"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a street"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        th"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ief
+        who"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        discovers she"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        has"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        magical"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        powers in"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a unique"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        magic"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        system calle"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        All"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"omancy."}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\n**Recommendation
+        Score:"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        9"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"/10**\n\nThis"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book is highly recommended for several reasons:"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Innovative"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Magic System:**"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson is"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        renowne"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        for his"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        intr"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"icate
+        an"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        logical"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        magic systems"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        an"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        All"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"omancy
+        is one of his"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        best"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **Strong"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Character Development:** Vin''s"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        transformation"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        from street"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        thief to powerful Mistborn is"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        compelling"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **Worl"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d-Building:**
+        The Final"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Empire presents"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a unique"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":","}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        dark"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy setting"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **Plot"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":**"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Engaging"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        he"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ist
+        story"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        combine"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        with epic"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy elements"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        **Author"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s
+        Reputation"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":":**
+        Brandon Sanderson is considere"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        one of the premier"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        fantasy authors of"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        the"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        modern"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        era\n\nThis"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        book is perfect"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        for fantasy"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        readers"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        who enjoy detaile"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        magic"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        systems, strong"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        character ar"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"cs,
+        and innovative"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        worl"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d-building.
+        It"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''s
+        also"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        a"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        great entry"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        point into"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson''s work for new readers"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}           }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0    }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":542,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":318}              }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"           }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af33266cee76878-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:05:08 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:05:06Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:05:06Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:05:06Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:05:06Z'
+      request-id:
+      - req_011CWBX37g51fcMisWoyEKbo
+      x-envoy-upstream-service-time:
+      - '2112'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_0/sync.yaml
@@ -1,0 +1,234 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '412'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3VRQW6DMBD8CvKlF6hwikvCMWqi5tBckKpIVWU5sAUaYxNsR00j/t51JJSmVU4s
+        O7Mzu+MTaXUJkmSkkMKVEBmtFNgoiSbxhMWMJiQkTYl4ayoeU/b6ve5oamG7Xx5oOmvzee4myLHH
+        DjwLjBEVYKPX0jeEMY2xQllsFVpZwCp7O418C18eOX8ysrqTMpBa7wLXBbaGYOvrRn3ovhW20SrA
+        Kljl83UQR+kje4goTafR5p4M4UVSa8mdgXFx/+9w9ad8mW7obFe/1M9ztiiZ+KyOC2Qp0fq5Ciz3
+        ftz7+WHVOVzqRBqzVYhfOZJheA+JsbrjPQgM7dr4DBjYO1AFaisnZUjcORkv6JW51TtQhmQJZRiN
+        KGrgBWr5M/k1Ix5xhMtb2DjrDaCroYVeSM7a//wLSuu/6BAS7ezv1jTBc6A/NAVw20CPh/r3LEVf
+        Ygg/eD3mfkACAAA=
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af331a5fbe4e0b0-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:04:38 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:37Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:38Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:35Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:37Z'
+      request-id:
+      - req_011CWBWzqmYaXQakQXGWLHnB
+      x-envoy-upstream-service-time:
+      - '3055'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"citations":null,"text":"I''ll look
+      up the book information for ISBN 0-7653-1178-X.","type":"text"},{"id":"toolu_01DSF7X19khMhHB5Ed5ajgyE","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01DSF7X19khMhHB5Ed5ajgyE","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-0","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '865'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3VUXW/bNhT9K4ReBhh2Zrt20+nNzpKhBVYEddAOWAaDoq4lLhSpkZQdIch/37mU
+        1TYN+mBL4v0+5/A+ZY0ryWR5pozsSpoFZy3F2Wq2nC/X8/VilU0zXcLehGo/X9x+1nVoP3ykTb0+
+        /nHzyS629vQGPrFvib0oBFkRDrwzfCBD0CFKG3GknI2Et/zvp9E/0iNb0iPPtjJQKZwVsSZhnHvo
+        2qmoydMvIR2VFKU2cNH24Hwjo4Yv3pKxgH9+b+/tZLLFq/g9OYd8Mrm3MzGZ3OloCF/iTzRUOG9z
+        cYewG22lEddNqz0Njpsu1s6z59ZLW6LEDg/ygGZwuMWEnFesV6vzSVcYHWoq+fRDZ3qxXE/Fcj5/
+        O9jf77Yf2TSfXb5dv5ktFpfvZn8NvW4K18U0AHedur2rdRB6GPmgfYhpNgz9uiEAIxWo0w1QGQcT
+        0Wvjqv5CvI/sYAW1WokDWJChF9YdyYhAkTNKcXLelOLEMAsZargZE8TBuyY1EB56ZChFIyvkQFfF
+        SJK2gCHiP9mLzlt+bwA74qMTlUT+0LXkrYydB8qy0EZHTeFimP0TKdc0ZMuByZ1ynnLx26+LOcNw
+        BmKYPYhaVzWA9WMMmmDqAx2Jc3uSwCPkA+DXj4paTgrLFx5wVnTalGiQafgKn1AIiwSMRGf1fx2l
+        UU5kzKxEXuNarnLG7QyUjjVGB4ho+khnXEIfIjVhKL6L3gGJq1p6qSJ5SDHlQteRy98Q44GqmKRF
+        LYZNjc5hKlrpo1adkR7zMgetd1FWzoJf8VmfVXhtK5RG6K1xKe2VawptkbYmdiRDXDAMHb9QAPNu
+        hfO6SuI/yX5IeeXBjsLJZtAUZ/2isR96tCA18170IAT5gBtDmPBSKSxw2iTZc5WK7HilduTButhF
+        TEbpam0gSnBkDFoU+HmUcNqyJiGd7/V95ULD2gRBYDrQK2FAYAdSMalhrG3cMUFJoSWloWgG0gWC
+        zh3K/ev6b8vkBYPDQODF0OPA+FfljNfJBMeXDptOF4ZY6ZZOCGE48PEKgovs+Z9pFqJr94NIsemg
+        3z00YLOzIRDEZxVWou2MmWZd2qL5U6Zt28V9dA9kQ5avV0usUalq2iflQuD7lx7z0c4E/cw2xnIB
+        amvoBDdov25e+3+zLuofrc/TDKvr+6Plu0vMQ/6oFe1xzz0m5eVfSl9mz8//A7qSBtFtBgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af331ba8d6ce0b0-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:04:45 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:04:40Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:04:45Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:04:38Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:04:40Z'
+      request-id:
+      - req_011CWBX15q8nEKGER5gyUqoa
+      x-envoy-upstream-service-time:
+      - '6672'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,232 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '795'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3VQ3UrDMBR+l1w30HZr1+5OQXejIhvCnEjImuMamia1STal9N09GRSd4l3y/fKd
+        gbRGgCJLUinuBVBrtAZH5zSjaZxmcZmWJCJSoKK1BxYnJc/T5iq/2a3lfblfrIrNZv58ixr32UFQ
+        gbX8AAj0RgWAWyut49ohVBntAF/Ll2HSO2MU8xamlvD32HPXQnHaCfHxcFptm8f1tWvk0xFVmrfB
+        dwDH9sY0TOo3E8y68xg8EGn3GvmYLvJsRpNkUdAtGcfXiFhnOtYDx42XxWfCwrsHXWG29kpFxJ9n
+        hMCQzJxpQFuyLLI57uBVDazCLCeNZpeKeOKRFv9xkzcUQFdDCz1XLGv/6r/ZpP7NjhEx3v2E8hnO
+        gf4oK2BOQo9Dw/EF7wUe4QuQGdZx7wEAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af35476ae98268b-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:28:27 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:25Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:27Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:21Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:25Z'
+      request-id:
+      - req_011CWBYoxghHR8PiWS8mAYYT
+      x-envoy-upstream-service-time:
+      - '5422'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_01Lme8wZddxNwGXkPRBtkiUv","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01Lme8wZddxNwGXkPRBtkiUv","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1148'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3WRb0vDMBCHv0q51y10dRXadwrz3QZOwYmTkqXHGkyTmlxks/S7e+0c/sNXSe55
+        Lrkf6aG1NWooQWoRaky8NQYpmSd5kqVZnhZZATGomo3W76t0VqxuD7SRS/OwXjyuN6ur7v2wkezQ
+        scPRQu/FHrngrB4LwnvlSRjikrSGkHflU3/2CQ8jmZYS+i2QIo1bKKMtLLlxZ50po/sGoxtlhI4W
+        bacc85i5CNRYd3KvnTC1NdEdL+g4xknpeBY/Gvl8Pp3DTispSFlTHVFMzVmaXg4wPMfgyXaVQ8Ht
+        PAyauqLgDHwCj68BjeSpTdA6hjAFLXtQpgtUkX1B46EsLmecVMgGK8l3TU/9NNIzZ1z/x8694wPY
+        NdiiE7rK27/+F501v+kQgw30vXRRcBx0b0piRQodBx2/pxauhmH4AC/PDvARAgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af35499cd7d268b-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:28:31 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:30Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:31Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:27Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:30Z'
+      request-id:
+      - req_011CWBYpNg5g5B2HCZSiQ2xE
+      x-envoy-upstream-service-time:
+      - '4653'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,344 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '809'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_019ePzZCrcd8S8NiEkwZwSmL","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}     }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_015zK6BhzxxiWkzta5EqChHU","name":"get_book_info","input":{}}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        "}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"0-"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"7653-1178"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-X\"}"}}
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0            }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}     }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"       }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af35503aecf4881-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:28:46 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:44Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:44Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:44Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:44Z'
+      request-id:
+      - req_011CWBYqd6H7tpqwRmG7xE3v
+      x-envoy-upstream-service-time:
+      - '2072'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_015zK6BhzxxiWkzta5EqChHU","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_015zK6BhzxxiWkzta5EqChHU","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1162'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_017uMVEE3CgBY65GNrDxGdGX","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}   }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":
+        \"Mistborn: The"}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Final Empire\", \"author\": \"Brandon"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson\", \"pages\": "}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"544,
+        \"publication_year\": "}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2006}"}              }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0    }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}               }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"               }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af3551a9ac94881-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:28:50 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:47Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:47Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:47Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:47Z'
+      request-id:
+      - req_011CWBYqtoaxvvtaSc6Re9tX
+      x-envoy-upstream-service-time:
+      - '2095'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,339 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '809'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_0128qhrHNjCfb1pqibZ2K2MS","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}  }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01PANxkp6SQDrVL4uizVPErk","name":"get_book_info","input":{}}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        \"0"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-7653"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-11"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"78-X\"}"}            }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0}
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}      }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop" }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af354cdaf510af0-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:28:37 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:35Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:35Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:35Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:35Z'
+      request-id:
+      - req_011CWBYpzC1dTmRdamoyxMid
+      x-envoy-upstream-service-time:
+      - '2313'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01PANxkp6SQDrVL4uizVPErk","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01PANxkp6SQDrVL4uizVPErk","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}],"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1162'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-stream-helper:
+      - beta.messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_017pkmvZPJ9UfxmNEs58ZcZP","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}            }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":
+        \"Mistborn: The"}               }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Final Empire\", \"author\": \"Brandon"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Sanderson\", \"pages\": "}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"544,
+        \"publication_year\": "}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2006}"}           }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0 }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"            }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af354e4683a0af0-NRT
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Wed, 17 Dec 2025 03:28:41 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:39Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:39Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:39Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:39Z'
+      request-id:
+      - req_011CWBYqFiexYtpRaNMXN6na
+      x-envoy-upstream-service-time:
+      - '2493'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,232 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '795'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3VQ3U7CMBR+l16vyQaMDe69MiSEqBiNaUp7pIWuHf0hIuHdPSVZFI137feb75xJ
+        5yQYMifC8CSBBmctRDqhNR2Vo7qcjWakIFqiogtbVlbLdfMy+1yt213g6rBvXSN28gM18dRDVkEI
+        fAsIeGcywEPQIXIbERLORsDX/PU86KNzhqUAQ0v+J+x5Wi5WQq3VI1d3J3+8l9MHWDSosrzLvi1E
+        tnFuz7R9d9ls+4TBZ6LDxiJf0mZaj2lVNS19JpfLW0FCdD3zwHHjbfGVCHBIYAVm22RMQdJ1Rg7M
+        ySy6PdhA5m09wR1cKGACs6J2lt0qyoFHWv7HDd5cAL2CDjw3rO7+6r/ZSv1mLwVxKf6EpmOcA/6o
+        BbCowePQfHzJvcQjfAGckALd7wEAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af35433dd80c1a7-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:28:14 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:13Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:14Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:11Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:13Z'
+      request-id:
+      - req_011CWBYoAv7vXCStFhiPxZhg
+      x-envoy-upstream-service-time:
+      - '3359'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_01VPMRchWhUahEyrvKd6TeM7","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01VPMRchWhUahEyrvKd6TeM7","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
+      Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-beta:
+      - structured-outputs-2025-11-13
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1148'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper:
+      - beta.messages.parse
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages?beta=true
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAA/3WRTUvEMBCG/0qZcwvd2i60NxU/Dq4XFQRXSrYZt8E0qclEdin97067Ln7hKck8
+        zyTzkgE6K1FDBY0WQWLirTFISZ4USZZmRVpmJcSgJBud39bpYnWV9y/Fze7x9nrVPuxMuz/vThU7
+        tO9xstB7sUUuOKungvBeeRKGuNRYQ8i76mk4+oS7icxLBcMaSJHGNVTRGlbcuLHOVNF9i9GlMkJH
+        F12vHPOYuQjUWndwz5ww0projhd0HOOg9DyLn4wiz+dz2GjVCFLW1HsUc3OWpssRxucYPNm+dii4
+        nYdBI2sKzsAn8PgW0DQ8tQlaxxDmoNUAyvSBarKvaDxU5XLBSUXTYt3wXfNTP430yBnL/9ixd3oA
+        +xY7dELXRffX/6KL9jcdY7CBvpdOSo6D7l01WJNCx0Gn75HCSRjHD0RC0PwRAgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-RAY:
+      - 9af35449ffd8c1a7-NRT
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 03:28:18 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - accept-encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-17T03:28:17Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-17T03:28:18Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-17T03:28:14Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-17T03:28:17Z'
+      request-id:
+      - req_011CWBYoS5gq34kcbTV6aLR2
+      x-envoy-upstream-service-time:
+      - '3908'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/async.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/async.yaml
@@ -1,0 +1,230 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1026'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJBba8JAEIX/y3neQJKaqHkTH/qiUnsRaSnLmkyTxWQ33Ysokv9eVpDW
+        lj7O+c6Zw8wZna6oRYGyFb6iyGqlyEWjKIvSOM3iaToFg6xQoLM1j5P7+X72dLfbruvZ+pWkfKnq
+        fLkBgzv1FFxkragJDEa3QRDWSuuEcmAotXKkHIq389XvtG65t3RtCbPncTLaNDPzuFo+HPLTPF09
+        H48LJRdgUKILuZoc32m951J96BBWvXcozpB2p1AgjsZ5dhclyXgSbTEM7wzW6Z4bElar2+ILsPTp
+        SZWEQvm2ZfCXM8LCsJk7vSdlUUzylKEUZUO8NCSc1IrfOuIrNySq/9g1Gwqob6gjI1qedX/93zRp
+        ftOBQXv3UxpNGCyZgyyJO0kGBcLzK2EqDMMXAAAA//8DAMLay1HvAQAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af08a4c1bb5b3e2-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:20:52 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:20:51Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:20:52Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:20:50Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:20:51Z'
+      request-id:
+      - req_011CWAudecuovGmxnisvHRZp
+      x-envoy-upstream-service-time:
+      - '2852'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_014VhArRNMPv6yC2NTxxLniL","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_014VhArRNMPv6yC2NTxxLniL","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1379'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dFHRatwwEPyVY591YDt3IdZj6YVCyb00pYFSxJ60sdXYK1datbkc/vci
+        H9eQlj5qZ2ZndnSCMTgaQIMdMDtap8BMst6st+umarZV27SgwDvQMKbOVPXu/XNz99Idfn35jDbs
+        nzs+3ny4BQVynKiwKCXsCBTEMJQBpuSTIAsosIGFWEB/PV34EsJgcqKLS3lnU9X7Gr+n3VOHuz1/
+        vH94aPcvV0sWxrHojBl9xGTDROYxxBFFyJmQZcpilqWmrOQpC+gTiJclzZ1PcgiR9eq+p9WtZxxW
+        u3HysQTALH2IoOFdRHaBV5+QHcUUGBRM2FECvd1sFEz5MHiL4gObI2EE3VTV9Tx/U5AkTCYSFtGb
+        6xYg0Y9MbAk052FQkJeu9Okc1Eh4Ik6g2+sbBRZtT8ZGOvu8ZVQXPBK6/2EXbTGgqaeRIg5mO/7L
+        f0Xr/m90VvCn1vOorloFieJPb8mIp1JZ+WKH0cE8/wYAAP//AwBeV1U/VQIAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af08a5f38acb3e2-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:20:55 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:20:54Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:20:55Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:20:52Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:20:54Z'
+      request-id:
+      - req_011CWAudsgUo1fMUSgceuApg
+      x-envoy-upstream-service-time:
+      - '2951'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -1,0 +1,393 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1040'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '1'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01BwHXKKbJf8SQezgtBSeRcr","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}
+        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01G7WYNjnrCr24DxsndLQpUs","name":"get_book_info","input":{}}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\""}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"0-7653-"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"117"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"8-X\"}"}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0             }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}
+        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"             }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af085552eded807-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:27 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:26Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:26Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:26Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:26Z'
+      request-id:
+      - req_011CWAuNfCDqDLbRHhdw3FWM
+      x-envoy-upstream-service-time:
+      - '1903'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01G7WYNjnrCr24DxsndLQpUs","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01G7WYNjnrCr24DxsndLQpUs","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tools":[{"name":"get_book_info","description":"Look up book information
+      by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1393'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - AsyncAnthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - async:asyncio
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01YE3LJ464bajjPFNV5e7ERJ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}
+        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01Qom3G3J4858nhkb2rfXcgk","name":"__mirascope_formatted_output_tool__","input":{}}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"titl"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":
+        \"M"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"istborn:
+        Th"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
+        Final E"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"mpire\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"au"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
+        \"Br"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"andon
+        Sande"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rson\""}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pages\": 5"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"44"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"publi"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cation_y"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ear\":"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        2006}"}        }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0           }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}              }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"            }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af085653b08d807-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:17:31 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:17:28Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:17:28Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:17:28Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:17:28Z'
+      request-id:
+      - req_011CWAuNrBGvQWp2ALKNn2a4
+      x-envoy-upstream-service-time:
+      - '2477'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/stream.yaml
@@ -1,0 +1,413 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1040'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01117ya4XX5QiTf5HUbWXuNk","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}
+        }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_016b72pBRjSFQFPv8dYQRSd1","name":"get_book_info","input":{}}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        \"0"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-7653-117"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"8-X\"}"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0               }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":862,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}          }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"          }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0848e2c0275ca-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:16:56 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:54Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:54Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:54Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:54Z'
+      request-id:
+      - req_011CWAuLK4TTsvvxArFd2gfT
+      x-envoy-upstream-service-time:
+      - '1831'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_016b72pBRjSFQFPv8dYQRSd1","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_016b72pBRjSFQFPv8dYQRSd1","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tools":[{"name":"get_book_info","description":"Look up book information
+      by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}],"tool_choice":{"type":"any"},"stream":true}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1393'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-helper-method:
+      - stream
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-stream-helper:
+      - messages
+      x-stainless-timeout:
+      - NOT_GIVEN
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01A54LS3PD4FGoQBK4smSP1w","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}         }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_017N4upydzuegMMVmP6LuaNy","name":"__mirascope_formatted_output_tool__","input":{}}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"titl"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":
+        \""}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Mis"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tborn"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        The Final "}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Em"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"pire\""}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"au"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor\":
+        "}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Brandon
+        "}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Sande"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rson\""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"pages\":"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
+        5"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"44"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"publi"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"cation_ye"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ar\":
+        20"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"06}"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0     }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":968,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}
+        }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"             }
+
+
+        '
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0849e78b975ca-SEA
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Date:
+      - Tue, 16 Dec 2025 19:16:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '1999000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:16:56Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:16:56Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:16:56Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2399000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:16:56Z'
+      request-id:
+      - req_011CWAuLWCRusPWon9ou5qSA
+      x-envoy-upstream-service-time:
+      - '2733'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/sync.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5/sync.yaml
@@ -1,0 +1,230 @@
+interactions:
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"}],"model":"claude-sonnet-4-5","system":"Always respond to the user''s
+      query using the __mirascope_formatted_output_tool__ tool for structured output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1026'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//dJBbS8NAEIX/yzxvIIlNL/uo9UVFCiKtiCzbzbRZmszEvai15L/LFopW
+        8XHOd84cZg7QcY0tSDCtjjVmnokwZKOsysq8rPJZOQMBtgYJnd+qvLi6XDQzmndzt5jcVOTWl7z5
+        eAQBYd9jcqH3eosgwHGbBO299UFTAAGGKSAFkM+Hkz8wtyp6PLWkOaq8uK6625VZLIv9He4+3x+W
+        /dN9aUEA6S7lthjUmnmnLG04hamPAeQBrF8TSMizybi6yIpiMs1WMAwvAnzgXjnUnum8+Ag8vkYk
+        gyAptq2AeDwjLUybVeAdkgc5HZcCjDYNKuNQB8ukzh35iTvU9X/slE0F2DfYodOtqrq//m9aNL/p
+        IIBj+CmNpgI8ujdrUAWLDiSk59fa1TAMXwAAAP//AwAUrzKR7wEAAA==
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af0824298f47600-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:15:23 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:15:22Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:15:22Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:15:20Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:15:22Z'
+      request-id:
+      - req_011CWAuDP6MQuNPCoGeT8eL6
+      x-envoy-upstream-service-time:
+      - '2801'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
+      the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
+      score"},{"role":"assistant","content":[{"id":"toolu_01E5mKXcPW1yLekzwSWpYN2i","input":{"isbn":"0-7653-1178-X"},"name":"get_book_info","type":"tool_use"}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01E5mKXcPW1yLekzwSWpYN2i","content":"Title:
+      Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
+      2006-07-25"}]}],"model":"claude-sonnet-4-5","system":"Always respond to the
+      user''s query using the __mirascope_formatted_output_tool__ tool for structured
+      output.","tool_choice":{"type":"any"},"tools":[{"name":"get_book_info","description":"Look
+      up book information by ISBN.","input_schema":{"properties":{"isbn":{"title":"Isbn","type":"string"}},"required":["isbn"],"additionalProperties":false,"type":"object"}},{"name":"__mirascope_formatted_output_tool__","description":"Use
+      this tool to extract data in BookSummary format for a final response.","input_schema":{"properties":{"title":{"title":"Title","type":"string"},"author":{"title":"Author","type":"string"},"pages":{"title":"Pages","type":"integer"},"publication_year":{"title":"Publication
+      Year","type":"integer"}},"required":["title","author","pages","publication_year"],"additionalProperties":false,"type":"object"}}]}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      anthropic-version:
+      - '2023-06-01'
+      connection:
+      - keep-alive
+      content-length:
+      - '1379'
+      content-type:
+      - application/json
+      host:
+      - api.anthropic.com
+      user-agent:
+      - Anthropic/Python 0.75.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 0.75.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.10.16
+      x-stainless-timeout:
+      - '600'
+    method: POST
+    uri: https://api.anthropic.com/v1/messages
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA3RRTWtbMRD8K2bPMrzn+IU83WKo6SG5JA05hCA20tpPRF+VVqXGvP8eZOOUtPSo
+        nZmd2dERfDTkQIJ2WA0tSwyBeLleDstVtxq6cTWCAGtAgi971fWbuxt8pqf+u37YXU3v4/YW1ymA
+        AD4kaiwqBfcEAnJ0bYCl2MIYGAToGJgCg3w5Xvgco1O10MWlvavq+tthHHdPqeLjNvzePPTl+XDw
+        VyAgoG86pbzNWHRMpHYxe2Qmo2LlVFmdlqq2MqTKII/Alk9p7m3ht5iDXPyYaLG1Ad3im082twBY
+        eYoZJGwyBhPD4hGDoVxiuy/hngrIYb0WkOqbsxrZxqAOhBnkquuu5/lVQOGYVCZsoi/XnYBCPysF
+        TSBDdU5APXUlj+egiuM7hQJyvL4RoFFPpHSms89XRnfBM6H5H3bRNgNKE3nK6NTg/+X/Qfvpb3QW
+        8FnredR3o4BC+ZfVpNhSq6x9scFsYJ4/AAAA//8DALB5E/xVAgAA
+    headers:
+      CF-Cache-Status:
+      - DYNAMIC
+      CF-Ray:
+      - 9af08254ea447600-SEA
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 16 Dec 2025 19:15:26 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Robots-Tag:
+      - none
+      anthropic-organization-id:
+      - 217a607f-ed5e-40af-8a7d-f83ed52d59d6
+      anthropic-ratelimit-input-tokens-limit:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-remaining:
+      - '2000000'
+      anthropic-ratelimit-input-tokens-reset:
+      - '2025-12-16T19:15:25Z'
+      anthropic-ratelimit-output-tokens-limit:
+      - '400000'
+      anthropic-ratelimit-output-tokens-remaining:
+      - '400000'
+      anthropic-ratelimit-output-tokens-reset:
+      - '2025-12-16T19:15:26Z'
+      anthropic-ratelimit-requests-limit:
+      - '4000'
+      anthropic-ratelimit-requests-remaining:
+      - '3999'
+      anthropic-ratelimit-requests-reset:
+      - '2025-12-16T19:15:23Z'
+      anthropic-ratelimit-tokens-limit:
+      - '2400000'
+      anthropic-ratelimit-tokens-remaining:
+      - '2400000'
+      anthropic-ratelimit-tokens-reset:
+      - '2025-12-16T19:15:25Z'
+      request-id:
+      - req_011CWAuDbbgBFMabctytxDdJ
+      x-envoy-upstream-service-time:
+      - '3371'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,355 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01SYA1TeD4PLFupKFua8hb67",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01StpMry6rBcxKo9hZWcRhXb",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01CEN6h9QtG2nWT3WndhxwWV",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+            "n_chunks": 20,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01PC8NRqTnvvRmvxMZwcENxQ",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+            "n_chunks": 21,
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,785 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "citations": None,
+                                "text": """\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+""",
+                                "type": "text",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "citations": None,
+                                "text": """\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+""",
+                                "type": "text",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": """\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+""",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [],
+            "n_chunks": 12,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": """\
+```json
+{
+  "title": "THE NAME OF THE WIND",
+  "author": {
+    "first_name": "Patrick",
+    "last_name": "Rothfuss"
+  },
+  "rating": 7
+}
+```\
+""",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "$defs": {
+    "Author": {
+      "description": "The author of a book.",
+      "properties": {
+        "first_name": {
+          "title": "First Name",
+          "type": "string"
+        },
+        "last_name": {
+          "title": "Last Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "first_name",
+        "last_name"
+      ],
+      "title": "Author",
+      "type": "object"
+    }
+  },
+  "description": "A book with a rating. The title should be in all caps!",
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "$ref": "#/$defs/Author"
+    },
+    "rating": {
+      "description": "For testing purposes, the rating should be 7",
+      "title": "Rating",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "rating"
+  ],
+  "title": "Book",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [],
+            "n_chunks": 12,
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/strict/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,314 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": '{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}',
+                                "type": "text",
+                                "parsed_output": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": '{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}',
+                                "type": "text",
+                                "parsed_output": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": '{"title":"THE NAME OF THE WIND","author":{"first_name":"Patrick","last_name":"Rothfuss"},"rating":7}',
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+            "n_chunks": 10,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": '{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}',
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [],
+            "n_chunks": 11,
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,355 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_019aWfaRXPZiV1osKoc9Hxp3",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name": "Patrick", "last_name": "Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01WnjVCN4GLM6EgWZHH3rTJe",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_013VdCQXhkCYJdz4DFi5jwyn",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+            "n_chunks": 19,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please recommend the most popular book by Patrick Rothfuss"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "THE NAME OF THE WIND", "author": {"first_name":"Patrick","last_name":"Rothfuss"}, "rating": 7}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01AxwMNBbuZ3sJQqwwB1SWsC",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "THE NAME OF THE WIND",
+                                    "author": {
+                                        "first_name": "Patrick",
+                                        "last_name": "Rothfuss",
+                                    },
+                                    "rating": 7,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "Book",
+                "description": "A book with a rating. The title should be in all caps!",
+                "schema": {
+                    "$defs": {
+                        "Author": {
+                            "description": "The author of a book.",
+                            "properties": {
+                                "first_name": {"title": "First Name", "type": "string"},
+                                "last_name": {"title": "Last Name", "type": "string"},
+                            },
+                            "required": ["first_name", "last_name"],
+                            "title": "Author",
+                            "type": "object",
+                        }
+                    },
+                    "description": "A book with a rating. The title should be in all caps!",
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"$ref": "#/$defs/Author"},
+                        "rating": {
+                            "description": "For testing purposes, the rating should be 7",
+                            "title": "Rating",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "rating"],
+                    "title": "Book",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [],
+            "n_chunks": 22,
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,509 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    ToolCall,
+    ToolOutput,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_0176CWuGNg3GA5AWjx5WTVwE",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_0176CWuGNg3GA5AWjx5WTVwE",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_0176CWuGNg3GA5AWjx5WTVwE",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01XQfhG8BNHheaw97Ljuo9yw",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_01P2XXYS2JDdtUSSmmVE3xXb",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01P2XXYS2JDdtUSSmmVE3xXb",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01P2XXYS2JDdtUSSmmVE3xXb",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_016ChedDUy1ajMhCKHMK5ccQ",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_01HYsYRRdWvFyrLs2u2r5b7W",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01HYsYRRdWvFyrLs2u2r5b7W",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01HYsYRRdWvFyrLs2u2r5b7W",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_012euX4hioGF1TpUKfY1bqH3",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 22,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_013deeHw3M7nyA6EmMtRqGos",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_013deeHw3M7nyA6EmMtRqGos",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_013deeHw3M7nyA6EmMtRqGos",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01CAH9sMR1TwyCQxWresAiGA",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 18,
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,896 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    ToolCall,
+    ToolOutput,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_017ixfwjNEJtpg1bS3mUJVsf",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_017ixfwjNEJtpg1bS3mUJVsf",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_017ixfwjNEJtpg1bS3mUJVsf",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```
+
+**Additional Information:**
+
+"Mistborn: The Final Empire" is the first book in Brandon Sanderson's acclaimed Mistborn trilogy. This epic fantasy novel is set in a dystopian world where ash falls from the sky, and the nobility possess magical abilities called Allomancy - the ability to "burn" metals ingested in their bodies to gain superhuman powers.
+
+The story follows Kelsier, a charismatic thief with extraordinary Allomantic abilities, and Vin, a young street urchin who discovers she has similar powers. Together, they plan an audacious heist to overthrow the seemingly immortal Lord Ruler who has dominated the world for a thousand years.
+
+**Recommendation Score: 9/10**
+
+This book is highly recommended for fans of:
+- Complex magic systems with detailed rules
+- Heist plots and strategic planning
+- Strong character development
+- Dark, atmospheric fantasy settings
+- Epic world-building
+
+The novel is particularly praised for its innovative magic system, compelling characters, and intricate plot twists. It's an excellent entry point for readers new to Brandon Sanderson's work.\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "citations": None,
+                                "text": """\
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```
+
+**Additional Information:**
+
+"Mistborn: The Final Empire" is the first book in Brandon Sanderson's acclaimed Mistborn trilogy. This epic fantasy novel is set in a dystopian world where ash falls from the sky, and the nobility possess magical abilities called Allomancy - the ability to "burn" metals ingested in their bodies to gain superhuman powers.
+
+The story follows Kelsier, a charismatic thief with extraordinary Allomantic abilities, and Vin, a young street urchin who discovers she has similar powers. Together, they plan an audacious heist to overthrow the seemingly immortal Lord Ruler who has dominated the world for a thousand years.
+
+**Recommendation Score: 9/10**
+
+This book is highly recommended for fans of:
+- Complex magic systems with detailed rules
+- Heist plots and strategic planning
+- Strong character development
+- Dark, atmospheric fantasy settings
+- Epic world-building
+
+The novel is particularly praised for its innovative magic system, compelling characters, and intricate plot twists. It's an excellent entry point for readers new to Brandon Sanderson's work.\
+""",
+                                "type": "text",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_012Z6zYsjZLUdcUPBbkfyz9Y",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_012Z6zYsjZLUdcUPBbkfyz9Y",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_012Z6zYsjZLUdcUPBbkfyz9Y",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```
+
+**Detailed Information:**
+
+This is the first book in Brandon Sanderson's acclaimed Mistborn trilogy. Set in a dark fantasy world where ash falls from the sky and mists dominate the night, the story follows Vin, a street urchin who discovers she possesses powerful magical abilities. The magic system, called Allomancy, allows certain individuals to "burn" metals to gain superhuman powers.
+
+**Recommendation Score: 9/10**
+
+This book is highly recommended for fans of fantasy with unique magic systems, intricate plotting, and compelling characters. Sanderson is known for his detailed world-building and innovative approach to magic, and this book showcases both brilliantly. It's particularly great if you enjoy heist stories combined with epic fantasy elements.\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "citations": None,
+                                "text": """\
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```
+
+**Detailed Information:**
+
+This is the first book in Brandon Sanderson's acclaimed Mistborn trilogy. Set in a dark fantasy world where ash falls from the sky and mists dominate the night, the story follows Vin, a street urchin who discovers she possesses powerful magical abilities. The magic system, called Allomancy, allows certain individuals to "burn" metals to gain superhuman powers.
+
+**Recommendation Score: 9/10**
+
+This book is highly recommended for fans of fantasy with unique magic systems, intricate plotting, and compelling characters. Sanderson is known for his detailed world-building and innovative approach to magic, and this book showcases both brilliantly. It's particularly great if you enjoy heist stories combined with epic fantasy elements.\
+""",
+                                "type": "text",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="I'll look up the book information for ISBN 0-7653-1178-X."
+                        ),
+                        ToolCall(
+                            id="toolu_01GRNUscW1x8wu9Zms9qbuke",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        ),
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "I'll look up the book information for ISBN 0-7653-1178-X.",
+                            },
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01GRNUscW1x8wu9Zms9qbuke",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            },
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01GRNUscW1x8wu9Zms9qbuke",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+Based on the book information retrieved, here is the detailed response:
+
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```
+
+**Additional Details & Recommendation:**
+
+**Mistborn: The Final Empire** by Brandon Sanderson is the first book in the acclaimed Mistborn series. This epic fantasy novel is set in a world where ash falls from the sky, mists dominate the night, and the immortal Lord Ruler has reigned for a thousand years.
+
+**Key Highlights:**
+- **Innovative Magic System**: Features "Allomancy," where people can ingest and "burn" metals to gain supernatural powers
+- **Heist Plot**: Combines epic fantasy with a clever heist storyline
+- **Strong Characters**: Features memorable protagonist Vin and the charismatic thief Kelsier
+- **World-building**: Rich, dark atmospheric setting with unique mechanics
+
+**Recommendation Score: 9/10**
+
+This book is highly recommended for:
+- Fans of epic fantasy with unique magic systems
+- Readers who enjoy heist narratives
+- Those looking for well-developed characters and plot twists
+- Brandon Sanderson fans (it's one of his most popular works)
+
+The book is accessible to newcomers while offering depth for experienced fantasy readers. It's the perfect starting point for the Cosmere universe!\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": """\
+Based on the book information retrieved, here is the detailed response:
+
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```
+
+**Additional Details & Recommendation:**
+
+**Mistborn: The Final Empire** by Brandon Sanderson is the first book in the acclaimed Mistborn series. This epic fantasy novel is set in a world where ash falls from the sky, mists dominate the night, and the immortal Lord Ruler has reigned for a thousand years.
+
+**Key Highlights:**
+- **Innovative Magic System**: Features "Allomancy," where people can ingest and "burn" metals to gain supernatural powers
+- **Heist Plot**: Combines epic fantasy with a clever heist storyline
+- **Strong Characters**: Features memorable protagonist Vin and the charismatic thief Kelsier
+- **World-building**: Rich, dark atmospheric setting with unique mechanics
+
+**Recommendation Score: 9/10**
+
+This book is highly recommended for:
+- Fans of epic fantasy with unique magic systems
+- Readers who enjoy heist narratives
+- Those looking for well-developed characters and plot twists
+- Brandon Sanderson fans (it's one of his most popular works)
+
+The book is accessible to newcomers while offering depth for experienced fantasy readers. It's the perfect starting point for the Cosmere universe!\
+""",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 97,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="""\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+"""
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_016nrHmi6KDhtJ6F4Ax2pgG2",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_016nrHmi6KDhtJ6F4Ax2pgG2",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_016nrHmi6KDhtJ6F4Ax2pgG2",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text="""\
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```\
+"""
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": """\
+```json
+{
+  "title": "Mistborn: The Final Empire",
+  "author": "Brandon Sanderson",
+  "pages": 544,
+  "publication_year": 2006
+}
+```\
+""",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "json",
+                "formatting_instructions": """\
+Respond only with valid JSON that matches this exact schema:
+{
+  "properties": {
+    "title": {
+      "title": "Title",
+      "type": "string"
+    },
+    "author": {
+      "title": "Author",
+      "type": "string"
+    },
+    "pages": {
+      "title": "Pages",
+      "type": "integer"
+    },
+    "publication_year": {
+      "title": "Publication Year",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "title",
+    "author",
+    "pages",
+    "publication_year"
+  ],
+  "title": "BookSummary",
+  "type": "object"
+}\
+""",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 10,
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,472 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    ToolCall,
+    ToolOutput,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_01VPMRchWhUahEyrvKd6TeM7",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01VPMRchWhUahEyrvKd6TeM7",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01VPMRchWhUahEyrvKd6TeM7",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": '{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}',
+                                "type": "text",
+                                "parsed_output": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_01Lme8wZddxNwGXkPRBtkiUv",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01Lme8wZddxNwGXkPRBtkiUv",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01Lme8wZddxNwGXkPRBtkiUv",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "text": '{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}',
+                                "type": "text",
+                                "parsed_output": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_01PANxkp6SQDrVL4uizVPErk",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01PANxkp6SQDrVL4uizVPErk",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01PANxkp6SQDrVL4uizVPErk",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": '{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}',
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 8,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_015zK6BhzxxiWkzta5EqChHU",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_015zK6BhzxxiWkzta5EqChHU",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_015zK6BhzxxiWkzta5EqChHU",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": '{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}',
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "strict",
+                "formatting_instructions": None,
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 8,
+        }
+    }
+)

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_claude_sonnet_4_5_snapshots.py
@@ -1,0 +1,509 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    SystemMessage,
+    Text,
+    ToolCall,
+    ToolOutput,
+    UserMessage,
+)
+
+sync_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_01E5mKXcPW1yLekzwSWpYN2i",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01E5mKXcPW1yLekzwSWpYN2i",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01E5mKXcPW1yLekzwSWpYN2i",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01A599fUpuaSFnxBR1sWyym3",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+async_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "provider_model_name": "claude-sonnet-4-5",
+            "params": {},
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_014VhArRNMPv6yC2NTxxLniL",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_014VhArRNMPv6yC2NTxxLniL",
+                                "input": {"isbn": "0-7653-1178-X"},
+                                "name": "get_book_info",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_014VhArRNMPv6yC2NTxxLniL",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "id": "toolu_01N1ajsEkgaENnKTXX9Nz329",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                                "name": "__mirascope_formatted_output_tool__",
+                                "type": "tool_use",
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+        }
+    }
+)
+stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_016b72pBRjSFQFPv8dYQRSd1",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_016b72pBRjSFQFPv8dYQRSd1",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_016b72pBRjSFQFPv8dYQRSd1",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_017N4upydzuegMMVmP6LuaNy",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 23,
+        }
+    }
+)
+async_stream_snapshot = snapshot(
+    {
+        "response": {
+            "provider": "anthropic",
+            "model_id": "anthropic/claude-sonnet-4-5",
+            "finish_reason": None,
+            "messages": [
+                SystemMessage(
+                    content=Text(
+                        text="Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output."
+                    )
+                ),
+                UserMessage(
+                    content=[
+                        Text(
+                            text="Please look up the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation score"
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolCall(
+                            id="toolu_01G7WYNjnrCr24DxsndLQpUs",
+                            name="get_book_info",
+                            args='{"isbn": "0-7653-1178-X"}',
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01G7WYNjnrCr24DxsndLQpUs",
+                                "name": "get_book_info",
+                                "input": {"isbn": "0-7653-1178-X"},
+                            }
+                        ],
+                    },
+                ),
+                UserMessage(
+                    content=[
+                        ToolOutput(
+                            id="toolu_01G7WYNjnrCr24DxsndLQpUs",
+                            name="get_book_info",
+                            value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
+                        )
+                    ]
+                ),
+                AssistantMessage(
+                    content=[
+                        Text(
+                            text='{"title": "Mistborn: The Final Empire", "author": "Brandon Sanderson", "pages": 544, "publication_year": 2006}'
+                        )
+                    ],
+                    provider_id="anthropic",
+                    model_id="anthropic/claude-sonnet-4-5",
+                    provider_model_name="claude-sonnet-4-5",
+                    raw_message={
+                        "role": "assistant",
+                        "content": [
+                            {
+                                "type": "tool_use",
+                                "id": "toolu_01Qom3G3J4858nhkb2rfXcgk",
+                                "name": "__mirascope_formatted_output_tool__",
+                                "input": {
+                                    "title": "Mistborn: The Final Empire",
+                                    "author": "Brandon Sanderson",
+                                    "pages": 544,
+                                    "publication_year": 2006,
+                                },
+                            }
+                        ],
+                    },
+                ),
+            ],
+            "format": {
+                "name": "BookSummary",
+                "description": None,
+                "schema": {
+                    "properties": {
+                        "title": {"title": "Title", "type": "string"},
+                        "author": {"title": "Author", "type": "string"},
+                        "pages": {"title": "Pages", "type": "integer"},
+                        "publication_year": {
+                            "title": "Publication Year",
+                            "type": "integer",
+                        },
+                    },
+                    "required": ["title", "author", "pages", "publication_year"],
+                    "title": "BookSummary",
+                    "type": "object",
+                },
+                "mode": "tool",
+                "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
+            },
+            "tools": [
+                {
+                    "name": "get_book_info",
+                    "description": "Look up book information by ISBN.",
+                    "parameters": """\
+{
+  "properties": {
+    "isbn": {
+      "title": "Isbn",
+      "type": "string"
+    }
+  },
+  "required": [
+    "isbn"
+  ],
+  "additionalProperties": false,
+  "defs": null
+}\
+""",
+                    "strict": False,
+                }
+            ],
+            "n_chunks": 18,
+        }
+    }
+)

--- a/python/tests/e2e/output/test_structured_output.py
+++ b/python/tests/e2e/output/test_structured_output.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 from mirascope import llm
-from tests.e2e.conftest import E2E_MODEL_IDS, FORMATTING_MODES
+from tests.e2e.conftest import FORMATTING_MODES, STRUCTURED_OUTPUT_MODEL_IDS
 from tests.utils import (
     Snapshot,
     snapshot_test,
@@ -29,7 +29,7 @@ class Book(BaseModel):
 # ============= SYNC TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_sync(
@@ -61,7 +61,7 @@ def test_structured_output_sync(
         assert book.rating == 7
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_sync_context(
@@ -97,7 +97,7 @@ def test_structured_output_sync_context(
 # ============= ASYNC TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio
@@ -130,7 +130,7 @@ async def test_structured_output_async(
         assert book.rating == 7
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio
@@ -167,7 +167,7 @@ async def test_structured_output_async_context(
 # ============= STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_stream(
@@ -201,7 +201,7 @@ def test_structured_output_stream(
         assert book.rating == 7
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_stream_context(
@@ -239,7 +239,7 @@ def test_structured_output_stream_context(
 # ============= ASYNC STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio
@@ -274,7 +274,7 @@ async def test_structured_output_async_stream(
         assert book.rating == 7
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio

--- a/python/tests/e2e/output/test_structured_output_with_tools.py
+++ b/python/tests/e2e/output/test_structured_output_with_tools.py
@@ -4,7 +4,7 @@ import pytest
 from pydantic import BaseModel
 
 from mirascope import llm
-from tests.e2e.conftest import E2E_MODEL_IDS, FORMATTING_MODES
+from tests.e2e.conftest import FORMATTING_MODES, STRUCTURED_OUTPUT_MODEL_IDS
 from tests.utils import (
     Snapshot,
     snapshot_test,
@@ -25,7 +25,7 @@ class BookSummary(BaseModel):
 # ============= SYNC TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_with_tools_sync(
@@ -71,7 +71,7 @@ def test_structured_output_with_tools_sync(
         assert book_summary.publication_year == 2006
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_with_tools_sync_context(
@@ -121,7 +121,7 @@ def test_structured_output_with_tools_sync_context(
 # ============= ASYNC TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio
@@ -168,7 +168,7 @@ async def test_structured_output_with_tools_async(
         assert book_summary.publication_year == 2006
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio
@@ -219,7 +219,7 @@ async def test_structured_output_with_tools_async_context(
 # ============= STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_with_tools_stream(
@@ -267,7 +267,7 @@ def test_structured_output_with_tools_stream(
         assert book_summary.publication_year == 2006
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 def test_structured_output_with_tools_stream_context(
@@ -319,7 +319,7 @@ def test_structured_output_with_tools_stream_context(
 # ============= ASYNC STREAM TESTS =============
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio
@@ -368,7 +368,7 @@ async def test_structured_output_with_tools_async_stream(
         assert book_summary.publication_year == 2006
 
 
-@pytest.mark.parametrize("model_id", E2E_MODEL_IDS)
+@pytest.mark.parametrize("model_id", STRUCTURED_OUTPUT_MODEL_IDS)
 @pytest.mark.parametrize("formatting_mode", FORMATTING_MODES)
 @pytest.mark.vcr
 @pytest.mark.asyncio


### PR DESCRIPTION
This was painful to implement as the strict structured outputs are not
attached to the main client, but instead to a beta client with distinct
types.

Implemented via some conditional logic to decide which client to use,
and a mix of conversion functions (where necssary) and casts (where
feasible)

Tested primarily via e2e coverage (added claude-sonnet-4-5 to all
structured output tests)