### PR TITLE
chore(cloud): provide prettier default config plus ignore file to avoid vscode/cursor using their own defaults

### DIFF
--- a/cloud/.prettierignore
+++ b/cloud/.prettierignore
@@ -1,0 +1,24 @@
+# Build outputs
+dist
+build
+.next
+out
+
+# Generated files
+node_modules
+.DS_Store
+package-lock.json
+bun.lock
+yarn.lock
+pnpm-lock.yaml
+.venv
+
+# Generated TypeScript files
+*.gen.ts
+
+# Markdown/MDX files (to preserve emphasis styles)
+*.md
+*.mdx
+
+# Large text files
+LICENSE

--- a/cloud/.prettierrc
+++ b/cloud/.prettierrc
@@ -1,0 +1,3 @@
+# Intentionally empty to use the default prettier config
+# todo(sebastian): add a prettier config when timing for reformatting is appropriate
+{}


### PR DESCRIPTION
This fixes an inconstancy between real-time editing/formatting (via Prettier VS Code extension) and pre-commit (`bun run format`). An absence of a prettier config makes it conform to vscode defaults. See log traces for details.

### With Config (after merge):

```
["INFO" - 12:00:57 PM] Formatting completed in 4ms.
["INFO" - 12:01:38 PM] Formatting file:///Users/mirascope/Projects/Mirascope/mirascope/cloud/src/components/home-page.tsx
["INFO" - 12:01:38 PM] Using config file at /Users/mirascope/Projects/Mirascope/mirascope/cloud/.prettierrc
```

### Without Config:

```
["INFO" - 12:00:11 PM] No local configuration (i.e. .prettierrc or .editorconfig) detected, falling back to VS Code configuration
["INFO" - 12:00:11 PM] Prettier Options:
{
  "arrowParens": "always",
  "bracketSpacing": true,
  "endOfLine": "auto",
  "htmlWhitespaceSensitivity": "css",
  "insertPragma": false,
  "singleAttributePerLine": false,
  "bracketSameLine": false,
  "jsxBracketSameLine": false,
  "jsxSingleQuote": false,
  "printWidth": 100,
  "proseWrap": "preserve",
  "quoteProps": "as-needed",
  "requirePragma": false,
  "semi": true,
  "singleQuote": false,
  "tabWidth": 2,
  "trailingComma": "es5",
  "useTabs": false,
  "embeddedLanguageFormatting": "auto",
  "vueIndentScriptAndStyle": false,
  "experimentalTernaries": false,
  "filepath": "/Users/mirascope/Projects/Mirascope/mirascope/cloud/src/components/home-page.tsx",
  "parser": "typescript"
}
```