### PR TITLE
Implement support for ollama provider

### DIFF
--- a/python/mirascope/llm/providers/__init__.py
+++ b/python/mirascope/llm/providers/__init__.py
@@ -9,6 +9,7 @@ from .google import GoogleModelId, GoogleProvider
 from .load_provider import load, load_provider
 from .mlx import MLXModelId, MLXProvider
 from .model_id import ModelId
+from .ollama import OllamaProvider
 from .openai import (
     OpenAIModelId,
     OpenAIProvider,
@@ -29,6 +30,7 @@ __all__ = [
     "MLXModelId",
     "MLXProvider",
     "ModelId",
+    "OllamaProvider",
     "OpenAIModelId",
     "OpenAIProvider",
     "Params",

--- a/python/mirascope/llm/providers/load_provider.py
+++ b/python/mirascope/llm/providers/load_provider.py
@@ -4,6 +4,7 @@ from .anthropic import AnthropicProvider
 from .base import Provider
 from .google import GoogleProvider
 from .mlx import MLXProvider
+from .ollama import OllamaProvider
 from .openai import OpenAIProvider
 from .openai.completions.provider import OpenAICompletionsProvider
 from .openai.responses.provider import OpenAIResponsesProvider
@@ -35,6 +36,8 @@ def load_provider(
             return GoogleProvider(api_key=api_key, base_url=base_url)
         case "mlx":  # pragma: no cover (MLX is only available on macOS)
             return MLXProvider()
+        case "ollama":
+            return OllamaProvider(api_key=api_key, base_url=base_url)
         case "openai":
             return OpenAIProvider(api_key=api_key, base_url=base_url)
         case "openai:completions":

--- a/python/mirascope/llm/providers/ollama/__init__.py
+++ b/python/mirascope/llm/providers/ollama/__init__.py
@@ -1,0 +1,19 @@
+"""Ollama provider implementation."""
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .provider import OllamaProvider
+else:
+    try:
+        from .provider import OllamaProvider
+    except ImportError:  # pragma: no cover
+        from .._missing_import_stubs import (
+            create_provider_stub,
+        )
+
+        OllamaProvider = create_provider_stub("openai", "OllamaProvider")
+
+__all__ = [
+    "OllamaProvider",
+]

--- a/python/mirascope/llm/providers/ollama/provider.py
+++ b/python/mirascope/llm/providers/ollama/provider.py
@@ -1,0 +1,71 @@
+"""Ollama provider implementation."""
+
+import os
+from typing import ClassVar
+
+from openai import AsyncOpenAI, OpenAI
+
+from ..openai.completions.base_provider import BaseOpenAICompletionsProvider
+
+
+class OllamaProvider(BaseOpenAICompletionsProvider):
+    """Provider for Ollama's OpenAI-compatible API.
+
+    Inherits from BaseOpenAICompletionsProvider with Ollama-specific configuration:
+    - Uses Ollama's local API endpoint (default: http://localhost:11434/v1/)
+    - API key is not required (Ollama ignores API keys)
+    - Supports OLLAMA_BASE_URL environment variable
+
+    Usage:
+        Register the provider with model ID prefixes you want to use:
+
+        ```python
+        import llm
+
+        # Register for ollama models
+        llm.register_provider("ollama", "ollama/")
+
+        # Now you can use ollama models directly
+        @llm.call("ollama/llama2")
+        def my_prompt():
+            return [llm.messages.user("Hello!")]
+        ```
+    """
+
+    id: ClassVar[str] = "ollama"
+    default_scope: ClassVar[str | list[str]] = "ollama/"
+    default_base_url: ClassVar[str | None] = "http://localhost:11434/v1/"
+    api_key_env_var: ClassVar[str] = "OLLAMA_API_KEY"
+    api_key_required: ClassVar[bool] = False
+    provider_name: ClassVar[str | None] = "Ollama"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        """Initialize the Ollama provider.
+
+        Args:
+            api_key: API key (optional). Defaults to OLLAMA_API_KEY env var or 'ollama'.
+            base_url: Custom base URL. Defaults to OLLAMA_BASE_URL env var
+                or http://localhost:11434/v1/.
+        """
+        resolved_api_key = api_key or os.environ.get(self.api_key_env_var) or "ollama"
+        resolved_base_url = (
+            base_url or os.environ.get("OLLAMA_BASE_URL") or self.default_base_url
+        )
+
+        self.client = OpenAI(
+            api_key=resolved_api_key,
+            base_url=resolved_base_url,
+        )
+        self.async_client = AsyncOpenAI(
+            api_key=resolved_api_key,
+            base_url=resolved_base_url,
+        )
+
+    def _model_name(self, model_id: str) -> str:
+        """Strip 'ollama/' prefix from model ID for Ollama API."""
+        return model_id.removeprefix("ollama/")

--- a/python/mirascope/llm/providers/provider_id.py
+++ b/python/mirascope/llm/providers/provider_id.py
@@ -7,9 +7,17 @@ KnownProviderId: TypeAlias = Literal[
     "anthropic-beta",  # Anthropic beta provider via AnthropicBetaProvider
     "google",  # Google provider via GoogleProvider
     "mlx",  # Local inference powered by `mlx-lm`, via MLXProvider
+    "ollama",  # Ollama provider via OllamaProvider
     "openai",  # OpenAI provider via OpenAIProvider (prefers Responses routing when available)
     "together",  # Together AI provider via TogetherProvider
 ]
 KNOWN_PROVIDER_IDS = get_args(KnownProviderId)
 
 ProviderId = KnownProviderId | str
+
+OpenAICompletionsCompatibleProviderId: TypeAlias = Literal[
+    "ollama",  # Ollama (OpenAI-compatible)
+    "openai",  # OpenAI via OpenAIProvider (routes to completions)
+    "openai:completions",  # OpenAI Completions API directly
+    "together",  # Together AI (OpenAI-compatible)
+]

--- a/python/mirascope/llm/providers/provider_registry.py
+++ b/python/mirascope/llm/providers/provider_registry.py
@@ -17,6 +17,7 @@ DEFAULT_AUTO_REGISTER_SCOPES: dict[str, ProviderId] = {
     "anthropic/": "anthropic",
     "google/": "google",
     "mlx-community/": "mlx",
+    "ollama/": "ollama",
     "openai/": "openai",
     "together/": "together",
 }

--- a/python/tests/e2e/input/cassettes/test_ollama_provider/ollama_gemma3_4b.yaml
+++ b/python/tests/e2e/input/cassettes/test_ollama_provider/ollama_gemma3_4b.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is 4200 + 42?"}],"model":"gemma3:4b"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '81'
+      content-type:
+      - application/json
+      host:
+      - localhost:11434
+      user-agent:
+      - OpenAI/Python 2.7.1
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 2.7.1
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.13.3
+    method: POST
+    uri: http://localhost:11434/v1/chat/completions
+  response:
+    body:
+      string: '{"id":"chatcmpl-674","object":"chat.completion","created":1765962162,"model":"gemma3:4b","system_fingerprint":"fp_ollama","choices":[{"index":0,"message":{"role":"assistant","content":"4200
+        + 42 = 4242\n"},"finish_reason":"stop"}],"usage":{"prompt_tokens":21,"completion_tokens":16,"total_tokens":37}}
+
+        '
+    headers:
+      Content-Length:
+      - '302'
+      Content-Type:
+      - application/json
+      Date:
+      - Wed, 17 Dec 2025 09:02:42 GMT
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/python/tests/e2e/input/snapshots/test_ollama_provider/ollama_gemma3_4b_snapshots.py
+++ b/python/tests/e2e/input/snapshots/test_ollama_provider/ollama_gemma3_4b_snapshots.py
@@ -1,0 +1,38 @@
+from inline_snapshot import snapshot
+
+from mirascope.llm import (
+    AssistantMessage,
+    Text,
+    UserMessage,
+)
+
+test_snapshot = snapshot(
+    {
+        "response": {
+            "provider_id": "ollama",
+            "model_id": "ollama/gemma3:4b",
+            "provider_model_name": "gemma3:4b",
+            "params": {},
+            "finish_reason": None,
+            "usage": {
+                "input_tokens": 21,
+                "output_tokens": 16,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+            },
+            "messages": [
+                UserMessage(content=[Text(text="What is 4200 + 42?")]),
+                AssistantMessage(
+                    content=[Text(text="4200 + 42 = 4242\n")],
+                    provider_id="ollama",
+                    model_id="ollama/gemma3:4b",
+                    provider_model_name="gemma3:4b",
+                    raw_message={"content": "4200 + 42 = 4242\n", "role": "assistant"},
+                ),
+            ],
+            "format": None,
+            "tools": [],
+        }
+    }
+)

--- a/python/tests/llm/providers/test_ollama_provider.py
+++ b/python/tests/llm/providers/test_ollama_provider.py
@@ -1,0 +1,77 @@
+"""Tests for OllamaProvider."""
+
+import os
+
+from mirascope.llm.providers.ollama.provider import OllamaProvider
+
+
+def test_ollama_provider_initialization() -> None:
+    """Test OllamaProvider initialization."""
+    provider = OllamaProvider()
+    assert provider.id == "ollama"
+    assert provider.default_scope == "ollama/"
+
+
+def test_ollama_provider_default_api_key() -> None:
+    """Test OllamaProvider uses default 'ollama' api_key."""
+    original_key = os.environ.pop("OLLAMA_API_KEY", None)
+    try:
+        provider = OllamaProvider()
+        assert provider.client.api_key == "ollama"
+    finally:
+        if original_key is not None:
+            os.environ["OLLAMA_API_KEY"] = original_key
+
+
+def test_ollama_provider_api_key_from_env() -> None:
+    """Test OllamaProvider uses OLLAMA_API_KEY from environment."""
+    original_key = os.environ.get("OLLAMA_API_KEY")
+    os.environ["OLLAMA_API_KEY"] = "env-test-key"
+    try:
+        provider = OllamaProvider()
+        assert provider.client.api_key == "env-test-key"
+    finally:
+        if original_key is not None:
+            os.environ["OLLAMA_API_KEY"] = original_key
+        else:
+            os.environ.pop("OLLAMA_API_KEY", None)
+
+
+def test_ollama_provider_custom_base_url() -> None:
+    """Test OllamaProvider with custom base_url."""
+    provider = OllamaProvider(base_url="http://custom.ollama.local:11434/v1/")
+    assert provider.id == "ollama"
+    assert str(provider.client.base_url) == "http://custom.ollama.local:11434/v1/"
+
+
+def test_ollama_provider_base_url_from_env() -> None:
+    """Test OllamaProvider uses OLLAMA_BASE_URL from environment."""
+    original_url = os.environ.get("OLLAMA_BASE_URL")
+    os.environ["OLLAMA_BASE_URL"] = "http://remote-ollama:11434/v1/"
+    try:
+        provider = OllamaProvider()
+        assert provider.id == "ollama"
+        assert str(provider.client.base_url) == "http://remote-ollama:11434/v1/"
+    finally:
+        if original_url is not None:
+            os.environ["OLLAMA_BASE_URL"] = original_url
+        else:
+            os.environ.pop("OLLAMA_BASE_URL", None)
+
+
+def test_ollama_provider_default_base_url() -> None:
+    """Test OllamaProvider uses default base_url."""
+    original_url = os.environ.pop("OLLAMA_BASE_URL", None)
+    try:
+        provider = OllamaProvider()
+        assert str(provider.client.base_url) == "http://localhost:11434/v1/"
+    finally:
+        if original_url is not None:
+            os.environ["OLLAMA_BASE_URL"] = original_url
+
+
+def test_ollama_provider_model_name() -> None:
+    """Test OllamaProvider strips 'ollama/' prefix from model_id."""
+    provider = OllamaProvider()
+    assert provider._model_name("ollama/gemma3:4b") == "gemma3:4b"  # pyright: ignore[reportPrivateUsage]
+    assert provider._model_name("gemma3:4b") == "gemma3:4b"  # pyright: ignore[reportPrivateUsage]


### PR DESCRIPTION
### TL;DR

Added support for Ollama, a local LLM server with an OpenAI-compatible API.

### What changed?

- Created a new `OllamaProvider` class that inherits from `OpenAICompletionsProvider`
- Added Ollama to the provider registry with the `ollama/` prefix
- Implemented model name resolution to strip the `ollama/` prefix
- Added default configuration for Ollama's local API endpoint (http://localhost:11434/v1/)
- Added support for environment variables `OLLAMA_API_KEY` and `OLLAMA_BASE_URL`
- Created tests for the Ollama provider functionality
- Added VCR cassettes and snapshots for e2e testing

### How to test?

1. Install Ollama locally (https://ollama.com)
2. Pull a model like `gemma3:4b` using Ollama
3. Run the following code:
```python
from mirascope.llm import call, register_provider

register_provider("ollama")

@call("ollama/gemma3:4b")
def add_numbers(a: int, b: int) -> str:
    return f"What is {a} + {b}?"

response = add_numbers(4200, 42)
print(response.pretty())
```

### Why make this change?

Ollama is a popular tool for running LLMs locally. Adding native support for Ollama allows Mirascope users to easily integrate with local models without needing to configure OpenAI-compatible settings manually. This enhances the library's flexibility by supporting both cloud-based and local LLM deployments.