### PR TITLE
fix(cloud): prettier formatting and exclusion of generated files

### DIFF
--- a/cloud/.prettierignore
+++ b/cloud/.prettierignore
@@ -15,6 +15,7 @@ pnpm-lock.yaml
 
 # Generated TypeScript files
 *.gen.ts
+src/routeTree.gen.ts
 
 # Markdown/MDX files (to preserve emphasis styles)
 *.md

--- a/cloud/db/migrations/meta/0003_snapshot.json
+++ b/cloud/db/migrations/meta/0003_snapshot.json
@@ -48,12 +48,8 @@
           "name": "sessions_user_id_users_id_fk",
           "tableFrom": "sessions",
           "tableTo": "users",
-          "columnsFrom": [
-            "user_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -109,9 +105,7 @@
         "users_email_unique": {
           "name": "users_email_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "email"
-          ]
+          "columns": ["email"]
         }
       },
       "policies": {},
@@ -157,9 +151,7 @@
         "organizations_name_unique": {
           "name": "organizations_name_unique",
           "nullsNotDistinct": false,
-          "columns": [
-            "name"
-          ]
+          "columns": ["name"]
         }
       },
       "policies": {},
@@ -210,12 +202,8 @@
           "name": "organization_memberships_id_users_id_fk",
           "tableFrom": "organization_memberships",
           "tableTo": "users",
-          "columnsFrom": [
-            "id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -223,12 +211,8 @@
           "name": "organization_memberships_organization_id_organizations_id_fk",
           "tableFrom": "organization_memberships",
           "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -236,10 +220,7 @@
       "compositePrimaryKeys": {
         "organization_memberships_id_organization_id_pk": {
           "name": "organization_memberships_id_organization_id_pk",
-          "columns": [
-            "id",
-            "organization_id"
-          ]
+          "columns": ["id", "organization_id"]
         }
       },
       "uniqueConstraints": {},
@@ -311,12 +292,8 @@
           "name": "organization_membership_audit_organization_id_organizations_id_fk",
           "tableFrom": "organization_membership_audit",
           "tableTo": "organizations",
-          "columnsFrom": [
-            "organization_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["organization_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -324,12 +301,8 @@
           "name": "organization_membership_audit_actor_id_users_id_fk",
           "tableFrom": "organization_membership_audit",
           "tableTo": "users",
-          "columnsFrom": [
-            "actor_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["actor_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         },
@@ -337,12 +310,8 @@
           "name": "organization_membership_audit_target_id_users_id_fk",
           "tableFrom": "organization_membership_audit",
           "tableTo": "users",
-          "columnsFrom": [
-            "target_id"
-          ],
-          "columnsTo": [
-            "id"
-          ],
+          "columnsFrom": ["target_id"],
+          "columnsTo": ["id"],
           "onDelete": "no action",
           "onUpdate": "no action"
         }
@@ -358,21 +327,12 @@
     "public.role": {
       "name": "role",
       "schema": "public",
-      "values": [
-        "OWNER",
-        "ADMIN",
-        "DEVELOPER",
-        "VIEWER"
-      ]
+      "values": ["OWNER", "ADMIN", "DEVELOPER", "VIEWER"]
     },
     "public.audit_action": {
       "name": "audit_action",
       "schema": "public",
-      "values": [
-        "GRANT",
-        "REVOKE",
-        "CHANGE"
-      ]
+      "values": ["GRANT", "REVOKE", "CHANGE"]
     }
   },
   "schemas": {},

--- a/cloud/src/routeTree.gen.ts
+++ b/cloud/src/routeTree.gen.ts
@@ -8,317 +8,316 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-
-import { Route as OrganizationsRouteImport } from "./routes/organizations";
-import { Route as LoginRouteImport } from "./routes/login";
-import { Route as IndexRouteImport } from "./routes/index";
-import { Route as AuthMeRouteImport } from "./routes/auth/me";
-import { Route as AuthGoogleRouteImport } from "./routes/auth/google";
-import { Route as AuthGithubRouteImport } from "./routes/auth/github";
-import { Route as AuthGoogleProxyCallbackRouteImport } from "./routes/auth/google.proxy-callback";
-import { Route as AuthGoogleCallbackRouteImport } from "./routes/auth/google.callback";
-import { Route as AuthGithubProxyCallbackRouteImport } from "./routes/auth/github.proxy-callback";
-import { Route as AuthGithubCallbackRouteImport } from "./routes/auth/github.callback";
-import { Route as ApiV0HealthRouteImport } from "./routes/api.v0.health";
-import { Route as ApiV0DocsRouteImport } from "./routes/api.v0.docs";
-import { Route as ApiV0SplatRouteImport } from "./routes/api.v0.$";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as OrganizationsRouteImport } from './routes/organizations'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as AuthMeRouteImport } from './routes/auth/me'
+import { Route as AuthGoogleRouteImport } from './routes/auth/google'
+import { Route as AuthGithubRouteImport } from './routes/auth/github'
+import { Route as AuthGoogleProxyCallbackRouteImport } from './routes/auth/google.proxy-callback'
+import { Route as AuthGoogleCallbackRouteImport } from './routes/auth/google.callback'
+import { Route as AuthGithubProxyCallbackRouteImport } from './routes/auth/github.proxy-callback'
+import { Route as AuthGithubCallbackRouteImport } from './routes/auth/github.callback'
+import { Route as ApiV0HealthRouteImport } from './routes/api.v0.health'
+import { Route as ApiV0DocsRouteImport } from './routes/api.v0.docs'
+import { Route as ApiV0SplatRouteImport } from './routes/api.v0.$'
 
 const OrganizationsRoute = OrganizationsRouteImport.update({
-  id: "/organizations",
-  path: "/organizations",
+  id: '/organizations',
+  path: '/organizations',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const LoginRoute = LoginRouteImport.update({
-  id: "/login",
-  path: "/login",
+  id: '/login',
+  path: '/login',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthMeRoute = AuthMeRouteImport.update({
-  id: "/auth/me",
-  path: "/auth/me",
+  id: '/auth/me',
+  path: '/auth/me',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthGoogleRoute = AuthGoogleRouteImport.update({
-  id: "/auth/google",
-  path: "/auth/google",
+  id: '/auth/google',
+  path: '/auth/google',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthGithubRoute = AuthGithubRouteImport.update({
-  id: "/auth/github",
-  path: "/auth/github",
+  id: '/auth/github',
+  path: '/auth/github',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const AuthGoogleProxyCallbackRoute = AuthGoogleProxyCallbackRouteImport.update({
-  id: "/proxy-callback",
-  path: "/proxy-callback",
+  id: '/proxy-callback',
+  path: '/proxy-callback',
   getParentRoute: () => AuthGoogleRoute,
-} as any);
+} as any)
 const AuthGoogleCallbackRoute = AuthGoogleCallbackRouteImport.update({
-  id: "/callback",
-  path: "/callback",
+  id: '/callback',
+  path: '/callback',
   getParentRoute: () => AuthGoogleRoute,
-} as any);
+} as any)
 const AuthGithubProxyCallbackRoute = AuthGithubProxyCallbackRouteImport.update({
-  id: "/proxy-callback",
-  path: "/proxy-callback",
+  id: '/proxy-callback',
+  path: '/proxy-callback',
   getParentRoute: () => AuthGithubRoute,
-} as any);
+} as any)
 const AuthGithubCallbackRoute = AuthGithubCallbackRouteImport.update({
-  id: "/callback",
-  path: "/callback",
+  id: '/callback',
+  path: '/callback',
   getParentRoute: () => AuthGithubRoute,
-} as any);
+} as any)
 const ApiV0HealthRoute = ApiV0HealthRouteImport.update({
-  id: "/api/v0/health",
-  path: "/api/v0/health",
+  id: '/api/v0/health',
+  path: '/api/v0/health',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiV0DocsRoute = ApiV0DocsRouteImport.update({
-  id: "/api/v0/docs",
-  path: "/api/v0/docs",
+  id: '/api/v0/docs',
+  path: '/api/v0/docs',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 const ApiV0SplatRoute = ApiV0SplatRouteImport.update({
-  id: "/api/v0/$",
-  path: "/api/v0/$",
+  id: '/api/v0/$',
+  path: '/api/v0/$',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
-  "/login": typeof LoginRoute;
-  "/organizations": typeof OrganizationsRoute;
-  "/auth/github": typeof AuthGithubRouteWithChildren;
-  "/auth/google": typeof AuthGoogleRouteWithChildren;
-  "/auth/me": typeof AuthMeRoute;
-  "/api/v0/$": typeof ApiV0SplatRoute;
-  "/api/v0/docs": typeof ApiV0DocsRoute;
-  "/api/v0/health": typeof ApiV0HealthRoute;
-  "/auth/github/callback": typeof AuthGithubCallbackRoute;
-  "/auth/github/proxy-callback": typeof AuthGithubProxyCallbackRoute;
-  "/auth/google/callback": typeof AuthGoogleCallbackRoute;
-  "/auth/google/proxy-callback": typeof AuthGoogleProxyCallbackRoute;
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/organizations': typeof OrganizationsRoute
+  '/auth/github': typeof AuthGithubRouteWithChildren
+  '/auth/google': typeof AuthGoogleRouteWithChildren
+  '/auth/me': typeof AuthMeRoute
+  '/api/v0/$': typeof ApiV0SplatRoute
+  '/api/v0/docs': typeof ApiV0DocsRoute
+  '/api/v0/health': typeof ApiV0HealthRoute
+  '/auth/github/callback': typeof AuthGithubCallbackRoute
+  '/auth/github/proxy-callback': typeof AuthGithubProxyCallbackRoute
+  '/auth/google/callback': typeof AuthGoogleCallbackRoute
+  '/auth/google/proxy-callback': typeof AuthGoogleProxyCallbackRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
-  "/login": typeof LoginRoute;
-  "/organizations": typeof OrganizationsRoute;
-  "/auth/github": typeof AuthGithubRouteWithChildren;
-  "/auth/google": typeof AuthGoogleRouteWithChildren;
-  "/auth/me": typeof AuthMeRoute;
-  "/api/v0/$": typeof ApiV0SplatRoute;
-  "/api/v0/docs": typeof ApiV0DocsRoute;
-  "/api/v0/health": typeof ApiV0HealthRoute;
-  "/auth/github/callback": typeof AuthGithubCallbackRoute;
-  "/auth/github/proxy-callback": typeof AuthGithubProxyCallbackRoute;
-  "/auth/google/callback": typeof AuthGoogleCallbackRoute;
-  "/auth/google/proxy-callback": typeof AuthGoogleProxyCallbackRoute;
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/organizations': typeof OrganizationsRoute
+  '/auth/github': typeof AuthGithubRouteWithChildren
+  '/auth/google': typeof AuthGoogleRouteWithChildren
+  '/auth/me': typeof AuthMeRoute
+  '/api/v0/$': typeof ApiV0SplatRoute
+  '/api/v0/docs': typeof ApiV0DocsRoute
+  '/api/v0/health': typeof ApiV0HealthRoute
+  '/auth/github/callback': typeof AuthGithubCallbackRoute
+  '/auth/github/proxy-callback': typeof AuthGithubProxyCallbackRoute
+  '/auth/google/callback': typeof AuthGoogleCallbackRoute
+  '/auth/google/proxy-callback': typeof AuthGoogleProxyCallbackRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
-  "/login": typeof LoginRoute;
-  "/organizations": typeof OrganizationsRoute;
-  "/auth/github": typeof AuthGithubRouteWithChildren;
-  "/auth/google": typeof AuthGoogleRouteWithChildren;
-  "/auth/me": typeof AuthMeRoute;
-  "/api/v0/$": typeof ApiV0SplatRoute;
-  "/api/v0/docs": typeof ApiV0DocsRoute;
-  "/api/v0/health": typeof ApiV0HealthRoute;
-  "/auth/github/callback": typeof AuthGithubCallbackRoute;
-  "/auth/github/proxy-callback": typeof AuthGithubProxyCallbackRoute;
-  "/auth/google/callback": typeof AuthGoogleCallbackRoute;
-  "/auth/google/proxy-callback": typeof AuthGoogleProxyCallbackRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/login': typeof LoginRoute
+  '/organizations': typeof OrganizationsRoute
+  '/auth/github': typeof AuthGithubRouteWithChildren
+  '/auth/google': typeof AuthGoogleRouteWithChildren
+  '/auth/me': typeof AuthMeRoute
+  '/api/v0/$': typeof ApiV0SplatRoute
+  '/api/v0/docs': typeof ApiV0DocsRoute
+  '/api/v0/health': typeof ApiV0HealthRoute
+  '/auth/github/callback': typeof AuthGithubCallbackRoute
+  '/auth/github/proxy-callback': typeof AuthGithubProxyCallbackRoute
+  '/auth/google/callback': typeof AuthGoogleCallbackRoute
+  '/auth/google/proxy-callback': typeof AuthGoogleProxyCallbackRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
+  fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    | "/"
-    | "/login"
-    | "/organizations"
-    | "/auth/github"
-    | "/auth/google"
-    | "/auth/me"
-    | "/api/v0/$"
-    | "/api/v0/docs"
-    | "/api/v0/health"
-    | "/auth/github/callback"
-    | "/auth/github/proxy-callback"
-    | "/auth/google/callback"
-    | "/auth/google/proxy-callback";
-  fileRoutesByTo: FileRoutesByTo;
+    | '/'
+    | '/login'
+    | '/organizations'
+    | '/auth/github'
+    | '/auth/google'
+    | '/auth/me'
+    | '/api/v0/$'
+    | '/api/v0/docs'
+    | '/api/v0/health'
+    | '/auth/github/callback'
+    | '/auth/github/proxy-callback'
+    | '/auth/google/callback'
+    | '/auth/google/proxy-callback'
+  fileRoutesByTo: FileRoutesByTo
   to:
-    | "/"
-    | "/login"
-    | "/organizations"
-    | "/auth/github"
-    | "/auth/google"
-    | "/auth/me"
-    | "/api/v0/$"
-    | "/api/v0/docs"
-    | "/api/v0/health"
-    | "/auth/github/callback"
-    | "/auth/github/proxy-callback"
-    | "/auth/google/callback"
-    | "/auth/google/proxy-callback";
+    | '/'
+    | '/login'
+    | '/organizations'
+    | '/auth/github'
+    | '/auth/google'
+    | '/auth/me'
+    | '/api/v0/$'
+    | '/api/v0/docs'
+    | '/api/v0/health'
+    | '/auth/github/callback'
+    | '/auth/github/proxy-callback'
+    | '/auth/google/callback'
+    | '/auth/google/proxy-callback'
   id:
-    | "__root__"
-    | "/"
-    | "/login"
-    | "/organizations"
-    | "/auth/github"
-    | "/auth/google"
-    | "/auth/me"
-    | "/api/v0/$"
-    | "/api/v0/docs"
-    | "/api/v0/health"
-    | "/auth/github/callback"
-    | "/auth/github/proxy-callback"
-    | "/auth/google/callback"
-    | "/auth/google/proxy-callback";
-  fileRoutesById: FileRoutesById;
+    | '__root__'
+    | '/'
+    | '/login'
+    | '/organizations'
+    | '/auth/github'
+    | '/auth/google'
+    | '/auth/me'
+    | '/api/v0/$'
+    | '/api/v0/docs'
+    | '/api/v0/health'
+    | '/auth/github/callback'
+    | '/auth/github/proxy-callback'
+    | '/auth/google/callback'
+    | '/auth/google/proxy-callback'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
-  LoginRoute: typeof LoginRoute;
-  OrganizationsRoute: typeof OrganizationsRoute;
-  AuthGithubRoute: typeof AuthGithubRouteWithChildren;
-  AuthGoogleRoute: typeof AuthGoogleRouteWithChildren;
-  AuthMeRoute: typeof AuthMeRoute;
-  ApiV0SplatRoute: typeof ApiV0SplatRoute;
-  ApiV0DocsRoute: typeof ApiV0DocsRoute;
-  ApiV0HealthRoute: typeof ApiV0HealthRoute;
+  IndexRoute: typeof IndexRoute
+  LoginRoute: typeof LoginRoute
+  OrganizationsRoute: typeof OrganizationsRoute
+  AuthGithubRoute: typeof AuthGithubRouteWithChildren
+  AuthGoogleRoute: typeof AuthGoogleRouteWithChildren
+  AuthMeRoute: typeof AuthMeRoute
+  ApiV0SplatRoute: typeof ApiV0SplatRoute
+  ApiV0DocsRoute: typeof ApiV0DocsRoute
+  ApiV0HealthRoute: typeof ApiV0HealthRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/organizations": {
-      id: "/organizations";
-      path: "/organizations";
-      fullPath: "/organizations";
-      preLoaderRoute: typeof OrganizationsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/login": {
-      id: "/login";
-      path: "/login";
-      fullPath: "/login";
-      preLoaderRoute: typeof LoginRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/auth/me": {
-      id: "/auth/me";
-      path: "/auth/me";
-      fullPath: "/auth/me";
-      preLoaderRoute: typeof AuthMeRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/auth/google": {
-      id: "/auth/google";
-      path: "/auth/google";
-      fullPath: "/auth/google";
-      preLoaderRoute: typeof AuthGoogleRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/auth/github": {
-      id: "/auth/github";
-      path: "/auth/github";
-      fullPath: "/auth/github";
-      preLoaderRoute: typeof AuthGithubRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/auth/google/proxy-callback": {
-      id: "/auth/google/proxy-callback";
-      path: "/proxy-callback";
-      fullPath: "/auth/google/proxy-callback";
-      preLoaderRoute: typeof AuthGoogleProxyCallbackRouteImport;
-      parentRoute: typeof AuthGoogleRoute;
-    };
-    "/auth/google/callback": {
-      id: "/auth/google/callback";
-      path: "/callback";
-      fullPath: "/auth/google/callback";
-      preLoaderRoute: typeof AuthGoogleCallbackRouteImport;
-      parentRoute: typeof AuthGoogleRoute;
-    };
-    "/auth/github/proxy-callback": {
-      id: "/auth/github/proxy-callback";
-      path: "/proxy-callback";
-      fullPath: "/auth/github/proxy-callback";
-      preLoaderRoute: typeof AuthGithubProxyCallbackRouteImport;
-      parentRoute: typeof AuthGithubRoute;
-    };
-    "/auth/github/callback": {
-      id: "/auth/github/callback";
-      path: "/callback";
-      fullPath: "/auth/github/callback";
-      preLoaderRoute: typeof AuthGithubCallbackRouteImport;
-      parentRoute: typeof AuthGithubRoute;
-    };
-    "/api/v0/health": {
-      id: "/api/v0/health";
-      path: "/api/v0/health";
-      fullPath: "/api/v0/health";
-      preLoaderRoute: typeof ApiV0HealthRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/v0/docs": {
-      id: "/api/v0/docs";
-      path: "/api/v0/docs";
-      fullPath: "/api/v0/docs";
-      preLoaderRoute: typeof ApiV0DocsRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
-    "/api/v0/$": {
-      id: "/api/v0/$";
-      path: "/api/v0/$";
-      fullPath: "/api/v0/$";
-      preLoaderRoute: typeof ApiV0SplatRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/organizations': {
+      id: '/organizations'
+      path: '/organizations'
+      fullPath: '/organizations'
+      preLoaderRoute: typeof OrganizationsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/me': {
+      id: '/auth/me'
+      path: '/auth/me'
+      fullPath: '/auth/me'
+      preLoaderRoute: typeof AuthMeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/google': {
+      id: '/auth/google'
+      path: '/auth/google'
+      fullPath: '/auth/google'
+      preLoaderRoute: typeof AuthGoogleRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/github': {
+      id: '/auth/github'
+      path: '/auth/github'
+      fullPath: '/auth/github'
+      preLoaderRoute: typeof AuthGithubRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/google/proxy-callback': {
+      id: '/auth/google/proxy-callback'
+      path: '/proxy-callback'
+      fullPath: '/auth/google/proxy-callback'
+      preLoaderRoute: typeof AuthGoogleProxyCallbackRouteImport
+      parentRoute: typeof AuthGoogleRoute
+    }
+    '/auth/google/callback': {
+      id: '/auth/google/callback'
+      path: '/callback'
+      fullPath: '/auth/google/callback'
+      preLoaderRoute: typeof AuthGoogleCallbackRouteImport
+      parentRoute: typeof AuthGoogleRoute
+    }
+    '/auth/github/proxy-callback': {
+      id: '/auth/github/proxy-callback'
+      path: '/proxy-callback'
+      fullPath: '/auth/github/proxy-callback'
+      preLoaderRoute: typeof AuthGithubProxyCallbackRouteImport
+      parentRoute: typeof AuthGithubRoute
+    }
+    '/auth/github/callback': {
+      id: '/auth/github/callback'
+      path: '/callback'
+      fullPath: '/auth/github/callback'
+      preLoaderRoute: typeof AuthGithubCallbackRouteImport
+      parentRoute: typeof AuthGithubRoute
+    }
+    '/api/v0/health': {
+      id: '/api/v0/health'
+      path: '/api/v0/health'
+      fullPath: '/api/v0/health'
+      preLoaderRoute: typeof ApiV0HealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v0/docs': {
+      id: '/api/v0/docs'
+      path: '/api/v0/docs'
+      fullPath: '/api/v0/docs'
+      preLoaderRoute: typeof ApiV0DocsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/v0/$': {
+      id: '/api/v0/$'
+      path: '/api/v0/$'
+      fullPath: '/api/v0/$'
+      preLoaderRoute: typeof ApiV0SplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 interface AuthGithubRouteChildren {
-  AuthGithubCallbackRoute: typeof AuthGithubCallbackRoute;
-  AuthGithubProxyCallbackRoute: typeof AuthGithubProxyCallbackRoute;
+  AuthGithubCallbackRoute: typeof AuthGithubCallbackRoute
+  AuthGithubProxyCallbackRoute: typeof AuthGithubProxyCallbackRoute
 }
 
 const AuthGithubRouteChildren: AuthGithubRouteChildren = {
   AuthGithubCallbackRoute: AuthGithubCallbackRoute,
   AuthGithubProxyCallbackRoute: AuthGithubProxyCallbackRoute,
-};
+}
 
 const AuthGithubRouteWithChildren = AuthGithubRoute._addFileChildren(
   AuthGithubRouteChildren,
-);
+)
 
 interface AuthGoogleRouteChildren {
-  AuthGoogleCallbackRoute: typeof AuthGoogleCallbackRoute;
-  AuthGoogleProxyCallbackRoute: typeof AuthGoogleProxyCallbackRoute;
+  AuthGoogleCallbackRoute: typeof AuthGoogleCallbackRoute
+  AuthGoogleProxyCallbackRoute: typeof AuthGoogleProxyCallbackRoute
 }
 
 const AuthGoogleRouteChildren: AuthGoogleRouteChildren = {
   AuthGoogleCallbackRoute: AuthGoogleCallbackRoute,
   AuthGoogleProxyCallbackRoute: AuthGoogleProxyCallbackRoute,
-};
+}
 
 const AuthGoogleRouteWithChildren = AuthGoogleRoute._addFileChildren(
   AuthGoogleRouteChildren,
-);
+)
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
@@ -330,16 +329,16 @@ const rootRouteChildren: RootRouteChildren = {
   ApiV0SplatRoute: ApiV0SplatRoute,
   ApiV0DocsRoute: ApiV0DocsRoute,
   ApiV0HealthRoute: ApiV0HealthRoute,
-};
+}
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
-  ._addFileTypes<FileRouteTypes>();
+  ._addFileTypes<FileRouteTypes>()
 
-import type { getRouter } from "./router.tsx";
-import type { createStart } from "@tanstack/react-start";
-declare module "@tanstack/react-start" {
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
   interface Register {
-    ssr: true;
-    router: Awaited<ReturnType<typeof getRouter>>;
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
   }
 }


### PR DESCRIPTION
This PR will:

1. Properly reformat a db migration snapshot (must have slipped prettier).
2. Exclude the generated `src/routeTree.gen.ts` from prettier to only produce a diff if routes actually changed.

Fixes behavior observed in https://app.graphite.com/github/pr/Mirascope/mirascope/1633/refactor(cloud)-refactor-UI-code-to-prepare-for-incremental-port-of-website-features#comment-PRRC_kwDOK1y0Xc6cfPiT.