### PR TITLE
fix(cloud): center app ui properly to avoid it hanging off to the side

### DIFF
--- a/cloud/app/components/centered-layout.tsx
+++ b/cloud/app/components/centered-layout.tsx
@@ -1,0 +1,10 @@
+import type { ReactNode } from "react";
+
+// Centers content in the middle of the page.
+export function CenteredLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="w-full min-h-[calc(100vh-var(--header-height))] grid place-items-center p-8">
+      {children}
+    </div>
+  );
+}

--- a/cloud/app/components/login-page.tsx
+++ b/cloud/app/components/login-page.tsx
@@ -152,7 +152,7 @@ export function LoginPage() {
   const { loginWithGitHub, loginWithGoogle } = useAuth();
 
   return (
-    <div className="flex justify-center items-center h-screen w-screen">
+    <div>
       <Card className="flex flex-col h-fit w-fit p-4">
         <CardHeader className="mb-2 text-center">
           <CardTitle className="text-2xl">Mirascope Cloud</CardTitle>

--- a/cloud/app/components/organizations-page.tsx
+++ b/cloud/app/components/organizations-page.tsx
@@ -154,18 +154,12 @@ export function OrganizationsPage() {
 
   if (isLoading) {
     return (
-      <div className="w-screen h-screen flex items-center justify-center">
-        <div className="text-muted-foreground">Loading organizations...</div>
-      </div>
+      <div className="text-muted-foreground">Loading organizations...</div>
     );
   }
 
   if (error) {
-    return (
-      <div className="w-screen h-screen flex items-center justify-center">
-        <div className="text-destructive">Failed to load organizations</div>
-      </div>
-    );
+    return <div className="text-destructive">Failed to load organizations</div>;
   }
 
   return (

--- a/cloud/app/routes/index.tsx
+++ b/cloud/app/routes/index.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from "react";
-
+import { CenteredLayout } from "@/app/components/centered-layout";
 import { FrontPage } from "@/app/components/front-page";
 import { Protected } from "@/app/components/protected";
 import { createFileRoute } from "@tanstack/react-router";
@@ -8,21 +7,12 @@ export const Route = createFileRoute("/")({
   component: App,
 });
 
-// Centers content in the middle of the page.
-const CenteredContent = ({ children }: { children: ReactNode }) => {
-  return (
-    <div className="w-full min-h-[calc(100vh-var(--header-height))] grid place-items-center p-8">
-      {children}
-    </div>
-  );
-};
-
 function App() {
   return (
-    <CenteredContent>
+    <CenteredLayout>
       <Protected>
         <FrontPage />
       </Protected>
-    </CenteredContent>
+    </CenteredLayout>
   );
 }

--- a/cloud/app/routes/login.tsx
+++ b/cloud/app/routes/login.tsx
@@ -1,6 +1,11 @@
+import { CenteredLayout } from "@/app/components/centered-layout";
 import { createFileRoute } from "@tanstack/react-router";
 import { LoginPage } from "@/app/components/login-page";
 
 export const Route = createFileRoute("/login")({
-  component: LoginPage,
+  component: () => (
+    <CenteredLayout>
+      <LoginPage />
+    </CenteredLayout>
+  ),
 });

--- a/cloud/app/routes/organizations.tsx
+++ b/cloud/app/routes/organizations.tsx
@@ -1,3 +1,4 @@
+import { CenteredLayout } from "@/app/components/centered-layout";
 import { OrganizationsPage } from "@/app/components/organizations-page";
 import { Protected } from "@/app/components/protected";
 import { createFileRoute } from "@tanstack/react-router";
@@ -8,8 +9,10 @@ export const Route = createFileRoute("/organizations")({
 
 function OrganizationsRoute() {
   return (
-    <Protected>
-      <OrganizationsPage />
-    </Protected>
+    <CenteredLayout>
+      <Protected>
+        <OrganizationsPage />
+      </Protected>
+    </CenteredLayout>
   );
 }


### PR DESCRIPTION
Fixes a problem where the use of screen width/height will no longer center properly when nested inside of other containers. See screenshot below.

![image.png](https://app.graphite.com/user-attachments/assets/708996ec-d74e-4b4b-891f-72358315ff28.png)

