### PR TITLE
chore: bump version to 2.0.0a4

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -21,12 +21,12 @@ To install the Mirascope v2 alpha, use the following command:
 <TabbedSection>
 <Tab value="uv">
 ```bash
-uv add "mirascope[all]==2.0.0-alpha.3"
+uv add "mirascope[all]==2.0.0-alpha.4"
 ```
 </Tab>
 <Tab value="pip">
 ```bash
-pip install "mirascope[all]==2.0.0-alpha.3"
+pip install "mirascope[all]==2.0.0-alpha.4"
 ```
 </Tab>
 </TabbedSection>

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirascope"
-version = "2.0.0-alpha.3"
+version = "2.0.0-alpha.4"
 description = "LLM abstractions that aren't obstructions"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/python/tests/ops/_internal/test_closure.py
+++ b/python/tests/ops/_internal/test_closure.py
@@ -750,7 +750,7 @@ def closure_inside_decorator_fn() -> str:
     assert closure.dependencies == snapshot(
         {
             "mirascope": {
-                "version": "2.0.0a3",
+                "version": "2.0.0a4",
                 "extras": ["all"],
             }
         }
@@ -784,7 +784,7 @@ def closure_inside_imported_decorator_fn() -> str:
     assert closure.dependencies == snapshot(
         {
             "mirascope": {
-                "version": "2.0.0a3",
+                "version": "2.0.0a4",
                 "extras": ["all"],
             }
         }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -952,7 +952,7 @@ wheels = [
 
 [[package]]
 name = "mirascope"
-version = "2.0.0a3"
+version = "2.0.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },


### PR DESCRIPTION
### TL;DR

Bump Mirascope version from 2.0.0-alpha.3 to 2.0.0-alpha.4

### What changed?

- Updated version number in `pyproject.toml` from 2.0.0-alpha.3 to 2.0.0-alpha.4
- Updated installation instructions in documentation to reference the new version
- Updated test snapshots to reflect the new version number
- Updated the lock file with the new version

### How to test?

1. Verify that the package installs correctly with the new version:
   ```bash
   uv add "mirascope[all]==2.0.0-alpha.4"
   # or
   pip install "mirascope[all]==2.0.0-alpha.4"
   ```
2. Run the test suite to ensure all tests pass with the updated version

### Why make this change?

This version bump prepares for the release of the next alpha version of Mirascope v2, incorporating the latest features and fixes that have been developed since alpha.3.