### PR TITLE
feat(api): add SDK traces flat endpoint with tests

### DIFF
--- a/cloud/api/api.ts
+++ b/cloud/api/api.ts
@@ -1,6 +1,7 @@
 import { HttpApi } from "@effect/platform";
 import { HealthApi } from "@/api/health.schemas";
 import { TracesApi } from "@/api/traces.schemas";
+import { SdkTracesApi } from "@/api/sdk.schemas";
 import { DocsApi } from "@/api/docs.schemas";
 import { OrganizationsApi } from "@/api/organizations.schemas";
 import { ProjectsApi } from "@/api/projects.schemas";
@@ -10,6 +11,7 @@ import { ApiKeysApi } from "@/api/api-keys.schemas";
 export * from "@/errors";
 export * from "@/api/health.schemas";
 export * from "@/api/traces.schemas";
+export * from "@/api/sdk.schemas";
 export * from "@/api/docs.schemas";
 export * from "@/api/organizations.schemas";
 export * from "@/api/projects.schemas";
@@ -19,6 +21,7 @@ export * from "@/api/api-keys.schemas";
 export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
   .add(HealthApi)
   .add(TracesApi)
+  .add(SdkTracesApi)
   .add(DocsApi)
   .add(OrganizationsApi)
   .add(ProjectsApi)

--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -2,6 +2,7 @@ import { HttpApiBuilder } from "@effect/platform";
 import { Layer } from "effect";
 import { checkHealthHandler } from "@/api/health.handlers";
 import { createTraceHandler } from "@/api/traces.handlers";
+import { sdkCreateTraceHandler } from "@/api/sdk.handlers";
 import { getOpenApiSpecHandler } from "@/api/docs.handlers";
 import {
   listOrganizationsHandler,
@@ -52,6 +53,13 @@ const TracesHandlersLive = HttpApiBuilder.group(
         payload,
       ),
     ),
+);
+
+const SdkTracesHandlersLive = HttpApiBuilder.group(
+  MirascopeCloudApi,
+  "sdkTraces",
+  (handlers) =>
+    handlers.handle("create", ({ payload }) => sdkCreateTraceHandler(payload)),
 );
 
 const DocsHandlersLive = HttpApiBuilder.group(
@@ -170,6 +178,7 @@ const ApiKeysHandlersLive = HttpApiBuilder.group(
 export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(HealthHandlersLive),
   Layer.provide(TracesHandlersLive),
+  Layer.provide(SdkTracesHandlersLive),
   Layer.provide(DocsHandlersLive),
   Layer.provide(OrganizationsHandlersLive),
   Layer.provide(ProjectsHandlersLive),

--- a/cloud/api/sdk.handlers.ts
+++ b/cloud/api/sdk.handlers.ts
@@ -1,0 +1,45 @@
+/**
+ * SDK Flat API Handlers
+ *
+ * These handlers require API key authentication and derive
+ * organizationId, projectId, and environmentId from the API key context.
+ */
+import { Effect, Option } from "effect";
+import { AuthenticatedUser, AuthenticatedApiKey } from "@/auth";
+import { UnauthorizedError } from "@/errors";
+import { createTraceHandler } from "@/api/traces.handlers";
+import type { CreateTraceRequest } from "@/api/sdk.schemas";
+
+export * from "@/api/sdk.schemas";
+
+/**
+ * Helper to require API key context for SDK endpoints.
+ * Validates that the request has both AuthenticatedUser and AuthenticatedApiKey.
+ * Uses Effect.serviceOption to make AuthenticatedApiKey optional in context,
+ * but fails with UnauthorizedError if not present.
+ */
+export const requireApiKeyContext = Effect.gen(function* () {
+  yield* AuthenticatedUser;
+  const maybeApiKey = yield* Effect.serviceOption(AuthenticatedApiKey);
+  if (Option.isNone(maybeApiKey)) {
+    return yield* Effect.fail(
+      new UnauthorizedError({ message: "API key required for this endpoint" }),
+    );
+  }
+  return maybeApiKey.value;
+});
+
+/**
+ * SDK handler for creating traces.
+ * Derives org/project/env from API key context.
+ */
+export const sdkCreateTraceHandler = (payload: CreateTraceRequest) =>
+  Effect.gen(function* () {
+    const apiKeyInfo = yield* requireApiKeyContext;
+    return yield* createTraceHandler(
+      apiKeyInfo.organizationId,
+      apiKeyInfo.projectId,
+      apiKeyInfo.environmentId,
+      payload,
+    );
+  });

--- a/cloud/api/sdk.schemas.ts
+++ b/cloud/api/sdk.schemas.ts
@@ -1,0 +1,40 @@
+/**
+ * SDK Flat API Schemas
+ *
+ * These endpoints provide flat paths for SDK usage with API key authentication.
+ * The organizationId, projectId, and environmentId are derived from the API key.
+ */
+import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
+import {
+  NotFoundError,
+  PermissionDeniedError,
+  DatabaseError,
+  AlreadyExistsError,
+  UnauthorizedError,
+} from "@/errors";
+import {
+  CreateTraceRequestSchema,
+  CreateTraceResponseSchema,
+} from "@/api/traces.schemas";
+
+// Re-export request/response types from traces module
+export {
+  CreateTraceRequestSchema,
+  CreateTraceResponseSchema,
+  type CreateTraceRequest,
+  type CreateTraceResponse,
+} from "@/api/traces.schemas";
+
+/**
+ * SDK Traces API - Flat paths for SDK usage
+ */
+export class SdkTracesApi extends HttpApiGroup.make("sdkTraces").add(
+  HttpApiEndpoint.post("create", "/traces")
+    .setPayload(CreateTraceRequestSchema)
+    .addSuccess(CreateTraceResponseSchema)
+    .addError(UnauthorizedError, { status: UnauthorizedError.status })
+    .addError(NotFoundError, { status: NotFoundError.status })
+    .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+    .addError(DatabaseError, { status: DatabaseError.status })
+    .addError(AlreadyExistsError, { status: AlreadyExistsError.status }),
+) {}

--- a/cloud/api/traces.test.ts
+++ b/cloud/api/traces.test.ts
@@ -1,6 +1,9 @@
 import { Effect } from "effect";
-import { describe, expect, TestApiContext } from "@/tests/api";
+import { describe, expect, TestApiContext, it } from "@/tests/api";
 import type { PublicProject, PublicEnvironment } from "@/db/schema";
+import { AuthenticatedApiKey, AuthenticatedUser } from "@/auth";
+import { sdkCreateTraceHandler } from "@/api/sdk.handlers";
+import { Database } from "@/db";
 
 describe.sequential("Traces API", (it) => {
   let project: PublicProject;
@@ -81,6 +84,153 @@ describe.sequential("Traces API", (it) => {
         });
 
         expect(result.partialSuccess).toBeDefined();
+      }),
+  );
+});
+
+// SDK Traces Handler Unit Tests (requires Database context)
+describe("SDK Traces Handler", () => {
+  const mockOwner = {
+    id: "test-owner-id",
+    email: "test@example.com",
+    name: "Test Owner",
+    deletedAt: null,
+  };
+
+  it.effect("sdkCreateTraceHandler - creates trace with API key auth", () =>
+    Effect.gen(function* () {
+      const db = yield* Database;
+
+      // Create test user
+      const owner = yield* db.users.create({
+        data: {
+          email: `sdk-test-${Date.now()}@example.com`,
+          name: "SDK Test User",
+        },
+      });
+
+      // Create test organization
+      const org = yield* db.organizations.create({
+        userId: owner.id,
+        data: { name: "SDK Test Org", slug: `sdk-test-org-${Date.now()}` },
+      });
+
+      // Create test project
+      const project = yield* db.organizations.projects.create({
+        userId: owner.id,
+        organizationId: org.id,
+        data: { name: "SDK Test Project", slug: "sdk-test-project" },
+      });
+
+      // Create test environment
+      const environment = yield* db.organizations.projects.environments.create({
+        userId: owner.id,
+        organizationId: org.id,
+        projectId: project.id,
+        data: { name: "SDK Test Environment", slug: "sdk-test-env" },
+      });
+
+      // Create API key
+      const createdApiKey =
+        yield* db.organizations.projects.environments.apiKeys.create({
+          userId: owner.id,
+          organizationId: org.id,
+          projectId: project.id,
+          environmentId: environment.id,
+          data: { name: "SDK Test API Key" },
+        });
+
+      // Construct ApiKeyInfo
+      const apiKeyInfo = {
+        apiKeyId: createdApiKey.id,
+        environmentId: environment.id,
+        projectId: project.id,
+        organizationId: org.id,
+        ownerId: owner.id,
+        ownerEmail: owner.email,
+        ownerName: owner.name,
+        ownerImageUrl: null,
+        ownerDeletedAt: null,
+      };
+
+      const payload = {
+        resourceSpans: [
+          {
+            resource: {
+              attributes: [
+                {
+                  key: "service.name",
+                  value: { stringValue: "sdk-test-service" },
+                },
+              ],
+            },
+            scopeSpans: [
+              {
+                scope: { name: "sdk-test-scope", version: "1.0.0" },
+                spans: [
+                  {
+                    traceId: "sdk-trace-handler-test",
+                    spanId: "sdk-span-handler-test",
+                    name: "sdk-test-span",
+                    startTimeUnixNano: "1000000000",
+                    endTimeUnixNano: "2000000000",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      };
+
+      // Call SDK handler with API key context
+      const result = yield* sdkCreateTraceHandler(payload).pipe(
+        Effect.provideService(AuthenticatedUser, owner),
+        Effect.provideService(AuthenticatedApiKey, apiKeyInfo),
+      );
+
+      expect(result.partialSuccess).toBeDefined();
+
+      // Cleanup
+      yield* db.organizations.delete({
+        organizationId: org.id,
+        userId: owner.id,
+      });
+      yield* db.users.delete({ userId: owner.id });
+    }),
+  );
+
+  it.effect(
+    "sdkCreateTraceHandler - fails without API key auth (UnauthorizedError)",
+    () =>
+      Effect.gen(function* () {
+        const payload = {
+          resourceSpans: [
+            {
+              scopeSpans: [
+                {
+                  spans: [
+                    {
+                      traceId: "test",
+                      spanId: "test",
+                      name: "test",
+                      startTimeUnixNano: "1000000000",
+                      endTimeUnixNano: "2000000000",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        };
+
+        // Call SDK handler without API key context - should fail
+        const error = yield* sdkCreateTraceHandler(payload).pipe(
+          Effect.provideService(AuthenticatedUser, mockOwner),
+          Effect.flip,
+        );
+
+        expect(error._tag).toBe("UnauthorizedError");
+        expect(error.message).toBe("API key required for this endpoint");
       }),
   );
 });


### PR DESCRIPTION
### TL;DR

Added SDK-specific API endpoints that use API key authentication to derive organization, project, and environment context.

### What changed?

- Created new SDK API endpoints with flat paths for easier SDK integration
- Added `sdk.schemas.ts` to define the SDK API endpoints and schemas
- Added `sdk.handlers.ts` with handlers that require API key authentication
- Implemented `requireApiKeyContext` helper to validate API key presence
- Added `sdkCreateTraceHandler` that derives org/project/env from API key context
- Integrated SDK endpoints into the existing API router
- Added comprehensive tests for the SDK trace handler

### How to test?

1. Create an API key for a specific environment
2. Send a request to the new `/traces` endpoint with the API key in the header
3. Verify that a trace is created in the correct organization, project, and environment
4. Try sending a request without an API key and verify it returns an unauthorized error

### Why make this change?

This change simplifies SDK integration by providing flat API paths that don't require clients to specify organization, project, and environment IDs in the URL. Instead, these values are derived from the API key context, making the SDK implementation more straightforward and reducing the potential for errors when integrating with the API.