### PR TITLE
feat(api): add SDK functions flat endpoint with tests

### DIFF
--- a/cloud/api/api.ts
+++ b/cloud/api/api.ts
@@ -1,22 +1,22 @@
 import { HttpApi } from "@effect/platform";
 import { HealthApi } from "@/api/health.schemas";
-import { TracesApi } from "@/api/traces.schemas";
-import { SdkTracesApi } from "@/api/sdk.schemas";
+import { TracesApi, SdkTracesApi } from "@/api/traces.schemas";
 import { DocsApi } from "@/api/docs.schemas";
 import { OrganizationsApi } from "@/api/organizations.schemas";
 import { ProjectsApi } from "@/api/projects.schemas";
 import { EnvironmentsApi } from "@/api/environments.schemas";
 import { ApiKeysApi } from "@/api/api-keys.schemas";
+import { FunctionsApi, SdkFunctionsApi } from "@/api/functions.schemas";
 
 export * from "@/errors";
 export * from "@/api/health.schemas";
 export * from "@/api/traces.schemas";
-export * from "@/api/sdk.schemas";
 export * from "@/api/docs.schemas";
 export * from "@/api/organizations.schemas";
 export * from "@/api/projects.schemas";
 export * from "@/api/environments.schemas";
 export * from "@/api/api-keys.schemas";
+export * from "@/api/functions.schemas";
 
 export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
   .add(HealthApi)
@@ -26,4 +26,6 @@ export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
   .add(OrganizationsApi)
   .add(ProjectsApi)
   .add(EnvironmentsApi)
-  .add(ApiKeysApi) {}
+  .add(ApiKeysApi)
+  .add(FunctionsApi)
+  .add(SdkFunctionsApi) {}

--- a/cloud/api/functions.test.ts
+++ b/cloud/api/functions.test.ts
@@ -1,0 +1,509 @@
+import { describe as vitestDescribe, it as vitestIt, expect } from "vitest";
+import { Effect } from "effect";
+import {
+  describe,
+  expect as testApiExpect,
+  TestApiContext,
+  it,
+} from "@/tests/api";
+import type { PublicProject, PublicEnvironment } from "@/db/schema";
+import { toPublicFunction, toFunctionResponse } from "@/api/functions.handlers";
+import { AuthenticatedApiKey, AuthenticatedUser } from "@/auth";
+import {
+  sdkRegisterFunctionHandler,
+  sdkGetFunctionByHashHandler,
+  sdkGetFunctionHandler,
+  sdkListFunctionsHandler,
+} from "@/api/functions.handlers";
+import { Database } from "@/db";
+
+// =============================================================================
+// API Route Tests (using TestApiContext with hierarchical paths)
+// =============================================================================
+
+describe.sequential("Functions API", (it) => {
+  let project: PublicProject;
+  let environment: PublicEnvironment;
+
+  it.effect(
+    "POST /organizations/:orgId/projects - create project for functions test",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        project = yield* client.projects.create({
+          path: { organizationId: org.id },
+          payload: {
+            name: "Functions Test Project",
+            slug: "functions-test-project",
+          },
+        });
+        testApiExpect(project.id).toBeDefined();
+      }),
+  );
+
+  it.effect(
+    "POST /organizations/:orgId/projects/:projId/environments - create environment for functions test",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        environment = yield* client.environments.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: {
+            name: "Functions Test Environment",
+            slug: "functions-test-env",
+          },
+        });
+        testApiExpect(environment.id).toBeDefined();
+      }),
+  );
+
+  it.effect(
+    "POST /organizations/:orgId/projects/:projId/environments/:envId/functions - registers function",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.functions.register({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          payload: {
+            code: "def test_func(): pass",
+            hash: `api-test-hash-${Date.now()}`,
+            signature: "def test_func() -> None",
+            signatureHash: "api-sig-hash",
+            name: "test_func",
+          },
+        });
+        testApiExpect(result.id).toBeDefined();
+        testApiExpect(result.name).toBe("test_func");
+        testApiExpect(result.isNew).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "POST /organizations/:orgId/projects/:projId/environments/:envId/functions - registers function with optional fields",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.functions.register({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          payload: {
+            code: "def test_func_with_meta(): return 'hello'",
+            hash: `api-test-hash-meta-${Date.now()}`,
+            signature: "def test_func_with_meta() -> str",
+            signatureHash: "api-sig-hash-meta",
+            name: "test_func_with_meta",
+            description: "A test function with metadata",
+            tags: ["test", "api"],
+            metadata: { source: "api-test" },
+            dependencies: { numpy: { version: "1.0.0", extras: ["full"] } },
+          },
+        });
+        testApiExpect(result.id).toBeDefined();
+        testApiExpect(result.name).toBe("test_func_with_meta");
+        testApiExpect(result.description).toBe("A test function with metadata");
+        testApiExpect(result.tags).toEqual(["test", "api"]);
+        testApiExpect(result.metadata).toEqual({ source: "api-test" });
+        testApiExpect(result.dependencies).toEqual({
+          numpy: { version: "1.0.0", extras: ["full"] },
+        });
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/environments/:envId/functions - lists functions",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.functions.list({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          urlParams: {},
+        });
+        testApiExpect(result.total).toBeGreaterThanOrEqual(1);
+        testApiExpect(result.functions.length).toBeGreaterThanOrEqual(1);
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/environments/:envId/functions - filters by name",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.functions.list({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          urlParams: { name: "test_func" },
+        });
+        testApiExpect(result.total).toBeGreaterThanOrEqual(1);
+        testApiExpect(
+          result.functions.every((f) => f.name === "test_func"),
+        ).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/environments/:envId/functions - filters by tags",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.functions.list({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          urlParams: { tags: "api" },
+        });
+        testApiExpect(result.total).toBeGreaterThanOrEqual(1);
+        testApiExpect(
+          result.functions.every((f) => f.tags?.includes("api")),
+        ).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/environments/:envId/functions - paginates with limit and offset",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.functions.list({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          urlParams: { limit: 1, offset: 0 },
+        });
+        testApiExpect(result.functions.length).toBeLessThanOrEqual(1);
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/environments/:envId/functions/:functionId - gets function by ID",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+
+        // First create a function to get
+        const created = yield* client.functions.register({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          payload: {
+            code: "def get_by_id_func(): pass",
+            hash: `get-by-id-hash-${Date.now()}`,
+            signature: "def get_by_id_func() -> None",
+            signatureHash: "get-by-id-sig-hash",
+            name: "get_by_id_func",
+          },
+        });
+
+        const result = yield* client.functions.get({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            id: created.id,
+          },
+        });
+
+        testApiExpect(result.id).toBe(created.id);
+        testApiExpect(result.name).toBe("get_by_id_func");
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/environments/:envId/functions/by-hash/:hash - gets function by hash",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const uniqueHash = `get-by-hash-api-${Date.now()}`;
+
+        // First create a function to get
+        yield* client.functions.register({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+          },
+          payload: {
+            code: "def get_by_hash_func(): pass",
+            hash: uniqueHash,
+            signature: "def get_by_hash_func() -> None",
+            signatureHash: "get-by-hash-sig-hash",
+            name: "get_by_hash_func",
+          },
+        });
+
+        const result = yield* client.functions.getByHash({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            hash: uniqueHash,
+          },
+        });
+
+        testApiExpect(result.hash).toBe(uniqueHash);
+        testApiExpect(result.name).toBe("get_by_hash_func");
+      }),
+  );
+});
+
+// =============================================================================
+// Utility Function Tests (pure functions, no database required)
+// =============================================================================
+
+vitestDescribe("Utility Functions", () => {
+  vitestDescribe("toPublicFunction", () => {
+    vitestIt("converts dates to ISO strings", () => {
+      const now = new Date();
+      const fn = {
+        id: "test-id",
+        hash: "test-hash",
+        signatureHash: "sig-hash",
+        name: "test",
+        description: null,
+        version: "1.0",
+        tags: null,
+        metadata: null,
+        code: "def test(): pass",
+        signature: "def test() -> None",
+        dependencies: null,
+        environmentId: "env-id",
+        projectId: "project-id",
+        organizationId: "org-id",
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      const result = toPublicFunction(fn);
+
+      expect(result.createdAt).toBe(now.toISOString());
+      expect(result.updatedAt).toBe(now.toISOString());
+    });
+
+    vitestIt("handles null dates", () => {
+      const fn = {
+        id: "test-id",
+        hash: "test-hash",
+        signatureHash: "sig-hash",
+        name: "test",
+        description: null,
+        version: "1.0",
+        tags: null,
+        metadata: null,
+        code: "def test(): pass",
+        signature: "def test() -> None",
+        dependencies: null,
+        environmentId: "env-id",
+        projectId: "project-id",
+        organizationId: "org-id",
+        createdAt: null,
+        updatedAt: null,
+      };
+
+      const result = toPublicFunction(fn);
+
+      expect(result.createdAt).toBeNull();
+      expect(result.updatedAt).toBeNull();
+    });
+  });
+
+  vitestDescribe("toFunctionResponse", () => {
+    vitestIt("converts dates to ISO strings with isNew field", () => {
+      const now = new Date();
+      const fn = {
+        id: "test-id",
+        hash: "test-hash",
+        signatureHash: "sig-hash",
+        name: "test",
+        description: null,
+        version: "1.0",
+        tags: null,
+        metadata: null,
+        code: "def test(): pass",
+        signature: "def test() -> None",
+        dependencies: null,
+        environmentId: "env-id",
+        projectId: "project-id",
+        organizationId: "org-id",
+        createdAt: now,
+        updatedAt: now,
+        isNew: true,
+      };
+
+      const result = toFunctionResponse(fn);
+
+      expect(result.createdAt).toBe(now.toISOString());
+      expect(result.updatedAt).toBe(now.toISOString());
+      expect(result.isNew).toBe(true);
+    });
+  });
+});
+
+// =============================================================================
+// SDK Handler Tests (requires Database context)
+// =============================================================================
+
+describe("SDK Functions Handler", () => {
+  const mockOwner = {
+    id: "test-owner-id",
+    email: "test@example.com",
+    name: "Test Owner",
+    deletedAt: null,
+  };
+
+  it.effect(
+    "sdkRegisterFunctionHandler - registers function with API key auth",
+    () =>
+      Effect.gen(function* () {
+        const db = yield* Database;
+
+        // Create test user
+        const owner = yield* db.users.create({
+          data: {
+            email: `sdk-fn-test-${Date.now()}@example.com`,
+            name: "SDK Functions Test User",
+          },
+        });
+
+        // Create test organization
+        const org = yield* db.organizations.create({
+          userId: owner.id,
+          data: {
+            name: "SDK Functions Test Org",
+            slug: `sdk-fn-org-${Date.now()}`,
+          },
+        });
+
+        // Create test project
+        const project = yield* db.organizations.projects.create({
+          userId: owner.id,
+          organizationId: org.id,
+          data: { name: "SDK Functions Test Project", slug: "sdk-fn-project" },
+        });
+
+        // Create test environment
+        const environment =
+          yield* db.organizations.projects.environments.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            data: { name: "SDK Functions Test Env", slug: "sdk-fn-env" },
+          });
+
+        // Create API key
+        const createdApiKey =
+          yield* db.organizations.projects.environments.apiKeys.create({
+            userId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            environmentId: environment.id,
+            data: { name: "SDK Functions Test API Key" },
+          });
+
+        // Construct ApiKeyInfo
+        const apiKeyInfo = {
+          apiKeyId: createdApiKey.id,
+          environmentId: environment.id,
+          projectId: project.id,
+          organizationId: org.id,
+          ownerId: owner.id,
+          ownerEmail: owner.email,
+          ownerName: owner.name,
+          ownerImageUrl: null,
+          ownerDeletedAt: null,
+        };
+
+        const payload = {
+          code: "def my_function(): pass",
+          hash: `test-hash-${Date.now()}`,
+          signature: "def my_function(): ...",
+          signatureHash: `sig-hash-${Date.now()}`,
+          name: "my_function",
+          description: "Test function",
+          tags: ["test"],
+          metadata: { key: "value" },
+        };
+
+        // Call SDK handler with API key context
+        const result = yield* sdkRegisterFunctionHandler(payload).pipe(
+          Effect.provideService(AuthenticatedUser, owner),
+          Effect.provideService(AuthenticatedApiKey, apiKeyInfo),
+        );
+
+        expect(result.id).toBeDefined();
+        expect(result.name).toBe("my_function");
+        expect(result.hash).toBe(payload.hash);
+        expect(result.isNew).toBe(true);
+
+        // Test getByHash
+        const byHash = yield* sdkGetFunctionByHashHandler(payload.hash).pipe(
+          Effect.provideService(AuthenticatedUser, owner),
+          Effect.provideService(AuthenticatedApiKey, apiKeyInfo),
+        );
+        expect(byHash.id).toBe(result.id);
+
+        // Test get
+        const byId = yield* sdkGetFunctionHandler(result.id).pipe(
+          Effect.provideService(AuthenticatedUser, owner),
+          Effect.provideService(AuthenticatedApiKey, apiKeyInfo),
+        );
+        expect(byId.id).toBe(result.id);
+
+        // Test list
+        const listResult = yield* sdkListFunctionsHandler({}).pipe(
+          Effect.provideService(AuthenticatedUser, owner),
+          Effect.provideService(AuthenticatedApiKey, apiKeyInfo),
+        );
+        expect(listResult.total).toBeGreaterThan(0);
+        expect(listResult.functions.some((f) => f.id === result.id)).toBe(true);
+
+        // Cleanup
+        yield* db.organizations.delete({
+          organizationId: org.id,
+          userId: owner.id,
+        });
+        yield* db.users.delete({ userId: owner.id });
+      }),
+  );
+
+  it.effect(
+    "sdkRegisterFunctionHandler - fails without API key auth (UnauthorizedError)",
+    () =>
+      Effect.gen(function* () {
+        const payload = {
+          code: "def test(): pass",
+          hash: "test-hash",
+          signature: "def test(): ...",
+          signatureHash: "sig-hash",
+          name: "test",
+        };
+
+        // Call SDK handler without API key context - should fail
+        const error = yield* sdkRegisterFunctionHandler(payload).pipe(
+          Effect.provideService(AuthenticatedUser, mockOwner),
+          Effect.flip,
+        );
+
+        expect(error._tag).toBe("UnauthorizedError");
+        expect(error.message).toBe("API key required for this endpoint");
+      }),
+  );
+});

--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -1,8 +1,7 @@
 import { HttpApiBuilder } from "@effect/platform";
 import { Layer } from "effect";
 import { checkHealthHandler } from "@/api/health.handlers";
-import { createTraceHandler } from "@/api/traces.handlers";
-import { sdkCreateTraceHandler } from "@/api/sdk.handlers";
+import { createTraceHandler, sdkCreateTraceHandler } from "@/api/traces.handlers";
 import { getOpenApiSpecHandler } from "@/api/docs.handlers";
 import {
   listOrganizationsHandler,
@@ -31,6 +30,16 @@ import {
   getApiKeyHandler,
   deleteApiKeyHandler,
 } from "@/api/api-keys.handlers";
+import {
+  registerFunctionHandler,
+  getFunctionHandler,
+  getFunctionByHashHandler,
+  listFunctionsHandler,
+  sdkRegisterFunctionHandler,
+  sdkGetFunctionHandler,
+  sdkGetFunctionByHashHandler,
+  sdkListFunctionsHandler,
+} from "@/api/functions.handlers";
 import { MirascopeCloudApi } from "@/api/api";
 
 export { MirascopeCloudApi };
@@ -175,6 +184,59 @@ const ApiKeysHandlersLive = HttpApiBuilder.group(
       ),
 );
 
+<<<<<<< HEAD
+=======
+const FunctionsHandlersLive = HttpApiBuilder.group(
+  MirascopeCloudApi,
+  "functions",
+  (handlers) =>
+    handlers
+      .handle("register", ({ path, payload }) =>
+        registerFunctionHandler(
+          path.organizationId,
+          path.projectId,
+          path.environmentId,
+          payload,
+        ),
+      )
+      .handle("get", ({ path }) =>
+        getFunctionHandler(
+          path.organizationId,
+          path.projectId,
+          path.environmentId,
+          path.id,
+        ),
+      )
+      .handle("getByHash", ({ path }) =>
+        getFunctionByHashHandler(
+          path.organizationId,
+          path.projectId,
+          path.environmentId,
+          path.hash,
+        ),
+      )
+      .handle("list", ({ path, urlParams }) =>
+        listFunctionsHandler(
+          path.organizationId,
+          path.projectId,
+          path.environmentId,
+          urlParams,
+        ),
+      ),
+);
+
+const SdkFunctionsHandlersLive = HttpApiBuilder.group(
+  MirascopeCloudApi,
+  "sdkFunctions",
+  (handlers) =>
+    handlers
+      .handle("register", ({ payload }) => sdkRegisterFunctionHandler(payload))
+      .handle("get", ({ path }) => sdkGetFunctionHandler(path.id))
+      .handle("getByHash", ({ path }) => sdkGetFunctionByHashHandler(path.hash))
+      .handle("list", ({ urlParams }) => sdkListFunctionsHandler(urlParams)),
+);
+
+>>>>>>> 0edae451b (feat(api): add SDK functions flat endpoint with tests)
 export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(HealthHandlersLive),
   Layer.provide(TracesHandlersLive),
@@ -184,4 +246,9 @@ export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(ProjectsHandlersLive),
   Layer.provide(EnvironmentsHandlersLive),
   Layer.provide(ApiKeysHandlersLive),
+<<<<<<< HEAD
+=======
+  Layer.provide(FunctionsHandlersLive),
+  Layer.provide(SdkFunctionsHandlersLive),
+>>>>>>> 0edae451b (feat(api): add SDK functions flat endpoint with tests)
 );

--- a/cloud/api/sdk.handlers.ts
+++ b/cloud/api/sdk.handlers.ts
@@ -8,7 +8,13 @@ import { Effect, Option } from "effect";
 import { AuthenticatedUser, AuthenticatedApiKey } from "@/auth";
 import { UnauthorizedError } from "@/errors";
 import { createTraceHandler } from "@/api/traces.handlers";
-import type { CreateTraceRequest } from "@/api/sdk.schemas";
+import {
+  registerFunctionHandler,
+  getFunctionByHashHandler,
+  getFunctionHandler,
+  listFunctionsHandler,
+} from "@/api/functions.handlers";
+import type { CreateTraceRequest, RegisterFunctionRequest } from "@/api/sdk.schemas";
 
 export * from "@/api/sdk.schemas";
 
@@ -41,5 +47,70 @@ export const sdkCreateTraceHandler = (payload: CreateTraceRequest) =>
       apiKeyInfo.projectId,
       apiKeyInfo.environmentId,
       payload,
+    );
+  });
+
+/**
+ * SDK handler for registering functions.
+ * Derives org/project/env from API key context.
+ */
+export const sdkRegisterFunctionHandler = (payload: RegisterFunctionRequest) =>
+  Effect.gen(function* () {
+    const apiKeyInfo = yield* requireApiKeyContext;
+    return yield* registerFunctionHandler(
+      apiKeyInfo.organizationId,
+      apiKeyInfo.projectId,
+      apiKeyInfo.environmentId,
+      payload,
+    );
+  });
+
+/**
+ * SDK handler for getting function by hash.
+ * Derives org/project/env from API key context.
+ */
+export const sdkGetFunctionByHashHandler = (hash: string) =>
+  Effect.gen(function* () {
+    const apiKeyInfo = yield* requireApiKeyContext;
+    return yield* getFunctionByHashHandler(
+      apiKeyInfo.organizationId,
+      apiKeyInfo.projectId,
+      apiKeyInfo.environmentId,
+      hash,
+    );
+  });
+
+/**
+ * SDK handler for getting function by ID.
+ * Derives org/project/env from API key context.
+ */
+export const sdkGetFunctionHandler = (id: string) =>
+  Effect.gen(function* () {
+    const apiKeyInfo = yield* requireApiKeyContext;
+    return yield* getFunctionHandler(
+      apiKeyInfo.organizationId,
+      apiKeyInfo.projectId,
+      apiKeyInfo.environmentId,
+      id,
+    );
+  });
+
+/**
+ * SDK handler for listing functions.
+ * Derives org/project/env from API key context.
+ */
+export const sdkListFunctionsHandler = (params: {
+  name?: string;
+  tags?: string;
+  limit?: number;
+  offset?: number;
+}) =>
+  Effect.gen(function* () {
+    const apiKeyInfo = yield* requireApiKeyContext;
+    return yield* listFunctionsHandler(
+      apiKeyInfo.organizationId,
+      apiKeyInfo.projectId,
+      apiKeyInfo.environmentId,
+      params,
     );
   });

--- a/cloud/api/sdk.schemas.ts
+++ b/cloud/api/sdk.schemas.ts
@@ -5,6 +5,7 @@
  * The organizationId, projectId, and environmentId are derived from the API key.
  */
 import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
+import { Schema } from "effect";
 import {
   NotFoundError,
   PermissionDeniedError,
@@ -25,6 +26,90 @@ export {
   type CreateTraceResponse,
 } from "@/api/traces.schemas";
 
+// Re-export request/response types from functions module
+export {
+  type RegisterFunctionRequest,
+  type FunctionResponse,
+  type PublicFunction,
+  type ListFunctionsResponse,
+} from "@/api/functions.schemas";
+
+// Function schemas (redeclared for SDK endpoints)
+const DependencyInfoSchema = Schema.Struct({
+  version: Schema.String,
+  extras: Schema.NullOr(Schema.Array(Schema.String)),
+});
+
+const RegisterFunctionRequestSchema = Schema.Struct({
+  code: Schema.String,
+  hash: Schema.String,
+  signature: Schema.String,
+  signatureHash: Schema.String,
+  name: Schema.String,
+  description: Schema.optional(Schema.NullOr(Schema.String)),
+  tags: Schema.optional(Schema.NullOr(Schema.Array(Schema.String))),
+  metadata: Schema.optional(
+    Schema.NullOr(Schema.Record({ key: Schema.String, value: Schema.String })),
+  ),
+  dependencies: Schema.optional(
+    Schema.NullOr(
+      Schema.Record({ key: Schema.String, value: DependencyInfoSchema }),
+    ),
+  ),
+});
+
+const FunctionResponseSchema = Schema.Struct({
+  id: Schema.String,
+  hash: Schema.String,
+  signatureHash: Schema.String,
+  name: Schema.String,
+  description: Schema.NullOr(Schema.String),
+  version: Schema.String,
+  tags: Schema.NullOr(Schema.Array(Schema.String)),
+  metadata: Schema.NullOr(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
+  code: Schema.String,
+  signature: Schema.String,
+  dependencies: Schema.NullOr(
+    Schema.Record({ key: Schema.String, value: DependencyInfoSchema }),
+  ),
+  environmentId: Schema.String,
+  projectId: Schema.String,
+  organizationId: Schema.String,
+  createdAt: Schema.NullOr(Schema.String),
+  updatedAt: Schema.NullOr(Schema.String),
+  isNew: Schema.Boolean,
+});
+
+const PublicFunctionSchema = Schema.Struct({
+  id: Schema.String,
+  hash: Schema.String,
+  signatureHash: Schema.String,
+  name: Schema.String,
+  description: Schema.NullOr(Schema.String),
+  version: Schema.String,
+  tags: Schema.NullOr(Schema.Array(Schema.String)),
+  metadata: Schema.NullOr(
+    Schema.Record({ key: Schema.String, value: Schema.String }),
+  ),
+  code: Schema.String,
+  signature: Schema.String,
+  dependencies: Schema.NullOr(
+    Schema.Record({ key: Schema.String, value: DependencyInfoSchema }),
+  ),
+  environmentId: Schema.String,
+  projectId: Schema.String,
+  organizationId: Schema.String,
+  createdAt: Schema.NullOr(Schema.String),
+  updatedAt: Schema.NullOr(Schema.String),
+});
+
+const ListFunctionsResponseSchema = Schema.Struct({
+  functions: Schema.Array(PublicFunctionSchema),
+  total: Schema.Number,
+});
+
 /**
  * SDK Traces API - Flat paths for SDK usage
  */
@@ -38,3 +123,52 @@ export class SdkTracesApi extends HttpApiGroup.make("sdkTraces").add(
     .addError(DatabaseError, { status: DatabaseError.status })
     .addError(AlreadyExistsError, { status: AlreadyExistsError.status }),
 ) {}
+
+/**
+ * SDK Functions API - Flat paths for SDK usage
+ */
+export class SdkFunctionsApi extends HttpApiGroup.make("sdkFunctions")
+  .add(
+    HttpApiEndpoint.post("register", "/functions")
+      .setPayload(RegisterFunctionRequestSchema)
+      .addSuccess(FunctionResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status })
+      .addError(AlreadyExistsError, { status: AlreadyExistsError.status }),
+  )
+  .add(
+    HttpApiEndpoint.get("getByHash", "/functions/by-hash/:hash")
+      .setPath(Schema.Struct({ hash: Schema.String }))
+      .addSuccess(PublicFunctionSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.get("get", "/functions/:id")
+      .setPath(Schema.Struct({ id: Schema.String }))
+      .addSuccess(PublicFunctionSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.get("list", "/functions")
+      .setUrlParams(
+        Schema.Struct({
+          name: Schema.optional(Schema.String),
+          tags: Schema.optional(Schema.String),
+          limit: Schema.optional(Schema.NumberFromString),
+          offset: Schema.optional(Schema.NumberFromString),
+        }),
+      )
+      .addSuccess(ListFunctionsResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  ) {}

--- a/cloud/api/traces.test.ts
+++ b/cloud/api/traces.test.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect";
 import { describe, expect, TestApiContext, it } from "@/tests/api";
 import type { PublicProject, PublicEnvironment } from "@/db/schema";
 import { AuthenticatedApiKey, AuthenticatedUser } from "@/auth";
-import { sdkCreateTraceHandler } from "@/api/sdk.handlers";
+import { sdkCreateTraceHandler } from "@/api/traces.handlers";
 import { Database } from "@/db";
 
 describe.sequential("Traces API", (it) => {


### PR DESCRIPTION
### TL;DR

Added SDK functions API endpoints with comprehensive test coverage.

### What changed?

- Consolidated SDK-related code by moving SDK trace handlers from `sdk.handlers.ts` to `traces.handlers.ts`
- Added new functions API endpoints with both regular and SDK (flat) paths
- Created comprehensive test suite for the functions API
- Added function-related schemas and handlers
- Updated API exports and router configuration to include the new endpoints

The PR introduces several new endpoints:
- Regular paths: `/organizations/:orgId/projects/:projId/environments/:envId/functions/...`
- SDK flat paths: `/functions/...` (for API key authenticated requests)

### How to test?

1. Run the test suite with `pnpm test cloud/api/functions.test.ts`
2. Test the API endpoints manually:
   - Register a function: `POST /functions` with API key auth
   - Get function by ID: `GET /functions/:id`
   - Get function by hash: `GET /functions/by-hash/:hash`
   - List functions: `GET /functions` (with optional filters)

### Why make this change?

This change enables SDK clients to register and retrieve functions using a simplified API structure. The flat paths make it easier for SDK implementations to work with functions without needing to know the full organizational hierarchy. The comprehensive test suite ensures reliability of these new endpoints.