### PR TITLE
refactor: convert FormattableT to Format at the model layer

### DIFF
--- a/python/mirascope/llm/formatting/__init__.py
+++ b/python/mirascope/llm/formatting/__init__.py
@@ -5,7 +5,7 @@ The `@format` decorator can be applied to classes to specify how LLM
 outputs should be structured and parsed.
 """
 
-from .format import Format, format, resolve_format
+from .format import Format, ensure_format_has_mode, format
 from .from_call_args import FromCallArgs
 from .partial import Partial
 from .types import FormattableT, FormattingMode
@@ -17,6 +17,6 @@ __all__ = [
     "FormattingMode",
     "FromCallArgs",
     "Partial",
+    "ensure_format_has_mode",
     "format",
-    "resolve_format",
 ]

--- a/python/mirascope/llm/models/models.py
+++ b/python/mirascope/llm/models/models.py
@@ -9,7 +9,7 @@ from typing import overload
 from typing_extensions import Unpack
 
 from ..context import Context, DepsT
-from ..formatting import Format, FormattableT
+from ..formatting import Format, FormattableT, format as format_fn
 from ..messages import Message, UserContent
 from ..providers import (
     ModelId,
@@ -203,6 +203,8 @@ class Model:
         Returns:
             An `llm.Response` object containing the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return self.provider.call(
             model_id=self.model_id,
             messages=messages,
@@ -261,6 +263,8 @@ class Model:
         Returns:
             An `llm.AsyncResponse` object containing the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return await self.provider.call_async(
             model_id=self.model_id,
             messages=messages,
@@ -319,6 +323,8 @@ class Model:
         Returns:
             An `llm.StreamResponse` object for iterating over the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return self.provider.stream(
             model_id=self.model_id,
             messages=messages,
@@ -377,6 +383,8 @@ class Model:
         Returns:
             An `llm.AsyncStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return await self.provider.stream_async(
             model_id=self.model_id,
             messages=messages,
@@ -448,6 +456,8 @@ class Model:
         Returns:
             An `llm.ContextResponse` object containing the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return self.provider.context_call(
             ctx=ctx,
             model_id=self.model_id,
@@ -520,6 +530,8 @@ class Model:
         Returns:
             An `llm.AsyncContextResponse` object containing the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return await self.provider.context_call_async(
             ctx=ctx,
             model_id=self.model_id,
@@ -596,6 +608,8 @@ class Model:
         Returns:
             An `llm.ContextStreamResponse` object for iterating over the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return self.provider.context_stream(
             ctx=ctx,
             model_id=self.model_id,
@@ -674,6 +688,8 @@ class Model:
         Returns:
             An `llm.AsyncContextStreamResponse` object for asynchronously iterating over the LLM-generated content.
         """
+        if not isinstance(format, Format) and format is not None:
+            format = format_fn(format)
         return await self.provider.context_stream_async(
             ctx=ctx,
             model_id=self.model_id,

--- a/python/mirascope/llm/providers/anthropic/_utils/encode.py
+++ b/python/mirascope/llm/providers/anthropic/_utils/encode.py
@@ -13,7 +13,7 @@ from ....exceptions import FeatureNotSupportedError, FormattingModeNotSupportedE
 from ....formatting import (
     Format,
     FormattableT,
-    resolve_format,
+    ensure_format_has_mode,
 )
 from ....messages import AssistantMessage, Message, UserMessage
 from ....tools import FORMAT_TOOL_NAME, AnyToolSchema, BaseToolkit
@@ -291,7 +291,7 @@ def encode_request(
     model_id: AnthropicModelId,
     messages: Sequence[Message],
     tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-    format: type[FormattableT] | Format[FormattableT] | None,
+    format: Format[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, MessageCreateKwargs]:
     """Prepares a request for the Anthropic messages.create method."""
@@ -306,8 +306,8 @@ def encode_request(
 
     tools = tools.tools if isinstance(tools, BaseToolkit) else tools or []
     anthropic_tools = [convert_tool_to_tool_param(tool) for tool in tools]
-    format = resolve_format(format, default_mode=DEFAULT_FORMAT_MODE)
     if format is not None:
+        format = ensure_format_has_mode(format, default_mode=DEFAULT_FORMAT_MODE)
         if format.mode == "strict":
             raise FormattingModeNotSupportedError(
                 formatting_mode="strict",

--- a/python/mirascope/llm/providers/anthropic/beta_provider.py
+++ b/python/mirascope/llm/providers/anthropic/beta_provider.py
@@ -58,7 +58,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` using the beta Anthropic API."""
@@ -96,7 +96,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` using the beta Anthropic API."""
@@ -131,7 +131,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` using the beta Anthropic API."""
@@ -169,7 +169,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` using the beta Anthropic API."""
@@ -204,7 +204,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` using the beta Anthropic API."""
@@ -237,7 +237,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` using the beta Anthropic API."""
@@ -267,7 +267,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` using the beta Anthropic API."""
@@ -300,7 +300,7 @@ class AnthropicBetaProvider(BaseProvider[Anthropic]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/base/base_provider.py
+++ b/python/mirascope/llm/providers/base/base_provider.py
@@ -157,7 +157,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> Response[FormattableT]:
         """Generate an `llm.Response` with a response format."""
@@ -170,7 +170,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` with an optional response format."""
@@ -182,7 +182,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling this client's LLM provider.
@@ -213,7 +213,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Implementation for call(). Subclasses override this method."""
@@ -245,7 +245,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` with a response format."""
@@ -261,7 +261,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` with an optional response format."""
@@ -276,7 +276,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling this client's LLM provider.
@@ -312,7 +312,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Implementation for context_call(). Subclasses override this method."""
@@ -338,7 +338,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` with a response format."""
@@ -351,7 +351,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` with an optional response format."""
@@ -363,7 +363,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling this client's LLM provider.
@@ -394,7 +394,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Implementation for call_async(). Subclasses override this method."""
@@ -426,7 +426,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` with a response format."""
@@ -442,7 +442,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` with an optional response format."""
@@ -457,7 +457,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling this client's LLM provider.
@@ -493,7 +493,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Implementation for context_call_async(). Subclasses override this method."""
@@ -519,7 +519,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> StreamResponse[FormattableT]:
         """Stream an `llm.StreamResponse` with a response format."""
@@ -532,7 +532,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Stream an `llm.StreamResponse` with an optional response format."""
@@ -544,7 +544,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from this client's LLM provider.
@@ -579,7 +579,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Implementation for stream(). Subclasses override this method."""
@@ -611,7 +611,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT, FormattableT]:
         """Stream an `llm.ContextStreamResponse` with a response format."""
@@ -627,7 +627,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -644,7 +644,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -686,7 +686,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -714,7 +714,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncStreamResponse[FormattableT]:
         """Stream an `llm.AsyncStreamResponse` with a response format."""
@@ -727,7 +727,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Stream an `llm.AsyncStreamResponse` with an optional response format."""
@@ -739,7 +739,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from this client's LLM provider.
@@ -774,7 +774,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Implementation for stream_async(). Subclasses override this method."""
@@ -806,7 +806,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT],
+        format: Format[FormattableT],
         **params: Unpack[Params],
     ) -> AsyncContextStreamResponse[DepsT, FormattableT]:
         """Stream an `llm.AsyncContextStreamResponse` with a response format."""
@@ -822,7 +822,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]
@@ -840,7 +840,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]
@@ -883,7 +883,7 @@ class BaseProvider(Generic[ProviderClientT], ABC):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]

--- a/python/mirascope/llm/providers/google/_utils/encode.py
+++ b/python/mirascope/llm/providers/google/_utils/encode.py
@@ -14,7 +14,7 @@ from ....exceptions import FeatureNotSupportedError
 from ....formatting import (
     Format,
     FormattableT,
-    resolve_format,
+    ensure_format_has_mode,
 )
 from ....messages import AssistantMessage, Message, UserMessage
 from ....tools import FORMAT_TOOL_NAME, AnyToolSchema, BaseToolkit
@@ -176,7 +176,7 @@ def encode_request(
     model_id: GoogleModelId,
     messages: Sequence[Message],
     tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-    format: type[FormattableT] | Format[FormattableT] | None,
+    format: Format[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, GoogleKwargs]:
     """Prepares a request for the genai `Client.models.generate_content` method."""
@@ -226,8 +226,8 @@ def encode_request(
     # Older google models do not allow strict mode when using tools; if so, we use tool
     # mode when tools are present by default for compatibility. Otherwise, prefer strict mode.
     default_mode = "tool" if tools and not allows_strict_mode_with_tools else "strict"
-    format = resolve_format(format, default_mode=default_mode)
     if format is not None:
+        format = ensure_format_has_mode(format, default_mode=default_mode)
         if (
             format.mode in ("strict", "json")
             and tools

--- a/python/mirascope/llm/providers/google/provider.py
+++ b/python/mirascope/llm/providers/google/provider.py
@@ -64,7 +64,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the Google GenAI API.
@@ -115,7 +115,7 @@ class GoogleProvider(BaseProvider[Client]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the Google GenAI API.
@@ -164,7 +164,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the Google GenAI API.
@@ -215,7 +215,7 @@ class GoogleProvider(BaseProvider[Client]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the Google GenAI API.
@@ -264,7 +264,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the Google GenAI API.
@@ -311,7 +311,7 @@ class GoogleProvider(BaseProvider[Client]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the Google GenAI API.
@@ -356,7 +356,7 @@ class GoogleProvider(BaseProvider[Client]):
         model_id: GoogleModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the Google GenAI API.
@@ -403,7 +403,7 @@ class GoogleProvider(BaseProvider[Client]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/mirascope/provider.py
+++ b/python/mirascope/llm/providers/mirascope/provider.py
@@ -150,7 +150,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by calling through the Mirascope Router."""
@@ -172,7 +172,7 @@ class MirascopeProvider(BaseProvider[None]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by calling through the Mirascope Router."""
@@ -192,7 +192,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by calling through the Mirascope Router."""
@@ -214,7 +214,7 @@ class MirascopeProvider(BaseProvider[None]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by calling through the Mirascope Router."""
@@ -234,7 +234,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Stream an `llm.StreamResponse` by calling through the Mirascope Router."""
@@ -256,7 +256,7 @@ class MirascopeProvider(BaseProvider[None]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
@@ -278,7 +278,7 @@ class MirascopeProvider(BaseProvider[None]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Stream an `llm.AsyncStreamResponse` by calling through the Mirascope Router."""
@@ -300,7 +300,7 @@ class MirascopeProvider(BaseProvider[None]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT, None]

--- a/python/mirascope/llm/providers/mlx/encoding/base.py
+++ b/python/mirascope/llm/providers/mlx/encoding/base.py
@@ -22,7 +22,7 @@ class BaseEncoder(abc.ABC):
         self,
         messages: Sequence[Message],
         tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, TokenIds]:
         """Encode the request messages into a format suitable for the model.
 

--- a/python/mirascope/llm/providers/mlx/encoding/transformers.py
+++ b/python/mirascope/llm/providers/mlx/encoding/transformers.py
@@ -81,7 +81,7 @@ class TransformersEncoder(BaseEncoder):
         self,
         messages: Sequence[Message],
         tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, TokenIds]:
         """Encode a request into a format suitable for the model."""
         tool_schemas = tools.tools if isinstance(tools, BaseToolkit) else tools or []

--- a/python/mirascope/llm/providers/mlx/mlx.py
+++ b/python/mirascope/llm/providers/mlx/mlx.py
@@ -133,7 +133,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         params: Params,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, ChunkIterator]:
         """Stream response chunks synchronously.
@@ -156,7 +156,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         params: Params,
     ) -> tuple[Sequence[Message], Format[FormattableT] | None, AsyncChunkIterator]:
         """Stream response chunks asynchronously.
@@ -180,7 +180,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         params: Params,
     ) -> tuple[
         Sequence[Message],
@@ -216,7 +216,7 @@ class MLX:
         self,
         messages: Sequence[Message],
         tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-        format: type[FormattableT] | Format[FormattableT] | None,
+        format: Format[FormattableT] | None,
         params: Params,
     ) -> tuple[
         Sequence[Message],

--- a/python/mirascope/llm/providers/mlx/provider.py
+++ b/python/mirascope/llm/providers/mlx/provider.py
@@ -85,7 +85,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` using MLX model.
@@ -129,7 +129,7 @@ class MLXProvider(BaseProvider[None]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` using MLX model.
@@ -171,7 +171,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` using MLX model by asynchronously calloing
@@ -219,7 +219,7 @@ class MLXProvider(BaseProvider[None]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncResponse` using MLX model by asynchronously calloing
@@ -265,7 +265,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from MLX model output.
@@ -306,7 +306,7 @@ class MLXProvider(BaseProvider[None]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from MLX model output.
@@ -345,7 +345,7 @@ class MLXProvider(BaseProvider[None]):
         model_id: MLXModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from MLX model output.
@@ -386,7 +386,7 @@ class MLXProvider(BaseProvider[None]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/openai/completions/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/completions/_utils/encode.py
@@ -15,7 +15,7 @@ from .....exceptions import (
 from .....formatting import (
     Format,
     FormattableT,
-    resolve_format,
+    ensure_format_has_mode,
 )
 from .....messages import AssistantMessage, Message, UserMessage
 from .....tools import FORMAT_TOOL_NAME, AnyToolSchema, BaseToolkit
@@ -280,7 +280,7 @@ def encode_request(
     model_id: OpenAIModelId,
     messages: Sequence[Message],
     tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-    format: type[FormattableT] | Format[FormattableT] | None,
+    format: Format[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, ChatCompletionCreateKwargs]:
     """Prepares a request for the `OpenAI.chat.completions.create` method."""
@@ -325,8 +325,8 @@ def encode_request(
 
     model_supports_strict = base_model_name not in MODELS_WITHOUT_JSON_SCHEMA_SUPPORT
     default_mode = "strict" if model_supports_strict else "tool"
-    format = resolve_format(format, default_mode=default_mode)
     if format is not None:
+        format = ensure_format_has_mode(format, default_mode=default_mode)
         if format.mode == "strict":
             if not model_supports_strict:
                 raise FormattingModeNotSupportedError(

--- a/python/mirascope/llm/providers/openai/completions/base_provider.py
+++ b/python/mirascope/llm/providers/openai/completions/base_provider.py
@@ -97,7 +97,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the API.
@@ -152,7 +152,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the API.
@@ -205,7 +205,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the API.
@@ -260,7 +260,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the API.
@@ -313,7 +313,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the API.
@@ -364,7 +364,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the API.
@@ -414,7 +414,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         model_id: str,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the API.
@@ -465,7 +465,7 @@ class BaseOpenAICompletionsProvider(BaseProvider[OpenAI]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/openai/provider.py
+++ b/python/mirascope/llm/providers/openai/provider.py
@@ -157,7 +157,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the OpenAI API.
@@ -190,7 +190,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextResponse` by synchronously calling the OpenAI API.
@@ -222,7 +222,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the OpenAI API.
@@ -254,7 +254,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate an `llm.AsyncContextResponse` by asynchronously calling the OpenAI API.
@@ -285,7 +285,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate an `llm.StreamResponse` by synchronously streaming from the OpenAI API.
@@ -318,7 +318,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate an `llm.ContextStreamResponse` by synchronously streaming from the OpenAI API.
@@ -350,7 +350,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate an `llm.AsyncStreamResponse` by asynchronously streaming from the OpenAI API.
@@ -382,7 +382,7 @@ class OpenAIProvider(BaseProvider[OpenAI]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/providers/openai/responses/_utils/encode.py
+++ b/python/mirascope/llm/providers/openai/responses/_utils/encode.py
@@ -33,7 +33,7 @@ from .....exceptions import FeatureNotSupportedError
 from .....formatting import (
     Format,
     FormattableT,
-    resolve_format,
+    ensure_format_has_mode,
 )
 from .....messages import AssistantMessage, Message, UserMessage
 from .....tools import FORMAT_TOOL_NAME, AnyToolSchema, BaseToolkit
@@ -249,7 +249,7 @@ def encode_request(
     model_id: OpenAIModelId,
     messages: Sequence[Message],
     tools: Sequence[AnyToolSchema] | BaseToolkit[AnyToolSchema] | None,
-    format: type[FormattableT] | Format[FormattableT] | None,
+    format: Format[FormattableT] | None,
     params: Params,
 ) -> tuple[Sequence[Message], Format[FormattableT] | None, ResponseCreateKwargs]:
     """Prepares a request for the `OpenAI.responses.create` method."""
@@ -299,8 +299,8 @@ def encode_request(
     model_supports_strict = model_id not in MODELS_WITHOUT_JSON_SCHEMA_SUPPORT
     default_mode = "strict" if model_supports_strict else "tool"
 
-    format = resolve_format(format, default_mode=default_mode)
     if format is not None:
+        format = ensure_format_has_mode(format, default_mode=default_mode)
         if format.mode == "strict":
             kwargs["text"] = {"format": _create_strict_response_format(format)}
         elif format.mode == "tool":

--- a/python/mirascope/llm/providers/openai/responses/provider.py
+++ b/python/mirascope/llm/providers/openai/responses/provider.py
@@ -67,7 +67,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> Response | Response[FormattableT]:
         """Generate an `llm.Response` by synchronously calling the OpenAI Responses API.
@@ -116,7 +116,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncResponse | AsyncResponse[FormattableT]:
         """Generate an `llm.AsyncResponse` by asynchronously calling the OpenAI Responses API.
@@ -165,7 +165,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[Tool] | Toolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> StreamResponse | StreamResponse[FormattableT]:
         """Generate a `llm.StreamResponse` by synchronously streaming from the OpenAI Responses API.
@@ -214,7 +214,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         model_id: OpenAIModelId,
         messages: Sequence[Message],
         tools: Sequence[AsyncTool] | AsyncToolkit | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncStreamResponse | AsyncStreamResponse[FormattableT]:
         """Generate a `llm.AsyncStreamResponse` by asynchronously streaming from the OpenAI Responses API.
@@ -266,7 +266,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextResponse[DepsT] | ContextResponse[DepsT, FormattableT]:
         """Generate a `llm.ContextResponse` by synchronously calling the OpenAI Responses API with context.
@@ -319,7 +319,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> AsyncContextResponse[DepsT] | AsyncContextResponse[DepsT, FormattableT]:
         """Generate a `llm.AsyncContextResponse` by asynchronously calling the OpenAI Responses API with context.
@@ -372,7 +372,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         tools: Sequence[Tool | ContextTool[DepsT]]
         | ContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> ContextStreamResponse[DepsT] | ContextStreamResponse[DepsT, FormattableT]:
         """Generate a `llm.ContextStreamResponse` by synchronously streaming from the OpenAI Responses API with context.
@@ -426,7 +426,7 @@ class OpenAIResponsesProvider(BaseProvider[OpenAI]):
         tools: Sequence[AsyncTool | AsyncContextTool[DepsT]]
         | AsyncContextToolkit[DepsT]
         | None = None,
-        format: type[FormattableT] | Format[FormattableT] | None = None,
+        format: Format[FormattableT] | None = None,
         **params: Unpack[Params],
     ) -> (
         AsyncContextStreamResponse[DepsT]

--- a/python/mirascope/llm/responses/base_response.py
+++ b/python/mirascope/llm/responses/base_response.py
@@ -57,6 +57,9 @@ class BaseResponse(RootResponse[ToolkitT, FormattableT]):
         self.toolkit = toolkit
         self.finish_reason = finish_reason
         self.usage = usage
+
+        if format is not None and format.mode is None:
+            raise RuntimeError("When format is present, it must have non-None mode.")
         self.format = format
 
         # Process content in the assistant message, organizing it by type and

--- a/python/mirascope/llm/responses/base_stream_response.py
+++ b/python/mirascope/llm/responses/base_stream_response.py
@@ -195,6 +195,9 @@ class BaseStreamResponse(
         self.params = params
         self.toolkit = toolkit
         self.usage = usage
+
+        if format is not None and format.mode is None:
+            raise RuntimeError("When format is present, it must have non-None mode.")
         self.format = format
 
         # Internal-only lists which we mutate (append) during chunk processing

--- a/python/tests/llm/formatting/test_format.py
+++ b/python/tests/llm/formatting/test_format.py
@@ -147,3 +147,23 @@ def test_format_nested_models() -> None:
             "formatting_instructions": "Always respond to the user's query using the __mirascope_formatted_output_tool__ tool for structured output.",
         }
     )
+
+
+def test_resolve_format_sets_mode() -> None:
+    """Test that `resolve_format` sets format mode properly."""
+
+    class Empty(BaseModel):
+        pass
+
+    format = llm.format(Empty)
+    assert format is not None
+    assert format.mode is None
+
+    format_json = llm.formatting.ensure_format_has_mode(format, "json")
+    assert format_json is not None
+    assert format_json.mode == "json"
+    assert format.mode is None  # Returned a replacement, not mutated original format
+
+    format_strict = llm.formatting.ensure_format_has_mode(format, "strict")
+    assert format_strict is not None
+    assert format_strict.mode == "strict"

--- a/python/tests/llm/responses/test_response.py
+++ b/python/tests/llm/responses/test_response.py
@@ -814,3 +814,38 @@ def test_response_tools_initialization() -> None:
         assistant_message=assistant_message,
     )
     assert isinstance(response.toolkit, llm.AsyncContextToolkit)
+
+
+def test_response_format_mode_none_raises_error() -> None:
+    """Test that Response initialization raises RuntimeError when format.mode is None."""
+
+    class Book(BaseModel):
+        title: str
+        author: str
+
+    # Create a format with mode=None
+    format_with_none_mode = llm.format(Book, mode=None)
+    assert format_with_none_mode is not None
+    assert format_with_none_mode.mode is None
+
+    text_content = [llm.Text(text='{"title": "The Hobbit", "author": "Tolkien"}')]
+    assistant_message = llm.messages.assistant(
+        text_content, model_id="openai/gpt-5-mini", provider_id="openai"
+    )
+
+    with pytest.raises(
+        RuntimeError, match="When format is present, it must have non-None mode"
+    ):
+        llm.Response(
+            raw={"test": "response"},
+            usage=None,
+            provider_id="openai",
+            model_id="openai/gpt-5-mini",
+            provider_model_name="gpt-5-mini",
+            params={},
+            tools=[],
+            input_messages=[],
+            assistant_message=assistant_message,
+            finish_reason=None,
+            format=format_with_none_mode,
+        )

--- a/python/tests/llm/responses/test_stream_response.py
+++ b/python/tests/llm/responses/test_stream_response.py
@@ -1430,6 +1430,38 @@ def test_response_toolkit_initialization() -> None:
     assert isinstance(response.toolkit, llm.AsyncContextToolkit)
 
 
+def test_stream_response_format_mode_none_raises_error() -> None:
+    """Test that StreamResponse initialization raises RuntimeError when format.mode is None."""
+    from pydantic import BaseModel
+
+    class Book(BaseModel):
+        title: str
+        author: str
+
+    # Create a format with mode=None
+    format_with_none_mode = llm.format(Book, mode=None)
+    assert format_with_none_mode is not None
+    assert format_with_none_mode.mode is None
+
+    def chunk_iter() -> llm.ChunkIterator:
+        yield llm.TextStartChunk()
+        yield llm.TextChunk(delta="Hello")
+        yield llm.TextEndChunk()
+
+    with pytest.raises(
+        RuntimeError, match="When format is present, it must have non-None mode"
+    ):
+        llm.StreamResponse(
+            provider_id="openai",
+            model_id="openai/gpt-5-mini",
+            provider_model_name="gpt-5-mini",
+            params={},
+            input_messages=[],
+            chunk_iterator=chunk_iter(),
+            format=format_with_none_mode,
+        )
+
+
 class TestUsageTracking:
     """Test usage tracking in streams."""
 


### PR DESCRIPTION
This will allow us to determine if necessary call args are provided at
the model layer