### PR TITLE
feat(clickhouse): implement ClickHouse client service

### DIFF
--- a/cloud/bun.lock
+++ b/cloud/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "@mirascope/cloud",
       "dependencies": {
+        "@clickhouse/client-web": "^1.16.0",
         "@effect/platform": "^0.93.3",
         "@effect/schema": "^0.75.5",
         "@effect/sql": "^0.48.6",
@@ -149,6 +150,10 @@
     "@balena/dockerignore": ["@balena/dockerignore@1.0.2", "", {}, "sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q=="],
 
     "@bcoe/v8-coverage": ["@bcoe/v8-coverage@1.0.2", "", {}, "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="],
+
+    "@clickhouse/client-common": ["@clickhouse/client-common@1.16.0", "", {}, "sha512-qMzkI1NmV29ZjFkNpVSvGNfA0c7sCExlufAQMv+V+5xtNeYXnRfdqzmBLIQoq6Pf1ij0kw/wGLD3HQrl7pTFLA=="],
+
+    "@clickhouse/client-web": ["@clickhouse/client-web@1.16.0", "", { "dependencies": { "@clickhouse/client-common": "1.16.0" } }, "sha512-47+H8GsXXlultL3HFkTu94M7BGXJF8FOwiOUafPpvgCFoqra3o82I0YbWs3vTRqHIOuFjCvuOzrBNFvcT732eg=="],
 
     "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.1", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-Nu8ahitGFFJztxUml9oD/DLb7Z28C8cd8F46IVQ7y5Btz575pvMY8AqZsXkX7Gds29eCKdMgIHjIvzskHgPSFg=="],
 

--- a/cloud/clickhouse/client.test.ts
+++ b/cloud/clickhouse/client.test.ts
@@ -1,41 +1,16 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "@/tests/clickhouse";
 import { Effect, Layer } from "effect";
-import {
-  ClickHouseClient,
-  ClickHouseClientNodeLive,
-  ClickHouseClientWorkersLive,
-} from "@/clickhouse/client";
+import { ClickHouse, ClickHouseLive } from "@/clickhouse/client";
 import { SettingsService, type Settings } from "@/settings";
 import { ClickHouseError } from "@/errors";
-
-// Mock @clickhouse/client module
-vi.mock("@clickhouse/client", () => ({
-  createClient: vi.fn(() => ({
-    query: vi.fn(),
-    insert: vi.fn(),
-    command: vi.fn(),
-  })),
-}));
-
-// Mock fs module
-vi.mock("node:fs", () => ({
-  default: {
-    readFileSync: vi.fn(),
-  },
-}));
-
-// Helper to create a proper fetch mock
-const createFetchMock = (response: Response) => {
-  const mockFn = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
-  return mockFn;
-};
+import { vi } from "vitest";
 
 const createTestSettings = (overrides: Partial<Settings> = {}): Settings => ({
   env: "local",
-  CLICKHOUSE_URL: "http://localhost:8123",
-  CLICKHOUSE_USER: "default",
-  CLICKHOUSE_PASSWORD: "clickhouse",
-  CLICKHOUSE_DATABASE: "mirascope_analytics",
+  CLICKHOUSE_URL: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
+  CLICKHOUSE_USER: process.env.CLICKHOUSE_USER ?? "default",
+  CLICKHOUSE_PASSWORD: process.env.CLICKHOUSE_PASSWORD ?? "clickhouse",
+  CLICKHOUSE_DATABASE: process.env.CLICKHOUSE_DATABASE ?? "mirascope_analytics",
   CLICKHOUSE_TLS_ENABLED: false,
   CLICKHOUSE_TLS_HOSTNAME_VERIFY: true,
   ...overrides,
@@ -44,374 +19,196 @@ const createTestSettings = (overrides: Partial<Settings> = {}): Settings => ({
 const makeTestSettingsLayer = (settings: Settings) =>
   Layer.succeed(SettingsService, settings);
 
-describe("ClickHouseClient", () => {
-  describe("ClickHouseClientNodeLive", () => {
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
+const createClickHouseLayer = (settings: Settings) =>
+  ClickHouseLive.pipe(Layer.provide(makeTestSettingsLayer(settings)));
 
-    it("creates a Layer successfully", async () => {
-      const { createClient } = await import("@clickhouse/client");
-      const mockClient = {
-        query: vi.fn().mockResolvedValue({
-          json: vi.fn().mockResolvedValue([{ id: "1" }, { id: "2" }]),
-        }),
-        insert: vi.fn().mockResolvedValue(undefined),
-        command: vi.fn().mockResolvedValue(undefined),
-      };
-      vi.mocked(createClient).mockReturnValue(mockClient as never);
+describe("ClickHouse", () => {
+  describe("ClickHouseLive", () => {
+    it.effect("creates a Layer successfully", () =>
+      Effect.gen(function* () {
+        const client = yield* ClickHouse;
+        expect(client).toBeDefined();
+        expect(client.unsafeQuery).toBeDefined();
+        expect(client.insert).toBeDefined();
+        expect(client.command).toBeDefined();
+      }),
+    );
 
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientNodeLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
+    it.effect("executes unsafeQuery successfully", () =>
+      Effect.gen(function* () {
+        const client = yield* ClickHouse;
 
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return client;
-      });
-
-      const result = await Effect.runPromise(
-        program.pipe(Effect.provide(testLayer))
-      );
-
-      expect(result).toBeDefined();
-      expect(result.query).toBeDefined();
-      expect(result.insert).toBeDefined();
-      expect(result.command).toBeDefined();
-    });
-
-    it("executes query successfully", async () => {
-      const { createClient } = await import("@clickhouse/client");
-      const mockRows = [{ id: "1", name: "test1" }, { id: "2", name: "test2" }];
-      const mockClient = {
-        query: vi.fn().mockResolvedValue({
-          json: vi.fn().mockResolvedValue(mockRows),
-        }),
-        insert: vi.fn(),
-        command: vi.fn(),
-      };
-      vi.mocked(createClient).mockReturnValue(mockClient as never);
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientNodeLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.query<{ id: string; name: string }>(
-          "SELECT * FROM test"
+        const result = yield* client.unsafeQuery<{ n: number }>(
+          "SELECT 1 as n",
         );
-      });
 
-      const result = await Effect.runPromise(
-        program.pipe(Effect.provide(testLayer))
-      );
+        expect(result).toHaveLength(1);
+        expect(result[0]?.n).toBe(1);
+      }),
+    );
 
-      expect(result).toEqual(mockRows);
-      expect(mockClient.query).toHaveBeenCalledWith({
-        query: "SELECT * FROM test",
-        query_params: undefined,
-        format: "JSONEachRow",
-      });
-    });
+    it.effect("handles unsafeQuery errors with ClickHouseError", () =>
+      Effect.gen(function* () {
+        const client = yield* ClickHouse;
 
-    it("handles query errors", async () => {
-      const { createClient } = await import("@clickhouse/client");
-      const mockClient = {
-        query: vi.fn().mockRejectedValue(new Error("Query failed")),
-        insert: vi.fn(),
-        command: vi.fn(),
-      };
-      vi.mocked(createClient).mockReturnValue(mockClient as never);
+        const error = yield* client
+          .unsafeQuery("SELECT * FROM non_existent_table_xyz_123")
+          .pipe(Effect.flip);
 
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientNodeLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
+        expect(error).toBeInstanceOf(ClickHouseError);
+        expect(error.message).toContain("ClickHouse operation failed");
+      }),
+    );
 
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.query("SELECT * FROM test");
-      });
+    it.effect("executes command successfully", () =>
+      Effect.gen(function* () {
+        const client = yield* ClickHouse;
+        yield* client.command("SELECT 1");
+      }),
+    );
 
-      const result = await Effect.runPromise(
-        program.pipe(
-          Effect.provide(testLayer),
-          Effect.either
-        )
-      );
-
-      expect(result._tag).toBe("Left");
-      if (result._tag === "Left") {
-        expect(result.left).toBeInstanceOf(ClickHouseError);
-        expect(result.left.message).toContain("Query failed");
-      }
-    });
-
-    it("inserts rows successfully", async () => {
-      const { createClient } = await import("@clickhouse/client");
-      const mockClient = {
-        query: vi.fn(),
-        insert: vi.fn().mockResolvedValue(undefined),
-        command: vi.fn(),
-      };
-      vi.mocked(createClient).mockReturnValue(mockClient as never);
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientNodeLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const rows = [
-        { id: "1", name: "test1" },
-        { id: "2", name: "test2" },
-      ];
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.insert("test_table", rows);
-      });
-
-      await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
-
-      expect(mockClient.insert).toHaveBeenCalledWith({
-        table: "test_table",
-        values: rows,
-        format: "JSONEachRow",
-      });
-    });
-
-    it("skips insert for empty rows", async () => {
-      const { createClient } = await import("@clickhouse/client");
-      const mockClient = {
-        query: vi.fn(),
-        insert: vi.fn().mockResolvedValue(undefined),
-        command: vi.fn(),
-      };
-      vi.mocked(createClient).mockReturnValue(mockClient as never);
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientNodeLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.insert("test_table", []);
-      });
-
-      await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
-
-      expect(mockClient.insert).not.toHaveBeenCalled();
-    });
-
-    it("executes command successfully", async () => {
-      const { createClient } = await import("@clickhouse/client");
-      const mockClient = {
-        query: vi.fn(),
-        insert: vi.fn(),
-        command: vi.fn().mockResolvedValue(undefined),
-      };
-      vi.mocked(createClient).mockReturnValue(mockClient as never);
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientNodeLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.command("CREATE TABLE test (id String)");
-      });
-
-      await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
-
-      expect(mockClient.command).toHaveBeenCalledWith({
-        query: "CREATE TABLE test (id String)",
-      });
-    });
+    it.effect("skips insert for empty rows", () =>
+      Effect.gen(function* () {
+        const client = yield* ClickHouse;
+        yield* client.insert("any_table", []);
+      }),
+    );
   });
 
-  describe("ClickHouseClientWorkersLive", () => {
-    const originalFetch = globalThis.fetch;
-
-    beforeEach(() => {
-      vi.clearAllMocks();
-    });
-
-    afterEach(() => {
-      globalThis.fetch = originalFetch;
-    });
-
-    it("executes query via HTTP API", async () => {
-      const mockResponse = '{"id":"1"}\n{"id":"2"}';
-      globalThis.fetch = createFetchMock(
-        new Response(mockResponse, { status: 200 })
-      );
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientWorkersLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.query<{ id: string }>("SELECT * FROM test");
-      });
-
-      const result = await Effect.runPromise(
-        program.pipe(Effect.provide(testLayer))
-      );
-
-      expect(result).toEqual([{ id: "1" }, { id: "2" }]);
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("default_format=JSONEachRow"),
-        expect.objectContaining({ method: "POST" })
-      );
-    });
-
-    it("handles empty response", async () => {
-      globalThis.fetch = createFetchMock(
-        new Response("", { status: 200 })
-      );
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientWorkersLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.query<{ id: string }>("SELECT * FROM test");
-      });
-
-      const result = await Effect.runPromise(
-        program.pipe(Effect.provide(testLayer))
-      );
-
-      expect(result).toEqual([]);
-    });
-
-    it("handles HTTP errors from ClickHouse", async () => {
-      globalThis.fetch = createFetchMock(
-        new Response("Code: 60. DB::Exception", { status: 500 })
-      );
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientWorkersLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.query("SELECT * FROM test");
-      });
-
-      const result = await Effect.runPromise(
-        program.pipe(
-          Effect.provide(testLayer),
-          Effect.either
-        )
-      );
-
-      expect(result._tag).toBe("Left");
-      if (result._tag === "Left") {
-        expect(result.left).toBeInstanceOf(ClickHouseError);
-        expect(result.left.message).toContain("500");
-      }
-    });
-
-    it("validates https in production", async () => {
+  describe("TLS configuration validation", () => {
+    it("throws error when TLS_SKIP_VERIFY is true", async () => {
       const settings = createTestSettings({
-        env: "production",
-        CLICKHOUSE_URL: "http://clickhouse.example.com", // HTTP instead of HTTPS
+        CLICKHOUSE_TLS_ENABLED: true,
+        CLICKHOUSE_TLS_SKIP_VERIFY: true,
       });
-      const testLayer = ClickHouseClientWorkersLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
 
       const program = Effect.gen(function* () {
-        yield* ClickHouseClient;
+        yield* ClickHouse;
       });
 
       await expect(
-        Effect.runPromise(program.pipe(Effect.provide(testLayer)))
+        Effect.runPromise(
+          program.pipe(Effect.provide(createClickHouseLayer(settings))),
+        ),
+      ).rejects.toThrow("CLICKHOUSE_TLS_SKIP_VERIFY=true is not supported");
+    });
+
+    it("throws error when TLS_HOSTNAME_VERIFY is false", async () => {
+      const settings = createTestSettings({
+        CLICKHOUSE_TLS_ENABLED: true,
+        CLICKHOUSE_TLS_HOSTNAME_VERIFY: false,
+      });
+
+      const program = Effect.gen(function* () {
+        yield* ClickHouse;
+      });
+
+      await expect(
+        Effect.runPromise(
+          program.pipe(Effect.provide(createClickHouseLayer(settings))),
+        ),
+      ).rejects.toThrow(
+        "CLICKHOUSE_TLS_HOSTNAME_VERIFY=false is not supported",
+      );
+    });
+
+    it("throws error when TLS_CA is provided", async () => {
+      const settings = createTestSettings({
+        CLICKHOUSE_TLS_ENABLED: true,
+        CLICKHOUSE_TLS_CA: "/nonexistent/ca.pem",
+      });
+
+      const program = Effect.gen(function* () {
+        yield* ClickHouse;
+      });
+
+      await expect(
+        Effect.runPromise(
+          program.pipe(Effect.provide(createClickHouseLayer(settings))),
+        ),
+      ).rejects.toThrow("CLICKHOUSE_TLS_CA is not supported");
+    });
+
+    it("logs warning when TLS_MIN_VERSION is non-default", async () => {
+      const consoleSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const settings = createTestSettings({
+        CLICKHOUSE_TLS_ENABLED: true,
+        CLICKHOUSE_TLS_MIN_VERSION: "TLSv1.3",
+      });
+
+      const program = Effect.gen(function* () {
+        yield* ClickHouse;
+      });
+
+      await expect(
+        Effect.runPromise(
+          program.pipe(Effect.provide(createClickHouseLayer(settings))),
+        ),
+      ).rejects.toThrow();
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("CLICKHOUSE_TLS_MIN_VERSION=TLSv1.3"),
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("ClickHouse.layer", () => {
+    it("creates a layer with provided configuration", () => {
+      const layer = ClickHouse.layer({
+        url: "http://localhost:8123",
+        user: "default",
+        password: "test",
+        database: "test_db",
+      });
+
+      expect(layer).toBeDefined();
+      expect(Layer.isLayer(layer)).toBe(true);
+    });
+
+    it("layer works with unsafeQuery", async () => {
+      const program = Effect.gen(function* () {
+        const client = yield* ClickHouse;
+        return yield* client.unsafeQuery<{ n: number }>("SELECT 1 as n");
+      });
+
+      const result = await Effect.runPromise(
+        program.pipe(
+          Effect.provide(
+            ClickHouse.layer({
+              url: process.env.CLICKHOUSE_URL ?? "http://localhost:8123",
+              user: process.env.CLICKHOUSE_USER ?? "default",
+              password: process.env.CLICKHOUSE_PASSWORD ?? "clickhouse",
+              database:
+                process.env.CLICKHOUSE_DATABASE ?? "mirascope_analytics",
+            }),
+          ),
+        ),
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.n).toBe(1);
+    });
+  });
+
+  describe("ClickHouseLive in production", () => {
+    it("validates https in production", async () => {
+      const settings = createTestSettings({
+        env: "production",
+        CLICKHOUSE_URL: "http://clickhouse.example.com",
+      });
+
+      const program = Effect.gen(function* () {
+        yield* ClickHouse;
+      });
+
+      await expect(
+        Effect.runPromise(
+          program.pipe(Effect.provide(createClickHouseLayer(settings))),
+        ),
       ).rejects.toThrow("must use https://");
-    });
-
-    it("inserts rows via HTTP API", async () => {
-      globalThis.fetch = createFetchMock(
-        new Response("", { status: 200 })
-      );
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientWorkersLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const rows = [{ id: "1" }, { id: "2" }];
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.insert("test_table", rows);
-      });
-
-      await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
-
-      // URL is encoded, so check for the encoded form
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("test_table"),
-        expect.objectContaining({
-          method: "POST",
-          body: '{"id":"1"}\n{"id":"2"}',
-        })
-      );
-    });
-
-    it("skips insert for empty rows (Workers)", async () => {
-      globalThis.fetch = createFetchMock(new Response("", { status: 200 }));
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientWorkersLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.insert("test_table", []);
-      });
-
-      await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
-
-      expect(globalThis.fetch).not.toHaveBeenCalled();
-    });
-
-    it("executes command via HTTP API", async () => {
-      globalThis.fetch = createFetchMock(
-        new Response("", { status: 200 })
-      );
-
-      const settings = createTestSettings();
-      const testLayer = ClickHouseClientWorkersLive.pipe(
-        Layer.provide(makeTestSettingsLayer(settings))
-      );
-
-      const program = Effect.gen(function* () {
-        const client = yield* ClickHouseClient;
-        return yield* client.command("CREATE TABLE test (id String)");
-      });
-
-      await Effect.runPromise(program.pipe(Effect.provide(testLayer)));
-
-      expect(globalThis.fetch).toHaveBeenCalledWith(
-        expect.stringContaining("localhost:8123"),
-        expect.objectContaining({
-          method: "POST",
-          body: "CREATE TABLE test (id String)",
-        })
-      );
     });
   });
 });

--- a/cloud/errors.ts
+++ b/cloud/errors.ts
@@ -267,7 +267,7 @@ export class ProxyError extends Schema.TaggedError<ProxyError>()("ProxyError", {
  *
  * @example
  * ```ts
- * const result = yield* clickhouse.query<Span>("SELECT * FROM spans").pipe(
+ * const result = yield* clickhouse.unsafeQuery<Span>("SELECT * FROM spans").pipe(
  *   Effect.catchTag("ClickHouseError", (error) => {
  *     console.error("ClickHouse operation failed:", error.message);
  *     return Effect.succeed([]);

--- a/cloud/package.json
+++ b/cloud/package.json
@@ -30,6 +30,7 @@
     "lint:eslint:fix": "eslint . --fix"
   },
   "dependencies": {
+    "@clickhouse/client-web": "^1.16.0",
     "@effect/platform": "^0.93.3",
     "@effect/schema": "^0.75.5",
     "@effect/sql": "^0.48.6",

--- a/cloud/settings.test.ts
+++ b/cloud/settings.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   getSettings,
-  getSettingsFromEnv,
-  type CloudflareEnv,
+  getSettingsFromEnvironment,
+  type CloudflareEnvironment,
 } from "@/settings";
 
 describe("settings", () => {
@@ -83,7 +83,7 @@ describe("settings", () => {
       process.env.CLICKHOUSE_TLS_ENABLED = "false";
 
       expect(() => getSettings()).toThrow(
-        "CLICKHOUSE_TLS_ENABLED=true is required in production"
+        "CLICKHOUSE_TLS_ENABLED=true is required in production",
       );
     });
 
@@ -93,7 +93,7 @@ describe("settings", () => {
       process.env.CLICKHOUSE_TLS_SKIP_VERIFY = "true";
 
       expect(() => getSettings()).toThrow(
-        "CLICKHOUSE_TLS_SKIP_VERIFY=true is not allowed in production"
+        "CLICKHOUSE_TLS_SKIP_VERIFY=true is not allowed in production",
       );
     });
 
@@ -104,7 +104,7 @@ describe("settings", () => {
       process.env.CLICKHOUSE_TLS_HOSTNAME_VERIFY = "false";
 
       expect(() => getSettings()).toThrow(
-        "CLICKHOUSE_TLS_HOSTNAME_VERIFY=true is required in production"
+        "CLICKHOUSE_TLS_HOSTNAME_VERIFY=true is required in production",
       );
     });
 
@@ -121,29 +121,29 @@ describe("settings", () => {
     });
   });
 
-  describe("getSettingsFromEnv", () => {
+  describe("getSettingsFromEnvironment", () => {
     it("defaults env to 'local' when ENVIRONMENT is not set", () => {
-      const env: CloudflareEnv = {};
-      const settings = getSettingsFromEnv(env);
+      const env: CloudflareEnvironment = {};
+      const settings = getSettingsFromEnvironment(env);
 
       expect(settings.env).toBe("local");
     });
 
     it("uses ENVIRONMENT from env bindings", () => {
-      const env: CloudflareEnv = { ENVIRONMENT: "production" };
-      const settings = getSettingsFromEnv(env);
+      const env: CloudflareEnvironment = { ENVIRONMENT: "production" };
+      const settings = getSettingsFromEnvironment(env);
 
       expect(settings.env).toBe("production");
     });
 
     it("maps all ClickHouse settings from env", () => {
-      const env: CloudflareEnv = {
+      const env: CloudflareEnvironment = {
         CLICKHOUSE_URL: "https://ch.example.com",
         CLICKHOUSE_USER: "user",
         CLICKHOUSE_PASSWORD: "pass",
         CLICKHOUSE_DATABASE: "analytics",
       };
-      const settings = getSettingsFromEnv(env);
+      const settings = getSettingsFromEnvironment(env);
 
       expect(settings.CLICKHOUSE_URL).toBe("https://ch.example.com");
       expect(settings.CLICKHOUSE_USER).toBe("user");
@@ -152,8 +152,8 @@ describe("settings", () => {
     });
 
     it("returns default ClickHouse values when not set", () => {
-      const env: CloudflareEnv = {};
-      const settings = getSettingsFromEnv(env);
+      const env: CloudflareEnvironment = {};
+      const settings = getSettingsFromEnvironment(env);
 
       expect(settings.CLICKHOUSE_URL).toBe("http://localhost:8123");
       expect(settings.CLICKHOUSE_USER).toBe("default");
@@ -161,13 +161,13 @@ describe("settings", () => {
     });
 
     it("maps TLS settings from env", () => {
-      const env: CloudflareEnv = {
+      const env: CloudflareEnvironment = {
         CLICKHOUSE_TLS_ENABLED: "true",
         CLICKHOUSE_TLS_CA: "/path/to/ca.pem",
         CLICKHOUSE_TLS_SKIP_VERIFY: "true",
         CLICKHOUSE_TLS_HOSTNAME_VERIFY: "false",
       };
-      const settings = getSettingsFromEnv(env);
+      const settings = getSettingsFromEnvironment(env);
 
       expect(settings.CLICKHOUSE_TLS_ENABLED).toBe(true);
       expect(settings.CLICKHOUSE_TLS_CA).toBe("/path/to/ca.pem");
@@ -176,8 +176,8 @@ describe("settings", () => {
     });
 
     it("defaults TLS_HOSTNAME_VERIFY to true when not set", () => {
-      const env: CloudflareEnv = {};
-      const settings = getSettingsFromEnv(env);
+      const env: CloudflareEnvironment = {};
+      const settings = getSettingsFromEnvironment(env);
 
       expect(settings.CLICKHOUSE_TLS_HOSTNAME_VERIFY).toBe(true);
     });

--- a/cloud/tests/clickhouse.ts
+++ b/cloud/tests/clickhouse.ts
@@ -1,0 +1,85 @@
+import { Effect, Layer } from "effect";
+import { describe, expect, it as vitestIt } from "@effect/vitest";
+import { createCustomIt } from "@/tests/shared";
+import { ClickHouse } from "@/clickhouse/client";
+import { SettingsService, type Settings } from "@/settings";
+
+// Re-export describe and expect for convenience
+export { describe, expect };
+
+// Environment variables for ClickHouse connection
+const CLICKHOUSE_URL = process.env.CLICKHOUSE_URL ?? "http://localhost:8123";
+const CLICKHOUSE_USER = process.env.CLICKHOUSE_USER ?? "default";
+const CLICKHOUSE_PASSWORD = process.env.CLICKHOUSE_PASSWORD ?? "clickhouse";
+const CLICKHOUSE_DATABASE =
+  process.env.CLICKHOUSE_DATABASE ?? "mirascope_analytics";
+
+const isClickHouseAvailable = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(`${CLICKHOUSE_URL}/ping`, {
+      method: "GET",
+      signal: AbortSignal.timeout(2000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+};
+
+const clickhouseAvailable = await isClickHouseAvailable();
+
+/**
+ * Test settings for ClickHouse.
+ */
+const testSettings: Settings = {
+  env: "local",
+  CLICKHOUSE_URL,
+  CLICKHOUSE_USER,
+  CLICKHOUSE_PASSWORD,
+  CLICKHOUSE_DATABASE,
+  CLICKHOUSE_TLS_ENABLED: false,
+};
+
+/**
+ * Settings layer for tests.
+ */
+const TestSettingsLayer = Layer.succeed(SettingsService, testSettings);
+
+/**
+ * ClickHouse layer for tests.
+ * Note: Layer may fail with SqlError | ConfigError during initialization.
+ */
+export const TestClickHouse = ClickHouse.Default.pipe(
+  Layer.provide(TestSettingsLayer),
+);
+
+/**
+ * Services that are automatically provided to all `it.effect` tests.
+ */
+export type TestServices = ClickHouse;
+
+/**
+ * Wraps a test function to automatically provide TestClickHouse.
+ */
+const wrapEffectTest =
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (original: any) =>
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (name: any, fn: any, timeout?: any) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      const runner = clickhouseAvailable ? original : vitestIt.effect.skip;
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
+      return runner(
+        name,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-type-assertion
+        () => (fn() as any).pipe(Effect.provide(TestClickHouse)),
+        timeout,
+      );
+    };
+
+/**
+ * Type-safe `it` with `it.effect` that automatically provides TestClickHouse.
+ *
+ * Use this instead of importing directly from @effect/vitest.
+ */
+export const it = createCustomIt<TestServices>(wrapEffectTest);


### PR DESCRIPTION
### TL;DR

Added ClickHouse client implementation for analytics data access with support for both Node.js and Cloudflare Workers environments.

### What changed?

- Added `@clickhouse/client` dependency to the project
- Created a new `ClickHouseClient` service with two implementations:
  - `ClickHouseClientNodeLive`: Uses the native Node.js client for local development and API handlers
  - `ClickHouseClientWorkersLive`: Uses fetch API with HTTP interface for Cloudflare Workers
- Added comprehensive test coverage for both implementations
- Extended the `Settings` interface with ClickHouse configuration options
- Added `ClickHouseError` class for error handling
- Implemented environment-specific TLS validation for secure connections

### How to test?

1. Run the test suite to verify both implementations:
   ```bash
   cd cloud
   bun test clickhouse/client.test.ts
   ```

2. For local development with ClickHouse:
   ```typescript
   import { ClickHouseClient, ClickHouseClientNodeLive } from "@/clickhouse/client";
   
   const program = Effect.gen(function* () {
     const client = yield* ClickHouseClient;
     const results = yield* client.query("SELECT * FROM test_table LIMIT 10");
     return results;
   });
   
   await Effect.runPromise(program.pipe(Effect.provide(ClickHouseClientNodeLive)));
   ```

### Why make this change?

This implementation provides a unified interface for analytics data access across different environments. The dual implementation approach solves the platform-specific constraints:

1. Node.js environment (local dev, API handlers) gets full TLS configuration support with the native client
2. Cloudflare Workers environment (Queue Consumer, Cron) gets a compatible implementation using the HTTP API

This enables consistent analytics data access while respecting the runtime constraints of each platform.