### PR TITLE
fix(ci): use clickhouse-client for multi-statement SQL init

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,11 +211,7 @@ jobs:
         run: bun install --frozen-lockfile
 
       - name: Initialize ClickHouse
-        run: |
-          for script in docker/clickhouse/init/*.sql; do
-            echo "Running $script..."
-            curl -s "http://${CLICKHOUSE_USER}:${CLICKHOUSE_PASSWORD}@localhost:8123/" --data-binary @"$script"
-          done
+        run: bun run clickhouse:migrate
 
       - name: Run `vitest` with code coverage
         run: bun run test:coverage

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -249,6 +249,9 @@ cloud/
 ├── clickhouse/                    # ClickHouse analytics services
 │   ├── client.ts                  # Effect service for ClickHouse access
 │   ├── search.ts                  # Analytics/search queries and transforms
+│   ├── migrator.ts                # Schema migration runner (run: bun run clickhouse:migrate)
+│   ├── migrations/                # SQL migration files (versioned, applied on startup)
+│   │   └── *.sql
 │   └── [other files]              # utils.ts, tests, etc.
 ├── workers/                       # Cloudflare Workers (queues/cron/polling)
 │   ├── clickhouseQueueConsumer.ts # Queue consumer for outbox sync
@@ -260,9 +263,7 @@ cloud/
 │   └── db.ts                      # Database test utilities
 ├── docker/                        # Docker configuration
 │   ├── compose.yml
-│   ├── clickhouse/                # ClickHouse init SQL
-│   │   └── init/                  # Schema + index creation scripts
-│   └── data/                      # Docker data directory
+│   └── data/                      # Docker data directory (gitignored)
 ├── dist/                          # Build output
 │   ├── client/                    # Client build artifacts
 │   └── server/                    # Server build artifacts

--- a/cloud/docker/compose.yml
+++ b/cloud/docker/compose.yml
@@ -29,7 +29,6 @@ services:
       - "9000:9000"
     volumes:
       - ./data/clickhouse:/var/lib/clickhouse
-      - ./clickhouse/init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8123/ping"]
       interval: 5s


### PR DESCRIPTION
The consolidated 00_init.sql contains multiple statements (CREATE DATABASE,
CREATE TABLE, ALTER TABLE). ClickHouse's HTTP interface doesn't support
multi-statement queries, so curl --data-binary fails silently after the
first statement.

Solution: Use docker exec with clickhouse-client --multiquery to properly
execute all statements in the init scripts.