### PR TITLE
refactor(python-sdk): simple tool constructors

### DIFF
--- a/python/mirascope/llm/formatting/format.py
+++ b/python/mirascope/llm/formatting/format.py
@@ -116,16 +116,13 @@ class Format(Generic[FormattableT]):
                 "Format tool function should not be called."
             )  # pragma: no cover
 
-        tool_schema = cast(
-            ToolSchema[ToolFn[..., None]], ToolSchema.__new__(ToolSchema)
+        return ToolSchema(
+            fn=cast(ToolFn[..., None], _unused_format_fn),
+            name=FORMAT_TOOL_NAME,
+            description=description,
+            parameters=parameters,
+            strict=True,
         )
-        tool_schema.fn = _unused_format_fn
-        tool_schema.name = FORMAT_TOOL_NAME
-        tool_schema.description = description
-        tool_schema.parameters = parameters
-        tool_schema.strict = True
-
-        return tool_schema
 
 
 def format(

--- a/python/mirascope/llm/tools/decorator.py
+++ b/python/mirascope/llm/tools/decorator.py
@@ -62,15 +62,19 @@ class ToolDecorator:
         is_async = _tool_utils.is_async_tool_fn(fn)
 
         if is_context and is_async:
-            return AsyncContextTool[DepsT, JsonableCovariantT, P](
+            return AsyncContextTool[DepsT, JsonableCovariantT, P].from_function(
                 fn, strict=self.strict
             )
         elif is_context:
-            return ContextTool[DepsT, JsonableCovariantT, P](fn, strict=self.strict)
+            return ContextTool[DepsT, JsonableCovariantT, P].from_function(
+                fn, strict=self.strict
+            )
         elif is_async:
-            return AsyncTool[P, JsonableCovariantT](fn, strict=self.strict)
+            return AsyncTool[P, JsonableCovariantT].from_function(
+                fn, strict=self.strict
+            )
         else:
-            return Tool[P, JsonableCovariantT](fn, strict=self.strict)
+            return Tool[P, JsonableCovariantT].from_function(fn, strict=self.strict)
 
 
 @overload

--- a/python/mirascope/llm/tools/tools.py
+++ b/python/mirascope/llm/tools/tools.py
@@ -40,10 +40,27 @@ class Tool(
     This class is not instantiated directly but created by the `@tool()` decorator.
     """
 
-    def __init__(
-        self, fn: ToolFn[AnyP, JsonableCovariantT], *, strict: bool = False
-    ) -> None:
-        super().__init__(fn, strict=strict, is_context_tool=False)
+    @classmethod
+    def from_function(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls, fn: ToolFn[AnyP, JsonableCovariantT], *, strict: bool = False
+    ) -> Tool[AnyP, JsonableCovariantT]:
+        """Create a `Tool` by inspecting a function and its docstring.
+
+        Args:
+            fn: The function to extract schema from
+            strict: Whether the tool should use strict mode when supported
+
+        Returns:
+            a `Tool` representing the function
+        """
+        schema = ToolSchema.from_function(fn, strict=strict, is_context_tool=False)
+        return cls(
+            fn=cast(ToolFn[AnyP, JsonableCovariantT], schema.fn),
+            name=schema.name,
+            description=schema.description,
+            parameters=schema.parameters,
+            strict=schema.strict,
+        )
 
     def __call__(self, *args: AnyP.args, **kwargs: AnyP.kwargs) -> JsonableCovariantT:
         """Call the underlying function directly."""
@@ -69,10 +86,27 @@ class AsyncTool(
     This class is not instantiated directly but created by the `@tool()` decorator.
     """
 
-    def __init__(
-        self, fn: AsyncToolFn[AnyP, JsonableCovariantT], *, strict: bool = False
-    ) -> None:
-        super().__init__(fn, strict=strict, is_context_tool=False)
+    @classmethod
+    def from_function(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls, fn: AsyncToolFn[AnyP, JsonableCovariantT], *, strict: bool = False
+    ) -> AsyncTool[AnyP, JsonableCovariantT]:
+        """Create an `AsyncTool` by inspecting a function and its docstring.
+
+        Args:
+            fn: The function to extract schema from
+            strict: Whether the tool should use strict mode when supported
+
+        Returns:
+            an `AsyncTool` representing the function
+        """
+        schema = ToolSchema.from_function(fn, strict=strict, is_context_tool=False)
+        return cls(
+            fn=cast(AsyncToolFn[AnyP, JsonableCovariantT], schema.fn),
+            name=schema.name,
+            description=schema.description,
+            parameters=schema.parameters,
+            strict=schema.strict,
+        )
 
     def __call__(
         self, *args: AnyP.args, **kwargs: AnyP.kwargs
@@ -100,13 +134,30 @@ class ContextTool(
     This class is not instantiated directly but created by the `@tool()` decorator.
     """
 
-    def __init__(
-        self,
+    @classmethod
+    def from_function(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls,
         fn: ContextToolFn[DepsT, AnyP, JsonableCovariantT],
         *,
         strict: bool = False,
-    ) -> None:
-        super().__init__(fn, strict=strict, is_context_tool=True)
+    ) -> ContextTool[DepsT, JsonableCovariantT, AnyP]:
+        """Create a `ContextTool` by inspecting a function and its docstring.
+
+        Args:
+            fn: The function to extract schema from
+            strict: Whether the tool should use strict mode when supported
+
+        Returns:
+            a `ContextTool` representing the function
+        """
+        schema = ToolSchema.from_function(fn, strict=strict, is_context_tool=True)
+        return cls(
+            fn=cast(ContextToolFn[DepsT, AnyP, JsonableCovariantT], schema.fn),
+            name=schema.name,
+            description=schema.description,
+            parameters=schema.parameters,
+            strict=schema.strict,
+        )
 
     def __call__(
         self,
@@ -141,13 +192,30 @@ class AsyncContextTool(
     This class is not instantiated directly but created by the `@tool()` decorator.
     """
 
-    def __init__(
-        self,
+    @classmethod
+    def from_function(  # pyright: ignore[reportIncompatibleMethodOverride]
+        cls,
         fn: AsyncContextToolFn[DepsT, AnyP, JsonableCovariantT],
         *,
         strict: bool = False,
-    ) -> None:
-        super().__init__(fn, strict=strict, is_context_tool=True)
+    ) -> AsyncContextTool[DepsT, JsonableCovariantT, AnyP]:
+        """Create an `AsyncContextTool` by inspecting a function and its docstring.
+
+        Args:
+            fn: The function to extract schema from
+            strict: Whether the tool should use strict mode when supported
+
+        Returns:
+            an `AsyncContextTool` representing the function
+        """
+        schema = ToolSchema.from_function(fn, strict=strict, is_context_tool=True)
+        return cls(
+            fn=cast(AsyncContextToolFn[DepsT, AnyP, JsonableCovariantT], schema.fn),
+            name=schema.name,
+            description=schema.description,
+            parameters=schema.parameters,
+            strict=schema.strict,
+        )
 
     def __call__(
         self,


### PR DESCRIPTION
Separates generating ToolSchemas (and Tools) from functions as a class
method rather than the constructor.

This way we can construct MCP tools even though they aren't derived from
a function. Also simplifies format tool construction