### PR TITLE
refactor(router): DRY streaming/non-streaming with shared route-utils

### DIFF
--- a/cloud/api/router/non-streaming.ts
+++ b/cloud/api/router/non-streaming.ts
@@ -1,0 +1,113 @@
+/**
+ * @fileoverview Handler for non-streaming router responses.
+ *
+ * Processes non-streaming responses from AI providers, extracting usage
+ * information and performing metering.
+ */
+
+import { Effect } from "effect";
+import { Database } from "@/db";
+import { Payments } from "@/payments";
+import { DatabaseError, NotFoundError, PermissionDeniedError } from "@/errors";
+import { getCostCalculator } from "@/api/router/providers";
+import type { ProxyResult } from "@/api/router/proxy";
+import {
+  type RouterRequestContext,
+  type ValidatedRouterRequest,
+  handleRouterRequestFailure,
+} from "@/api/router/utils";
+
+/**
+ * Handles a non-streaming response.
+ *
+ * Extracts usage from response body, calculates cost, updates database,
+ * and settles fund reservation.
+ *
+ * @param proxyResult - Result from proxying to provider
+ * @param context - Router request context
+ * @param validated - Validated request information
+ * @returns Final response for the client
+ */
+export function handleNonStreamingResponse(
+  proxyResult: ProxyResult,
+  context: RouterRequestContext,
+  validated: ValidatedRouterRequest,
+): Effect.Effect<
+  Response,
+  DatabaseError | NotFoundError | PermissionDeniedError,
+  Database | Payments
+> {
+  return Effect.gen(function* () {
+    const db = yield* Database;
+    const payments = yield* Payments;
+
+    const costCalculator = getCostCalculator(validated.provider);
+
+    // Extract usage from response body
+    const usage = proxyResult.body
+      ? costCalculator.extractUsage(proxyResult.body)
+      : null;
+
+    const costResult = usage
+      ? yield* costCalculator.calculate(validated.modelId, usage)
+      : null;
+
+    if (costResult && costResult.totalCost > 0) {
+      // Update router request and settle reservation (errors swallowed, cron will reconcile)
+      yield* Effect.gen(function* () {
+        yield* db.organizations.projects.environments.apiKeys.routerRequests.update(
+          {
+            userId: context.request.userId,
+            organizationId: context.request.organizationId,
+            projectId: context.request.projectId,
+            environmentId: context.request.environmentId,
+            apiKeyId: context.request.apiKeyId,
+            routerRequestId: context.routerRequestId,
+            data: {
+              inputTokens: usage!.inputTokens
+                ? BigInt(usage!.inputTokens)
+                : null,
+              outputTokens: usage!.outputTokens
+                ? BigInt(usage!.outputTokens)
+                : null,
+              cacheReadTokens: usage!.cacheReadTokens
+                ? BigInt(usage!.cacheReadTokens)
+                : null,
+              cacheWriteTokens: usage!.cacheWriteTokens
+                ? BigInt(usage!.cacheWriteTokens)
+                : null,
+              cacheWriteBreakdown: usage!.cacheWriteBreakdown || null,
+              costCenticents: costResult.totalCost,
+              status: "success",
+              completedAt: new Date(),
+            },
+          },
+        );
+
+        // Settle reservation - this updates DB and charges the meter
+        yield* payments.products.router.settleFunds(
+          context.reservationId,
+          costResult.totalCost,
+        );
+      }).pipe(
+        Effect.catchAll((error) => {
+          console.error(
+            `[handleNonStreamingResponse] Error updating request ${context.routerRequestId} or settling reservation ${context.reservationId}:`,
+            error,
+          );
+          return Effect.succeed(undefined);
+        }),
+      );
+    } else {
+      // No usage or cost calculation failed, update request and release funds
+      yield* handleRouterRequestFailure(
+        context.routerRequestId,
+        context.reservationId,
+        context.request,
+        "No usage data or cost calculation failed",
+      );
+    }
+
+    return proxyResult.response;
+  });
+}

--- a/cloud/api/router/utils.test.ts
+++ b/cloud/api/router/utils.test.ts
@@ -14,11 +14,11 @@ import {
   createPendingRouterRequest,
   reserveRouterFunds,
   handleRouterRequestFailure,
-  handleNonStreamingResponse,
-  handleStreamingResponse,
   type ValidatedRouterRequest,
   type RouterRequestContext,
-} from "@/api/router/route-handlers";
+} from "@/api/router/utils";
+import { handleStreamingResponse } from "@/api/router/streaming";
+import { handleNonStreamingResponse } from "@/api/router/non-streaming";
 import { DefaultMockPayments, MockPayments } from "@/tests/payments";
 import { InternalError, UnauthorizedError, DatabaseError } from "@/errors";
 import type { ProxyResult } from "@/api/router/proxy";

--- a/cloud/api/router/utils.ts
+++ b/cloud/api/router/utils.ts
@@ -1,8 +1,8 @@
 /**
- * @fileoverview Helper functions for router request handling.
+ * @fileoverview Shared utilities for router request handling.
  *
  * Provides reusable utilities for processing router requests including
- * authentication, validation, fund reservation, and response handling.
+ * authentication, validation, fund reservation, and failure handling.
  */
 
 import { Effect } from "effect";
@@ -16,22 +16,29 @@ import {
   DatabaseError,
   NotFoundError,
   PermissionDeniedError,
-  ProxyError,
 } from "@/errors";
 import {
   isValidProvider,
   extractModelId,
-  getCostCalculator,
   type ProviderName,
 } from "@/api/router/providers";
 import { estimateCost } from "@/api/router/cost-estimator";
-import type { ProxyResult } from "@/api/router/proxy";
-import {
-  parseStreamingResponse,
-  type StreamMeteringContext,
-  type RouterRequestIdentifiers,
-  type ResponseMetadata,
-} from "@/api/router/streaming";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Router request identifiers for database operations.
+ */
+export interface RouterRequestIdentifiers {
+  userId: string;
+  organizationId: string;
+  projectId: string;
+  environmentId: string;
+  apiKeyId: string;
+  routerRequestId: string;
+}
 
 /**
  * Result of router request validation.
@@ -52,6 +59,10 @@ export interface RouterRequestContext {
   reservationId: string;
   request: RouterRequestIdentifiers;
 }
+
+// =============================================================================
+// Validation Functions
+// =============================================================================
 
 /**
  * Validates and authenticates a router request.
@@ -133,6 +144,10 @@ export function validateRouterRequest(
   });
 }
 
+// =============================================================================
+// Database Functions
+// =============================================================================
+
 /**
  * Creates a pending router request in the database.
  *
@@ -169,6 +184,10 @@ export function createPendingRouterRequest(
   });
 }
 
+// =============================================================================
+// Payment Functions
+// =============================================================================
+
 /**
  * Reserves funds for a router request.
  *
@@ -203,15 +222,17 @@ export function reserveRouterFunds(
   });
 }
 
+// =============================================================================
+// Error Handling Functions
+// =============================================================================
+
 /**
  * Handles failure by updating router request and releasing funds.
  *
- * This is a common error handling pattern used throughout the router.
- *
  * @param routerRequestId - Router request ID
- * @param reservationId - Reservation ID
- * @param request - Request identifiers
- * @param errorMessage - Error message to store
+ * @param reservationId - Reservation ID to release
+ * @param request - Router request identifiers
+ * @param errorMessage - Error message to record
  */
 export function handleRouterRequestFailure(
   routerRequestId: string,
@@ -256,150 +277,5 @@ export function handleRouterRequestFailure(
         return Effect.succeed(undefined);
       }),
     );
-  });
-}
-
-/**
- * Handles a streaming response.
- *
- * Parses the streaming response with Effect Streams, performing metering
- * in the stream finalizer.
- *
- * @param proxyResult - Result from proxying to provider
- * @param context - Router request context
- * @param validated - Validated request information
- * @param responseMetadata - Original response metadata
- * @param databaseUrl - Database URL for metering
- * @param stripeConfig - Stripe configuration for metering
- * @returns Final response for the client
- */
-export function handleStreamingResponse(
-  proxyResult: ProxyResult,
-  context: RouterRequestContext,
-  validated: ValidatedRouterRequest,
-  responseMetadata: ResponseMetadata,
-  databaseUrl: string,
-  stripeConfig: {
-    apiKey: string;
-    routerPriceId: string;
-    routerMeterId: string;
-  },
-): Effect.Effect<Response, ProxyError> {
-  return Effect.gen(function* () {
-    const meteringContext: StreamMeteringContext = {
-      provider: validated.provider,
-      modelId: validated.modelId,
-      reservationId: context.reservationId,
-      request: context.request,
-      response: responseMetadata,
-      databaseUrl,
-      stripeApiKey: stripeConfig.apiKey,
-      routerPriceId: stripeConfig.routerPriceId,
-      routerMeterId: stripeConfig.routerMeterId,
-    };
-
-    const streamParseResult = yield* parseStreamingResponse(
-      proxyResult.response,
-      proxyResult.streamFormat!,
-      meteringContext,
-    );
-
-    const finalResponse = yield* streamParseResult.responseEffect;
-    return finalResponse;
-  });
-}
-
-/**
- * Handles a non-streaming response.
- *
- * Extracts usage from response body, calculates cost, updates database,
- * and settles fund reservation.
- *
- * @param proxyResult - Result from proxying to provider
- * @param context - Router request context
- * @param validated - Validated request information
- * @returns Final response for the client
- */
-export function handleNonStreamingResponse(
-  proxyResult: ProxyResult,
-  context: RouterRequestContext,
-  validated: ValidatedRouterRequest,
-): Effect.Effect<
-  Response,
-  DatabaseError | NotFoundError | PermissionDeniedError,
-  Database | Payments
-> {
-  return Effect.gen(function* () {
-    const db = yield* Database;
-    const payments = yield* Payments;
-
-    const costCalculator = getCostCalculator(validated.provider);
-
-    // Extract usage from response body
-    const usage = proxyResult.body
-      ? costCalculator.extractUsage(proxyResult.body)
-      : null;
-
-    const costResult = usage
-      ? yield* costCalculator.calculate(validated.modelId, usage)
-      : null;
-
-    if (costResult && costResult.totalCost > 0) {
-      // Update router request and settle reservation (errors swallowed, cron will reconcile)
-      yield* Effect.gen(function* () {
-        yield* db.organizations.projects.environments.apiKeys.routerRequests.update(
-          {
-            userId: context.request.userId,
-            organizationId: context.request.organizationId,
-            projectId: context.request.projectId,
-            environmentId: context.request.environmentId,
-            apiKeyId: context.request.apiKeyId,
-            routerRequestId: context.routerRequestId,
-            data: {
-              inputTokens: usage!.inputTokens
-                ? BigInt(usage!.inputTokens)
-                : null,
-              outputTokens: usage!.outputTokens
-                ? BigInt(usage!.outputTokens)
-                : null,
-              cacheReadTokens: usage!.cacheReadTokens
-                ? BigInt(usage!.cacheReadTokens)
-                : null,
-              cacheWriteTokens: usage!.cacheWriteTokens
-                ? BigInt(usage!.cacheWriteTokens)
-                : null,
-              cacheWriteBreakdown: usage!.cacheWriteBreakdown || null,
-              costCenticents: costResult.totalCost,
-              status: "success",
-              completedAt: new Date(),
-            },
-          },
-        );
-
-        // Settle reservation - this updates DB and charges the meter
-        yield* payments.products.router.settleFunds(
-          context.reservationId,
-          costResult.totalCost,
-        );
-      }).pipe(
-        Effect.catchAll((error) => {
-          console.error(
-            `[handleNonStreamingResponse] Error updating request ${context.routerRequestId} or settling reservation ${context.reservationId}:`,
-            error,
-          );
-          return Effect.succeed(undefined);
-        }),
-      );
-    } else {
-      // No usage or cost calculation failed, update request and release funds
-      yield* handleRouterRequestFailure(
-        context.routerRequestId,
-        context.reservationId,
-        context.request,
-        "No usage data or cost calculation failed",
-      );
-    }
-
-    return proxyResult.response;
   });
 }

--- a/cloud/app/routes/router.v0.$provider.$.tsx
+++ b/cloud/app/routes/router.v0.$provider.$.tsx
@@ -11,9 +11,9 @@ import {
   createPendingRouterRequest,
   reserveRouterFunds,
   handleRouterRequestFailure,
-  handleStreamingResponse,
-  handleNonStreamingResponse,
-} from "@/api/router/route-handlers";
+} from "@/api/router/utils";
+import { handleStreamingResponse } from "@/api/router/streaming";
+import { handleNonStreamingResponse } from "@/api/router/non-streaming";
 
 /**
  * Unified Provider Proxy Route


### PR DESCRIPTION
### TL;DR

Refactored router request handling by extracting common utilities to a new file.

### What changed?

- Created a new file `route-utils.ts` to house shared router functionality
- Moved `handleRouterRequestFailure` function from `route-handlers.ts` to `route-utils.ts`
- Moved `RouterRequestIdentifiers` type from `streaming.ts` to `route-utils.ts`
- Updated imports across affected files to reference the new location
- Improved error message in `performStreamMetering` to be more descriptive

### How to test?

- Run the existing test suite to ensure all router functionality continues to work
- Verify that router requests still properly handle failures and release funds
- Test streaming and non-streaming router requests to confirm they function correctly

### Why make this change?

This refactoring improves code organization by centralizing common router utilities in a dedicated file. The `handleRouterRequestFailure` function and `RouterRequestIdentifiers` type are used across multiple router components, so moving them to a shared location reduces duplication and makes the codebase more maintainable.