### PR TITLE
dev(python-sdk): add placeholder llm.retries and llm.RetryConfig

### DIFF
--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -3,6 +3,10 @@
 # Remove items from this list as we add comprehensive tests for each module
 # Goal: When this exclude list is empty, we have 100% coverage across the entire codebase
 omit =
+
+    # TODO: We'll get full coverage for retries when we wire in to e2e testing
+    mirascope/llm/retries/*
+
     # NOTE: MLX modules are excluded because the `mlx` package is macOS-only (Apple Silicon).
     # CI runs on Linux where `mlx` is not available, so these modules cannot be tested there.
     # TODO: Add a macOS CI job to run MLX tests and restore coverage for these modules.

--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -20,6 +20,7 @@ from . import (
     prompts,
     providers,
     responses,
+    retries,
     tools,
     types,
 )
@@ -144,6 +145,9 @@ from .responses import (
     Usage,
     UsageDeltaChunk,
 )
+from .retries import (
+    RetryConfig,
+)
 from .tools import (
     AnyToolFn,
     AnyTools,
@@ -249,6 +253,7 @@ __all__ = [
     "RawMessageChunk",
     "Response",
     "ResponseValidationError",
+    "RetryConfig",
     "RootResponse",
     "ServerError",
     "Stream",
@@ -309,6 +314,7 @@ __all__ = [
     "register_provider",
     "reset_provider_registry",
     "responses",
+    "retries",
     "tool",
     "tools",
     "types",

--- a/python/mirascope/llm/retries/__init__.py
+++ b/python/mirascope/llm/retries/__init__.py
@@ -1,0 +1,14 @@
+"""Retry functionality for reliable LLM interactions.
+
+This module provides retry capabilities for LLM calls, including:
+- Automatic retry on failures (connection errors, rate limits, etc.)
+- Configurable retry strategies and backoff
+- Fallback models
+- Retry metadata tracking
+"""
+
+from .retry_config import RetryConfig
+
+__all__ = [
+    "RetryConfig",
+]

--- a/python/mirascope/llm/retries/retry_config.py
+++ b/python/mirascope/llm/retries/retry_config.py
@@ -1,0 +1,41 @@
+"""Configuration for retry behavior."""
+
+from dataclasses import dataclass
+
+from ..exceptions import (
+    ConnectionError,
+    RateLimitError,
+    ServerError,
+    TimeoutError,
+)
+
+DEFAULT_RETRYABLE_ERRORS: tuple[type[Exception], ...] = (
+    ConnectionError,
+    RateLimitError,
+    ServerError,
+    TimeoutError,
+)
+"""Default exceptions that trigger a retry.
+
+These are transient errors that are likely to succeed on retry:
+- ConnectionError: Network issues, DNS failures
+- RateLimitError: Rate limits exceeded (429)
+- ServerError: Provider-side errors (500+)
+- TimeoutError: Request timeouts
+"""
+
+DEFAULT_MAX_ATTEMPTS: int = 3
+"""Default maximum number of attempts (1 initial + 2 retries)."""
+
+
+@dataclass(frozen=True)
+class RetryConfig:
+    """Configuration for retry behavior with defaults applied.
+
+    Attributes:
+        max_attempts: Maximum number of attempts (including the initial attempt).
+        retry_on: Tuple of exception types that should trigger a retry.
+    """
+
+    max_attempts: int = DEFAULT_MAX_ATTEMPTS
+    retry_on: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERRORS

--- a/python/tests/llm/retries/__init__.py
+++ b/python/tests/llm/retries/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the retry module."""


### PR DESCRIPTION
This is just the start of the retries skeleton. The RetryConfig has a
comment docstring but no actual code or configuration yet.

There is a test coverage exclusion for the whole retries module - we
will add coverage as e2e testing is setup