### PR TITLE
dev(python-sdk): add RetryModel and RetryResponse/AsyncRetryResponse

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -146,7 +146,10 @@ from .responses import (
     UsageDeltaChunk,
 )
 from .retries import (
+    AsyncRetryResponse,
     RetryConfig,
+    RetryModel,
+    RetryResponse,
 )
 from .tools import (
     AnyToolFn,
@@ -194,6 +197,7 @@ __all__ = [
     "AsyncContextTools",
     "AsyncPrompt",
     "AsyncResponse",
+    "AsyncRetryResponse",
     "AsyncStream",
     "AsyncStreamResponse",
     "AsyncTextStream",
@@ -254,6 +258,8 @@ __all__ = [
     "Response",
     "ResponseValidationError",
     "RetryConfig",
+    "RetryModel",
+    "RetryResponse",
     "RootResponse",
     "ServerError",
     "Stream",

--- a/python/mirascope/llm/retries/__init__.py
+++ b/python/mirascope/llm/retries/__init__.py
@@ -8,7 +8,7 @@ This module provides retry capabilities for LLM calls, including:
 """
 
 from .retry_config import RetryConfig
+from .retry_models import RetryModel
+from .retry_responses import AsyncRetryResponse, RetryResponse
 
-__all__ = [
-    "RetryConfig",
-]
+__all__ = ["AsyncRetryResponse", "RetryConfig", "RetryModel", "RetryResponse"]

--- a/python/mirascope/llm/retries/retry_models.py
+++ b/python/mirascope/llm/retries/retry_models.py
@@ -1,0 +1,292 @@
+"""RetryModel extends Model to add retry logic."""
+
+from collections.abc import Sequence
+from typing import cast, overload
+from typing_extensions import Unpack
+
+from ..formatting import FormatSpec, FormattableT
+from ..messages import Message, UserContent
+from ..models import Model, Params
+from ..providers import ModelId
+from ..responses import (
+    AsyncResponse,
+    Response,
+)
+from ..tools import (
+    AsyncTools,
+    Tools,
+)
+from .retry_config import RetryConfig
+from .retry_responses import (
+    AsyncRetryResponse,
+    RetryResponse,
+)
+
+
+class RetryModel(Model):
+    """Extends Model with retry logic.
+
+    This class wraps a Model (or creates one from a ModelId) and overrides call methods
+    to return RetryResponse instances instead of Response instances. In the future, it
+    will implement actual retry logic for handling failures, rate limits, and validation
+    errors.
+
+    Example:
+        Wrapping an existing Model:
+
+        ```python
+        model = llm.Model("openai/gpt-4o", temperature=0.7)
+        retry_model = llm.RetryModel(model, RetryConfig(max_attempts=3))
+        ```
+
+        Creating from a ModelId:
+
+        ```python
+        retry_model = llm.RetryModel(
+            "openai/gpt-4o",
+            RetryConfig(max_attempts=3),
+            temperature=0.7,
+        )
+        ```
+    """
+
+    retry_config: RetryConfig
+    """The RetryConfig specifying retry behavior."""
+
+    @overload
+    def __init__(
+        self,
+        model: Model,
+        retry_config: RetryConfig,
+    ) -> None:
+        """Wrap an existing Model with retry logic."""
+        ...
+
+    @overload
+    def __init__(
+        self,
+        model: ModelId,
+        retry_config: RetryConfig,
+        **params: Unpack[Params],
+    ) -> None:
+        """Create a RetryModel from a ModelId with optional params."""
+        ...
+
+    def __init__(
+        self,
+        model: Model | ModelId,
+        retry_config: RetryConfig,
+        **params: Unpack[Params],
+    ) -> None:
+        """Initialize a RetryModel.
+
+        Args:
+            model: Either a Model instance to wrap, or a ModelId string to create
+                a new Model from.
+            retry_config: Configuration for retry behavior.
+            **params: Additional parameters for the model. Only used when `model`
+                is a ModelId string; ignored when wrapping an existing Model.
+        """
+        if isinstance(model, Model):
+            # Wrap existing Model - copy its model_id and params
+            super().__init__(model.model_id, **model.params)
+        else:
+            # Create from ModelId
+            super().__init__(model, **params)
+        self.retry_config = retry_config
+
+    @overload
+    def call(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: Tools | None = None,
+        format: None = None,
+    ) -> RetryResponse[None]: ...
+
+    @overload
+    def call(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: Tools | None = None,
+        format: FormatSpec[FormattableT],
+    ) -> RetryResponse[FormattableT]: ...
+
+    @overload
+    def call(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: Tools | None = None,
+        format: FormatSpec[FormattableT] | None,
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]: ...
+
+    def call(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: Tools | None = None,
+        format: FormatSpec[FormattableT] | None = None,
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]:
+        """Generate a RetryResponse by calling this model's LLM provider.
+
+        Args:
+            content: User content or LLM messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+
+        Returns:
+            A RetryResponse object containing the LLM-generated content and retry metadata.
+        """
+        # TODO: Wire in retry implementation
+        response = super().call(content, tools=tools, format=format)
+        return RetryResponse(
+            response=cast(Response[FormattableT], response),
+            retry_config=self.retry_config,
+        )
+
+    @overload
+    async def call_async(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: AsyncTools | None = None,
+        format: None = None,
+    ) -> AsyncRetryResponse[None]: ...
+
+    @overload
+    async def call_async(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: AsyncTools | None = None,
+        format: FormatSpec[FormattableT],
+    ) -> AsyncRetryResponse[FormattableT]: ...
+
+    @overload
+    async def call_async(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: AsyncTools | None = None,
+        format: FormatSpec[FormattableT] | None,
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]: ...
+
+    async def call_async(
+        self,
+        content: UserContent | Sequence[Message],
+        *,
+        tools: AsyncTools | None = None,
+        format: FormatSpec[FormattableT] | None = None,
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]:
+        """Generate an AsyncRetryResponse by asynchronously calling this model's LLM provider.
+
+        Args:
+            content: User content or LLM messages to send to the LLM.
+            tools: Optional tools that the model may invoke.
+            format: Optional response format specifier.
+
+        Returns:
+            An AsyncRetryResponse object containing the LLM-generated content and retry metadata.
+        """
+        # TODO: Wire in retry implementation
+        response = await super().call_async(content, tools=tools, format=format)
+        return AsyncRetryResponse(
+            response=cast(AsyncResponse[FormattableT], response),
+            retry_config=self.retry_config,
+        )
+
+    # Resume methods
+
+    @overload
+    def resume(
+        self,
+        *,
+        response: Response[None],
+        content: UserContent,
+    ) -> RetryResponse[None]: ...
+
+    @overload
+    def resume(
+        self,
+        *,
+        response: Response[FormattableT],
+        content: UserContent,
+    ) -> RetryResponse[FormattableT]: ...
+
+    @overload
+    def resume(
+        self,
+        *,
+        response: Response[None] | Response[FormattableT],
+        content: UserContent,
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]: ...
+
+    def resume(
+        self,
+        *,
+        response: Response[None] | Response[FormattableT],
+        content: UserContent,
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]:
+        """Generate a new RetryResponse by extending another response's messages.
+
+        Args:
+            response: Previous response to extend.
+            content: Additional user content to append.
+
+        Returns:
+            A new RetryResponse containing the extended conversation.
+        """
+        # TODO: Wire in retry implementation
+        new_response = super().resume(response=response, content=content)
+        return RetryResponse(
+            response=cast(Response[FormattableT], new_response),
+            retry_config=self.retry_config,
+        )
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse[None],
+        content: UserContent,
+    ) -> AsyncRetryResponse[None]: ...
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncRetryResponse[FormattableT]: ...
+
+    @overload
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse[None] | AsyncResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]: ...
+
+    async def resume_async(
+        self,
+        *,
+        response: AsyncResponse[None] | AsyncResponse[FormattableT],
+        content: UserContent,
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]:
+        """Generate a new AsyncRetryResponse by extending another response's messages.
+
+        Args:
+            response: Previous async response to extend.
+            content: Additional user content to append.
+
+        Returns:
+            A new AsyncRetryResponse containing the extended conversation.
+        """
+        # TODO: Wire in retry implementation
+        new_response = await super().resume_async(response=response, content=content)
+        return AsyncRetryResponse(
+            response=cast(AsyncResponse[FormattableT], new_response),
+            retry_config=self.retry_config,
+        )

--- a/python/mirascope/llm/retries/retry_responses.py
+++ b/python/mirascope/llm/retries/retry_responses.py
@@ -1,0 +1,126 @@
+"""Retry response classes that extend base responses with retry metadata."""
+
+from typing import TYPE_CHECKING, overload
+
+from ..formatting import FormattableT
+from ..messages import UserContent
+from ..responses import (
+    AsyncResponse,
+    Response,
+)
+from .retry_config import RetryConfig
+
+if TYPE_CHECKING:
+    from .retry_models import RetryModel
+
+
+class RetryResponse(Response[FormattableT]):
+    """Response that includes retry metadata.
+
+    Extends `Response` directly, copying all attributes from a wrapped response
+    and adding retry configuration.
+    """
+
+    retry_config: RetryConfig
+    """Configuration for retry behavior."""
+
+    def __init__(
+        self, response: Response[FormattableT], retry_config: RetryConfig
+    ) -> None:
+        """Initialize a RetryResponse.
+
+        Args:
+            response: The successful response from the LLM.
+            retry_config: Configuration for retry behavior.
+        """
+        # Copy all attributes from the wrapped response
+        for key, value in response.__dict__.items():
+            object.__setattr__(self, key, value)
+        self.retry_config = retry_config
+
+    @property
+    def model(self) -> "RetryModel":
+        """A RetryModel with parameters matching this response."""
+        from .retry_models import RetryModel
+
+        base_model = super().model
+        return RetryModel(base_model, retry_config=self.retry_config)
+
+    @overload
+    def resume(
+        self: "RetryResponse[None]", content: UserContent
+    ) -> "RetryResponse[None]": ...
+
+    @overload
+    def resume(
+        self: "RetryResponse[FormattableT]", content: UserContent
+    ) -> "RetryResponse[FormattableT]": ...
+
+    def resume(
+        self, content: UserContent
+    ) -> "RetryResponse[None] | RetryResponse[FormattableT]":
+        """Generate a new RetryResponse using this response's messages with additional user content.
+
+        Args:
+            content: The new user message content to append to the message history.
+
+        Returns:
+            A new RetryResponse instance generated from the extended message history.
+        """
+        return self.model.resume(response=self, content=content)
+
+
+class AsyncRetryResponse(AsyncResponse[FormattableT]):
+    """Async response that includes retry metadata.
+
+    Extends `AsyncResponse` directly, copying all attributes from a wrapped response
+    and adding retry configuration.
+    """
+
+    retry_config: RetryConfig
+    """Configuration for retry behavior."""
+
+    def __init__(
+        self, response: AsyncResponse[FormattableT], retry_config: RetryConfig
+    ) -> None:
+        """Initialize an AsyncRetryResponse.
+
+        Args:
+            response: The successful async response from the LLM.
+            retry_config: Configuration for retry behavior.
+        """
+        # Copy all attributes from the wrapped response
+        for key, value in response.__dict__.items():
+            object.__setattr__(self, key, value)
+        self.retry_config = retry_config
+
+    @property
+    def model(self) -> "RetryModel":
+        """A RetryModel with parameters matching this response."""
+        from .retry_models import RetryModel
+
+        base_model = super().model
+        return RetryModel(base_model, retry_config=self.retry_config)
+
+    @overload
+    async def resume(
+        self: "AsyncRetryResponse[None]", content: UserContent
+    ) -> "AsyncRetryResponse[None]": ...
+
+    @overload
+    async def resume(
+        self: "AsyncRetryResponse[FormattableT]", content: UserContent
+    ) -> "AsyncRetryResponse[FormattableT]": ...
+
+    async def resume(
+        self, content: UserContent
+    ) -> "AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]":
+        """Generate a new AsyncRetryResponse using this response's messages with additional user content.
+
+        Args:
+            content: The new user message content to append to the message history.
+
+        Returns:
+            A new AsyncRetryResponse instance generated from the extended message history.
+        """
+        return await self.model.resume_async(response=self, content=content)


### PR DESCRIPTION
This is just the wiring / skeletons for the classes, there is no actual
retry logic yet (just placeholder comments in RetryModel).

General principles:
- All of the retry logic is consolidated inside RetryModel — everything
  else uses RetryModel
- Retry* classes should have equivalent accessors to the non-retry
  variants (e.g. RetryModel.params proxies to Model.params)
- Retry* classes have their underlying class as wrapped_X (e.g.
  RetryModel.wrapped_model)
- I am just doing Sync and Async cases for now — Context is boilerplate
  that can come later, and Streaming needs its own consideration