### PR TITLE
dev(python-sdk): Add RetryCall/RetryPrompt (and async variants)

### DIFF
--- a/python/mirascope/llm/__init__.py
+++ b/python/mirascope/llm/__init__.py
@@ -146,9 +146,13 @@ from .responses import (
     UsageDeltaChunk,
 )
 from .retries import (
+    AsyncRetryCall,
+    AsyncRetryPrompt,
     AsyncRetryResponse,
+    RetryCall,
     RetryConfig,
     RetryModel,
+    RetryPrompt,
     RetryResponse,
 )
 from .tools import (
@@ -197,6 +201,8 @@ __all__ = [
     "AsyncContextTools",
     "AsyncPrompt",
     "AsyncResponse",
+    "AsyncRetryCall",
+    "AsyncRetryPrompt",
     "AsyncRetryResponse",
     "AsyncStream",
     "AsyncStreamResponse",
@@ -257,8 +263,10 @@ __all__ = [
     "RawMessageChunk",
     "Response",
     "ResponseValidationError",
+    "RetryCall",
     "RetryConfig",
     "RetryModel",
+    "RetryPrompt",
     "RetryResponse",
     "RootResponse",
     "ServerError",

--- a/python/mirascope/llm/retries/__init__.py
+++ b/python/mirascope/llm/retries/__init__.py
@@ -7,8 +7,21 @@ This module provides retry capabilities for LLM calls, including:
 - Retry metadata tracking
 """
 
+from .retry_calls import AsyncRetryCall, BaseRetryCall, RetryCall
 from .retry_config import RetryConfig
 from .retry_models import RetryModel
+from .retry_prompts import AsyncRetryPrompt, BaseRetryPrompt, RetryPrompt
 from .retry_responses import AsyncRetryResponse, RetryResponse
 
-__all__ = ["AsyncRetryResponse", "RetryConfig", "RetryModel", "RetryResponse"]
+__all__ = [
+    "AsyncRetryCall",
+    "AsyncRetryPrompt",
+    "AsyncRetryResponse",
+    "BaseRetryCall",
+    "BaseRetryPrompt",
+    "RetryCall",
+    "RetryConfig",
+    "RetryModel",
+    "RetryPrompt",
+    "RetryResponse",
+]

--- a/python/mirascope/llm/retries/retry_calls.py
+++ b/python/mirascope/llm/retries/retry_calls.py
@@ -1,0 +1,123 @@
+"""RetryCall extends Call to return RetryResponse instead of Response."""
+
+from typing import Generic, TypeVar, overload
+
+from ..calls.calls import BaseCall
+from ..formatting import FormattableT
+from ..types import P
+from .retry_config import RetryConfig
+from .retry_models import RetryModel
+from .retry_prompts import (
+    AsyncRetryPrompt,
+    BaseRetryPrompt,
+    RetryPrompt,
+)
+from .retry_responses import (
+    AsyncRetryResponse,
+    RetryResponse,
+)
+
+RetryPromptT = TypeVar("RetryPromptT", bound=BaseRetryPrompt)
+
+
+class BaseRetryCall(BaseCall[RetryPromptT], Generic[RetryPromptT]):
+    """Base class for retry-enabled calls with shared model wrapping."""
+
+    @property
+    def retry_config(self) -> RetryConfig:
+        """The retry configuration from the prompt."""
+        return self.prompt.retry_config
+
+    @property
+    def model(self) -> RetryModel:
+        """The model used for generating responses. May be overwritten via `with llm.model(...)`."""
+        model = super().model
+        if isinstance(model, RetryModel):
+            return model
+        return RetryModel(model, self.retry_config)
+
+
+class RetryCall(BaseRetryCall[RetryPrompt[P, FormattableT]], Generic[P, FormattableT]):
+    """A retry-enabled call that extends BaseRetryCall and returns RetryResponse.
+
+    This extends BaseRetryCall with a RetryPrompt and returns RetryResponse
+    instead of Response. The prompt contains the retry configuration.
+
+    The model can be overridden at runtime using `with llm.model(...)` context manager.
+    """
+
+    @overload
+    def __call__(
+        self: "RetryCall[P, None]", *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[None]: ...
+
+    @overload
+    def __call__(
+        self: "RetryCall[P, FormattableT]", *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[FormattableT]: ...
+
+    def __call__(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]:
+        """Generates a retry response using the LLM."""
+        return self.call(*args, **kwargs)
+
+    @overload
+    def call(
+        self: "RetryCall[P, None]", *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[None]: ...
+
+    @overload
+    def call(
+        self: "RetryCall[P, FormattableT]", *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[FormattableT]: ...
+
+    def call(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]:
+        """Generates a retry response using the LLM."""
+        return self.prompt.call(self.model, *args, **kwargs)
+
+
+class AsyncRetryCall(
+    BaseRetryCall[AsyncRetryPrompt[P, FormattableT]], Generic[P, FormattableT]
+):
+    """An async retry-enabled call that extends BaseRetryCall and returns AsyncRetryResponse.
+
+    This extends BaseRetryCall with an AsyncRetryPrompt and returns AsyncRetryResponse
+    instead of AsyncResponse. The prompt contains the retry configuration.
+
+    The model can be overridden at runtime using `with llm.model(...)` context manager.
+    """
+
+    @overload
+    async def __call__(
+        self: "AsyncRetryCall[P, None]", *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[None]: ...
+
+    @overload
+    async def __call__(
+        self: "AsyncRetryCall[P, FormattableT]", *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[FormattableT]: ...
+
+    async def __call__(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]:
+        """Generates a retry response using the LLM asynchronously."""
+        return await self.call(*args, **kwargs)
+
+    @overload
+    async def call(
+        self: "AsyncRetryCall[P, None]", *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[None]: ...
+
+    @overload
+    async def call(
+        self: "AsyncRetryCall[P, FormattableT]", *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[FormattableT]: ...
+
+    async def call(
+        self, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]:
+        """Generates a retry response using the LLM asynchronously."""
+        return await self.prompt.call(self.model, *args, **kwargs)

--- a/python/mirascope/llm/retries/retry_prompts.py
+++ b/python/mirascope/llm/retries/retry_prompts.py
@@ -1,0 +1,173 @@
+"""RetryPrompt extends Prompt to return RetryResponse instead of Response."""
+
+from collections.abc import Callable
+from typing import Any, Generic, overload
+
+from ..formatting import FormatSpec, FormattableT
+from ..models import Model
+from ..prompts import (
+    AsyncPrompt,
+    Prompt,
+)
+from ..prompts.prompts import BasePrompt
+from ..prompts.protocols import AsyncMessageTemplate, MessageTemplate
+from ..providers import ModelId
+from ..tools import AsyncToolkit, Toolkit
+from ..types import P
+from .retry_config import RetryConfig
+from .retry_models import RetryModel
+from .retry_responses import (
+    AsyncRetryResponse,
+    RetryResponse,
+)
+
+
+def _ensure_retry_model(model: Model, config: RetryConfig) -> RetryModel:
+    """Ensure a model has retry capabilities, adding them if necessary."""
+    if isinstance(model, RetryModel):
+        return model
+    return RetryModel(model=model, retry_config=config)
+
+
+class BaseRetryPrompt(BasePrompt[Callable[..., Any]]):
+    """Base class for retry-enabled prompts that adds retry_config."""
+
+    retry_config: RetryConfig
+    """Configuration for retry behavior."""
+
+
+class RetryPrompt(BaseRetryPrompt, Prompt[P, FormattableT], Generic[P, FormattableT]):
+    """A retry-enabled prompt that extends Prompt and returns RetryResponse.
+
+    This extends Prompt and overrides call methods to return RetryResponse
+    instead of Response. It handles wrapping the provided Model in a RetryModel
+    if necessary.
+    """
+
+    def __init__(
+        self,
+        *,
+        fn: MessageTemplate[P],
+        toolkit: Toolkit,
+        format: FormatSpec[FormattableT] | None,
+        retry_config: RetryConfig,
+    ) -> None:
+        super().__init__(fn=fn, toolkit=toolkit, format=format)
+        self.retry_config = retry_config
+
+    @overload
+    def __call__(
+        self: "RetryPrompt[P, None]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> RetryResponse[None]: ...
+
+    @overload
+    def __call__(
+        self: "RetryPrompt[P, FormattableT]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> RetryResponse[FormattableT]: ...
+
+    def __call__(
+        self, model: Model | ModelId, *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]:
+        """Generates a retry response using the provided model."""
+        return self.call(model, *args, **kwargs)
+
+    @overload
+    def call(
+        self: "RetryPrompt[P, None]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> RetryResponse[None]: ...
+
+    @overload
+    def call(
+        self: "RetryPrompt[P, FormattableT]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> RetryResponse[FormattableT]: ...
+
+    def call(
+        self, model: Model | ModelId, *args: P.args, **kwargs: P.kwargs
+    ) -> RetryResponse[None] | RetryResponse[FormattableT]:
+        """Generates a retry response using the provided model."""
+        if isinstance(model, str):
+            model = Model(model)
+        retry_model = _ensure_retry_model(model, self.retry_config)
+        messages = self.messages(*args, **kwargs)
+        return retry_model.call(
+            content=messages, tools=self.toolkit, format=self.format
+        )
+
+
+class AsyncRetryPrompt(
+    BaseRetryPrompt, AsyncPrompt[P, FormattableT], Generic[P, FormattableT]
+):
+    """An async retry-enabled prompt that extends AsyncPrompt and returns AsyncRetryResponse."""
+
+    def __init__(
+        self,
+        *,
+        fn: AsyncMessageTemplate[P],
+        toolkit: AsyncToolkit,
+        format: FormatSpec[FormattableT] | None,
+        retry_config: RetryConfig,
+    ) -> None:
+        super().__init__(fn=fn, toolkit=toolkit, format=format)
+        self.retry_config = retry_config
+
+    @overload
+    async def __call__(
+        self: "AsyncRetryPrompt[P, None]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> AsyncRetryResponse[None]: ...
+
+    @overload
+    async def __call__(
+        self: "AsyncRetryPrompt[P, FormattableT]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> AsyncRetryResponse[FormattableT]: ...
+
+    async def __call__(
+        self, model: Model | ModelId, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]:
+        """Generates a retry response using the provided model asynchronously."""
+        return await self.call(model, *args, **kwargs)
+
+    @overload
+    async def call(
+        self: "AsyncRetryPrompt[P, None]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> AsyncRetryResponse[None]: ...
+
+    @overload
+    async def call(
+        self: "AsyncRetryPrompt[P, FormattableT]",
+        model: Model | ModelId,
+        *args: P.args,
+        **kwargs: P.kwargs,
+    ) -> AsyncRetryResponse[FormattableT]: ...
+
+    async def call(
+        self, model: Model | ModelId, *args: P.args, **kwargs: P.kwargs
+    ) -> AsyncRetryResponse[None] | AsyncRetryResponse[FormattableT]:
+        """Generates a retry response using the provided model asynchronously."""
+        if isinstance(model, str):
+            model = Model(model)
+        retry_model = _ensure_retry_model(model, self.retry_config)
+        messages = await self.messages(*args, **kwargs)
+        return await retry_model.call_async(
+            content=messages, tools=self.toolkit, format=self.format
+        )

--- a/python/tests/llm/retries/test_retry_calls.py
+++ b/python/tests/llm/retries/test_retry_calls.py
@@ -1,0 +1,86 @@
+"""Tests for RetryCall model override behavior."""
+
+from mirascope import llm
+
+
+def _create_retry_call(retry_config: llm.RetryConfig) -> llm.RetryCall[..., None]:
+    """Helper to create a RetryCall for testing."""
+
+    def my_prompt() -> str:
+        return "test"
+
+    prompt = llm.RetryPrompt(
+        fn=my_prompt,
+        toolkit=llm.tools.Toolkit(tools=None),
+        format=None,
+        retry_config=retry_config,
+    )
+    return llm.RetryCall(
+        default_model=llm.Model("openai/gpt-4o"),
+        prompt=prompt,
+    )
+
+
+class TestRetryCallModelOverride:
+    """Tests for how RetryCall handles model overrides via context."""
+
+    def test_retry_call_wraps_default_model_in_retry_model(self) -> None:
+        """Test that RetryCall.model wraps the default model in RetryModel."""
+        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+
+        model = retry_call.model
+
+        assert isinstance(model, llm.RetryModel)
+        assert model.model_id == "openai/gpt-4o"
+        assert model.retry_config.max_attempts == 3
+
+    def test_retry_call_wraps_context_model_in_retry_model(self) -> None:
+        """Test that RetryCall.model wraps context override in RetryModel."""
+        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+
+        with llm.model("anthropic/claude-sonnet-4-0"):
+            model = retry_call.model
+
+            assert isinstance(model, llm.RetryModel)
+            assert model.model_id == "anthropic/claude-sonnet-4-0"
+            # Uses the prompt's retry config when wrapping
+            assert model.retry_config.max_attempts == 3
+
+    def test_retry_call_uses_override_retry_model_directly(self) -> None:
+        """Test that if context override is a RetryModel, it's used as-is."""
+        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+
+        override_retry_model = llm.RetryModel(
+            "anthropic/claude-sonnet-4-0",
+            llm.RetryConfig(max_attempts=5),
+        )
+
+        with override_retry_model:
+            model = retry_call.model
+
+            assert isinstance(model, llm.RetryModel)
+            assert model.model_id == "anthropic/claude-sonnet-4-0"
+            # The override's retry config should win, not the prompt's
+            assert model.retry_config.max_attempts == 5
+
+    def test_retry_call_override_retry_model_is_same_instance(self) -> None:
+        """Test that the override RetryModel is returned directly, not re-wrapped."""
+        retry_call = _create_retry_call(llm.RetryConfig(max_attempts=3))
+
+        override_retry_model = llm.RetryModel(
+            "anthropic/claude-sonnet-4-0",
+            llm.RetryConfig(max_attempts=5),
+        )
+
+        with override_retry_model:
+            model = retry_call.model
+            # Should be the exact same instance, not wrapped
+            assert model is override_retry_model
+
+    def test_retry_config_property_returns_prompt_config(self) -> None:
+        """Test that retry_config property returns the prompt's retry config."""
+        config = llm.RetryConfig(max_attempts=7)
+        retry_call = _create_retry_call(config)
+
+        assert retry_call.retry_config is config
+        assert retry_call.retry_config.max_attempts == 7


### PR DESCRIPTION
Just skeletons, observing the same principles for how we set up Retry*
classes as in the preceding PRs.