### PR TITLE
feat(python-sdk): basic retry behavior with testing

### DIFF
--- a/python/mirascope/llm/retries/retry_config.py
+++ b/python/mirascope/llm/retries/retry_config.py
@@ -69,6 +69,11 @@ class RetryConfig:
     retry_on: tuple[type[Exception], ...] = DEFAULT_RETRYABLE_ERRORS
     """Tuple of exception types that should trigger a retry."""
 
+    def __post_init__(self) -> None:
+        """Validate configuration values."""
+        if self.max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
+
     @classmethod
     def from_args(cls, **args: Unpack[RetryArgs]) -> "RetryConfig":
         """Create a RetryConfig from RetryArgs kwargs."""

--- a/python/mirascope/llm/retries/retry_responses.py
+++ b/python/mirascope/llm/retries/retry_responses.py
@@ -9,6 +9,7 @@ from ..responses import (
     Response,
 )
 from .retry_config import RetryConfig
+from .utils import RetryState
 
 if TYPE_CHECKING:
     from .retry_models import RetryModel
@@ -24,19 +25,27 @@ class RetryResponse(Response[FormattableT]):
     retry_config: RetryConfig
     """Configuration for retry behavior."""
 
+    retry_state: RetryState
+    """State tracking retry attempts and any exceptions caught."""
+
     def __init__(
-        self, response: Response[FormattableT], retry_config: RetryConfig
+        self,
+        response: Response[FormattableT],
+        retry_config: RetryConfig,
+        retry_state: RetryState,
     ) -> None:
         """Initialize a RetryResponse.
 
         Args:
             response: The successful response from the LLM.
             retry_config: Configuration for retry behavior.
+            retry_state: State tracking retry attempts and exceptions.
         """
         # Copy all attributes from the wrapped response
         for key, value in response.__dict__.items():
             object.__setattr__(self, key, value)
         self.retry_config = retry_config
+        self.retry_state = retry_state
 
     @property
     def model(self) -> "RetryModel":
@@ -80,19 +89,27 @@ class AsyncRetryResponse(AsyncResponse[FormattableT]):
     retry_config: RetryConfig
     """Configuration for retry behavior."""
 
+    retry_state: RetryState
+    """State tracking retry attempts and any exceptions caught."""
+
     def __init__(
-        self, response: AsyncResponse[FormattableT], retry_config: RetryConfig
+        self,
+        response: AsyncResponse[FormattableT],
+        retry_config: RetryConfig,
+        retry_state: RetryState,
     ) -> None:
         """Initialize an AsyncRetryResponse.
 
         Args:
             response: The successful async response from the LLM.
             retry_config: Configuration for retry behavior.
+            retry_state: State tracking retry attempts and exceptions.
         """
         # Copy all attributes from the wrapped response
         for key, value in response.__dict__.items():
             object.__setattr__(self, key, value)
         self.retry_config = retry_config
+        self.retry_state = retry_state
 
     @property
     def model(self) -> "RetryModel":

--- a/python/mirascope/llm/retries/utils.py
+++ b/python/mirascope/llm/retries/utils.py
@@ -1,0 +1,93 @@
+"""Utility functions for retry logic."""
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TypeVar
+
+from .retry_config import RetryConfig
+
+_ResultT = TypeVar("_ResultT")
+
+
+def _empty_exception_list() -> list[BaseException]:
+    return []
+
+
+@dataclass
+class RetryState:
+    """Tracks the state of retry attempts with resolved configuration.
+
+    This captures both the concrete retry settings that were used and the
+    results of the retry process.
+
+    Attributes:
+        max_attempts: The maximum attempts that were configured.
+        retry_on: The exception types that triggered retries.
+        attempts: The number of attempts made (1 = succeeded on first try).
+        exceptions: The list of exceptions caught during failed attempts.
+    """
+
+    max_attempts: int
+    retry_on: tuple[type[BaseException], ...]
+    attempts: int = 1
+    exceptions: list[BaseException] = field(default_factory=_empty_exception_list)
+
+
+def with_retry(
+    fn: Callable[[], _ResultT],
+    config: RetryConfig,
+) -> tuple[_ResultT, RetryState]:
+    """Execute a function with retry logic.
+
+    Args:
+        fn: The function to execute.
+        config: Retry configuration.
+
+    Returns:
+        A tuple of (result, retry_state).
+
+    Raises:
+        Exception: The last exception encountered if all retry attempts fail.
+    """
+    state = RetryState(max_attempts=config.max_attempts, retry_on=config.retry_on)
+    for attempt in range(1, config.max_attempts + 1):
+        try:
+            result = fn()
+            state.attempts = attempt
+            return result, state
+        except config.retry_on as e:
+            state.exceptions.append(e)
+            if attempt == config.max_attempts:
+                state.attempts = attempt
+                raise
+    raise AssertionError("Unreachable")  # pragma: no cover
+
+
+async def with_retry_async(
+    fn: Callable[[], Awaitable[_ResultT]],
+    config: RetryConfig,
+) -> tuple[_ResultT, RetryState]:
+    """Execute an async function with retry logic.
+
+    Args:
+        fn: The async function to execute.
+        config: Retry configuration.
+
+    Returns:
+        A tuple of (result, retry_state).
+
+    Raises:
+        Exception: The last exception encountered if all retry attempts fail.
+    """
+    state = RetryState(max_attempts=config.max_attempts, retry_on=config.retry_on)
+    for attempt in range(1, config.max_attempts + 1):
+        try:
+            result = await fn()
+            state.attempts = attempt
+            return result, state
+        except config.retry_on as e:
+            state.exceptions.append(e)
+            if attempt == config.max_attempts:
+                state.attempts = attempt
+                raise
+    raise AssertionError("Unreachable")  # pragma: no cover

--- a/python/tests/llm/retries/mock_provider.py
+++ b/python/tests/llm/retries/mock_provider.py
@@ -1,0 +1,246 @@
+"""Mock Provider for testing retry logic."""
+
+from collections.abc import Sequence
+from typing import Any, ClassVar
+from typing_extensions import Unpack
+
+from mirascope import llm
+from mirascope.llm import (
+    AsyncContextResponse,
+    AsyncContextStreamResponse,
+    AsyncContextToolkit,
+    AsyncResponse,
+    AsyncStreamResponse,
+    AsyncToolkit,
+    Context,
+    ContextResponse,
+    ContextStreamResponse,
+    ContextToolkit,
+    DepsT,
+    Format,
+    FormattableT,
+    OutputParser,
+    Params,
+    Response,
+    StreamResponse,
+    Toolkit,
+)
+from mirascope.llm.providers import BaseProvider
+from mirascope.llm.providers.base import ProviderErrorMap
+
+
+class MockProvider(BaseProvider[None]):
+    """A mock Provider for testing that returns configurable responses.
+
+    The provider can be configured with a sequence of exceptions to raise before
+    eventually returning a successful response. This allows testing retry logic
+    with predictable failure patterns.
+    """
+
+    # TODO Consider unifying with test provider.
+    # cf #2101 (https://github.com/Mirascope/mirascope/issues/2120)
+
+    id: ClassVar[llm.ProviderId] = "mock"
+    default_scope: ClassVar[str | list[str]] = "mock/"
+    error_map: ClassVar[ProviderErrorMap] = {}
+
+    def __init__(self) -> None:
+        """Initialize the MockProvider."""
+        self.client = None
+        self._exceptions: list[BaseException] = []
+        self._call_count = 0
+
+    @property
+    def call_count(self) -> int:
+        """The number of times _call() has been invoked."""
+        return self._call_count
+
+    def set_exceptions(self, exceptions: Sequence[BaseException]) -> None:
+        """Set exceptions to raise before returning a successful response.
+
+        Args:
+            exceptions: A list of exceptions to raise in order. Once exhausted,
+                subsequent calls will return the mock response.
+        """
+        self._exceptions = list(exceptions)
+
+    def _make_response(
+        self, model_id: str, messages: Sequence[llm.messages.Message]
+    ) -> Response[Any]:
+        """Create a minimal valid Response for testing."""
+        return Response(
+            raw={"mock": True},
+            usage=None,
+            provider_id="mock",
+            model_id=model_id,
+            provider_model_name="test-model",
+            params={},
+            tools=None,
+            input_messages=list(messages),
+            assistant_message=llm.messages.assistant(
+                [llm.Text(text="mock response")],
+                model_id=model_id,
+                provider_id="mock",
+            ),
+            finish_reason=None,
+        )
+
+    def _make_async_response(
+        self, model_id: str, messages: Sequence[llm.messages.Message]
+    ) -> AsyncResponse[Any]:
+        """Create a minimal valid AsyncResponse for testing."""
+        return AsyncResponse(
+            raw={"mock": True},
+            usage=None,
+            provider_id="mock",
+            model_id=model_id,
+            provider_model_name="test-model",
+            params={},
+            tools=None,
+            input_messages=list(messages),
+            assistant_message=llm.messages.assistant(
+                [llm.Text(text="mock response")],
+                model_id=model_id,
+                provider_id="mock",
+            ),
+            finish_reason=None,
+        )
+
+    def _call(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: Toolkit,
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> Response[Any]:
+        """Return the configured response or raise the next configured exception."""
+        self._call_count += 1
+        if self._exceptions:
+            raise self._exceptions.pop(0)
+        return self._make_response(model_id, messages)
+
+    async def _call_async(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: AsyncToolkit,
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncResponse[Any]:
+        """Return the configured response or raise the next configured exception."""
+        self._call_count += 1
+        if self._exceptions:
+            raise self._exceptions.pop(0)
+        return self._make_async_response(model_id, messages)
+
+    def _context_call(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: ContextToolkit[DepsT],
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> ContextResponse[DepsT, None] | ContextResponse[DepsT, FormattableT]:
+        """Not implemented for mock."""
+        raise NotImplementedError
+
+    async def _context_call_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: AsyncContextToolkit[DepsT],
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncContextResponse[DepsT, None] | AsyncContextResponse[DepsT, FormattableT]:
+        """Not implemented for mock."""
+        raise NotImplementedError
+
+    def _stream(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: Toolkit,
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> StreamResponse[Any]:
+        """Not implemented for mock."""
+        raise NotImplementedError
+
+    async def _stream_async(
+        self,
+        *,
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: AsyncToolkit,
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> AsyncStreamResponse[Any]:
+        """Not implemented for mock."""
+        raise NotImplementedError
+
+    def _context_stream(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: ContextToolkit[DepsT],
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> (
+        ContextStreamResponse[DepsT, None] | ContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Not implemented for mock."""
+        raise NotImplementedError
+
+    async def _context_stream_async(
+        self,
+        *,
+        ctx: Context[DepsT],
+        model_id: str,
+        messages: Sequence[llm.messages.Message],
+        toolkit: AsyncContextToolkit[DepsT],
+        format: type[FormattableT]
+        | Format[FormattableT]
+        | OutputParser[FormattableT]
+        | None = None,
+        **params: Unpack[Params],
+    ) -> (
+        AsyncContextStreamResponse[DepsT, None]
+        | AsyncContextStreamResponse[DepsT, FormattableT]
+    ):
+        """Not implemented for mock."""
+        raise NotImplementedError
+
+    def get_error_status(self, e: Exception) -> int | None:
+        """Return None for mock provider."""
+        return None

--- a/python/tests/llm/retries/test_retries.py
+++ b/python/tests/llm/retries/test_retries.py
@@ -1,0 +1,455 @@
+"""Tests for retry decorator with @llm.call pattern."""
+
+from collections.abc import Generator, Sequence
+
+import pytest
+
+from mirascope import llm
+
+from .mock_provider import MockProvider
+
+SERVER_ERROR = llm.ServerError("server error", provider="test")
+CONNECTION_ERROR = llm.ConnectionError("connection failed", provider="test")
+RATE_LIMIT_ERROR = llm.RateLimitError("rate limited", provider="test")
+TIMEOUT_ERROR = llm.TimeoutError("timeout", provider="test")
+
+# Common exception sequences used across tests
+DEFAULT_RETRYABLE_EXCEPTIONS: Sequence[llm.Error] = [
+    SERVER_ERROR,
+    CONNECTION_ERROR,
+    RATE_LIMIT_ERROR,
+    TIMEOUT_ERROR,
+]
+
+RESUME_TEST_EXCEPTIONS: Sequence[llm.Error] = [
+    CONNECTION_ERROR,
+    RATE_LIMIT_ERROR,
+]
+
+
+@pytest.fixture
+def mock_provider() -> Generator[MockProvider, None, None]:
+    """Fixture that provides a MockProvider and cleans up after the test."""
+    llm.reset_provider_registry()
+    provider = MockProvider()
+    llm.register_provider(provider, scope="mock/")
+    yield provider
+    llm.reset_provider_registry()
+
+
+class TestSyncRetryCall:
+    """Tests for sync @llm.retry with @llm.call decorator pattern."""
+
+    def test_call_succeeds_first_attempt(self, mock_provider: MockProvider) -> None:
+        """Test that a successful first call returns immediately with correct state."""
+
+        @llm.retry(max_attempts=3)
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        response = greet()
+
+        assert response.pretty() == "mock response"
+        assert response.retry_state.attempts == 1
+        assert response.retry_state.exceptions == []
+        assert response.retry_state.max_attempts == 3
+        assert response.model_id == "mock/test-model"
+        assert mock_provider.call_count == 1
+
+    def test_call_retries_on_default_exceptions(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that all default retryable exceptions are caught and retried."""
+        mock_provider.set_exceptions(DEFAULT_RETRYABLE_EXCEPTIONS)
+
+        @llm.retry(max_attempts=5)
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        response = greet()
+
+        assert response.pretty() == "mock response"
+        assert response.retry_state.attempts == 5
+        assert response.retry_state.exceptions == DEFAULT_RETRYABLE_EXCEPTIONS
+        assert mock_provider.call_count == 5
+
+    def test_call_retries_on_custom_exception(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that custom retry_on exceptions are caught."""
+        exceptions: list[BaseException] = [AssertionError("custom error")]
+        mock_provider.set_exceptions(exceptions)
+
+        @llm.retry(max_attempts=2, retry_on=(AssertionError,))
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        response = greet()
+
+        assert response.pretty() == "mock response"
+        assert response.retry_state.attempts == 2
+        assert response.retry_state.exceptions == exceptions
+        assert mock_provider.call_count == 2
+
+    def test_call_raises_after_max_attempts_exhausted(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that exception is re-raised when max_attempts is exhausted."""
+        mock_provider.set_exceptions(
+            [llm.ConnectionError("connection failed", provider="test")]
+        )
+
+        @llm.retry(max_attempts=1)
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        with pytest.raises(llm.ConnectionError, match="connection failed"):
+            greet()
+
+        assert mock_provider.call_count == 1
+
+    def test_resume_retries_on_failure(self, mock_provider: MockProvider) -> None:
+        """Test that resume retries on transient errors."""
+
+        @llm.retry(max_attempts=3)
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        # Get initial successful response
+        response = greet()
+        assert mock_provider.call_count == 1
+
+        # Configure errors for the resume call
+        mock_provider.set_exceptions(RESUME_TEST_EXCEPTIONS)
+
+        # Resume should retry through the errors
+        resumed = response.resume("Follow up")
+        assert resumed.pretty() == "mock response"
+        assert resumed.retry_state.attempts == 3
+        assert resumed.retry_state.exceptions == RESUME_TEST_EXCEPTIONS
+        assert mock_provider.call_count == 4  # 1 initial + 3 resume attempts
+
+    def test_resume_raises_after_max_attempts_exhausted(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that resume re-raises when max_attempts is exhausted."""
+
+        @llm.retry(max_attempts=1)
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        # Get initial successful response
+        response = greet()
+        assert mock_provider.call_count == 1
+
+        # Configure persistent error for the resume call
+        mock_provider.set_exceptions([SERVER_ERROR])
+
+        with pytest.raises(llm.ServerError, match="server error"):
+            response.resume("Follow up")
+
+        assert mock_provider.call_count == 2  # 1 initial + 1 resume attempt
+
+
+@pytest.mark.asyncio
+class TestAsyncRetryCall:
+    """Tests for async @llm.retry with @llm.call decorator pattern."""
+
+    async def test_call_async_succeeds_first_attempt(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that a successful first call returns immediately with correct state."""
+
+        @llm.retry(max_attempts=3)
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        response = await greet()
+
+        assert response.pretty() == "mock response"
+        assert response.retry_state.attempts == 1
+        assert response.retry_state.exceptions == []
+        assert response.retry_state.max_attempts == 3
+        assert response.model_id == "mock/test-model"
+        assert mock_provider.call_count == 1
+
+    async def test_call_async_retries_on_default_exceptions(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that all default retryable exceptions are caught and retried."""
+        mock_provider.set_exceptions(DEFAULT_RETRYABLE_EXCEPTIONS)
+
+        @llm.retry(max_attempts=5)
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        response = await greet()
+
+        assert response.pretty() == "mock response"
+        assert response.retry_state.attempts == 5
+        assert response.retry_state.exceptions == DEFAULT_RETRYABLE_EXCEPTIONS
+        assert mock_provider.call_count == 5
+
+    async def test_call_async_retries_on_custom_exception(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that custom retry_on exceptions are caught."""
+        exceptions: list[BaseException] = [AssertionError("custom error")]
+        mock_provider.set_exceptions(exceptions)
+
+        @llm.retry(max_attempts=2, retry_on=(AssertionError,))
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        response = await greet()
+
+        assert response.pretty() == "mock response"
+        assert response.retry_state.attempts == 2
+        assert response.retry_state.exceptions == exceptions
+        assert mock_provider.call_count == 2
+
+    async def test_call_async_raises_after_max_attempts_exhausted(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that exception is re-raised when max_attempts is exhausted."""
+        mock_provider.set_exceptions(
+            [llm.ConnectionError("connection failed", provider="test")]
+        )
+
+        @llm.retry(max_attempts=1)
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        with pytest.raises(llm.ConnectionError, match="connection failed"):
+            await greet()
+
+        assert mock_provider.call_count == 1
+
+    async def test_resume_async_retries_on_failure(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that async resume retries on transient errors."""
+
+        @llm.retry(max_attempts=3)
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        # Get initial successful response
+        response = await greet()
+        assert mock_provider.call_count == 1
+
+        # Configure errors for the resume call
+        mock_provider.set_exceptions(RESUME_TEST_EXCEPTIONS)
+
+        # Resume should retry through the errors
+        resumed = await response.resume("Follow up")
+        assert resumed.pretty() == "mock response"
+        assert resumed.retry_state.attempts == 3
+        assert resumed.retry_state.exceptions == RESUME_TEST_EXCEPTIONS
+        assert mock_provider.call_count == 4  # 1 initial + 3 resume attempts
+
+    async def test_resume_async_raises_after_max_attempts_exhausted(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that async resume re-raises when max_attempts is exhausted."""
+
+        @llm.retry(max_attempts=1)
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        # Get initial successful response
+        response = await greet()
+        assert mock_provider.call_count == 1
+
+        # Configure persistent error for the resume call
+        mock_provider.set_exceptions([SERVER_ERROR])
+
+        with pytest.raises(llm.ServerError, match="server error"):
+            await response.resume("Follow up")
+
+        assert mock_provider.call_count == 2  # 1 initial + 1 resume attempt
+
+
+class TestRetryConfigValidation:
+    """Tests for RetryConfig validation."""
+
+    def test_max_attempts_zero_raises_value_error(self) -> None:
+        """Test that max_attempts=0 raises ValueError."""
+        with pytest.raises(ValueError, match="max_attempts must be at least 1"):
+            llm.retry(max_attempts=0)
+
+    def test_max_attempts_negative_raises_value_error(self) -> None:
+        """Test that negative max_attempts raises ValueError."""
+        with pytest.raises(ValueError, match="max_attempts must be at least 1"):
+            llm.retry(max_attempts=-1)
+
+    def test_max_attempts_one_is_valid(self, mock_provider: MockProvider) -> None:
+        """Test that max_attempts=1 is valid (no retries, just one attempt)."""
+
+        @llm.retry(max_attempts=1)
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        response = greet()
+        assert response.retry_state.max_attempts == 1
+
+
+class TestRetryDecorator:
+    """Tests for the @llm.retry decorator itself."""
+
+    def test_retry_on_model(self, mock_provider: MockProvider) -> None:
+        """Test that retry() works directly on a Model."""
+        model = llm.Model("mock/test-model")
+        retry_model = llm.retry(model, max_attempts=3)
+
+        response = retry_model.call("hello")
+
+        assert response.pretty() == "mock response"
+        assert response.retry_state.attempts == 1
+        assert response.retry_state.max_attempts == 3
+
+    def test_retry_on_retry_model_updates_config(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that retry() on a RetryModel updates the config."""
+        model = llm.Model("mock/test-model")
+        retry_model = llm.retry(model, max_attempts=3)
+        updated_retry_model = llm.retry(retry_model, max_attempts=5)
+
+        response = updated_retry_model.call("hello")
+
+        assert response.retry_state.max_attempts == 5
+
+    def test_retry_on_call_produces_retry_call(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that retry() on a Call produces a RetryCall."""
+
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        retry_call = llm.retry(greet, max_attempts=3)
+
+        assert isinstance(retry_call, llm.RetryCall)
+        response = retry_call()
+        assert response.retry_state.max_attempts == 3
+
+    def test_retry_on_retry_call_updates_config(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that retry() on a RetryCall updates the config."""
+
+        @llm.retry(max_attempts=3)
+        @llm.call("mock/test-model")
+        def greet() -> str:
+            return "Hello"
+
+        updated = llm.retry(greet, max_attempts=5)
+        response = updated()
+        assert response.retry_state.max_attempts == 5
+
+    def test_retry_on_prompt(self, mock_provider: MockProvider) -> None:
+        """Test that retry() works on a Prompt."""
+
+        @llm.prompt
+        def greet() -> str:
+            return "Hello"
+
+        retry_prompt = llm.retry(greet, max_attempts=3)
+
+        assert isinstance(retry_prompt, llm.RetryPrompt)
+        model = llm.Model("mock/test-model")
+        response = retry_prompt(model)
+        assert response.retry_state.max_attempts == 3
+
+    def test_retry_on_retry_prompt_updates_config(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that retry() on a RetryPrompt updates the config."""
+
+        @llm.prompt
+        def greet() -> str:
+            return "Hello"
+
+        retry_prompt = llm.retry(greet, max_attempts=3)
+        updated = llm.retry(retry_prompt, max_attempts=5)
+
+        model = llm.Model("mock/test-model")
+        response = updated(model)
+        assert response.retry_state.max_attempts == 5
+
+
+@pytest.mark.asyncio
+class TestAsyncRetryDecorator:
+    """Tests for @llm.retry with async prompts and calls."""
+
+    async def test_retry_on_async_call(self, mock_provider: MockProvider) -> None:
+        """Test that retry() works on an AsyncCall."""
+
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        retry_call = llm.retry(greet, max_attempts=3)
+
+        assert isinstance(retry_call, llm.AsyncRetryCall)
+        response = await retry_call()
+        assert response.retry_state.max_attempts == 3
+
+    async def test_retry_on_async_retry_call_updates_config(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that retry() on an AsyncRetryCall updates the config."""
+
+        @llm.retry(max_attempts=3)
+        @llm.call("mock/test-model")
+        async def greet() -> str:
+            return "Hello"
+
+        updated = llm.retry(greet, max_attempts=5)
+        response = await updated()
+        assert response.retry_state.max_attempts == 5
+
+    async def test_retry_on_async_prompt(self, mock_provider: MockProvider) -> None:
+        """Test that retry() works on an AsyncPrompt."""
+
+        @llm.prompt
+        async def greet() -> str:
+            return "Hello"
+
+        retry_prompt = llm.retry(greet, max_attempts=3)
+
+        assert isinstance(retry_prompt, llm.AsyncRetryPrompt)
+        model = llm.Model("mock/test-model")
+        response = await retry_prompt(model)
+        assert response.retry_state.max_attempts == 3
+
+    async def test_retry_on_async_retry_prompt_updates_config(
+        self, mock_provider: MockProvider
+    ) -> None:
+        """Test that retry() on an AsyncRetryPrompt updates the config."""
+
+        @llm.prompt
+        async def greet() -> str:
+            return "Hello"
+
+        retry_prompt = llm.retry(greet, max_attempts=3)
+        updated = llm.retry(retry_prompt, max_attempts=5)
+
+        model = llm.Model("mock/test-model")
+        response = await updated(model)
+        assert response.retry_state.max_attempts == 5


### PR DESCRIPTION
This adds basic retry behavior for call / async_calls (no streaming).
We support automatically retrying on supported error types.