### PR TITLE
feat(clickhouse): extract span transform

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -249,6 +249,8 @@ cloud/
 ├── clickhouse/                    # ClickHouse analytics services
 │   ├── client.ts                  # Effect service for ClickHouse access
 │   ├── search.ts                  # Analytics/search queries and transforms
+│   ├── transform.ts               # Span-to-ClickHouse row transform utilities
+│   ├── realtimeSpans.ts           # Effect interface for realtime span access (Durable Object)
 │   ├── migrate.sh                 # Schema migration runner (run: bun run clickhouse:migrate)
 │   ├── migrations/                # SQL migration files (versioned, applied on startup)
 │   │   ├── *.up.sql
@@ -259,7 +261,10 @@ cloud/
 │   └── outboxProcessor.ts         # Shared processing logic
 ├── tests/                         # Test utilities
 │   ├── api.ts                     # API test utilities
-│   └── db.ts                      # Database test utilities
+│   ├── db.ts                      # Database test utilities
+│   ├── clickhouse.ts              # ClickHouse test utilities
+│   └── clickhouse/                # ClickHouse test fixtures
+│       └── fixtures.ts            # Effect-native transform test fixtures
 ├── docker/                        # Docker configuration
 │   ├── compose.yml
 │   └── data/                      # Docker data directory (gitignored)

--- a/cloud/clickhouse/realtimeSpans.ts
+++ b/cloud/clickhouse/realtimeSpans.ts
@@ -1,0 +1,86 @@
+/**
+ * @fileoverview Effect interface and types for realtime span access.
+ *
+ * Provides a shared contract for Durable Object backed span caching used
+ * by ingestion and realtime search paths.
+ */
+
+import { Context, Effect } from "effect";
+import type {
+  SpanSearchInput,
+  SearchResponse,
+  TraceDetailInput,
+  TraceDetailResponse,
+} from "@/clickhouse/search";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type RealtimeSpanStatus = {
+  code?: number;
+  message?: string;
+};
+
+export type RealtimeSpanInput = {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string | null;
+  name: string;
+  kind?: number;
+  startTimeUnixNano?: string;
+  endTimeUnixNano?: string;
+  attributes?: Record<string, unknown> | null;
+  droppedAttributesCount?: number;
+  events?: ReadonlyArray<unknown>;
+  droppedEventsCount?: number;
+  status?: RealtimeSpanStatus;
+  links?: ReadonlyArray<unknown>;
+  droppedLinksCount?: number;
+};
+
+export type RealtimeSpansUpsertRequest = {
+  environmentId: string;
+  projectId: string;
+  organizationId: string;
+  receivedAt: number;
+  serviceName: string | null;
+  serviceVersion: string | null;
+  resourceAttributes: Record<string, unknown> | null;
+  spans: RealtimeSpanInput[];
+};
+
+export type RealtimeSpanExistsInput = {
+  environmentId: string;
+  traceId: string;
+  spanId: string;
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+export const createSpanCacheKey = (traceId: string, spanId: string): string =>
+  `${traceId}:${spanId}`;
+
+// =============================================================================
+// Service
+// =============================================================================
+
+export class RealtimeSpans extends Context.Tag("RealtimeSpans")<
+  RealtimeSpans,
+  {
+    readonly upsert: (
+      request: RealtimeSpansUpsertRequest,
+    ) => Effect.Effect<void, Error>;
+    readonly search: (
+      input: SpanSearchInput,
+    ) => Effect.Effect<SearchResponse, Error>;
+    readonly getTraceDetail: (
+      input: TraceDetailInput,
+    ) => Effect.Effect<TraceDetailResponse, Error>;
+    readonly exists: (
+      input: RealtimeSpanExistsInput,
+    ) => Effect.Effect<boolean, Error>;
+  }
+>() {}

--- a/cloud/clickhouse/transform.test.ts
+++ b/cloud/clickhouse/transform.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Tests for ClickHouse span transform.
+ */
+
+import { describe, expect, it } from "@effect/vitest";
+import { Effect } from "effect";
+import {
+  transformSpanForClickHouse,
+  formatDateTime64,
+} from "@/clickhouse/transform";
+import { TestTransformInputFixture } from "@/tests/clickhouse/fixtures";
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("transformSpanForClickHouse", () => {
+  it.effect("maps span fields and attributes into ClickHouse format", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture();
+
+      const row = transformSpanForClickHouse(input);
+
+      expect(row.name_lower).toBe("llm.call");
+      expect(row.duration_ms).toBe(1000);
+      expect(row.model).toBe("gpt-4");
+      expect(row.provider).toBe("openai");
+      expect(row.input_tokens).toBe(12);
+      expect(row.output_tokens).toBe(34);
+      expect(row.cost_usd).toBe(0.01);
+      expect(row.function_id).toBe("function-1");
+      expect(row.function_name).toBe("summarize");
+      expect(row.function_version).toBe("v1");
+      expect(row.error_type).toBe("Error");
+      expect(row.error_message).toBe("boom");
+      expect(row.attributes).toBe(JSON.stringify(input.span.attributes));
+      expect(row.events).toBe(JSON.stringify(input.span.events));
+      expect(row.links).toBe(JSON.stringify(input.span.links));
+      expect(row.resource_attributes).toBe(
+        JSON.stringify(input.resourceAttributes),
+      );
+      expect(row.created_at).toBe(
+        formatDateTime64(new Date(input.receivedAt), 3),
+      );
+      expect(row._version).toBeTypeOf("number");
+    }),
+  );
+
+  it.effect("returns null duration for negative durations", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture({
+        span: {
+          startTimeUnixNano: "1700000001000000000",
+          endTimeUnixNano: "1700000000000000000",
+        },
+      });
+
+      const row = transformSpanForClickHouse(input);
+
+      expect(row.duration_ms).toBeNull();
+      expect(row.start_time).toBe(
+        formatDateTime64(
+          new Date(
+            Number(BigInt(input.span.startTimeUnixNano!) / BigInt(1000000)),
+          ),
+          9,
+        ),
+      );
+      expect(row.end_time).toBe(
+        formatDateTime64(
+          new Date(
+            Number(BigInt(input.span.endTimeUnixNano!) / BigInt(1000000)),
+          ),
+          9,
+        ),
+      );
+    }),
+  );
+});

--- a/cloud/clickhouse/transform.ts
+++ b/cloud/clickhouse/transform.ts
@@ -1,0 +1,194 @@
+/**
+ * @fileoverview Utilities for transforming spans into ClickHouse analytics rows.
+ *
+ * This module is shared between ingestion and realtime paths to ensure a
+ * consistent mapping from OTLP spans into the `spans_analytics` schema.
+ */
+
+import type { RealtimeSpanInput } from "@/clickhouse/realtimeSpans";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type SpansAnalyticsRow = {
+  trace_id: string;
+  span_id: string;
+  parent_span_id: string | null;
+  environment_id: string;
+  project_id: string;
+  organization_id: string;
+  start_time: string;
+  end_time: string | null;
+  duration_ms: number | null;
+  name: string;
+  name_lower: string;
+  kind: number | null;
+  status_code: number | null;
+  status_message: string | null;
+  model: string | null;
+  provider: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  total_tokens: number | null;
+  cost_usd: number | null;
+  function_id: string | null;
+  function_name: string | null;
+  function_version: string | null;
+  error_type: string | null;
+  error_message: string | null;
+  attributes: string;
+  events: string | null;
+  links: string | null;
+  service_name: string | null;
+  service_version: string | null;
+  resource_attributes: string | null;
+  created_at: string;
+  synced_at: string;
+  _version: number;
+};
+
+export type SpanTransformInput = {
+  span: RealtimeSpanInput;
+  environmentId: string;
+  projectId: string;
+  organizationId: string;
+  receivedAt: number;
+  serviceName: string | null;
+  serviceVersion: string | null;
+  resourceAttributes: Record<string, unknown> | null;
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Format Date as ClickHouse DateTime64 string.
+ *
+ * Example (precision=9): "2024-01-01 12:34:56.123000000"
+ */
+export const formatDateTime64 = (date: Date, precision: number): string => {
+  const iso = date.toISOString(); // YYYY-MM-DDTHH:MM:SS.mmmZ
+  const [datePart, timePart] = iso.split("T");
+  const timeWithoutZone = timePart?.replace("Z", "") ?? "00:00:00.000";
+  const [time, milliseconds = ""] = timeWithoutZone.split(".");
+  const paddedFraction = milliseconds
+    .padEnd(precision, "0")
+    .slice(0, precision);
+  return `${datePart} ${time}.${paddedFraction}`;
+};
+
+/**
+ * Extract attribute value from JSONB attributes.
+ */
+const getAttributeValue = (
+  attributes: Record<string, unknown> | null,
+  key: string,
+): unknown => {
+  if (!attributes) return null;
+  return attributes[key] ?? null;
+};
+
+// =============================================================================
+// Transform
+// =============================================================================
+
+/**
+ * Transform a span + trace into ClickHouse analytics format.
+ */
+export const transformSpanForClickHouse = ({
+  span,
+  environmentId,
+  projectId,
+  organizationId,
+  receivedAt,
+  serviceName,
+  serviceVersion,
+  resourceAttributes,
+}: SpanTransformInput): SpansAnalyticsRow => {
+  const attributes = span.attributes ?? null;
+  const status = span.status ?? null;
+
+  // Calculate duration in milliseconds
+  // Fallback to null if end_time < start_time (negative duration)
+  let durationMs: number | null = null;
+  if (span.startTimeUnixNano && span.endTimeUnixNano) {
+    const startNs = BigInt(span.startTimeUnixNano);
+    const endNs = BigInt(span.endTimeUnixNano);
+    const calculatedMs = Number((endNs - startNs) / BigInt(1000000));
+    // Only set if non-negative (negative indicates data inconsistency)
+    durationMs = calculatedMs >= 0 ? calculatedMs : null;
+  }
+
+  // Convert Unix nano to ISO string
+  const startTime = span.startTimeUnixNano
+    ? new Date(Number(BigInt(span.startTimeUnixNano) / BigInt(1000000)))
+    : new Date(receivedAt);
+  const endTime = span.endTimeUnixNano
+    ? new Date(Number(BigInt(span.endTimeUnixNano) / BigInt(1000000)))
+    : null;
+
+  return {
+    trace_id: span.traceId,
+    span_id: span.spanId,
+    parent_span_id: span.parentSpanId ?? null,
+    environment_id: environmentId,
+    project_id: projectId,
+    organization_id: organizationId,
+    start_time: formatDateTime64(startTime, 9),
+    end_time: endTime ? formatDateTime64(endTime, 9) : null,
+    duration_ms: durationMs,
+    name: span.name,
+    name_lower: span.name.toLowerCase(),
+    kind: span.kind ?? null,
+    status_code: status?.code ?? null,
+    status_message: status?.message ?? null,
+    // LLM-specific attributes
+    model: getAttributeValue(attributes, "gen_ai.request.model") as
+      | string
+      | null,
+    provider: getAttributeValue(attributes, "gen_ai.system") as string | null,
+    input_tokens: getAttributeValue(attributes, "gen_ai.usage.input_tokens") as
+      | number
+      | null,
+    output_tokens: getAttributeValue(
+      attributes,
+      "gen_ai.usage.output_tokens",
+    ) as number | null,
+    total_tokens: null, // Calculated if needed
+    cost_usd: getAttributeValue(attributes, "gen_ai.usage.cost") as
+      | number
+      | null,
+    function_id: getAttributeValue(attributes, "mirascope.function_id") as
+      | string
+      | null,
+    function_name: getAttributeValue(attributes, "mirascope.function_name") as
+      | string
+      | null,
+    function_version: getAttributeValue(
+      attributes,
+      "mirascope.function_version",
+    ) as string | null,
+    error_type: getAttributeValue(attributes, "exception.type") as
+      | string
+      | null,
+    error_message: getAttributeValue(attributes, "exception.message") as
+      | string
+      | null,
+    // Full JSON attributes
+    attributes: JSON.stringify(attributes ?? {}),
+    events: span.events ? JSON.stringify(span.events) : null,
+    links: span.links ? JSON.stringify(span.links) : null,
+    // Trace-level info
+    service_name: serviceName,
+    service_version: serviceVersion,
+    resource_attributes: resourceAttributes
+      ? JSON.stringify(resourceAttributes)
+      : null,
+    // Timestamps
+    created_at: formatDateTime64(new Date(receivedAt), 3),
+    synced_at: formatDateTime64(new Date(), 3),
+    _version: Date.now(),
+  };
+};

--- a/cloud/tests/clickhouse/fixtures.ts
+++ b/cloud/tests/clickhouse/fixtures.ts
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Effect-native test fixtures for ClickHouse transform tests.
+ */
+
+import { Effect } from "effect";
+import type { SpanTransformInput } from "@/clickhouse/transform";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/** Default span fixture for transform testing. */
+const TestTransformSpanFixtureData: SpanTransformInput["span"] = {
+  traceId: "otel-trace-1",
+  spanId: "otel-span-1",
+  parentSpanId: null,
+  name: "LLM.Call",
+  kind: 1,
+  startTimeUnixNano: "1700000000000000000",
+  endTimeUnixNano: "1700000001000000000",
+  attributes: {
+    "gen_ai.request.model": "gpt-4",
+    "gen_ai.system": "openai",
+    "gen_ai.usage.input_tokens": 12,
+    "gen_ai.usage.output_tokens": 34,
+    "gen_ai.usage.cost": 0.01,
+    "mirascope.function_id": "function-1",
+    "mirascope.function_name": "summarize",
+    "mirascope.function_version": "v1",
+    "exception.type": "Error",
+    "exception.message": "boom",
+  },
+  status: { code: 2, message: "ERROR" },
+  events: [{ name: "event" }],
+  links: [{ traceId: "link-trace" }],
+};
+
+/** Default transform input fixture data. */
+const TestTransformInputFixtureData: SpanTransformInput = {
+  span: TestTransformSpanFixtureData,
+  environmentId: "00000000-0000-0000-0000-000000000020",
+  projectId: "00000000-0000-0000-0000-000000000030",
+  organizationId: "00000000-0000-0000-0000-000000000040",
+  receivedAt: new Date("2024-01-01T00:00:00.123Z").getTime(),
+  serviceName: "svc",
+  serviceVersion: "1.0.0",
+  resourceAttributes: { region: "us-east-1" },
+};
+
+// =============================================================================
+// Effect-native Fixtures
+// =============================================================================
+
+type SpanOverrides = Partial<SpanTransformInput["span"]>;
+type InputOverrides = Omit<Partial<SpanTransformInput>, "span"> & {
+  span?: SpanOverrides;
+};
+
+/**
+ * Effect-native test fixture for transform span.
+ *
+ * Use `yield* TestTransformSpanFixture()` or `yield* TestTransformSpanFixture({ ...overrides })`.
+ */
+export const TestTransformSpanFixture = (
+  overrides: SpanOverrides = {},
+): Effect.Effect<SpanTransformInput["span"]> =>
+  Effect.succeed({ ...TestTransformSpanFixtureData, ...overrides });
+
+/**
+ * Effect-native test fixture for transform input.
+ *
+ * Use `yield* TestTransformInputFixture()` or `yield* TestTransformInputFixture({ ...overrides })`.
+ */
+export const TestTransformInputFixture = (
+  overrides: InputOverrides = {},
+): Effect.Effect<SpanTransformInput> => {
+  const { span: spanOverrides, ...inputOverrides } = overrides;
+  return Effect.succeed({
+    ...TestTransformInputFixtureData,
+    ...inputOverrides,
+    span: { ...TestTransformSpanFixtureData, ...spanOverrides },
+  });
+};


### PR DESCRIPTION
### TL;DR

Added ClickHouse span transformation utilities for analytics data processing.

### What changed?

- Created `transform.ts` in the ClickHouse module to handle conversion of OTLP spans into ClickHouse analytics row format
- Added comprehensive tests in `transform.test.ts` to verify the transformation logic
- Implemented `RealtimeSpans` interface to define the contract between ingestion and realtime search paths
- Added helper functions for DateTime64 formatting and attribute extraction
- Defined type interfaces for span analytics rows and transformation inputs

### How to test?

1. Run the unit tests for the transform module:
   ```
   npm test cloud/clickhouse/transform.test.ts
   ```
2. Verify that spans are correctly transformed with all expected fields:
   - Basic span metadata (trace_id, span_id, etc.)
   - Timing information (start_time, end_time, duration_ms)
   - LLM-specific attributes (model, provider, tokens, cost)
   - Function metadata (function_id, function_name, function_version)
   - Error information (error_type, error_message)

### Why make this change?

This implementation provides a consistent way to transform OpenTelemetry spans into a format optimized for ClickHouse analytics storage. By centralizing this transformation logic, we ensure that both ingestion and realtime paths use the same schema and field mappings, which is critical for reliable analytics and querying. The code specifically handles LLM-related attributes to enable AI-specific analytics and monitoring.