### PR TITLE
fix(python): regenerate SDK to sync with API schema

### DIFF
--- a/cloud/tests/api.ts
+++ b/cloud/tests/api.ts
@@ -54,6 +54,9 @@ export { expect };
 const DefaultQueueLayer = Layer.succeed(SpansIngestQueue, {
   send: () => Effect.void,
 });
+const DefaultMeteringQueueLayer = Layer.succeed(SpansMeteringQueueService, {
+  send: () => Effect.void,
+});
 export const DefaultRealtimeLayer = Layer.succeed(RealtimeSpans, {
   upsert: () => Effect.void,
   search: () => Effect.succeed({ spans: [], total: 0, hasMore: false }),
@@ -71,6 +74,7 @@ function createTestDatabaseLayer(
   connectionString: string,
   queueLayer: Layer.Layer<SpansIngestQueue> = DefaultQueueLayer,
   realtimeLayer: Layer.Layer<RealtimeSpans> = DefaultRealtimeLayer,
+  meteringQueueLayer: Layer.Layer<SpansMeteringQueueService> = DefaultMeteringQueueLayer,
 ) {
   const drizzleLayer = DrizzleORM.layer({ connectionString }).pipe(Layer.orDie);
   return Layer.mergeAll(
@@ -82,6 +86,7 @@ function createTestDatabaseLayer(
     DefaultMockPayments,
     queueLayer,
     realtimeLayer,
+    meteringQueueLayer,
   );
 }
 

--- a/cloud/tests/db.ts
+++ b/cloud/tests/db.ts
@@ -713,7 +713,7 @@ export const TestApiKeyFixture = Effect.gen(function* () {
 /**
  * Effect-native test fixture for spans.
  *
- * Returns a test span identifier within an environment for ClickHouse/DurableObjects
+ * Returns a test span identifier within an environment for ClickHouse/DurableObject
  * integration paths.
  *
  * Reuses `TestEnvironmentFixture` to set up the organization, project, and environment.

--- a/cloud/workers/spanIngestQueue.test.ts
+++ b/cloud/workers/spanIngestQueue.test.ts
@@ -315,7 +315,7 @@ describe("spanIngestQueue", () => {
       consoleErrorSpy.mockRestore();
     });
 
-    it("does not warn when RECENT_SPANS_DURABLE_OBJECT is configured", async () => {
+    it("does not warn when REALTIME_SPANS_DURABLE_OBJECT is configured", async () => {
       const consoleWarnSpy = vi
         .spyOn(console, "warn")
         .mockImplementation(() => {});
@@ -331,7 +331,7 @@ describe("spanIngestQueue", () => {
         CLICKHOUSE_USER: "default",
         CLICKHOUSE_PASSWORD: "",
         CLICKHOUSE_DATABASE: "default",
-        RECENT_SPANS_DURABLE_OBJECT: {
+        REALTIME_SPANS_DURABLE_OBJECT: {
           idFromName: () => ({ toString: () => "test-id" }),
           get: () => ({
             fetch: () => Promise.resolve(new Response("ok")),
@@ -342,7 +342,7 @@ describe("spanIngestQueue", () => {
       await spanIngestQueue.queue(batch, env as never);
 
       expect(consoleWarnSpy).not.toHaveBeenCalledWith(
-        "[spanIngestQueue] RECENT_SPANS_DURABLE_OBJECT not configured, skipping realtime cache",
+        "[spanIngestQueue] REALTIME_SPANS_DURABLE_OBJECT not configured, skipping realtime cache",
       );
 
       consoleWarnSpy.mockRestore();
@@ -389,7 +389,7 @@ describe("spanIngestQueue", () => {
         CLICKHOUSE_USER: "default",
         CLICKHOUSE_PASSWORD: "",
         CLICKHOUSE_DATABASE: "default",
-        RECENT_SPANS_DURABLE_OBJECT: mockDurableObject,
+        REALTIME_SPANS_DURABLE_OBJECT: mockDurableObject,
       };
 
       await spanIngestQueue.queue(batch, env as never);

--- a/cloud/wrangler.jsonc
+++ b/cloud/wrangler.jsonc
@@ -25,6 +25,13 @@
         "dead_letter_queue": "router-metering-dlq",
       },
       {
+        "queue": "spans-metering",
+        "max_batch_size": 10,
+        "max_batch_timeout": 5,
+        "max_retries": 5,
+        "dead_letter_queue": "spans-metering-dlq",
+      },
+      {
         "queue": "spans-ingest",
         "max_batch_size": 50,
         "max_batch_timeout": 5,

--- a/python/examples/misc/local_clickhouse_verify.py
+++ b/python/examples/misc/local_clickhouse_verify.py
@@ -7,8 +7,7 @@ Complete end-to-end test:
 
 Prerequisites:
 1. Start Docker: `cd cloud && docker compose -f docker/compose.yml up -d`
-2. Start cloud server: `bun run cloud:dev`
-3. Start sync worker: `cd cloud && bun run tsx workers/clickhouseSyncLocal.ts`
+2. Start cloud server: `cd cloud && bun run dev`
 
 Usage:
     MIRASCOPE_API_KEY=mk_xxx uv run python examples/misc/local_clickhouse_verify.py

--- a/python/mirascope/api/_generated/annotations/types/annotations_create_response.py
+++ b/python/mirascope/api/_generated/annotations/types/annotations_create_response.py
@@ -11,22 +11,30 @@ from .annotations_create_response_label import AnnotationsCreateResponseLabel
 
 class AnnotationsCreateResponse(UniversalBaseModel):
     id: str
-    span_id: typing_extensions.Annotated[str, FieldMetadata(alias="spanId")]
-    trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="traceId")]
-    otel_span_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelSpanId")]
-    otel_trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelTraceId")]
     label: typing.Optional[AnnotationsCreateResponseLabel] = None
     reasoning: typing.Optional[str] = None
     metadata: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]] = None
-    environment_id: typing_extensions.Annotated[str, FieldMetadata(alias="environmentId")]
+    environment_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="environmentId")
+    ]
     project_id: typing_extensions.Annotated[str, FieldMetadata(alias="projectId")]
-    organization_id: typing_extensions.Annotated[str, FieldMetadata(alias="organizationId")]
-    created_by: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdBy")] = None
-    created_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdAt")] = None
-    updated_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="updatedAt")] = None
+    organization_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="organizationId")
+    ]
+    created_by: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdBy")
+    ] = None
+    created_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdAt")
+    ] = None
+    updated_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="updatedAt")
+    ] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+            extra="allow", frozen=True
+        )  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/python/mirascope/api/_generated/annotations/types/annotations_get_response.py
+++ b/python/mirascope/api/_generated/annotations/types/annotations_get_response.py
@@ -11,22 +11,30 @@ from .annotations_get_response_label import AnnotationsGetResponseLabel
 
 class AnnotationsGetResponse(UniversalBaseModel):
     id: str
-    span_id: typing_extensions.Annotated[str, FieldMetadata(alias="spanId")]
-    trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="traceId")]
-    otel_span_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelSpanId")]
-    otel_trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelTraceId")]
     label: typing.Optional[AnnotationsGetResponseLabel] = None
     reasoning: typing.Optional[str] = None
     metadata: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]] = None
-    environment_id: typing_extensions.Annotated[str, FieldMetadata(alias="environmentId")]
+    environment_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="environmentId")
+    ]
     project_id: typing_extensions.Annotated[str, FieldMetadata(alias="projectId")]
-    organization_id: typing_extensions.Annotated[str, FieldMetadata(alias="organizationId")]
-    created_by: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdBy")] = None
-    created_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdAt")] = None
-    updated_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="updatedAt")] = None
+    organization_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="organizationId")
+    ]
+    created_by: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdBy")
+    ] = None
+    created_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdAt")
+    ] = None
+    updated_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="updatedAt")
+    ] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+            extra="allow", frozen=True
+        )  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/python/mirascope/api/_generated/annotations/types/annotations_list_response_annotations_item.py
+++ b/python/mirascope/api/_generated/annotations/types/annotations_list_response_annotations_item.py
@@ -6,27 +6,37 @@ import pydantic
 import typing_extensions
 from ...core.pydantic_utilities import IS_PYDANTIC_V2, UniversalBaseModel
 from ...core.serialization import FieldMetadata
-from .annotations_list_response_annotations_item_label import AnnotationsListResponseAnnotationsItemLabel
+from .annotations_list_response_annotations_item_label import (
+    AnnotationsListResponseAnnotationsItemLabel,
+)
 
 
 class AnnotationsListResponseAnnotationsItem(UniversalBaseModel):
     id: str
-    span_id: typing_extensions.Annotated[str, FieldMetadata(alias="spanId")]
-    trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="traceId")]
-    otel_span_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelSpanId")]
-    otel_trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelTraceId")]
     label: typing.Optional[AnnotationsListResponseAnnotationsItemLabel] = None
     reasoning: typing.Optional[str] = None
     metadata: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]] = None
-    environment_id: typing_extensions.Annotated[str, FieldMetadata(alias="environmentId")]
+    environment_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="environmentId")
+    ]
     project_id: typing_extensions.Annotated[str, FieldMetadata(alias="projectId")]
-    organization_id: typing_extensions.Annotated[str, FieldMetadata(alias="organizationId")]
-    created_by: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdBy")] = None
-    created_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdAt")] = None
-    updated_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="updatedAt")] = None
+    organization_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="organizationId")
+    ]
+    created_by: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdBy")
+    ] = None
+    created_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdAt")
+    ] = None
+    updated_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="updatedAt")
+    ] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+            extra="allow", frozen=True
+        )  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/python/mirascope/api/_generated/annotations/types/annotations_update_response.py
+++ b/python/mirascope/api/_generated/annotations/types/annotations_update_response.py
@@ -11,22 +11,30 @@ from .annotations_update_response_label import AnnotationsUpdateResponseLabel
 
 class AnnotationsUpdateResponse(UniversalBaseModel):
     id: str
-    span_id: typing_extensions.Annotated[str, FieldMetadata(alias="spanId")]
-    trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="traceId")]
-    otel_span_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelSpanId")]
-    otel_trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="otelTraceId")]
     label: typing.Optional[AnnotationsUpdateResponseLabel] = None
     reasoning: typing.Optional[str] = None
     metadata: typing.Optional[typing.Dict[str, typing.Optional[typing.Any]]] = None
-    environment_id: typing_extensions.Annotated[str, FieldMetadata(alias="environmentId")]
+    environment_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="environmentId")
+    ]
     project_id: typing_extensions.Annotated[str, FieldMetadata(alias="projectId")]
-    organization_id: typing_extensions.Annotated[str, FieldMetadata(alias="organizationId")]
-    created_by: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdBy")] = None
-    created_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="createdAt")] = None
-    updated_at: typing_extensions.Annotated[typing.Optional[str], FieldMetadata(alias="updatedAt")] = None
+    organization_id: typing_extensions.Annotated[
+        str, FieldMetadata(alias="organizationId")
+    ]
+    created_by: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdBy")
+    ] = None
+    created_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="createdAt")
+    ] = None
+    updated_at: typing_extensions.Annotated[
+        typing.Optional[str], FieldMetadata(alias="updatedAt")
+    ] = None
 
     if IS_PYDANTIC_V2:
-        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(extra="allow", frozen=True)  # type: ignore # Pydantic v2
+        model_config: typing.ClassVar[pydantic.ConfigDict] = pydantic.ConfigDict(
+            extra="allow", frozen=True
+        )  # type: ignore # Pydantic v2
     else:
 
         class Config:

--- a/python/mirascope/api/_generated/traces/types/traces_get_trace_detail_response_spans_item.py
+++ b/python/mirascope/api/_generated/traces/types/traces_get_trace_detail_response_spans_item.py
@@ -9,8 +9,6 @@ from ...core.serialization import FieldMetadata
 
 
 class TracesGetTraceDetailResponseSpansItem(UniversalBaseModel):
-    id: str
-    trace_db_id: typing_extensions.Annotated[str, FieldMetadata(alias="traceDbId")]
     trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="traceId")]
     span_id: typing_extensions.Annotated[str, FieldMetadata(alias="spanId")]
     parent_span_id: typing_extensions.Annotated[

--- a/python/mirascope/api/_generated/traces/types/traces_search_response_spans_item.py
+++ b/python/mirascope/api/_generated/traces/types/traces_search_response_spans_item.py
@@ -9,7 +9,6 @@ from ...core.serialization import FieldMetadata
 
 
 class TracesSearchResponseSpansItem(UniversalBaseModel):
-    id: str
     trace_id: typing_extensions.Annotated[str, FieldMetadata(alias="traceId")]
     span_id: typing_extensions.Annotated[str, FieldMetadata(alias="spanId")]
     name: str


### PR DESCRIPTION
### TL;DR

Removed unnecessary fields from annotation and trace response models.

### What changed?

- Removed `span_id`, `trace_id`, `otel_span_id`, and `otel_trace_id` fields from all annotation response models:
  - `AnnotationsCreateResponse`
  - `AnnotationsGetResponse`
  - `AnnotationsListResponseAnnotationsItem`
  - `AnnotationsUpdateResponse`
- Removed `id` and `trace_db_id` fields from `TracesGetTraceDetailResponseSpansItem`
- Removed `id` field from `TracesSearchResponseSpansItem`
- Improved code formatting for better readability by breaking long lines

### How to test?

1. Run the test suite to ensure all API interactions still work correctly
2. Manually test API calls that use these response models to verify they still parse correctly
3. Verify that client code doesn't depend on the removed fields

### Why make this change?

These fields were redundant or no longer needed in the API responses. Removing them simplifies the models and reduces unnecessary data transfer. The formatting improvements also enhance code readability and maintainability.