### PR TITLE
fix: use JsonableCovariantT for ToolOutput

### DIFF
--- a/python/mirascope/llm/content/tool_output.py
+++ b/python/mirascope/llm/content/tool_output.py
@@ -3,11 +3,11 @@
 from dataclasses import dataclass
 from typing import Generic, Literal
 
-from ..types import JsonableT
+from ..types import JsonableCovariantT
 
 
 @dataclass(kw_only=True)
-class ToolOutput(Generic[JsonableT]):
+class ToolOutput(Generic[JsonableCovariantT]):
     """Tool output content for a message.
 
     Represents the output from a tool call. This is part of a user message's
@@ -22,5 +22,5 @@ class ToolOutput(Generic[JsonableT]):
     name: str
     """The name of the tool that created this output."""
 
-    value: JsonableT
+    value: JsonableCovariantT
     """The output value from the tool call."""


### PR DESCRIPTION
This allows things like the following to typecheck:

```python

output: llm.ToolOutput[float] = float_tool.execute(tool_call)
response = response.resume(output)
```

Previously, this would produce a type error because resume would accept
`ToolOutput[Jsonable]` which is invariant.