### PR TITLE
chore(python-sdk): prep for beta.0 release

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mirascope"
-version = "2.0.0-alpha.6"
+version = "2.0.0-beta.0"
 description = "LLM abstractions that aren't obstructions"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -22,7 +22,7 @@ keywords = [
     "prompt engineering",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
@@ -55,10 +55,10 @@ Changelog = "https://github.com/Mirascope/mirascope/releases"
 # in mirascope/_stubs.py to ensure proper import stubbing for missing dependencies.
 # The mapping translates PyPI package names to their Python import names.
 [project.optional-dependencies]
-anthropic = ["anthropic>=0.75.0,<1.0"]
+anthropic = ["anthropic>=0.76.0,<1.0"]
 api = ["pydantic-settings>=2.12.0"]
-google = ["google-genai>=1.57.0,<2", "pillow>=10.4.0,<11", "proto-plus>=1.24.0"]
-openai = ["openai>=2.14.0,<3"]
+google = ["google-genai>=1.58.0,<2", "pillow>=10.4.0,<11", "proto-plus>=1.24.0"]
+openai = ["openai>=2.15.0,<3"]
 mcp = ["mcp>=1.25.0,<2"]
 ops = [
     "opentelemetry-sdk>=1.38.0,<2",

--- a/python/tests/e2e/output/cassettes/test_call/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -20,7 +20,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -32,11 +34,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -46,73 +48,55 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01CjEJDsZzyaFNq4guqt6gin","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}
-        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_016sBANX4Cx7hWJYehKPAGDU","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}          }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}           }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"4200
-        + 42 ="}  }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        + 42 ="}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        4242"}    }
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        4242"}     }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0        }
-
-
-        event: ping
-
-        data: {"type": "ping"}
-
-
-        event: ping
-
-        data: {"type": "ping"}
+        data: {"type":"content_block_stop","index":0}
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":15}           }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":17,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":15}            }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"      }
+        data: {"type":"message_stop"}
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b0271989bc0753e-SEA
+      - 9beae7051e5dcdf7-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -120,15 +104,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:29:42 GMT
+      - Fri, 16 Jan 2026 04:34:49 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -138,29 +118,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:29:41Z'
+      - '2026-01-16T04:34:47Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:29:41Z'
+      - '2026-01-16T04:34:47Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:29:41Z'
+      - '2026-01-16T04:34:47Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:29:41Z'
+      - '2026-01-16T04:34:47Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2EB7dXoC3SpB8WQagL
+      - req_011CXAS9E9YmJChAEAxBRMxg
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1372'
+      - '1849'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_thinking/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_thinking/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -21,7 +21,7 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
       x-api-key:
       - <filtered>
       x-stainless-arch:
@@ -35,7 +35,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -49,207 +49,261 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"id\":\"msg_01Rq9qrMccYDLvoZnNsKW5xE\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":67,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":5,\"service_tier\":\"standard\"}}
-        \ }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}
-        \     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"I
-        need to find all\"}         }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent:
-        content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        primes below 400 that contain\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \\\"\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79\\\"
-        as a substring.\\n\\nLet\"}        }\n\nevent: content_block_delta\ndata:
+      string: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"id\":\"msg_014CoHSE1Vi5yxd7k1Mf7GKm\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":67,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":8,\"service_tier\":\"standard\"}}
+        \             }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}
+        \    }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"I
+        need to find all primes below\"}       }\n\nevent: content_block_delta\ndata:
         {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me think\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        about what\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        numbers\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        below\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        400 contain \\\"79\\\"\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        as a substring:\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
-        Numbers\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        starting\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        with 79: 790\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        791, 792, ...\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        (these\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        are all \"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2265\"}
-        \    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        790\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",\"}
-        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        so above\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        400)\\n- Numbers ending\"}         }\n\nevent: content_block_delta\ndata:
+        400 that contain \\\"\"}               }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79\\\"
+        as a substring.\\n\\nFirst\"}              }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        let me think\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        about what numbers\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        below\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        400 coul\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
+        contain \\\"79\\\"\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        as a substring:\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
+        Numbers\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        of\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        the form 79X\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        (\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"where
+        X is a digit):\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        790\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        791, 792, \"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"793,
+        794, 795,\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        796, 797, 798\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        799\\n- Numbers of the\"}             }\n\nevent: content_block_delta\ndata:
         {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        with 79: 79\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        form X\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79
+        (where X is a digit\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"):
         179\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        279\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        379\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
-        Numbers with\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        79 in the middle: This\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        woul\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        be numbers\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        like X\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79Y\"}
+        279\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        379\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
+        Numbers of the form X\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79\"}
+        \    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Y\"}
+        \              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        (where X\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        and Y are digits): This\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        would give\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        us numbers with\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        at\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        least 4\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        digits,\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        starting\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        from\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        1\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"790\"}
+        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",\"}
+        \            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        which\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        is above\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        400.\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nSo
+        I need to check\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":\"}
+        \  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-\"}
+        \   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        79\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        itself\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
+        179\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",\"}
         \     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        where X and Y are digits, but\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        for\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        numbers\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        below 400, this\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        would mean\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        numbers\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        like 1\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"790\"}
-        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        2\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"790,
-        3790, etc.,\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        which are all above\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        400.\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nSo
-        the candidates\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        are\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":\"}
+        279, 379\\n- \"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"790,
+        791, 792,\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        793, 794, 795\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        796, 797, \"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"798,
+        799\\n\\nWait\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        let me be more systematic\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".\"}
+        \         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        Numbers\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        below\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        400 that contain \\\"79\\\"\"}            }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        as a substring:\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nTwo\"}
+        \ }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"-digit:\"}
+        \         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        79\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\nThree-digit:
+        179\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        279, 379,\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        790\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        791, 792, \"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"793,
+        794, 795,\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        796, 797, 798\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        799\\n\\nBut\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        wait, we\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'re\"}}\n\nevent:
+        content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        looking at\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        numbers below\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        400, so \"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"790\"}
+        \             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"-\"}}\n\nevent:
+        content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"799
+        are all above\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        400. Let me rec\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"ons\"}
+        \           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"ider.\\n\\nActually,
+        let me list\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        all possibilities\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        more\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        carefully:\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
+        79 (two\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        digits)\\n- X\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79
+        where\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        X =\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        1, 2, 3\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":\"}
+        \              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        so\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        179, 279, 379\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        \"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"(three
+        digits,\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        all below\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        400)\\n- \"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79X
+        where X = 0\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",\"}
+        \           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"1,2,3,4,\"}
+        \ }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"5,6,7,8,\"}
+        \      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"9:
+        so 790,\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"791,792,793,794,\"}
+        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"795,796,797,798,\"}
+        \          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"799
+        (three\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        digits, but\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        these\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        are all \"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2265
+        790\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        \"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\">\"}
+        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        400)\\n\\nSo the candidates\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        are:\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        79, 179, 279\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        379\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\"}
+        \     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nNow\"}
         \     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        79\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        179, 279, \"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"379\"}
-        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nNow\"}
-        \         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        I need to check which of these are\"}            }\n\nevent: content_block_delta\ndata:
+        I'll\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        test\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        each for\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        primality.\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        For\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        79,\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        I check\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        divisibility by primes up to \u221A\"}    }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79
+        \u2248 8\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".9
+        \"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"(so
+        2, 3,\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        5, 7):\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        it\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'s
+        odd, digit\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        sum is 16\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        \"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"(not
+        divisible by 3),\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        doesn't end in 0 or\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        5, an\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
+        79 \xF7 \"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"7
+        \"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2248
+        11.3\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".\"}
+        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        So 79 is prime.\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        For\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        179, I nee\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
+        to check divisibility by primes up\"}               }\n\nevent: content_block_delta\ndata:
         {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        prime:\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\n79\"}
-        \    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":
-        Let\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me check if 79 is prime\"}           }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".\"}
-        \ }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
-        Not\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        divisible by 2 (it\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'s
-        odd)\\n- Not divisible\"}            }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        by 3 (7\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"+\"}
-        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"9=16,
-        not divisible by\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        3)\\n- Not divisible\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        by 5 (doesn't en\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        in 0 or 5)\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
-        Not divisible by 7\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        (79\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\xF7
-        7 =\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        11.28\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"...)\"}
-        \           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n-
-        Nee\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        to check up to \u221A79 \"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2248
-        8.9,\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        so I need to check \"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"2,
-        3, 5,\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        7\\n- 79 \"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\xF7
-        7\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        = 11 \"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"remainder
-        2, so not\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        divisible by 7\\n- Since\"}              }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \u221A\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79
-        \"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"<
-        9\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        I only\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        need to check pr\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"imes
-        up to 8\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",\"}
-        \         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        which\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        are 2, 3, \"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"5,
-        7\\n- 79\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        is prime\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\n179\"}
-        \      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":
-        Let me check if 179 \"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"is
-        prime.\\n- Not divisible\"}             }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        by 2 (it's od\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d)\\n-
-        Not divisible by \"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"3
-        (1\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"+7+9=17,
-        not\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        divisible by 3)\\n-\"}               }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        Not divisible by 5 (\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"doesn't
-        end in 0 or\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        5)\\n\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\n-
-        Since\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \u221A179 \"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2248
-        13.4,\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        I nee\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        to check primes up to 13\"}        }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":\"}
-        \         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        7\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        11, an\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        13.\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        Testing\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        these\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":\"}
-        \    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        179 \xF7 \"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"7
-        = 25 remainder \"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"4,
-        179 \xF7\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        11 = 16 \"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"remainder
-        3, an\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        179 \xF7 \"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"13
-        = 13 remainder \"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"10.
-        None divide evenly, so\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        179 is prime.\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nFor\"}
+        to \u221A179 \u2248\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        13.4,\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        which\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        includes\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        2, 3, 5\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        7, 11, \"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"13.\"}
+        \       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\n179\"}
+        \            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        is odd, has\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        digit sum 17 (not divis\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"ible
+        by 3), doesn't en\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
+        in 0 or 5,\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        and testing\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        7\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",\"}
+        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        11, an\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
+        13 all\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        give\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        non\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"-integer\"}
+        \          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        results. So 179 is also\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        prime.\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        Now\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        checking\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        279:\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        the\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        digit sum is 18\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        which is divisible by 3\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        so 279 =\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        3 \xD7 93 \"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"=
+        9\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        \xD7 31,\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        making\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        it composite\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".
+        For\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        379,\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        I need to test\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        pr\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"imes
+        up to about\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        19.5.\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        It\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'s
+        odd, the\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        digit sum is 19 \"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"(not
+        divisible by 3),\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        an\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
+        it\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        doesn't end in 0 or\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        5,\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        so I\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'ll
+        continue\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        checking \"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"7,
+        11, 13,\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        17, an\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
+        19.\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nTesting\"}
         \ }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        279,\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        the\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        digit\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        sum is 2+7+9\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"=18,
-        which is divisible by\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        3, so 279 =\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        3 \xD7 93 \"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"an\"}
-        \          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        isn\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'t
-        prime.\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        Moving\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        to\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        379:\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        it\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'s
-        odd, the\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        digit sum \"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"19\"}
-        \ }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        isn\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'t
-        divisible by 3, it\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        doesn't end in 0 or\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        5, and testing\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        7\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        gives\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        379\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \xF7 7 \"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"=
-        54.\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"14...
-        I\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        nee\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        to continue\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        checking divis\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"ibility
-        by\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        primes up to \u221A379 \"}            }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2248
-        19.5.\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        19\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        = 19 remainder 18\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".\"}
-        \      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        Since\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        379 isn\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'t
-        divisible by any\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        prime up to its\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        square root, it\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'s
-        prime.\\n\\nThe\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        primes under\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        400 containing\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \\\"79\\\" are \"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79,
-        179, and 379\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2014\"}
-        \       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"three\"}
-        \     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        total\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".\"}
-        \             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"EpETCkYICxgCKkBJVu+z+gbsCY7wfmvTdEQwUQU82ei3LoS84bynmxgp9ooZbDoBjybEUWCZX7nKHt9b9nTPjO8HwZQqg5veTQpfEgyozj9DbOHbjUXXAY4aDESzj1n7Sn9LonwcOCIwmbMBD7QxlJ86WZ1inOkJUc/8kp8Eu580jqp2Ml4UAuL3afvI8mxLGUfE8eKT80/NKvgRiDLqydWxob21Yg2jIWCiE6sAJmfN/gQdbdtbicKl0365PF8nJF7/Wshh9N9DIW6BBSv5kYgepFe2xiPs7l8rNmPObytIgU+1EyOUTALaGIB2twERDteQDs6+KL9hR/6Ql6SCNrbXg6s07WTSqwWj/oIngzPVMmxT7Ewa4HSMN0eQ+WIYAcsllRI/7iNW+LFhC59ES3guP312OicOkgQIHcSGqUPJeyMpZ+SX63LCETVYVta8YMRo/VAyaoDZPj4DJ/FcpMIw5U/jYDJ7x6vgMru0JCOBAoe+f32hRIMP5NIyVBHfmtMnoc9vJlDy5rcAFyH74F3e5kSeuXBv6ynxTjfiE1yGQwecmNLMoO+Culvvfo1ivLGziYuoJrE/6VVp7CWDSpogw5aDr9kYysIipkvYnEn11muidpgMoDkAZq0BCsb3ILqiJNEN52BEwom4KjCNZyxQcwNHyAdWPV1AczK9R8nfL9bhoHofQJx0mwNjA2VAPfXnP78kFavFBfIiTibafHzvv7fIy9cxLmiKm5ei8jN0kchrsEDqpdSrfoAzYliozOgtcOAcRGRMrCAdPvj5X7AaIdDgx/hqgAj/w0aqMbgPgzUHtFBdEsKESj5jnqLkuXwhOPpWBeA8B3/koW5l0mzlLr5pb4E4Ae4thhCT6xBS9taDGJo0m5JkIDlbXhSpNexPqKfraX0FvSoW8PXXkgL6+PQpllluLoBwhb3PqiIvLsjd9s1tXTjcwrNqERycB+olEYUjDJUhUZyccdRJ8UBWpQHfPR/u8WV3FaJg/M9KzuTjhI5btNS5l+BTeonkY1nIjVb/Seijj/etk1lAhROiGV5k0HsNbaDtbvKUW9CRLGlktcskw/D/Qh16xoTUlapPYcvQROvryfprDV27su4uqSQ+frowsuVAM0OkhmHLerrlj7TrS0pvk1+AqK2Izyou1dp1+z6LqIO9fqzZxUxeSzM3A5nI4Yym5mQj6aeoXpVaMkZz3A7X2ORS074oxpa8JNaNRG/dai7MbdwncFmt6PSXzE+nQH9Tw+jfUJ3VPQieQet5y6V2evj6vEFTW4QcGEkT1YgJXadva5sUu3+gB761WXrk4KDkUmOSiiNIuE9uikPAXHPPK2SWGEPHS6TgQdfnoJ7+QRsoY5DaPrB6EmLus21ifBAMWRbSrPQCYEFZnwAxR5VrUqatEIjCO4p/ThJUBzfzQahqVeRnitpjEkqEyl8mAnfYUWgRWlruwtWQ0vK6mLCdivXrTTT4PztdcSifv3gMtiqzmcZ0FxupslVZD3RfrCM4knK1ozkN4wlNMyzUrLP/fBi/jXuChygju3NEzhEuBlyI1LJ0NFNLsh3Y/9Pj5DK1hR6GH5w+TJy2AmuxdKQytTkOcpbiZvb+CuPZhNsuX7Pmc9OxApcRhSCLipeXdGO3l57farrQpthgOhBz7Gf5TEzVL0lEI8Gf2jbUBj/8v22SLbcQcEID3alogtPQgl7IoOJwcKzqfZQkCigCc7K6wJE0jY/NFfQ9C//BvzQkb8oJqm7edF7mMCRanUhWcWNUfpLJPERUVpt+NDwfuNTYsgJveZqs/AM1uyFO74TlNucALAYN/fSm662+41MuzfyOQM2d1AXnz854+9yU3aH5ftc7rhZ8nBjySKwxIDTpO5j/KMfql2jtbDZDnbcQOn81gggez0ccAKMJQUJ7t1ajfLcQPyI/mtJGSiUofuVSA1CdMyrncj0kmCLEJprP73A9HDvLzRG9KSXvDtLkdsH3KAlJ6W4GIA+BWf2IuhQZsmuwwNNEose6zH3G7D242D6zreQICZqtPC+MCnZGr537Zo7QWBqVhxgX2aBlhGrYvAgFvVqBWoWBPng4hrghS2WKyQeBDhNKGodO4jQwHS4RlD31AmObPMn/hF9YXF8lCHl5SpkURYk5awG3JtIHMt//+tLLhjYJNJcdoCGfKL9vn4DSY4MLl88IplJdSX4e64usOW1fNDvs+0awaImZKAiGd3vhOc3bcVL/JCxi1iy13hBB21dk+W5UI49bsOOXk9rCGSjVqd1cM+oUfaZIKCf1vGAY3COsoQcEiYnVdG4PpYzGlxR6buI/luiltnrk9iHLjXE4C6wuESBt7wpZDKq+78QOH2Z5ZRSTZHZn+1CLLBb2Zc2CxMUvbh2SV2gfpiRMeAiuWHbMpIduy6nN0W9zXwV4AAeenwvY0GlpN0d3pnNwHJVwqySg1FOqFX2hwdVMtLWBegP9TSFC2W9+KiLyDEaLxpf70CZ+W3YDGyCQaDecBD4xMzj8HTTWJBZ0lRmFWUYS8lse+o9F9La1LI6F9iJkTJWiBRxKmU34dIkXR1/SYu9YADJeqBagdeOWG35aXdXbZ1I8zZ+doNzU6GKntTqh4e+4V8Hj0abkdTP1lQKiui8YgpTN+XpHd8fzBVFuY8ib4KtHIIlLf4FJzzIrDOBH+RJZkATjb7dkmDh9zXS6VRvUj6YrsaYNGhsn7YqIRgJJJVrwdKvhKIjB1w4SwWDv1B5aLE/wv6CcPAQgyL0hUYwLCEkmGNdHv6s3ja67T6W/VA1xMoQS6MB4w+T0BncpPQevggRwn8Eg1++OwJRm4bHu/vOXAo8XNKRs6hj6ODuunJFGa80n6ercePHy63fV53jP4raiq6SaJiDFvz6HwWWnFNsj75KQ0sGcIYo0wrhd4gTPHUDpV2Nf0Yp9v6iKZAOrmEIu2p6Wf+E7CD1CGtqP38c+d96P2sZbHEdx0S3o1Mkxn8Jp0kMGL4S5RNt7wzNj5yWXAB30lufc88Q+K+kYIzMrb+mBOojOwGntYbahqXTKwIsYsZ79KyVa66nATgIbkIHJnZnmXcMWFz88VvaHjoFxWBx5uMsr9Fu0TkQPlenT6ISnt3ihYu8KzPh7Tx10sqLeA5gB0ksu3nFhafJevLXMK01BdQP8R2+mVVwqL+0339MbKi6zDy5IbVuxJ9hRSNDSbgPXkd7mhhWy+Sdb2crD1MNkYP5EB12oYzBBPA7w74mSarlAOZ0RRR36jmtc92JYudeTLx+H6cjZB/GMV31jDRgB\"}
-        \        }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0}\n\nevent:
-        content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}
-        \   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"3\"}}\n\nevent:
-        content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1   }\n\nevent:
-        message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":67,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":1075}}\n\nevent:
-        message_stop\ndata: {\"type\":\"message_stop\"  }\n\n"
+        each\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        divis\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"or
+        shows\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        \"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"379
+        isn\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'t
+        divis\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"ible
+        by any of them\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
+        so it\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"'s
+        prime.\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        The complete\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        list of primes below 400 \"}             }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"containing
+        \\\"79\\\" is \"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79,
+        179, and 379\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2014\"}
+        \          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"three\"}
+        \             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
+        primes total\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".\"}
+        \   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"EqkWCkYICxgCKkBuWdt7SdfI8uwoJvhs2f68KkkOA4AtTJ7ViBxheVddrggCCdyC0LlChpQ4BXiSdyGg8jxxEjJgxgwCkAXMYxrREgxHXAegE5Z04zRcHKkaDBj3VZKkEvTVGfTg3yIwzoGFcs/Osj2u+/Z2hQeRRcUZfOxtsp8cWGHWjQTuCECDrLllUnKyGZVnT4h5rpCDKpAVLH7veqI/2y9FKTNcjVoVrThr4SsX8Cd3DJy5DodBA1QAiiMrM0bZ9wDBxT287c5ClHPsWD3oW2TB4YG7w0D6xTe2FFOLxlz4j0Sgr6Ne9FFYYFvzaMedz2kKBwcVjataXu5P1i8d4c/o72pMxkHZjZL1rExeQ7owHPvw8/y7a6VKiZaRykVcEjijHv2iku27uVs1O1T5Hmq4sjvtmoXUh0Lg3sdsPjzUk837lWg9f+XIPsEzg5tI9NWCUH3BiUhVqBEc2rA3c61gwwIW+EAE1ElF/Zayq1CsHWT57Ln+M6f2slNlIHfAyI+oQSBf6xVcEMn8Mf+T6SdAJHg7JotKdv8VJWPDvzAknjjLW8wOlFQAuXZgCLztQAcOm4HxYjeID2vUDyraL0UH9HKPW6iE8vaioUx5AjDavDJ7Pl8pUUZ92fAsFfx3AEWjMxdKEuub9dhpYUwYEZ102+XHFPKD8GfQkMovoaixGB3vLB17qFulp+iASh3bxqsS/apaWKckhvAOsz8e2TdVZ2EwmP9b9gQTpi6jx/kxY4W835B+53zRykAasDi1Cy3Xc2EtVlyZd/mLAKS+yABI9usxr9sAWmUagjocNrfyX4VdK0ZqCs6kes0BhnkyzCqCnRZxjBa8fnTijHCxc91XqKHuNkKAnQT1HV+NVGTRcV0avNnc86kTkpS3J0znFIc43HLd18MrAv3g3eaQZaMvxIe/m7bghhGr/XT8DTZ7ykPBoq4r9Bc4UUTqT3xfk2J/mCbjlxRNg/ipne+DSpp+0xgK9GF9uE2USNf9hOIWzAYYRNUxoVww88T5Mh3uk0T5//dboWLSmhUScFfx1QhjgjOBWCSVhsBeyEZaKlnFXOotTM4GSHE598XSZB7BMCq2HXYllbFMcVKEo9d4wueujXDkH8+oNJZtLUmggQOkzdpy7TXDbYrMZqEPO7/tFMmLU7iszLoP9E5TTI0Dmx3OB7DuRG1bFkXS1aoTkH8oADqncI09e1X4zmIKlKsBWQpdCkWiTnV09wC1CyHkX3km426dTNCehB1TNqefgN5rEwI8draC7aGaiE/0kzUevuLGlNnZ2TXSfLHGR+WvMZH16/Ojgzp9egX16KNaSdkYnv9gaUKtWuNAwDM277Ir23VQt+MfeHiuQazbuIlVGKM8RgC4tNsGuasZX4z7ru9psNcbqyrw33Tec7ox98vvupGqaqG2XSqzW+0jdPl1E0nLKSPcKzOYkXuHuba3MX+/IuRwaF6c/JdOlkkJOzWM7t6a8evr8KLgkm8HQtRfGD5lLNaQPwjkN7GNL/DeUPiRejwlW2Tq+y+7v6dtk+e2BbfRYowcNIdxapb2c/a9sL4W6W6RmtDkQv+dORUkyg+mvnEs+AM9F1q90Ef0qkJ7Q3/Q1oGCtaDuNJfUG4R/QNOaJaic2B7A+N/vBxCAQibgIaW4FVZE3329fiRqdcUqAe9GkOf85Tlizu7wlcyIxyW5uN5zx4jzJTypZ0V5iX+O8KAPGprtXIPvpUs4uyrFEzpek+3N/C7IOEJ524gJQZ9xPCQGZIQzPzKhWiThh+C07xR/rQ7yh99TCrJsLKRv7K4r3Cj4x5VdHF/P9moWfWEbbrldER3Td21u4rRbr8mX1pdv1JPZafJVEB6RguQzCbeRXKxnst6QuwCxzfDcC3Ht/PjJUAH3zlfr/fR9Y/suI1SeQq5zYPPF7vwcTIx9gNNp83G6RcBqNoB3WfsPhsWlRsc/+YXzUu1LD20Zz0vT12wc7wKWW1+GtmyHRWiUYGqEfOPXsUJMFhUpfvgHvifXBX7lqX9UilWoEGGomCSQPMD9XiCFBEUXMtAsiYe/hOoqKy2+8IB8lh9gmlfmJIomT+nxXan617SdsHfz4i/MOvkzwcrNVINdJqtvBVdAFcbtBXDkHMwwWy1eGznq+e5AY0VU09NAUUvHi64o8WUNILbzdw/fjT596gRZF8qMsjdggNMAv3jDXk0P685h5NIsVFwfYNgJEFCcQGxW7rvNgmQP8790GTr4C3qiOO3nWXzWlsltQXUh+cOYtCyPctv6xu6a1pbzXULochEunfXxSzjixB28FVpjYEhN0bV0MWIrYaFYPwvvq4IdaseYNfj9YEXwYgjaK20sYbT/QtaCOekcuxm43tXfz3iIsmsxb9gRJ1qqSlorljfG6BP3uriuQ0e2rO1HyD9NcscRyHHSoRqoaNGOMpha2Z6Zj7xC+lw243fDgNAMDlRH1S/TDUKHkV0motbmHw4UPJMDRffBpCf1bJUV0iJL2MPTRwfr3jQE3twzmzmwhI0zf68cLQrTeWE2cgbjFdsZUI6rJ3CO2Jj1G+vQp0szh6DZLozAcqH99pZMJYXXgmGtkj+AIeTs4ecDefZOBeSAOsojEuhzpzSgmrFVOI3Nql7QuCD6OXw/RI5o/V71PCQYSnTW/jU4vOq3zC1HXPj4LGT8iv4Wse6+usXOd1J2aiDakLBblFcXr3hqL3F0vDTaTZjc2S4qA4w358nBuXcK+bU4wtwP4nwGhLkItMAhIonVvuTzTtrDHuAO9KT2ZQFjnvWOnnbjHjVLWOEYRGV9TXTn/zuGqBv5X3SrlIjE+m6gLG3BgE8AuFd9DeBGkMMMambbi0s5dJ37Nda+F7PjA0ahfWLHV4Gn1So+++QjFv8o2qdpDVM/xA0Lw1lAyadGm6d8Wv2QdoB6CvOexwYqt/Icj52JsdFCha+M9vAdYKvfkl68x9sfMCq5SnlkgekXfCXakciLjiAlApBac/fXsPu8Z8k1X187qu2frgvb3bLb0gE+a1uwPOhGZvOFYAEFx2zxecHZOmQFQn6JXz2d235wBQ75ly20kWxR4EDdMwZqwSQuxDsqU/Hftt1Fu36y9QwzmjOev997hoHrjCFHgiEkvDuzPFRrCCfJL3J+PUdsdQrnJ2sqaeSL8B//5JHUAKGXaszJ3CxC+KnUT25yNUt3Uj/dbojzvDS7x/zS1mIFI6sv1HaecWNp4Kljm+LSHgbhOsEXv/eu53XmHUITmEBo9aIAMmX6/Y42oXR0tkcdpqRWjSZXLFeOi1o0iZPyOH7QRsiSLtjofR7WPMc+8hWAQm9xorTU8V2uHKoKV/J9HgalgEC7hB1LBNfMpPEPvHe+7KiJsa8vRBB+oZCUPbObbomRpZwmGmvjaz9nAhklEwcxyGXLecCGsqYIatI+tgf+VbIiJ8xHjwDX+Z6eBUtZ5VW0Fuekrz+4xMS/j8xg9SSS6J7y8QtzsfWFyPwZGGCi5YYB+VterfqdsaAmP1d3dM0lbjbZEbwJe+3g4ZJdo6ufQu0HWkK9Xyhe/ktJCE9bWbqUQck1iPErHY4JuIQ+i00wnnoXunG6+J8koFbWu8QDqqQvHQ2oqfqLxzdfG+t5/wIcL3wX/xW3nXyKBywXUu8JMb27DebEIEYnyANmpqsZL2aUEntYnl+Qz8ySr7NewlUsGBOx9QhupLspg42pzHHCSsy3JPPZ8r3JkAk0EHUw/eltjm7HKd8mz3fEawWaICIRD9Ft9jkLcFgp8EG0QAgpMjNKrc1ERHYQsRcOqIbpNYwbSRpjr8hf+WPRQnD8VRY/fnSWL3KQgxgB\"}
+        \         }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0
+        \             }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}
+        \           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"Looking\"}}\n\nevent:
+        content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        at numbers\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        below 400 that contain \\\"79\"}       }\n\nevent: content_block_delta\ndata:
+        {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\\"
+        as a substring:\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\n-\"}
+        \            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        Two\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"-digit:\"}
+        \     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        79\\n- Three-digit:\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        179, 279, 379\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n\\nChecking
+        which are prime:\\n- \"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"79:\"}
+        \            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        Prime\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n-
+        179: Prime  \\n-\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        279: Not\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
+        prime (divisible by 3)\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"\\n-
+        379: Prime\\n\\n3\"}    }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1
+        \              }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":67,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":1300}
+        \             }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"          }\n\n"
     headers:
       CF-RAY:
-      - 9baffc168d7d30ad-SEA
+      - 9beae72aa8231ef1-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -257,7 +311,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 09 Jan 2026 00:58:11 GMT
+      - Fri, 16 Jan 2026 04:34:53 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -271,33 +325,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2026-01-09T00:58:10Z'
+      - '2026-01-16T04:34:53Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2026-01-09T00:58:10Z'
+      - '2026-01-16T04:34:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2026-01-09T00:58:10Z'
+      - '2026-01-16T04:34:53Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2026-01-09T00:58:10Z'
+      - '2026-01-16T04:34:53Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CWvtxm6g5XKWztccxTr8N
+      - req_011CXAS9fr8DR1TnceL3Mo28
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '709'
+      - '591'
     status:
       code: 200
       message: OK
@@ -305,31 +359,37 @@ interactions:
     body: "{\"max_tokens\":16000,\"messages\":[{\"role\":\"user\",\"content\":\"How
       many primes below 400 contain 79 as a substring? Answer ONLY with the number,
       not sharing which primes they are.\"},{\"role\":\"assistant\",\"content\":[{\"type\":\"thinking\",\"thinking\":\"I
-      need to find all primes below 400 that contain \\\"79\\\" as a substring.\\n\\nLet
-      me think about what numbers below 400 contain \\\"79\\\" as a substring:\\n-
-      Numbers starting with 79: 790, 791, 792, ... (these are all \u2265 790, so above
-      400)\\n- Numbers ending with 79: 79, 179, 279, 379\\n- Numbers with 79 in the
-      middle: This would be numbers like X79Y where X and Y are digits, but for numbers
-      below 400, this would mean numbers like 1790, 2790, 3790, etc., which are all
-      above 400.\\n\\nSo the candidates are: 79, 179, 279, 379\\n\\nNow I need to
-      check which of these are prime:\\n\\n79: Let me check if 79 is prime.\\n- Not
-      divisible by 2 (it's odd)\\n- Not divisible by 3 (7+9=16, not divisible by 3)\\n-
-      Not divisible by 5 (doesn't end in 0 or 5)\\n- Not divisible by 7 (79 \xF7 7
-      = 11.28...)\\n- Need to check up to \u221A79 \u2248 8.9, so I need to check
-      2, 3, 5, 7\\n- 79 \xF7 7 = 11 remainder 2, so not divisible by 7\\n- Since \u221A79
-      < 9, I only need to check primes up to 8, which are 2, 3, 5, 7\\n- 79 is prime\\n\\n179:
-      Let me check if 179 is prime.\\n- Not divisible by 2 (it's odd)\\n- Not divisible
-      by 3 (1+7+9=17, not divisible by 3)\\n- Not divisible by 5 (doesn't end in 0
-      or 5)\\n\\n\\n- Since \u221A179 \u2248 13.4, I need to check primes up to 13:
-      7, 11, and 13. Testing these: 179 \xF7 7 = 25 remainder 4, 179 \xF7 11 = 16
-      remainder 3, and 179 \xF7 13 = 13 remainder 10. None divide evenly, so 179 is
-      prime.\\n\\nFor 279, the digit sum is 2+7+9=18, which is divisible by 3, so
-      279 = 3 \xD7 93 and isn't prime. Moving to 379: it's odd, the digit sum 19 isn't
-      divisible by 3, it doesn't end in 0 or 5, and testing 7 gives 379 \xF7 7 = 54.14...
-      I need to continue checking divisibility by primes up to \u221A379 \u2248 19.5.
-      19 = 19 remainder 18. Since 379 isn't divisible by any prime up to its square
-      root, it's prime.\\n\\nThe primes under 400 containing \\\"79\\\" are 79, 179,
-      and 379\u2014three total.\",\"signature\":\"EpETCkYICxgCKkBJVu+z+gbsCY7wfmvTdEQwUQU82ei3LoS84bynmxgp9ooZbDoBjybEUWCZX7nKHt9b9nTPjO8HwZQqg5veTQpfEgyozj9DbOHbjUXXAY4aDESzj1n7Sn9LonwcOCIwmbMBD7QxlJ86WZ1inOkJUc/8kp8Eu580jqp2Ml4UAuL3afvI8mxLGUfE8eKT80/NKvgRiDLqydWxob21Yg2jIWCiE6sAJmfN/gQdbdtbicKl0365PF8nJF7/Wshh9N9DIW6BBSv5kYgepFe2xiPs7l8rNmPObytIgU+1EyOUTALaGIB2twERDteQDs6+KL9hR/6Ql6SCNrbXg6s07WTSqwWj/oIngzPVMmxT7Ewa4HSMN0eQ+WIYAcsllRI/7iNW+LFhC59ES3guP312OicOkgQIHcSGqUPJeyMpZ+SX63LCETVYVta8YMRo/VAyaoDZPj4DJ/FcpMIw5U/jYDJ7x6vgMru0JCOBAoe+f32hRIMP5NIyVBHfmtMnoc9vJlDy5rcAFyH74F3e5kSeuXBv6ynxTjfiE1yGQwecmNLMoO+Culvvfo1ivLGziYuoJrE/6VVp7CWDSpogw5aDr9kYysIipkvYnEn11muidpgMoDkAZq0BCsb3ILqiJNEN52BEwom4KjCNZyxQcwNHyAdWPV1AczK9R8nfL9bhoHofQJx0mwNjA2VAPfXnP78kFavFBfIiTibafHzvv7fIy9cxLmiKm5ei8jN0kchrsEDqpdSrfoAzYliozOgtcOAcRGRMrCAdPvj5X7AaIdDgx/hqgAj/w0aqMbgPgzUHtFBdEsKESj5jnqLkuXwhOPpWBeA8B3/koW5l0mzlLr5pb4E4Ae4thhCT6xBS9taDGJo0m5JkIDlbXhSpNexPqKfraX0FvSoW8PXXkgL6+PQpllluLoBwhb3PqiIvLsjd9s1tXTjcwrNqERycB+olEYUjDJUhUZyccdRJ8UBWpQHfPR/u8WV3FaJg/M9KzuTjhI5btNS5l+BTeonkY1nIjVb/Seijj/etk1lAhROiGV5k0HsNbaDtbvKUW9CRLGlktcskw/D/Qh16xoTUlapPYcvQROvryfprDV27su4uqSQ+frowsuVAM0OkhmHLerrlj7TrS0pvk1+AqK2Izyou1dp1+z6LqIO9fqzZxUxeSzM3A5nI4Yym5mQj6aeoXpVaMkZz3A7X2ORS074oxpa8JNaNRG/dai7MbdwncFmt6PSXzE+nQH9Tw+jfUJ3VPQieQet5y6V2evj6vEFTW4QcGEkT1YgJXadva5sUu3+gB761WXrk4KDkUmOSiiNIuE9uikPAXHPPK2SWGEPHS6TgQdfnoJ7+QRsoY5DaPrB6EmLus21ifBAMWRbSrPQCYEFZnwAxR5VrUqatEIjCO4p/ThJUBzfzQahqVeRnitpjEkqEyl8mAnfYUWgRWlruwtWQ0vK6mLCdivXrTTT4PztdcSifv3gMtiqzmcZ0FxupslVZD3RfrCM4knK1ozkN4wlNMyzUrLP/fBi/jXuChygju3NEzhEuBlyI1LJ0NFNLsh3Y/9Pj5DK1hR6GH5w+TJy2AmuxdKQytTkOcpbiZvb+CuPZhNsuX7Pmc9OxApcRhSCLipeXdGO3l57farrQpthgOhBz7Gf5TEzVL0lEI8Gf2jbUBj/8v22SLbcQcEID3alogtPQgl7IoOJwcKzqfZQkCigCc7K6wJE0jY/NFfQ9C//BvzQkb8oJqm7edF7mMCRanUhWcWNUfpLJPERUVpt+NDwfuNTYsgJveZqs/AM1uyFO74TlNucALAYN/fSm662+41MuzfyOQM2d1AXnz854+9yU3aH5ftc7rhZ8nBjySKwxIDTpO5j/KMfql2jtbDZDnbcQOn81gggez0ccAKMJQUJ7t1ajfLcQPyI/mtJGSiUofuVSA1CdMyrncj0kmCLEJprP73A9HDvLzRG9KSXvDtLkdsH3KAlJ6W4GIA+BWf2IuhQZsmuwwNNEose6zH3G7D242D6zreQICZqtPC+MCnZGr537Zo7QWBqVhxgX2aBlhGrYvAgFvVqBWoWBPng4hrghS2WKyQeBDhNKGodO4jQwHS4RlD31AmObPMn/hF9YXF8lCHl5SpkURYk5awG3JtIHMt//+tLLhjYJNJcdoCGfKL9vn4DSY4MLl88IplJdSX4e64usOW1fNDvs+0awaImZKAiGd3vhOc3bcVL/JCxi1iy13hBB21dk+W5UI49bsOOXk9rCGSjVqd1cM+oUfaZIKCf1vGAY3COsoQcEiYnVdG4PpYzGlxR6buI/luiltnrk9iHLjXE4C6wuESBt7wpZDKq+78QOH2Z5ZRSTZHZn+1CLLBb2Zc2CxMUvbh2SV2gfpiRMeAiuWHbMpIduy6nN0W9zXwV4AAeenwvY0GlpN0d3pnNwHJVwqySg1FOqFX2hwdVMtLWBegP9TSFC2W9+KiLyDEaLxpf70CZ+W3YDGyCQaDecBD4xMzj8HTTWJBZ0lRmFWUYS8lse+o9F9La1LI6F9iJkTJWiBRxKmU34dIkXR1/SYu9YADJeqBagdeOWG35aXdXbZ1I8zZ+doNzU6GKntTqh4e+4V8Hj0abkdTP1lQKiui8YgpTN+XpHd8fzBVFuY8ib4KtHIIlLf4FJzzIrDOBH+RJZkATjb7dkmDh9zXS6VRvUj6YrsaYNGhsn7YqIRgJJJVrwdKvhKIjB1w4SwWDv1B5aLE/wv6CcPAQgyL0hUYwLCEkmGNdHv6s3ja67T6W/VA1xMoQS6MB4w+T0BncpPQevggRwn8Eg1++OwJRm4bHu/vOXAo8XNKRs6hj6ODuunJFGa80n6ercePHy63fV53jP4raiq6SaJiDFvz6HwWWnFNsj75KQ0sGcIYo0wrhd4gTPHUDpV2Nf0Yp9v6iKZAOrmEIu2p6Wf+E7CD1CGtqP38c+d96P2sZbHEdx0S3o1Mkxn8Jp0kMGL4S5RNt7wzNj5yWXAB30lufc88Q+K+kYIzMrb+mBOojOwGntYbahqXTKwIsYsZ79KyVa66nATgIbkIHJnZnmXcMWFz88VvaHjoFxWBx5uMsr9Fu0TkQPlenT6ISnt3ihYu8KzPh7Tx10sqLeA5gB0ksu3nFhafJevLXMK01BdQP8R2+mVVwqL+0339MbKi6zDy5IbVuxJ9hRSNDSbgPXkd7mhhWy+Sdb2crD1MNkYP5EB12oYzBBPA7w74mSarlAOZ0RRR36jmtc92JYudeTLx+H6cjZB/GMV31jDRgB\"},{\"type\":\"text\",\"text\":\"3\"}]},{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"If
+      need to find all primes below 400 that contain \\\"79\\\" as a substring.\\n\\nFirst,
+      let me think about what numbers below 400 could contain \\\"79\\\" as a substring:\\n-
+      Numbers of the form 79X (where X is a digit): 790, 791, 792, 793, 794, 795,
+      796, 797, 798, 799\\n- Numbers of the form X79 (where X is a digit): 179, 279,
+      379\\n- Numbers of the form X79Y (where X and Y are digits): This would give
+      us numbers with at least 4 digits, starting from 1790, which is above 400.\\n\\nSo
+      I need to check:\\n- 79 itself\\n- 179, 279, 379\\n- 790, 791, 792, 793, 794,
+      795, 796, 797, 798, 799\\n\\nWait, let me be more systematic. Numbers below
+      400 that contain \\\"79\\\" as a substring:\\n\\nTwo-digit: 79\\nThree-digit:
+      179, 279, 379, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799\\n\\nBut wait,
+      we're looking at numbers below 400, so 790-799 are all above 400. Let me reconsider.\\n\\nActually,
+      let me list all possibilities more carefully:\\n- 79 (two digits)\\n- X79 where
+      X = 1, 2, 3: so 179, 279, 379 (three digits, all below 400)\\n- 79X where X
+      = 0,1,2,3,4,5,6,7,8,9: so 790,791,792,793,794,795,796,797,798,799 (three digits,
+      but these are all \u2265 790 > 400)\\n\\nSo the candidates are: 79, 179, 279,
+      379\\n\\n\\nNow I'll test each for primality. For 79, I check divisibility by
+      primes up to \u221A79 \u2248 8.9 (so 2, 3, 5, 7): it's odd, digit sum is 16
+      (not divisible by 3), doesn't end in 0 or 5, and 79 \xF7 7 \u2248 11.3. So 79
+      is prime. For 179, I need to check divisibility by primes up to \u221A179 \u2248
+      13.4, which includes 2, 3, 5, 7, 11, 13.\\n\\n179 is odd, has digit sum 17 (not
+      divisible by 3), doesn't end in 0 or 5, and testing 7, 11, and 13 all give non-integer
+      results. So 179 is also prime. Now checking 279: the digit sum is 18, which
+      is divisible by 3, so 279 = 3 \xD7 93 = 9 \xD7 31, making it composite. For
+      379, I need to test primes up to about 19.5. It's odd, the digit sum is 19 (not
+      divisible by 3), and it doesn't end in 0 or 5, so I'll continue checking 7,
+      11, 13, 17, and 19.\\n\\nTesting each divisor shows 379 isn't divisible by any
+      of them, so it's prime. The complete list of primes below 400 containing \\\"79\\\"
+      is 79, 179, and 379\u2014three primes total.\",\"signature\":\"EqkWCkYICxgCKkBuWdt7SdfI8uwoJvhs2f68KkkOA4AtTJ7ViBxheVddrggCCdyC0LlChpQ4BXiSdyGg8jxxEjJgxgwCkAXMYxrREgxHXAegE5Z04zRcHKkaDBj3VZKkEvTVGfTg3yIwzoGFcs/Osj2u+/Z2hQeRRcUZfOxtsp8cWGHWjQTuCECDrLllUnKyGZVnT4h5rpCDKpAVLH7veqI/2y9FKTNcjVoVrThr4SsX8Cd3DJy5DodBA1QAiiMrM0bZ9wDBxT287c5ClHPsWD3oW2TB4YG7w0D6xTe2FFOLxlz4j0Sgr6Ne9FFYYFvzaMedz2kKBwcVjataXu5P1i8d4c/o72pMxkHZjZL1rExeQ7owHPvw8/y7a6VKiZaRykVcEjijHv2iku27uVs1O1T5Hmq4sjvtmoXUh0Lg3sdsPjzUk837lWg9f+XIPsEzg5tI9NWCUH3BiUhVqBEc2rA3c61gwwIW+EAE1ElF/Zayq1CsHWT57Ln+M6f2slNlIHfAyI+oQSBf6xVcEMn8Mf+T6SdAJHg7JotKdv8VJWPDvzAknjjLW8wOlFQAuXZgCLztQAcOm4HxYjeID2vUDyraL0UH9HKPW6iE8vaioUx5AjDavDJ7Pl8pUUZ92fAsFfx3AEWjMxdKEuub9dhpYUwYEZ102+XHFPKD8GfQkMovoaixGB3vLB17qFulp+iASh3bxqsS/apaWKckhvAOsz8e2TdVZ2EwmP9b9gQTpi6jx/kxY4W835B+53zRykAasDi1Cy3Xc2EtVlyZd/mLAKS+yABI9usxr9sAWmUagjocNrfyX4VdK0ZqCs6kes0BhnkyzCqCnRZxjBa8fnTijHCxc91XqKHuNkKAnQT1HV+NVGTRcV0avNnc86kTkpS3J0znFIc43HLd18MrAv3g3eaQZaMvxIe/m7bghhGr/XT8DTZ7ykPBoq4r9Bc4UUTqT3xfk2J/mCbjlxRNg/ipne+DSpp+0xgK9GF9uE2USNf9hOIWzAYYRNUxoVww88T5Mh3uk0T5//dboWLSmhUScFfx1QhjgjOBWCSVhsBeyEZaKlnFXOotTM4GSHE598XSZB7BMCq2HXYllbFMcVKEo9d4wueujXDkH8+oNJZtLUmggQOkzdpy7TXDbYrMZqEPO7/tFMmLU7iszLoP9E5TTI0Dmx3OB7DuRG1bFkXS1aoTkH8oADqncI09e1X4zmIKlKsBWQpdCkWiTnV09wC1CyHkX3km426dTNCehB1TNqefgN5rEwI8draC7aGaiE/0kzUevuLGlNnZ2TXSfLHGR+WvMZH16/Ojgzp9egX16KNaSdkYnv9gaUKtWuNAwDM277Ir23VQt+MfeHiuQazbuIlVGKM8RgC4tNsGuasZX4z7ru9psNcbqyrw33Tec7ox98vvupGqaqG2XSqzW+0jdPl1E0nLKSPcKzOYkXuHuba3MX+/IuRwaF6c/JdOlkkJOzWM7t6a8evr8KLgkm8HQtRfGD5lLNaQPwjkN7GNL/DeUPiRejwlW2Tq+y+7v6dtk+e2BbfRYowcNIdxapb2c/a9sL4W6W6RmtDkQv+dORUkyg+mvnEs+AM9F1q90Ef0qkJ7Q3/Q1oGCtaDuNJfUG4R/QNOaJaic2B7A+N/vBxCAQibgIaW4FVZE3329fiRqdcUqAe9GkOf85Tlizu7wlcyIxyW5uN5zx4jzJTypZ0V5iX+O8KAPGprtXIPvpUs4uyrFEzpek+3N/C7IOEJ524gJQZ9xPCQGZIQzPzKhWiThh+C07xR/rQ7yh99TCrJsLKRv7K4r3Cj4x5VdHF/P9moWfWEbbrldER3Td21u4rRbr8mX1pdv1JPZafJVEB6RguQzCbeRXKxnst6QuwCxzfDcC3Ht/PjJUAH3zlfr/fR9Y/suI1SeQq5zYPPF7vwcTIx9gNNp83G6RcBqNoB3WfsPhsWlRsc/+YXzUu1LD20Zz0vT12wc7wKWW1+GtmyHRWiUYGqEfOPXsUJMFhUpfvgHvifXBX7lqX9UilWoEGGomCSQPMD9XiCFBEUXMtAsiYe/hOoqKy2+8IB8lh9gmlfmJIomT+nxXan617SdsHfz4i/MOvkzwcrNVINdJqtvBVdAFcbtBXDkHMwwWy1eGznq+e5AY0VU09NAUUvHi64o8WUNILbzdw/fjT596gRZF8qMsjdggNMAv3jDXk0P685h5NIsVFwfYNgJEFCcQGxW7rvNgmQP8790GTr4C3qiOO3nWXzWlsltQXUh+cOYtCyPctv6xu6a1pbzXULochEunfXxSzjixB28FVpjYEhN0bV0MWIrYaFYPwvvq4IdaseYNfj9YEXwYgjaK20sYbT/QtaCOekcuxm43tXfz3iIsmsxb9gRJ1qqSlorljfG6BP3uriuQ0e2rO1HyD9NcscRyHHSoRqoaNGOMpha2Z6Zj7xC+lw243fDgNAMDlRH1S/TDUKHkV0motbmHw4UPJMDRffBpCf1bJUV0iJL2MPTRwfr3jQE3twzmzmwhI0zf68cLQrTeWE2cgbjFdsZUI6rJ3CO2Jj1G+vQp0szh6DZLozAcqH99pZMJYXXgmGtkj+AIeTs4ecDefZOBeSAOsojEuhzpzSgmrFVOI3Nql7QuCD6OXw/RI5o/V71PCQYSnTW/jU4vOq3zC1HXPj4LGT8iv4Wse6+usXOd1J2aiDakLBblFcXr3hqL3F0vDTaTZjc2S4qA4w358nBuXcK+bU4wtwP4nwGhLkItMAhIonVvuTzTtrDHuAO9KT2ZQFjnvWOnnbjHjVLWOEYRGV9TXTn/zuGqBv5X3SrlIjE+m6gLG3BgE8AuFd9DeBGkMMMambbi0s5dJ37Nda+F7PjA0ahfWLHV4Gn1So+++QjFv8o2qdpDVM/xA0Lw1lAyadGm6d8Wv2QdoB6CvOexwYqt/Icj52JsdFCha+M9vAdYKvfkl68x9sfMCq5SnlkgekXfCXakciLjiAlApBac/fXsPu8Z8k1X187qu2frgvb3bLb0gE+a1uwPOhGZvOFYAEFx2zxecHZOmQFQn6JXz2d235wBQ75ly20kWxR4EDdMwZqwSQuxDsqU/Hftt1Fu36y9QwzmjOev997hoHrjCFHgiEkvDuzPFRrCCfJL3J+PUdsdQrnJ2sqaeSL8B//5JHUAKGXaszJ3CxC+KnUT25yNUt3Uj/dbojzvDS7x/zS1mIFI6sv1HaecWNp4Kljm+LSHgbhOsEXv/eu53XmHUITmEBo9aIAMmX6/Y42oXR0tkcdpqRWjSZXLFeOi1o0iZPyOH7QRsiSLtjofR7WPMc+8hWAQm9xorTU8V2uHKoKV/J9HgalgEC7hB1LBNfMpPEPvHe+7KiJsa8vRBB+oZCUPbObbomRpZwmGmvjaz9nAhklEwcxyGXLecCGsqYIatI+tgf+VbIiJ8xHjwDX+Z6eBUtZ5VW0Fuekrz+4xMS/j8xg9SSS6J7y8QtzsfWFyPwZGGCi5YYB+VterfqdsaAmP1d3dM0lbjbZEbwJe+3g4ZJdo6ufQu0HWkK9Xyhe/ktJCE9bWbqUQck1iPErHY4JuIQ+i00wnnoXunG6+J8koFbWu8QDqqQvHQ2oqfqLxzdfG+t5/wIcL3wX/xW3nXyKBywXUu8JMb27DebEIEYnyANmpqsZL2aUEntYnl+Qz8ySr7NewlUsGBOx9QhupLspg42pzHHCSsy3JPPZ8r3JkAk0EHUw/eltjm7HKd8mz3fEawWaICIRD9Ft9jkLcFgp8EG0QAgpMjNKrc1ERHYQsRcOqIbpNYwbSRpjr8hf+WPRQnD8VRY/fnSWL3KQgxgB\"},{\"type\":\"text\",\"text\":\"Looking
+      at numbers below 400 that contain \\\"79\\\" as a substring:\\n\\n- Two-digit:
+      79\\n- Three-digit: 179, 279, 379\\n\\nChecking which are prime:\\n- 79: Prime\\n-
+      179: Prime  \\n- 279: Not prime (divisible by 3)\\n- 379: Prime\\n\\n3\"}]},{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"If
       you remember what the primes were, then share them, or say 'I don't remember.'\",\"cache_control\":{\"type\":\"ephemeral\"}}]}],\"model\":\"claude-sonnet-4-0\",\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},\"stream\":true}"
     headers:
       accept:
@@ -343,13 +403,13 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '5677'
+      - '6729'
       content-type:
       - application/json
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
       x-api-key:
       - <filtered>
       x-stainless-arch:
@@ -363,7 +423,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -377,144 +437,201 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
-      string: "event: message_start\ndata: {\"type\":\"message_start\",\"message\":{\"model\":\"claude-sonnet-4-20250514\",\"id\":\"msg_01WxBK8DBQyzRWdxjsPfeq3L\",\"type\":\"message\",\"role\":\"assistant\",\"content\":[],\"stop_reason\":null,\"stop_sequence\":null,\"usage\":{\"input_tokens\":97,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"cache_creation\":{\"ephemeral_5m_input_tokens\":0,\"ephemeral_1h_input_tokens\":0},\"output_tokens\":1,\"service_tier\":\"standard\"}}
-        \              }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":0,\"content_block\":{\"type\":\"thinking\",\"thinking\":\"\",\"signature\":\"\"}
-        \       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Let\"}
-        \             }\n\nevent: ping\ndata: {\"type\": \"ping\"}\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me think about pr\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"imes
-        below\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        400 that\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        contain \\\"\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79\\\"
-        as a substring.\\n\\nNumbers\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        containing\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \\\"79\\\" as a substring below\"}         }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        400 \"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"woul\"}
-        \  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        be:\\n79\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        179\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        279\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        379, 790\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        791\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        792\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        793, 794, \"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"795,
-        796, 797,\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        798, 799\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nBut\"}
-        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        we\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        need those\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        below\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        400, so:\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n79,
-        179, 279\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        379\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nNow\"}
-        \     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        I need to check which of these are\"}               }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        prime:\\n- 79: Let\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me check if this\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        is prime. 79 is not\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        divisible by 2, 3\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        5, 7...\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \u221A\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"79
-        \u2248 8\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".9,
-        so I need to check\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        up\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        to 8. 79 \"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\xF7
-        7 = \"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"11.28\"}
-        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"...,
-        not\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        divisible.\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        79 is\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        prime.\\n- 179: Let\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me check.\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \u221A\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"179
-        \u2248 13\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".4,
-        so I need to check\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        divis\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"ibility
-        up\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        to 13. 179 is\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        odd, not\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        divisible by 3\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        \"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"(\"}
-        \         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"1\"}
-        \  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"+7+9=\"}
-        \           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"17,
-        not divisible by 3\"}               }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"),
-        not divisible by 5,\"}              }\n\nevent: content_block_delta\ndata:
-        {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        7, 11, 13\"}    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".
-        179 is\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        prime.\\n- 279: \"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"279
-        =\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        3 \xD7 93 =\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        3 \xD7 3 \xD7\"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        31 = 9 \xD7\"}               }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        31. So\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        279 is\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        not prime.\\n- 379:\"}      }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        Let\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me check. \u221A379 \"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\u2248
-        19.5\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        so check\"}          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        up\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        to 19. 379 is\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        odd, \"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"3\"}
-        \          }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"+7+9=\"}
-        \           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"19
-        \"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"(not
-        divisible by 3),\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        not ending\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        in 0 or 5,\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        let\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me check 7:\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        379 \xF7 \"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"7
-        = 54\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".14...,
-        \"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"11\"}}\n\nevent:
-        content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\":\"}
-        \    }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        379 \xF7 \"}            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"11
-        = 34\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\".45\"}
-        \       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"...,
-        13: 379 \"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\xF7
-        13 =\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        29.15\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"...,
-        \"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"17:
-        379 \xF7\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        17 = 22.\"}}\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"29\"}
-        \            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"...,
-        19: 379 \"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\xF7
-        19 =\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        19.95\"}       }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"...\"}
-        \        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        So\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        379 appears\"} }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        to be prime.\\n\"}         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"\\n\\nThat\"}
-        \             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        gives\"}           }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        me\"}     }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        three\"}              }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"
-        primes: 79, 179\"}             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\",
-        an\"}  }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"d
-        379.\"}        }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"signature_delta\",\"signature\":\"Et8JCkYICxgCKkBJolNiXJlrl/yam9XKnuT4CSSOHPH+L51mM8VaHgaDMbfKChR1aqr90RSOqkGYtaxTEYpcRQTrwZkHT66jNKWSEgxng1sCJVZkl4kdx1saDL12G0WfMTF+5qRu3SIwMdWnrtG8Ow0lGhwvDkO0fKwTo7G+9C0KTUAc6KeFYUOXvTWtMaEKMaEGNOIDqpCYKsYIr21zp7zG0uXhMlfkZWoVF+6OH0X6P6ZfT8Rfi3RmJhjcSs9xzZe9SfTzRK/FBBS+T1mugT0QLVXk9v111SjQ8QTfHD63YFxkWbtyBovggVOk7my2dCb6YmjZXy+QOsSEffJ8Cy5T7P+yAdw7ZD+y2r98IN5opfTT5NAnsVQx9j4O27Hbk8GaklmKfV2c8f08j2my+Zu/REvCMVREHNCUX3Or15yzDho2d93xF0nE3MqYN25gD2hvCcJVm5vn1JJJ5xQWVTGMoLEdiHcLVAp3zfEpSEc2O+cveCRRCkW3Uh8SX38A0p38sMe1InLQkySAlSmByWrnk2MD3qV5RKzna8ZpmsGtrcBHfLV+T1Dwk9zqOQIfdQvKZj1zaWqxPyuUrt8i/xq62mzOZbe2bFtX46zbAzpxchXu0CGFP0DyzzJZnBWYw6W/siH3tJKz7BOvRn5EGaU8zUd6gBjBNc9YFXBEWp13M2ZUXYOPlO6FiuJJUw/OY7qKcVZ9riE5k7osGE+b81DxAwOMH5O3ZYEwkIz4uer2cpDL3887i++TYMciWnggi2R2qEJqKLgqf4s+6TvfQw8tPgNeQnLxRWZj381EUnq1DHn1fk2g0ZESrGovNldB6mDlv3BMvXF6JzDL3C4emRWxpM3bVEwJVEqh5yvWABb/H6McnXopBvUrmb2uR7aAs1Jgqnlfj8JCTpc1vfUxi228NdNXuIiYRgvk0Jii9/roAx2hs2nsyP3VRFkRqzNwRUXrHKmEUuJo/7zFEkvI7qo1dPKg1C71GsLPO4WBsm7fZKFsU2Krin8F5yyHjHvuW1uRqUbbtxG8SQe2TrkJkJwHCbkO9F+IuBOkPnYKjUzwnSqINXYvBsKl/9wHJuV27ijD1mMwQFns453fJxIS5uBwQSZ4uL5RGyzMp09tobyQpjGqAgy5mPUfa7pt8lccCPkSpHoA/i/8pl7PJnMa5eXpz7jMrz0h6kdZecFQAez53pitQd0W2TiK+3x1tkQS+4F/Ea30mPFi/+6947pm5tGlYmkLjKNrnA+1G/uYk+727vhwhyhWwdxSuCx2QXPkCP0lDU0/gM6Wu75FAJBTGlkacatDyCRxpW8aF7UwdlFiBtjbhRPz2+dQE6cqVy06jtlK176VtK7+StW3F7No5mk9omENJ9YbhW0y1nZZE4XDhuvls2BRN84xyN+xBjUuv0MfHiXkfEcWhUAGynyPcC21P2Zf/x50IqWxcJl5Ur+yKa3P9ef/rC0AVyyipfKoPg6bRDguczQqXbrBu8XJSOfMrk3GxTdFsqCs+d9hn8st/69MF3HMJYmjBV4Rahmhh3l7epuujnrdKQi+QalyTFUUXrJn6tcqPeg6TSwK2QiO2kvunVgJrjHEthmb7/Cx/iLWJN507qKmb2i1zbW0sa+eFPOtAy8muLUJM8HoAPMHS+xWZ9V5wxlsQV+Vp4vUPxMYAQ==\"}
-        \  }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":0
-        \        }\n\nevent: content_block_start\ndata: {\"type\":\"content_block_start\",\"index\":1,\"content_block\":{\"type\":\"text\",\"text\":\"\"}
-        \             }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"The\"}
-        \         }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
-        primes were\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\":\"}
-        \            }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"
-        79, 179, an\"}   }\n\nevent: content_block_delta\ndata: {\"type\":\"content_block_delta\",\"index\":1,\"delta\":{\"type\":\"text_delta\",\"text\":\"d
-        379.\"} }\n\nevent: content_block_stop\ndata: {\"type\":\"content_block_stop\",\"index\":1
-        \        }\n\nevent: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\",\"stop_sequence\":null},\"usage\":{\"input_tokens\":97,\"cache_creation_input_tokens\":0,\"cache_read_input_tokens\":0,\"output_tokens\":547}
-        \              }\n\nevent: message_stop\ndata: {\"type\":\"message_stop\"
-        \          }\n\n"
+      string: 'event: message_start
+
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01AaaGLkuEyaBRudM44R1fdr","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":175,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":7,"service_tier":"standard"}}      }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}              }
+
+
+        event: ping
+
+        data: {"type": "ping"}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"The
+        user is asking me to recall"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        the primes I"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        foun"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"d
+        in"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        my"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        previous answer"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"."}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        In"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        my previous response, I identifie"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"d:"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n\n-"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        79:"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        Prime\n- 179: Prime  "}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"\n-
+        279: Not prime ("}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"divisible
+        by 3)\n-"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        379: Prime\n\nSo"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        the primes were"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"
+        "}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"79,
+        179, and 379"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"."}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"EocDCkYICxgCKkBIWx+iJ3joRsE9k8/w9+ly1FAVn9xQOGgK4Vc/NWUXfZd9BNkvjZt12CdEUVSs89YudVpEgswF742zGYMGJCQdEgwgPNowuP5m6owI99kaDGFwdJ6m1bINUg8cAyIwQjFFx6xn3sO36DarsopqwcUcwzOkQfiZfl9nRFc6Jf9d+OBn5lm/jkwMYgtAlmeXKu4BQ/Bse686VoHfGJamMXt6eDyP816RwiHkrJLHjRMxmIIVyRZ20YI3g4UibqBO3sMklyMKGyfU7F1b1s2/aXEdj09lWawYzoqWf4H/FBoIMJTsZemg+Rwd/Id3ZOcVAMZwwhw+oKAV2rIk0s2nlwMLQHPn3n2qSz5OxVhLMWV937YY5dDbTWwo3wO64tgpjoY70v+S7FvaNvPnRo73lK1PmqlWvMZulqzOfOojV4eSPVY2aZC+TTHrMRMUrKbgwz7AS3MqpSb8zMABiOs+LtzrX6s00meSVNA859UNrC119bdYhVj8+LqZBIZDAtTHvhgB"}      }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":0  }
+
+
+        event: content_block_start
+
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"The"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"
+        primes were"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"
+        79, 179, and "}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"379."}            }
+
+
+        event: content_block_stop
+
+        data: {"type":"content_block_stop","index":1     }
+
+
+        event: message_delta
+
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":175,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":99}          }
+
+
+        event: message_stop
+
+        data: {"type":"message_stop"   }
+
+
+        '
     headers:
       CF-RAY:
-      - 9baffc6edace30ad-SEA
+      - 9beae7897cff1ef1-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -522,7 +639,7 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Fri, 09 Jan 2026 00:58:25 GMT
+      - Fri, 16 Jan 2026 04:35:10 GMT
       Server:
       - cloudflare
       Transfer-Encoding:
@@ -536,33 +653,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2026-01-09T00:58:24Z'
+      - '2026-01-16T04:35:08Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2026-01-09T00:58:24Z'
+      - '2026-01-16T04:35:08Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2026-01-09T00:58:24Z'
+      - '2026-01-16T04:35:08Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2026-01-09T00:58:24Z'
+      - '2026-01-16T04:35:08Z'
       cf-cache-status:
       - DYNAMIC
       request-id:
-      - req_011CWvtyoYJ3eDyP4jYTfxbR
+      - req_011CXASAnhR4Btf15YJsoKg2
       strict-transport-security:
       - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '681'
+      - '1906'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_call_with_tools/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_call_with_tools/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -22,7 +22,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -34,11 +36,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -48,28 +50,17 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01GF48vwA1p6wSgZrBTrqKWW","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}               }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01WdUbkAitn8UKENddqLxhYJ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":6,"service_tier":"standard"}}      }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''ll
-        retrieve the secrets for both passwords you"}        }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
 
 
         event: ping
@@ -79,8 +70,37 @@ interactions:
 
         event: content_block_delta
 
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
+        retrieve the secrets for"}       }
+
+
+        event: content_block_delta
+
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        provided."}       }
+        both passwords using"}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        parallel"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        function"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        calls"}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"."}    }
 
 
         event: content_block_stop
@@ -90,92 +110,75 @@ interactions:
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_0199cTXNM9CoZP2ivCetrRm3","name":"secret_retrieval_tool","input":{}}       }
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_012Hbq7BCqrkTwtEMQEzmrDs","name":"secret_retrieval_tool","input":{}}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}    }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"passwor"}       }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"passwor"}             }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"d\":
-        \"mellon\"}"}           }
+        \"mellon\"}"}          }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":1            }
+        data: {"type":"content_block_stop","index":1         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_011WQyAr9qBAfeS7Ce3mHF8A","name":"secret_retrieval_tool","input":{}}               }
+        data: {"type":"content_block_start","index":2,"content_block":{"type":"tool_use","id":"toolu_01Gq18vb6oWSFwfmhzGi5f8H","name":"secret_retrieval_tool","input":{}}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}          }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":""}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\""}        }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"password\":"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"pas"}               }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"
+        \"radianc"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"sw"}     }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"ord\":
-        \""}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"radiance"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\"}"}         }
+        data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"e\"}"}          }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":2             }
+        data: {"type":"content_block_stop","index":2     }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}}
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":416,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":111}  }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"     }
+        data: {"type":"message_stop"   }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027670aed0eb83-SEA
+      - 9beae7b7dda475b8-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -183,15 +186,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:33:00 GMT
+      - Fri, 16 Jan 2026 04:35:17 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -201,37 +200,41 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:32:59Z'
+      - '2026-01-16T04:35:15Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:32:59Z'
+      - '2026-01-16T04:35:15Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:32:59Z'
+      - '2026-01-16T04:35:15Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:32:59Z'
+      - '2026-01-16T04:35:15Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2UoRpiTiSH1iCKt2Kw
+      - req_011CXASBLSd5UTj9aRFBRC3m
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '709'
+      - '1469'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please retrieve
       the secrets associated with each of these passwords: mellon,radiance"},{"role":"assistant","content":[{"type":"text","text":"I''ll
-      retrieve the secrets for both passwords you provided."},{"type":"tool_use","id":"toolu_0199cTXNM9CoZP2ivCetrRm3","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_011WQyAr9qBAfeS7Ce3mHF8A","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_0199cTXNM9CoZP2ivCetrRm3","content":"Welcome
-      to Moria!","cache_control":null},{"type":"tool_result","tool_use_id":"toolu_011WQyAr9qBAfeS7Ce3mHF8A","content":"Life
+      retrieve the secrets for both passwords using parallel function calls."},{"type":"tool_use","id":"toolu_012Hbq7BCqrkTwtEMQEzmrDs","name":"secret_retrieval_tool","input":{"password":"mellon"}},{"type":"tool_use","id":"toolu_01Gq18vb6oWSFwfmhzGi5f8H","name":"secret_retrieval_tool","input":{"password":"radiance"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_012Hbq7BCqrkTwtEMQEzmrDs","content":"Welcome
+      to Moria!","cache_control":null},{"type":"tool_result","tool_use_id":"toolu_01Gq18vb6oWSFwfmhzGi5f8H","content":"Life
       before Death","cache_control":{"type":"ephemeral"}}]}],"model":"claude-sonnet-4-0","system":[{"type":"text","text":"Use
       parallel tool calling.","cache_control":{"type":"ephemeral"}}],"tools":[{"name":"secret_retrieval_tool","description":"A
       tool that requires a password to retrieve a secret.","input_schema":{"properties":{"password":{"title":"Password","type":"string"}},"required":["password"],"additionalProperties":false,"type":"object"},"cache_control":{"type":"ephemeral"}}],"stream":true}'
@@ -247,13 +250,15 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1230'
+      - '1247'
       content-type:
       - application/json
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -265,7 +270,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -279,28 +284,17 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01D2UYKSvWwhvdbKx2ssfang","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":602,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}          }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01XuyKKHm7neeGP7UnoEuQG6","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":604,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}    }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        are the secrets retrieve"}               }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}       }
 
 
         event: ping
@@ -310,84 +304,82 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        for"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here"}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        each"}}
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        password:\n\n-"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Passwor"}}
+        are the secrets retrieve"}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
-        \""}          }
+        for each"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        password:\n\n-"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        Passwor"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"d
+        \""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"mellon\":
-        **"}        }
+        **"}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Welcome"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Welcome
+        to Moria!**"} }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        to Moria!**\n-"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Password \"radiance\": **Life before"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n-
+        Password \"radiance\": **Life"}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Death**"}      }
+        before Death**"}         }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0 }
+        data: {"type":"content_block_stop","index":0              }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":602,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}    }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":604,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}             }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"        }
+        data: {"type":"message_stop"}
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b02767cdbedeb83-SEA
+      - 9beae7c929c875b8-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -395,15 +387,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:33:02 GMT
+      - Fri, 16 Jan 2026 04:35:19 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -413,29 +401,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:33:01Z'
+      - '2026-01-16T04:35:18Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:33:01Z'
+      - '2026-01-16T04:35:18Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:33:01Z'
+      - '2026-01-16T04:35:18Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:33:01Z'
+      - '2026-01-16T04:35:18Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2Uwn7buvyh3sN7KxCo
+      - req_011CXASBYLjezfCc4gEMB39c
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '836'
+      - '1151'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_max_tokens/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_max_tokens/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -19,7 +19,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -31,11 +33,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -45,28 +47,17 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01EHPvEH74k7qQmzLikTdFvB","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_014zR2dJLsynM9WM7cFnAhrQ","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}    }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        are all "} }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}               }
 
 
         event: ping
@@ -76,26 +67,55 @@ interactions:
 
         event: content_block_delta
 
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Here"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        are all"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        "}         }
+
+
+        event: content_block_delta
+
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"50
-        U.S. states:"}             }
+        U.S. states in"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n\n1.
-        Alabama\n2. Alaska"}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        alphab"}               }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n3.
-        Arizona\n4. Arkansas"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"etical
+        order:\n\n1. Alabama"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n5.
-        California\n6. Colora"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n2.
+        Alaska\n3. Arizona"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n4.
+        Arkansas\n5. California"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n6.
+        Colora"}      }
 
 
         event: content_block_delta
@@ -106,31 +126,28 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n9.
-        Florida\n10"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n9"}       }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0            }
+        data: {"type":"content_block_stop","index":0   }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":50}             }
+        data: {"type":"message_delta","delta":{"stop_reason":"max_tokens","stop_sequence":null},"usage":{"input_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":50}          }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"    }
+        data: {"type":"message_stop"  }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b0276f8cf8c1ef1-SEA
+      - 9beae7e65e3bba21-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -138,15 +155,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:33:22 GMT
+      - Fri, 16 Jan 2026 04:35:23 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -156,29 +169,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:33:21Z'
+      - '2026-01-16T04:35:23Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:33:21Z'
+      - '2026-01-16T04:35:23Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:33:21Z'
+      - '2026-01-16T04:35:23Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:33:21Z'
+      - '2026-01-16T04:35:23Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2WQVzCc9L6URHm1AbQ
+      - req_011CXASBtEZibsBDWLe83CxA
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '669'
+      - '556'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/json/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -33,7 +33,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -45,11 +47,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -59,28 +61,17 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01857syz7S2W8HfFpkitva6i","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}          }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01Fp4QZrVfGwEcx3adbNx9mi","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
-        \"THE"}   }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}               }
 
 
         event: ping
@@ -90,20 +81,36 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        NAME"} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"```"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"json\n{\n  \"title\":"}}
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        OF THE WIND\",\n  \""}  }
+        \"THE"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        NAME"}}
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        OF THE WIND\",\n  \""}           }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"author\":
-        {\n    \"first_"}         }
+        {\n    \"first_"}            }
 
 
         event: content_block_delta
@@ -115,41 +122,39 @@ interactions:
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"last_name\":
-        \"Rothf"}         }
+        \"Rothf"}          }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"uss\"\n  },\n  \""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":
-        7\n}"}}
+        7\n}\n```"}     }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0         }
+        data: {"type":"content_block_stop","index":0}
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":58}         }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":328,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}    }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"          }
+        data: {"type":"message_stop"         }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b02797e4cd575d9-SEA
+      - 9beae8798b8dec38-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -157,15 +162,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:35:06 GMT
+      - Fri, 16 Jan 2026 04:35:47 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -175,29 +176,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:35:04Z'
+      - '2026-01-16T04:35:46Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:35:04Z'
+      - '2026-01-16T04:35:46Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:35:04Z'
+      - '2026-01-16T04:35:46Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:35:04Z'
+      - '2026-01-16T04:35:46Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2e2562u2hCu7DWMSnx
+      - req_011CXASDcxrVyr87b2jMkCS5
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1747'
+      - '558'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -24,7 +24,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -36,11 +38,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -50,28 +52,17 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01GmnWEFpTMDbAtuUmiWtMVu","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}   }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01XuBx7UXPFJXBQnjpuTgdPf","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}               }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}
-        }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}          }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":\""}         }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}             }
 
 
         event: ping
@@ -81,58 +72,66 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"THE"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}      }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":\""}     }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"THE"}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        NAME"}       }
+        NAME"}          }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        OF THE WIND\",\"author\":{\""}     }
+        OF THE WIND\",\"author\":{\""}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"first_name\":\"Patrick\",\"last_"}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"first_name\":\"Patrick\",\"last_"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":\"Rothfuss\"},\""}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"rating\":7}"}
         }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"name\":\"Rothfuss\"}"}               }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",\"rating\":7}"}  }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0      }
+        data: {"type":"content_block_stop","index":0  }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":36}              }
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":414,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":36}               }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"              }
+        data: {"type":"message_stop" }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027957eba6a330-SEA
+      - 9beae8a3db07a372-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -140,15 +139,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:35:00 GMT
+      - Fri, 16 Jan 2026 04:35:55 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -158,29 +153,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:34:58Z'
+      - '2026-01-16T04:35:53Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:34:58Z'
+      - '2026-01-16T04:35:53Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:34:58Z'
+      - '2026-01-16T04:35:53Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:34:58Z'
+      - '2026-01-16T04:35:53Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2dZrW5SYFkMa6pfkCz
+      - req_011CXASE7tQeZwHwGZjUwPRZ
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1711'
+      - '1673'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output/tool/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -27,7 +27,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -39,11 +41,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -53,116 +55,139 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01Dv6oy8L37Tp9VBedsTdTiC","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}      }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01FdErJo6rgz31vzzjHb4Cfj","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":11,"service_tier":"standard"}}      }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01T2B5FmsMG1xY31XmoCCRTb","name":"__mirascope_formatted_output_tool__","input":{}}    }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01891B3yZSWpreEjFVKyBF9N","name":"__mirascope_formatted_output_tool__","input":{}}     }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\""}        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"t"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"titl"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"it"}   }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e\":
-        \"THE NA"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"le\""}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
+        \"THE NA"}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ME
-        OF THE WI"}            }
+        OF THE "}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ND\""}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\": "} }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"first_name"}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":\"Patr"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ick\",\"last"}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_name\":\"Roth"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"fuss\"}"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"WIND\""}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"ratin"}  }
+        \"auth"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"g\":
-        7}"}              }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"or\":
+        {\"first"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_na"}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"me\":\"Patrick"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\",\"last"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"_n"}       }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ame\":\"Rot"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"hf"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"uss\"}"}            }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"rat"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ing\":
+        7}"}}
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0              }
+        data: {"type":"content_block_stop","index":0     }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}
-        }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":563,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":81}            }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"              }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b0279b8a91c322f-SEA
+      - 9beae8879ea77557-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -170,15 +195,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:35:14 GMT
+      - Fri, 16 Jan 2026 04:35:51 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -188,29 +209,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:35:14Z'
+      - '2026-01-16T04:35:49Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:35:14Z'
+      - '2026-01-16T04:35:49Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:35:14Z'
+      - '2026-01-16T04:35:49Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:35:14Z'
+      - '2026-01-16T04:35:49Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2ei2esb34by5qG9Zc7
+      - req_011CXASDnaoUZqtjGPVSxneZ
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '721'
+      - '2711'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/json/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -29,7 +29,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -41,11 +43,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -55,28 +57,17 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_016sZJhJmfaoGNxkbPtKLGGk","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_018gBS7YY6cZxYtReacA5sED","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}     }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I"}       }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"''ll
-        look"}           }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}     }
 
 
         event: ping
@@ -86,78 +77,88 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        up the book information for ISBN"}    }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"I''ll
+        look up the book information for"}     }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        0-7653-1178"}             }
+        ISBN"}         }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}           }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        0-7653-1178"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"-X."}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0      }
+        data: {"type":"content_block_stop","index":0            }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01M967FW1bRxXjpDHxophJZg","name":"get_book_info","input":{}}              }
+        data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01My26oDaaNkgBerQJcroNv4","name":"get_book_info","input":{}}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}             }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"i"}  }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
+        \"0-"}  }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"sbn\":
-        \"0"} }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"76"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"-7653-1178-X"}         }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"53-"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"\"}"}     }
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"1178-"}          }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"X\"}"}
+        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":1             }
+        data: {"type":"content_block_stop","index":1         }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}      }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":594,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":84}          }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"          }
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027ec39bc13295-SEA
+      - 9beae9244d186826-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -165,15 +166,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:38:41 GMT
+      - Fri, 16 Jan 2026 04:36:15 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -183,29 +180,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:38:40Z'
+      - '2026-01-16T04:36:14Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:38:40Z'
+      - '2026-01-16T04:36:14Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:38:40Z'
+      - '2026-01-16T04:36:14Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:38:40Z'
+      - '2026-01-16T04:36:14Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2uw6t6iiutrHsf5rqU
+      - req_011CXASFdm3BTXqtVj1wK5of
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '718'
+      - '1400'
     status:
       code: 200
       message: OK
@@ -213,7 +214,7 @@ interactions:
     body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
       score"},{"role":"assistant","content":[{"type":"text","text":"I''ll look up
-      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01M967FW1bRxXjpDHxophJZg","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01M967FW1bRxXjpDHxophJZg","content":"Title:
+      the book information for ISBN 0-7653-1178-X."},{"type":"tool_use","id":"toolu_01My26oDaaNkgBerQJcroNv4","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01My26oDaaNkgBerQJcroNv4","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","cache_control":{"type":"ephemeral"}}]}],"model":"claude-sonnet-4-0","system":[{"type":"text","text":"Respond
       only with valid JSON that matches this exact schema:\n{\n  \"properties\": {\n    \"title\":
@@ -242,7 +243,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -254,7 +257,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -268,29 +271,17 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01323fNnaNYM5Ao7TLCopQyo","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}
-        }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_016vcYj9JxGXXuMNuWXs6anE","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}          }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}  }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
-        \"Mist"}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}    }
 
 
         event: ping
@@ -300,54 +291,64 @@ interactions:
 
         event: content_block_delta
 
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{"}
+        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\n  \"title\":
+        \"Mist"}  }
+
+
+        event: content_block_delta
+
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"born:
-        The Final Empire\",\n  "}   }
+        The Final Empire\",\n  "}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\"author\":
-        \"Brandon Sanderson"}         }
+        \"Brandon Sanderson"}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\",\n  \"pages\":
-        544"}               }
+        544"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",\n  \"publication_year\":"}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":",\n  \"publication_year\":"}       }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        2006\n}"}          }
+        2006\n}"}               }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0  }
+        data: {"type":"content_block_stop","index":0     }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":49}}
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":721,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":49}              }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"     }
+        data: {"type":"message_stop"             }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027ecd9d803295-SEA
+      - 9beae93398ed6826-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -355,15 +356,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:38:43 GMT
+      - Fri, 16 Jan 2026 04:36:17 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -373,29 +370,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:38:42Z'
+      - '2026-01-16T04:36:16Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:38:42Z'
+      - '2026-01-16T04:36:16Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:38:42Z'
+      - '2026-01-16T04:36:16Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:38:42Z'
+      - '2026-01-16T04:36:16Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2v3xt7Myo7ZRtBGc6k
+      - req_011CXASFpDaWtHBXyb1d7wsi
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1432'
+      - '566'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5/async_stream.yaml
@@ -23,7 +23,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -35,11 +37,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -49,61 +51,69 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_012oecBR2Yw2U7zeB9pSBCZs","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}       }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01EKFfL2wWAqtA6HvpP6eq2a","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}         }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01MeT9kdBuYqFV4mFqfDXVso","name":"get_book_info","input":{}}             }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01MHCLxpF4PVKhW69eNmBdEM","name":"get_book_info","input":{}}      }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}      }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"isbn\":
-        \"0"}               }
+        \"0"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-7653-1"}               }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-7"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"178-X\"}"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"653-1"}   }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"178-X\"}"}          }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0  }
+        data: {"type":"content_block_stop","index":0           }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}     }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":854,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":63}}
 
 
         event: message_stop
 
-        data: {"type":"message_stop"           }
+        data: {"type":"message_stop"  }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027e6a0bdf4715-SEA
+      - 9beae9603fd68a73-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -111,15 +121,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:38:30 GMT
+      - Fri, 16 Jan 2026 04:36:25 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -129,36 +135,40 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:38:26Z'
+      - '2026-01-16T04:36:23Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:38:26Z'
+      - '2026-01-16T04:36:23Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:38:26Z'
+      - '2026-01-16T04:36:23Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:38:26Z'
+      - '2026-01-16T04:36:23Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2tsu7wKM391orzyt6y
+      - req_011CXASGLidcJ9qADET7W5Yn
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '4336'
+      - '1530'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01MeT9kdBuYqFV4mFqfDXVso","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01MeT9kdBuYqFV4mFqfDXVso","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01MHCLxpF4PVKhW69eNmBdEM","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01MHCLxpF4PVKhW69eNmBdEM","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","cache_control":{"type":"ephemeral"}}]}],"model":"claude-sonnet-4-5","output_format":{"schema":{"type":"object","title":"BookSummary","properties":{"title":{"type":"string","title":"Title"},"author":{"type":"string","title":"Author"},"pages":{"type":"integer","title":"Pages"},"publication_year":{"type":"integer","title":"Publication
       Year"}},"additionalProperties":false,"required":["title","author","pages","publication_year"]},"type":"json_schema"},"tools":[{"name":"get_book_info","description":"Look
@@ -181,7 +191,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -193,7 +205,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -207,28 +219,18 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01RDLAQnC4vC7e56Z8LNerpi","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}     }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-5-20250929","id":"msg_01JLfMsmUXsSuCvNPiZUWpyk","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":1,"service_tier":"standard"}}
+        }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}      }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":
-        \"Mistborn: The"}}
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}   }
 
 
         event: ping
@@ -238,49 +240,62 @@ interactions:
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Final Empire\", \"author\": \"Brandon"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"{\""}               }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"title\":"}              }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
-        Sanderson\", \"pages\": "}      }
+        \"Mistborn: The Final Empire"}           }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"544,
-        \"publication_year\": "} }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"\",
+        \"author\": \"Brandon San"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"2006}"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"derson\",
+        \"pages\": 544,"}           }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"
+        \"publication_year\": 2006"}         }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"}"}        }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0        }
+        data: {"type":"content_block_stop","index":0     }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}}
+        data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":961,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":39}     }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"            }
+        data: {"type":"message_stop"        }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027e8cd97c4715-SEA
+      - 9beae96e0fb78a73-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -288,15 +303,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:38:34 GMT
+      - Fri, 16 Jan 2026 04:36:27 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -306,29 +317,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '1999000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:38:31Z'
+      - '2026-01-16T04:36:26Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:38:31Z'
+      - '2026-01-16T04:36:26Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:38:31Z'
+      - '2026-01-16T04:36:26Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2399000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:38:31Z'
+      - '2026-01-16T04:36:26Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2uHfN7Bs7ikYSetwB2
+      - req_011CXASGWAfAvqwJUYGZ3hyV
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '2295'
+      - '1345'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
+++ b/python/tests/e2e/output/cassettes/test_structured_output_with_tools/tool/anthropic_beta_claude_sonnet_4_0/async_stream.yaml
@@ -26,7 +26,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -38,11 +40,11 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
-      - '1'
+      - '0'
       x-stainless-runtime:
       - CPython
       x-stainless-runtime-version:
@@ -52,67 +54,69 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01R1SCwZXCUtCgP6QGwhzVdE","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":9,"service_tier":"standard"}}              }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01FYDwaVWugWvJXB1wbqx9QD","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":8,"service_tier":"standard"}}     }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_012x2VSJWaDWAf1NgQFzJ38i","name":"get_book_info","input":{}}       }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01KnpHp1mZTYQTyMbHX1TxSR","name":"get_book_info","input":{}}   }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}          }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}            }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"i"}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"i"}      }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"sbn\":
-        \"0-76"}     }
+        \"0-765"}     }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"53-"}
-        }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"3-1178"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"1178-X\"}"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"-X\"}"}            }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0  }
+        data: {"type":"content_block_stop","index":0          }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}      }
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":589,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":48}         }
 
 
         event: message_stop
 
-        data: {"type":"message_stop"  }
+        data: {"type":"message_stop"       }
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027f46ecbf27e2-SEA
+      - 9beae941d962980d-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -120,15 +124,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:39:03 GMT
+      - Fri, 16 Jan 2026 04:36:19 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -138,36 +138,40 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:39:01Z'
+      - '2026-01-16T04:36:19Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:39:01Z'
+      - '2026-01-16T04:36:19Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:39:01Z'
+      - '2026-01-16T04:36:19Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:39:01Z'
+      - '2026-01-16T04:36:19Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2wUwaWCL7bKzxfPmVD
+      - req_011CXASFywj96p27HZSHBAFm
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '2092'
+      - '668'
     status:
       code: 200
       message: OK
 - request:
     body: '{"max_tokens":16000,"messages":[{"role":"user","content":"Please look up
       the book with ISBN 0-7653-1178-X and provide detailed info and a recommendation
-      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_012x2VSJWaDWAf1NgQFzJ38i","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_012x2VSJWaDWAf1NgQFzJ38i","content":"Title:
+      score"},{"role":"assistant","content":[{"type":"tool_use","id":"toolu_01KnpHp1mZTYQTyMbHX1TxSR","name":"get_book_info","input":{"isbn":"0-7653-1178-X"}}]},{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_01KnpHp1mZTYQTyMbHX1TxSR","content":"Title:
       Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published:
       2006-07-25","cache_control":{"type":"ephemeral"}}]}],"model":"claude-sonnet-4-0","system":[{"type":"text","text":"Always
       respond to the user''s query using the __mirascope_formatted_output_tool__ tool
@@ -193,7 +197,9 @@ interactions:
       host:
       - api.anthropic.com
       user-agent:
-      - AsyncAnthropic/Python 0.75.0
+      - AsyncAnthropic/Python 0.76.0
+      x-api-key:
+      - <filtered>
       x-stainless-arch:
       - arm64
       x-stainless-async:
@@ -205,7 +211,7 @@ interactions:
       x-stainless-os:
       - MacOS
       x-stainless-package-version:
-      - 0.75.0
+      - 0.76.0
       x-stainless-read-timeout:
       - '600'
       x-stainless-retry-count:
@@ -219,134 +225,158 @@ interactions:
       x-stainless-timeout:
       - NOT_GIVEN
     method: POST
-    uri: https://api.anthropic.com/v1/messages
+    uri: https://api.anthropic.com/v1/messages?beta=true
   response:
     body:
       string: 'event: message_start
 
-        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01MWFr37TMPjqNuPLHPDRRFs","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}             }
+        data: {"type":"message_start","message":{"model":"claude-sonnet-4-20250514","id":"msg_01SrCgobYNcLrg6nDBPuDU9B","type":"message","role":"assistant","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":0},"output_tokens":16,"service_tier":"standard"}}          }
 
 
         event: content_block_start
 
-        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01X8JRbMUHADWWJfpGW7kj8Y","name":"__mirascope_formatted_output_tool__","input":{}}      }
+        data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01FGKBBHzTkBsrtHZmityqxV","name":"__mirascope_formatted_output_tool__","input":{}}   }
+
+
+        event: ping
+
+        data: {"type": "ping"}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":""}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"title\""}  }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"ti"}              }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":":
-        \"Mi"}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"st"}            }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"born:
-        Th"}           }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"e
-        Final "}    }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Empire\""}              }
-
-
-        event: content_block_delta
-
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"author\":"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"tle\":"}               }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        \"Brandon "}               }
+        \"Mi"}        }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"Sanderso"}             }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"stbo"}}
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"n\""}}
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"rn:
+        The Fi"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"na"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"l
+        Empire"}             }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\""}    }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pages\":"}            }
+        \"au"}             }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"
-        54"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"thor"}       }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4"}       }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        "}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"Brandon
+        Sa"} }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"nderson\""}         }
 
 
         event: content_block_delta
 
         data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
-        \"pub"} }
+        \"pages"}      }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"lication_yea"}         }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\":
+        54"}    }
 
 
         event: content_block_delta
 
-        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"r\":
-        2006}"}            }
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"4"}              }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":",
+        \"public"}        }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ation_"}  }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"year\":
+        20"}    }
+
+
+        event: content_block_delta
+
+        data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"06}"}       }
 
 
         event: content_block_stop
 
-        data: {"type":"content_block_stop","index":0            }
+        data: {"type":"content_block_stop","index":0 }
 
 
         event: message_delta
 
-        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}}
+        data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"input_tokens":695,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":109}      }
 
 
         event: message_stop
 
-        data: {"type":"message_stop" }
+        data: {"type":"message_stop"}
 
 
         '
     headers:
-      CF-Cache-Status:
-      - DYNAMIC
       CF-RAY:
-      - 9b027f555e6127e2-SEA
+      - 9beae9493dd0980d-SEA
       Cache-Control:
       - no-cache
       Connection:
@@ -354,15 +384,11 @@ interactions:
       Content-Type:
       - text/event-stream; charset=utf-8
       Date:
-      - Thu, 18 Dec 2025 23:39:05 GMT
+      - Fri, 16 Jan 2026 04:36:21 GMT
       Server:
       - cloudflare
-      Strict-Transport-Security:
-      - max-age=31536000; includeSubDomains; preload
       Transfer-Encoding:
       - chunked
-      Vary:
-      - accept-encoding
       X-Robots-Tag:
       - none
       anthropic-organization-id:
@@ -372,29 +398,33 @@ interactions:
       anthropic-ratelimit-input-tokens-remaining:
       - '2000000'
       anthropic-ratelimit-input-tokens-reset:
-      - '2025-12-18T23:39:03Z'
+      - '2026-01-16T04:36:20Z'
       anthropic-ratelimit-output-tokens-limit:
       - '400000'
       anthropic-ratelimit-output-tokens-remaining:
       - '400000'
       anthropic-ratelimit-output-tokens-reset:
-      - '2025-12-18T23:39:03Z'
+      - '2026-01-16T04:36:20Z'
       anthropic-ratelimit-requests-limit:
       - '4000'
       anthropic-ratelimit-requests-remaining:
       - '3999'
       anthropic-ratelimit-requests-reset:
-      - '2025-12-18T23:39:03Z'
+      - '2026-01-16T04:36:20Z'
       anthropic-ratelimit-tokens-limit:
       - '2400000'
       anthropic-ratelimit-tokens-remaining:
       - '2400000'
       anthropic-ratelimit-tokens-reset:
-      - '2025-12-18T23:39:03Z'
+      - '2026-01-16T04:36:20Z'
+      cf-cache-status:
+      - DYNAMIC
       request-id:
-      - req_011CWF2wepu7tAsByGqEudrP
+      - req_011CXASG51pprh5KXxQzU9D1
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
       x-envoy-upstream-service-time:
-      - '1764'
+      - '1546'
     status:
       code: 200
       message: OK

--- a/python/tests/e2e/output/snapshots/test_call_with_thinking/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_thinking/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -725,39 +725,54 @@ async_stream_snapshot = snapshot(
                             thought="""\
 I need to find all primes below 400 that contain "79" as a substring.
 
-Let me think about what numbers below 400 contain "79" as a substring:
-- Numbers starting with 79: 790, 791, 792, ... (these are all ≥ 790, so above 400)
-- Numbers ending with 79: 79, 179, 279, 379
-- Numbers with 79 in the middle: This would be numbers like X79Y where X and Y are digits, but for numbers below 400, this would mean numbers like 1790, 2790, 3790, etc., which are all above 400.
+First, let me think about what numbers below 400 could contain "79" as a substring:
+- Numbers of the form 79X (where X is a digit): 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+- Numbers of the form X79 (where X is a digit): 179, 279, 379
+- Numbers of the form X79Y (where X and Y are digits): This would give us numbers with at least 4 digits, starting from 1790, which is above 400.
+
+So I need to check:
+- 79 itself
+- 179, 279, 379
+- 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+
+Wait, let me be more systematic. Numbers below 400 that contain "79" as a substring:
+
+Two-digit: 79
+Three-digit: 179, 279, 379, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+
+But wait, we're looking at numbers below 400, so 790-799 are all above 400. Let me reconsider.
+
+Actually, let me list all possibilities more carefully:
+- 79 (two digits)
+- X79 where X = 1, 2, 3: so 179, 279, 379 (three digits, all below 400)
+- 79X where X = 0,1,2,3,4,5,6,7,8,9: so 790,791,792,793,794,795,796,797,798,799 (three digits, but these are all ≥ 790 > 400)
 
 So the candidates are: 79, 179, 279, 379
 
-Now I need to check which of these are prime:
 
-79: Let me check if 79 is prime.
-- Not divisible by 2 (it's odd)
-- Not divisible by 3 (7+9=16, not divisible by 3)
-- Not divisible by 5 (doesn't end in 0 or 5)
-- Not divisible by 7 (79 ÷ 7 = 11.28...)
-- Need to check up to √79 ≈ 8.9, so I need to check 2, 3, 5, 7
-- 79 ÷ 7 = 11 remainder 2, so not divisible by 7
-- Since √79 < 9, I only need to check primes up to 8, which are 2, 3, 5, 7
-- 79 is prime
+Now I'll test each for primality. For 79, I check divisibility by primes up to √79 ≈ 8.9 (so 2, 3, 5, 7): it's odd, digit sum is 16 (not divisible by 3), doesn't end in 0 or 5, and 79 ÷ 7 ≈ 11.3. So 79 is prime. For 179, I need to check divisibility by primes up to √179 ≈ 13.4, which includes 2, 3, 5, 7, 11, 13.
 
-179: Let me check if 179 is prime.
-- Not divisible by 2 (it's odd)
-- Not divisible by 3 (1+7+9=17, not divisible by 3)
-- Not divisible by 5 (doesn't end in 0 or 5)
+179 is odd, has digit sum 17 (not divisible by 3), doesn't end in 0 or 5, and testing 7, 11, and 13 all give non-integer results. So 179 is also prime. Now checking 279: the digit sum is 18, which is divisible by 3, so 279 = 3 × 93 = 9 × 31, making it composite. For 379, I need to test primes up to about 19.5. It's odd, the digit sum is 19 (not divisible by 3), and it doesn't end in 0 or 5, so I'll continue checking 7, 11, 13, 17, and 19.
 
-
-- Since √179 ≈ 13.4, I need to check primes up to 13: 7, 11, and 13. Testing these: 179 ÷ 7 = 25 remainder 4, 179 ÷ 11 = 16 remainder 3, and 179 ÷ 13 = 13 remainder 10. None divide evenly, so 179 is prime.
-
-For 279, the digit sum is 2+7+9=18, which is divisible by 3, so 279 = 3 × 93 and isn't prime. Moving to 379: it's odd, the digit sum 19 isn't divisible by 3, it doesn't end in 0 or 5, and testing 7 gives 379 ÷ 7 = 54.14... I need to continue checking divisibility by primes up to √379 ≈ 19.5. 19 = 19 remainder 18. Since 379 isn't divisible by any prime up to its square root, it's prime.
-
-The primes under 400 containing "79" are 79, 179, and 379—three total.\
+Testing each divisor shows 379 isn't divisible by any of them, so it's prime. The complete list of primes below 400 containing "79" is 79, 179, and 379—three primes total.\
 """
                         ),
-                        Text(text="3"),
+                        Text(
+                            text="""\
+Looking at numbers below 400 that contain "79" as a substring:
+
+- Two-digit: 79
+- Three-digit: 179, 279, 379
+
+Checking which are prime:
+- 79: Prime
+- 179: Prime  \n\
+- 279: Not prime (divisible by 3)
+- 379: Prime
+
+3\
+"""
+                        ),
                     ],
                     provider_id="anthropic",
                     model_id="anthropic-beta/claude-sonnet-4-0",
@@ -770,40 +785,56 @@ The primes under 400 containing "79" are 79, 179, and 379—three total.\
                                 "thinking": """\
 I need to find all primes below 400 that contain "79" as a substring.
 
-Let me think about what numbers below 400 contain "79" as a substring:
-- Numbers starting with 79: 790, 791, 792, ... (these are all ≥ 790, so above 400)
-- Numbers ending with 79: 79, 179, 279, 379
-- Numbers with 79 in the middle: This would be numbers like X79Y where X and Y are digits, but for numbers below 400, this would mean numbers like 1790, 2790, 3790, etc., which are all above 400.
+First, let me think about what numbers below 400 could contain "79" as a substring:
+- Numbers of the form 79X (where X is a digit): 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+- Numbers of the form X79 (where X is a digit): 179, 279, 379
+- Numbers of the form X79Y (where X and Y are digits): This would give us numbers with at least 4 digits, starting from 1790, which is above 400.
+
+So I need to check:
+- 79 itself
+- 179, 279, 379
+- 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+
+Wait, let me be more systematic. Numbers below 400 that contain "79" as a substring:
+
+Two-digit: 79
+Three-digit: 179, 279, 379, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+
+But wait, we're looking at numbers below 400, so 790-799 are all above 400. Let me reconsider.
+
+Actually, let me list all possibilities more carefully:
+- 79 (two digits)
+- X79 where X = 1, 2, 3: so 179, 279, 379 (three digits, all below 400)
+- 79X where X = 0,1,2,3,4,5,6,7,8,9: so 790,791,792,793,794,795,796,797,798,799 (three digits, but these are all ≥ 790 > 400)
 
 So the candidates are: 79, 179, 279, 379
 
-Now I need to check which of these are prime:
 
-79: Let me check if 79 is prime.
-- Not divisible by 2 (it's odd)
-- Not divisible by 3 (7+9=16, not divisible by 3)
-- Not divisible by 5 (doesn't end in 0 or 5)
-- Not divisible by 7 (79 ÷ 7 = 11.28...)
-- Need to check up to √79 ≈ 8.9, so I need to check 2, 3, 5, 7
-- 79 ÷ 7 = 11 remainder 2, so not divisible by 7
-- Since √79 < 9, I only need to check primes up to 8, which are 2, 3, 5, 7
-- 79 is prime
+Now I'll test each for primality. For 79, I check divisibility by primes up to √79 ≈ 8.9 (so 2, 3, 5, 7): it's odd, digit sum is 16 (not divisible by 3), doesn't end in 0 or 5, and 79 ÷ 7 ≈ 11.3. So 79 is prime. For 179, I need to check divisibility by primes up to √179 ≈ 13.4, which includes 2, 3, 5, 7, 11, 13.
 
-179: Let me check if 179 is prime.
-- Not divisible by 2 (it's odd)
-- Not divisible by 3 (1+7+9=17, not divisible by 3)
-- Not divisible by 5 (doesn't end in 0 or 5)
+179 is odd, has digit sum 17 (not divisible by 3), doesn't end in 0 or 5, and testing 7, 11, and 13 all give non-integer results. So 179 is also prime. Now checking 279: the digit sum is 18, which is divisible by 3, so 279 = 3 × 93 = 9 × 31, making it composite. For 379, I need to test primes up to about 19.5. It's odd, the digit sum is 19 (not divisible by 3), and it doesn't end in 0 or 5, so I'll continue checking 7, 11, 13, 17, and 19.
 
-
-- Since √179 ≈ 13.4, I need to check primes up to 13: 7, 11, and 13. Testing these: 179 ÷ 7 = 25 remainder 4, 179 ÷ 11 = 16 remainder 3, and 179 ÷ 13 = 13 remainder 10. None divide evenly, so 179 is prime.
-
-For 279, the digit sum is 2+7+9=18, which is divisible by 3, so 279 = 3 × 93 and isn't prime. Moving to 379: it's odd, the digit sum 19 isn't divisible by 3, it doesn't end in 0 or 5, and testing 7 gives 379 ÷ 7 = 54.14... I need to continue checking divisibility by primes up to √379 ≈ 19.5. 19 = 19 remainder 18. Since 379 isn't divisible by any prime up to its square root, it's prime.
-
-The primes under 400 containing "79" are 79, 179, and 379—three total.\
+Testing each divisor shows 379 isn't divisible by any of them, so it's prime. The complete list of primes below 400 containing "79" is 79, 179, and 379—three primes total.\
 """,
-                                "signature": "EpETCkYICxgCKkBJVu+z+gbsCY7wfmvTdEQwUQU82ei3LoS84bynmxgp9ooZbDoBjybEUWCZX7nKHt9b9nTPjO8HwZQqg5veTQpfEgyozj9DbOHbjUXXAY4aDESzj1n7Sn9LonwcOCIwmbMBD7QxlJ86WZ1inOkJUc/8kp8Eu580jqp2Ml4UAuL3afvI8mxLGUfE8eKT80/NKvgRiDLqydWxob21Yg2jIWCiE6sAJmfN/gQdbdtbicKl0365PF8nJF7/Wshh9N9DIW6BBSv5kYgepFe2xiPs7l8rNmPObytIgU+1EyOUTALaGIB2twERDteQDs6+KL9hR/6Ql6SCNrbXg6s07WTSqwWj/oIngzPVMmxT7Ewa4HSMN0eQ+WIYAcsllRI/7iNW+LFhC59ES3guP312OicOkgQIHcSGqUPJeyMpZ+SX63LCETVYVta8YMRo/VAyaoDZPj4DJ/FcpMIw5U/jYDJ7x6vgMru0JCOBAoe+f32hRIMP5NIyVBHfmtMnoc9vJlDy5rcAFyH74F3e5kSeuXBv6ynxTjfiE1yGQwecmNLMoO+Culvvfo1ivLGziYuoJrE/6VVp7CWDSpogw5aDr9kYysIipkvYnEn11muidpgMoDkAZq0BCsb3ILqiJNEN52BEwom4KjCNZyxQcwNHyAdWPV1AczK9R8nfL9bhoHofQJx0mwNjA2VAPfXnP78kFavFBfIiTibafHzvv7fIy9cxLmiKm5ei8jN0kchrsEDqpdSrfoAzYliozOgtcOAcRGRMrCAdPvj5X7AaIdDgx/hqgAj/w0aqMbgPgzUHtFBdEsKESj5jnqLkuXwhOPpWBeA8B3/koW5l0mzlLr5pb4E4Ae4thhCT6xBS9taDGJo0m5JkIDlbXhSpNexPqKfraX0FvSoW8PXXkgL6+PQpllluLoBwhb3PqiIvLsjd9s1tXTjcwrNqERycB+olEYUjDJUhUZyccdRJ8UBWpQHfPR/u8WV3FaJg/M9KzuTjhI5btNS5l+BTeonkY1nIjVb/Seijj/etk1lAhROiGV5k0HsNbaDtbvKUW9CRLGlktcskw/D/Qh16xoTUlapPYcvQROvryfprDV27su4uqSQ+frowsuVAM0OkhmHLerrlj7TrS0pvk1+AqK2Izyou1dp1+z6LqIO9fqzZxUxeSzM3A5nI4Yym5mQj6aeoXpVaMkZz3A7X2ORS074oxpa8JNaNRG/dai7MbdwncFmt6PSXzE+nQH9Tw+jfUJ3VPQieQet5y6V2evj6vEFTW4QcGEkT1YgJXadva5sUu3+gB761WXrk4KDkUmOSiiNIuE9uikPAXHPPK2SWGEPHS6TgQdfnoJ7+QRsoY5DaPrB6EmLus21ifBAMWRbSrPQCYEFZnwAxR5VrUqatEIjCO4p/ThJUBzfzQahqVeRnitpjEkqEyl8mAnfYUWgRWlruwtWQ0vK6mLCdivXrTTT4PztdcSifv3gMtiqzmcZ0FxupslVZD3RfrCM4knK1ozkN4wlNMyzUrLP/fBi/jXuChygju3NEzhEuBlyI1LJ0NFNLsh3Y/9Pj5DK1hR6GH5w+TJy2AmuxdKQytTkOcpbiZvb+CuPZhNsuX7Pmc9OxApcRhSCLipeXdGO3l57farrQpthgOhBz7Gf5TEzVL0lEI8Gf2jbUBj/8v22SLbcQcEID3alogtPQgl7IoOJwcKzqfZQkCigCc7K6wJE0jY/NFfQ9C//BvzQkb8oJqm7edF7mMCRanUhWcWNUfpLJPERUVpt+NDwfuNTYsgJveZqs/AM1uyFO74TlNucALAYN/fSm662+41MuzfyOQM2d1AXnz854+9yU3aH5ftc7rhZ8nBjySKwxIDTpO5j/KMfql2jtbDZDnbcQOn81gggez0ccAKMJQUJ7t1ajfLcQPyI/mtJGSiUofuVSA1CdMyrncj0kmCLEJprP73A9HDvLzRG9KSXvDtLkdsH3KAlJ6W4GIA+BWf2IuhQZsmuwwNNEose6zH3G7D242D6zreQICZqtPC+MCnZGr537Zo7QWBqVhxgX2aBlhGrYvAgFvVqBWoWBPng4hrghS2WKyQeBDhNKGodO4jQwHS4RlD31AmObPMn/hF9YXF8lCHl5SpkURYk5awG3JtIHMt//+tLLhjYJNJcdoCGfKL9vn4DSY4MLl88IplJdSX4e64usOW1fNDvs+0awaImZKAiGd3vhOc3bcVL/JCxi1iy13hBB21dk+W5UI49bsOOXk9rCGSjVqd1cM+oUfaZIKCf1vGAY3COsoQcEiYnVdG4PpYzGlxR6buI/luiltnrk9iHLjXE4C6wuESBt7wpZDKq+78QOH2Z5ZRSTZHZn+1CLLBb2Zc2CxMUvbh2SV2gfpiRMeAiuWHbMpIduy6nN0W9zXwV4AAeenwvY0GlpN0d3pnNwHJVwqySg1FOqFX2hwdVMtLWBegP9TSFC2W9+KiLyDEaLxpf70CZ+W3YDGyCQaDecBD4xMzj8HTTWJBZ0lRmFWUYS8lse+o9F9La1LI6F9iJkTJWiBRxKmU34dIkXR1/SYu9YADJeqBagdeOWG35aXdXbZ1I8zZ+doNzU6GKntTqh4e+4V8Hj0abkdTP1lQKiui8YgpTN+XpHd8fzBVFuY8ib4KtHIIlLf4FJzzIrDOBH+RJZkATjb7dkmDh9zXS6VRvUj6YrsaYNGhsn7YqIRgJJJVrwdKvhKIjB1w4SwWDv1B5aLE/wv6CcPAQgyL0hUYwLCEkmGNdHv6s3ja67T6W/VA1xMoQS6MB4w+T0BncpPQevggRwn8Eg1++OwJRm4bHu/vOXAo8XNKRs6hj6ODuunJFGa80n6ercePHy63fV53jP4raiq6SaJiDFvz6HwWWnFNsj75KQ0sGcIYo0wrhd4gTPHUDpV2Nf0Yp9v6iKZAOrmEIu2p6Wf+E7CD1CGtqP38c+d96P2sZbHEdx0S3o1Mkxn8Jp0kMGL4S5RNt7wzNj5yWXAB30lufc88Q+K+kYIzMrb+mBOojOwGntYbahqXTKwIsYsZ79KyVa66nATgIbkIHJnZnmXcMWFz88VvaHjoFxWBx5uMsr9Fu0TkQPlenT6ISnt3ihYu8KzPh7Tx10sqLeA5gB0ksu3nFhafJevLXMK01BdQP8R2+mVVwqL+0339MbKi6zDy5IbVuxJ9hRSNDSbgPXkd7mhhWy+Sdb2crD1MNkYP5EB12oYzBBPA7w74mSarlAOZ0RRR36jmtc92JYudeTLx+H6cjZB/GMV31jDRgB",
+                                "signature": "EqkWCkYICxgCKkBuWdt7SdfI8uwoJvhs2f68KkkOA4AtTJ7ViBxheVddrggCCdyC0LlChpQ4BXiSdyGg8jxxEjJgxgwCkAXMYxrREgxHXAegE5Z04zRcHKkaDBj3VZKkEvTVGfTg3yIwzoGFcs/Osj2u+/Z2hQeRRcUZfOxtsp8cWGHWjQTuCECDrLllUnKyGZVnT4h5rpCDKpAVLH7veqI/2y9FKTNcjVoVrThr4SsX8Cd3DJy5DodBA1QAiiMrM0bZ9wDBxT287c5ClHPsWD3oW2TB4YG7w0D6xTe2FFOLxlz4j0Sgr6Ne9FFYYFvzaMedz2kKBwcVjataXu5P1i8d4c/o72pMxkHZjZL1rExeQ7owHPvw8/y7a6VKiZaRykVcEjijHv2iku27uVs1O1T5Hmq4sjvtmoXUh0Lg3sdsPjzUk837lWg9f+XIPsEzg5tI9NWCUH3BiUhVqBEc2rA3c61gwwIW+EAE1ElF/Zayq1CsHWT57Ln+M6f2slNlIHfAyI+oQSBf6xVcEMn8Mf+T6SdAJHg7JotKdv8VJWPDvzAknjjLW8wOlFQAuXZgCLztQAcOm4HxYjeID2vUDyraL0UH9HKPW6iE8vaioUx5AjDavDJ7Pl8pUUZ92fAsFfx3AEWjMxdKEuub9dhpYUwYEZ102+XHFPKD8GfQkMovoaixGB3vLB17qFulp+iASh3bxqsS/apaWKckhvAOsz8e2TdVZ2EwmP9b9gQTpi6jx/kxY4W835B+53zRykAasDi1Cy3Xc2EtVlyZd/mLAKS+yABI9usxr9sAWmUagjocNrfyX4VdK0ZqCs6kes0BhnkyzCqCnRZxjBa8fnTijHCxc91XqKHuNkKAnQT1HV+NVGTRcV0avNnc86kTkpS3J0znFIc43HLd18MrAv3g3eaQZaMvxIe/m7bghhGr/XT8DTZ7ykPBoq4r9Bc4UUTqT3xfk2J/mCbjlxRNg/ipne+DSpp+0xgK9GF9uE2USNf9hOIWzAYYRNUxoVww88T5Mh3uk0T5//dboWLSmhUScFfx1QhjgjOBWCSVhsBeyEZaKlnFXOotTM4GSHE598XSZB7BMCq2HXYllbFMcVKEo9d4wueujXDkH8+oNJZtLUmggQOkzdpy7TXDbYrMZqEPO7/tFMmLU7iszLoP9E5TTI0Dmx3OB7DuRG1bFkXS1aoTkH8oADqncI09e1X4zmIKlKsBWQpdCkWiTnV09wC1CyHkX3km426dTNCehB1TNqefgN5rEwI8draC7aGaiE/0kzUevuLGlNnZ2TXSfLHGR+WvMZH16/Ojgzp9egX16KNaSdkYnv9gaUKtWuNAwDM277Ir23VQt+MfeHiuQazbuIlVGKM8RgC4tNsGuasZX4z7ru9psNcbqyrw33Tec7ox98vvupGqaqG2XSqzW+0jdPl1E0nLKSPcKzOYkXuHuba3MX+/IuRwaF6c/JdOlkkJOzWM7t6a8evr8KLgkm8HQtRfGD5lLNaQPwjkN7GNL/DeUPiRejwlW2Tq+y+7v6dtk+e2BbfRYowcNIdxapb2c/a9sL4W6W6RmtDkQv+dORUkyg+mvnEs+AM9F1q90Ef0qkJ7Q3/Q1oGCtaDuNJfUG4R/QNOaJaic2B7A+N/vBxCAQibgIaW4FVZE3329fiRqdcUqAe9GkOf85Tlizu7wlcyIxyW5uN5zx4jzJTypZ0V5iX+O8KAPGprtXIPvpUs4uyrFEzpek+3N/C7IOEJ524gJQZ9xPCQGZIQzPzKhWiThh+C07xR/rQ7yh99TCrJsLKRv7K4r3Cj4x5VdHF/P9moWfWEbbrldER3Td21u4rRbr8mX1pdv1JPZafJVEB6RguQzCbeRXKxnst6QuwCxzfDcC3Ht/PjJUAH3zlfr/fR9Y/suI1SeQq5zYPPF7vwcTIx9gNNp83G6RcBqNoB3WfsPhsWlRsc/+YXzUu1LD20Zz0vT12wc7wKWW1+GtmyHRWiUYGqEfOPXsUJMFhUpfvgHvifXBX7lqX9UilWoEGGomCSQPMD9XiCFBEUXMtAsiYe/hOoqKy2+8IB8lh9gmlfmJIomT+nxXan617SdsHfz4i/MOvkzwcrNVINdJqtvBVdAFcbtBXDkHMwwWy1eGznq+e5AY0VU09NAUUvHi64o8WUNILbzdw/fjT596gRZF8qMsjdggNMAv3jDXk0P685h5NIsVFwfYNgJEFCcQGxW7rvNgmQP8790GTr4C3qiOO3nWXzWlsltQXUh+cOYtCyPctv6xu6a1pbzXULochEunfXxSzjixB28FVpjYEhN0bV0MWIrYaFYPwvvq4IdaseYNfj9YEXwYgjaK20sYbT/QtaCOekcuxm43tXfz3iIsmsxb9gRJ1qqSlorljfG6BP3uriuQ0e2rO1HyD9NcscRyHHSoRqoaNGOMpha2Z6Zj7xC+lw243fDgNAMDlRH1S/TDUKHkV0motbmHw4UPJMDRffBpCf1bJUV0iJL2MPTRwfr3jQE3twzmzmwhI0zf68cLQrTeWE2cgbjFdsZUI6rJ3CO2Jj1G+vQp0szh6DZLozAcqH99pZMJYXXgmGtkj+AIeTs4ecDefZOBeSAOsojEuhzpzSgmrFVOI3Nql7QuCD6OXw/RI5o/V71PCQYSnTW/jU4vOq3zC1HXPj4LGT8iv4Wse6+usXOd1J2aiDakLBblFcXr3hqL3F0vDTaTZjc2S4qA4w358nBuXcK+bU4wtwP4nwGhLkItMAhIonVvuTzTtrDHuAO9KT2ZQFjnvWOnnbjHjVLWOEYRGV9TXTn/zuGqBv5X3SrlIjE+m6gLG3BgE8AuFd9DeBGkMMMambbi0s5dJ37Nda+F7PjA0ahfWLHV4Gn1So+++QjFv8o2qdpDVM/xA0Lw1lAyadGm6d8Wv2QdoB6CvOexwYqt/Icj52JsdFCha+M9vAdYKvfkl68x9sfMCq5SnlkgekXfCXakciLjiAlApBac/fXsPu8Z8k1X187qu2frgvb3bLb0gE+a1uwPOhGZvOFYAEFx2zxecHZOmQFQn6JXz2d235wBQ75ly20kWxR4EDdMwZqwSQuxDsqU/Hftt1Fu36y9QwzmjOev997hoHrjCFHgiEkvDuzPFRrCCfJL3J+PUdsdQrnJ2sqaeSL8B//5JHUAKGXaszJ3CxC+KnUT25yNUt3Uj/dbojzvDS7x/zS1mIFI6sv1HaecWNp4Kljm+LSHgbhOsEXv/eu53XmHUITmEBo9aIAMmX6/Y42oXR0tkcdpqRWjSZXLFeOi1o0iZPyOH7QRsiSLtjofR7WPMc+8hWAQm9xorTU8V2uHKoKV/J9HgalgEC7hB1LBNfMpPEPvHe+7KiJsa8vRBB+oZCUPbObbomRpZwmGmvjaz9nAhklEwcxyGXLecCGsqYIatI+tgf+VbIiJ8xHjwDX+Z6eBUtZ5VW0Fuekrz+4xMS/j8xg9SSS6J7y8QtzsfWFyPwZGGCi5YYB+VterfqdsaAmP1d3dM0lbjbZEbwJe+3g4ZJdo6ufQu0HWkK9Xyhe/ktJCE9bWbqUQck1iPErHY4JuIQ+i00wnnoXunG6+J8koFbWu8QDqqQvHQ2oqfqLxzdfG+t5/wIcL3wX/xW3nXyKBywXUu8JMb27DebEIEYnyANmpqsZL2aUEntYnl+Qz8ySr7NewlUsGBOx9QhupLspg42pzHHCSsy3JPPZ8r3JkAk0EHUw/eltjm7HKd8mz3fEawWaICIRD9Ft9jkLcFgp8EG0QAgpMjNKrc1ERHYQsRcOqIbpNYwbSRpjr8hf+WPRQnD8VRY/fnSWL3KQgxgB",
                             },
-                            {"type": "text", "text": "3"},
+                            {
+                                "type": "text",
+                                "text": """\
+Looking at numbers below 400 that contain "79" as a substring:
+
+- Two-digit: 79
+- Three-digit: 179, 279, 379
+
+Checking which are prime:
+- 79: Prime
+- 179: Prime  \n\
+- 279: Not prime (divisible by 3)
+- 379: Prime
+
+3\
+""",
+                            },
                         ],
                     },
                 ),
@@ -818,25 +849,17 @@ The primes under 400 containing "79" are 79, 179, and 379—three total.\
                     content=[
                         Thought(
                             thought="""\
-Let me think about primes below 400 that contain "79" as a substring.
+The user is asking me to recall the primes I found in my previous answer. In my previous response, I identified:
 
-Numbers containing "79" as a substring below 400 would be:
-79, 179, 279, 379, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+- 79: Prime
+- 179: Prime  \n\
+- 279: Not prime (divisible by 3)
+- 379: Prime
 
-But we need those below 400, so:
-79, 179, 279, 379
-
-Now I need to check which of these are prime:
-- 79: Let me check if this is prime. 79 is not divisible by 2, 3, 5, 7... √79 ≈ 8.9, so I need to check up to 8. 79 ÷ 7 = 11.28..., not divisible. 79 is prime.
-- 179: Let me check. √179 ≈ 13.4, so I need to check divisibility up to 13. 179 is odd, not divisible by 3 (1+7+9=17, not divisible by 3), not divisible by 5, 7, 11, 13. 179 is prime.
-- 279: 279 = 3 × 93 = 3 × 3 × 31 = 9 × 31. So 279 is not prime.
-- 379: Let me check. √379 ≈ 19.5, so check up to 19. 379 is odd, 3+7+9=19 (not divisible by 3), not ending in 0 or 5, let me check 7: 379 ÷ 7 = 54.14..., 11: 379 ÷ 11 = 34.45..., 13: 379 ÷ 13 = 29.15..., 17: 379 ÷ 17 = 22.29..., 19: 379 ÷ 19 = 19.95... So 379 appears to be prime.
-
-
-That gives me three primes: 79, 179, and 379.\
+So the primes were 79, 179, and 379.\
 """
                         ),
-                        Text(text="The primes were: 79, 179, and 379."),
+                        Text(text="The primes were 79, 179, and 379."),
                     ],
                     provider_id="anthropic",
                     model_id="anthropic-beta/claude-sonnet-4-0",
@@ -847,28 +870,20 @@ That gives me three primes: 79, 179, and 379.\
                             {
                                 "type": "thinking",
                                 "thinking": """\
-Let me think about primes below 400 that contain "79" as a substring.
+The user is asking me to recall the primes I found in my previous answer. In my previous response, I identified:
 
-Numbers containing "79" as a substring below 400 would be:
-79, 179, 279, 379, 790, 791, 792, 793, 794, 795, 796, 797, 798, 799
+- 79: Prime
+- 179: Prime  \n\
+- 279: Not prime (divisible by 3)
+- 379: Prime
 
-But we need those below 400, so:
-79, 179, 279, 379
-
-Now I need to check which of these are prime:
-- 79: Let me check if this is prime. 79 is not divisible by 2, 3, 5, 7... √79 ≈ 8.9, so I need to check up to 8. 79 ÷ 7 = 11.28..., not divisible. 79 is prime.
-- 179: Let me check. √179 ≈ 13.4, so I need to check divisibility up to 13. 179 is odd, not divisible by 3 (1+7+9=17, not divisible by 3), not divisible by 5, 7, 11, 13. 179 is prime.
-- 279: 279 = 3 × 93 = 3 × 3 × 31 = 9 × 31. So 279 is not prime.
-- 379: Let me check. √379 ≈ 19.5, so check up to 19. 379 is odd, 3+7+9=19 (not divisible by 3), not ending in 0 or 5, let me check 7: 379 ÷ 7 = 54.14..., 11: 379 ÷ 11 = 34.45..., 13: 379 ÷ 13 = 29.15..., 17: 379 ÷ 17 = 22.29..., 19: 379 ÷ 19 = 19.95... So 379 appears to be prime.
-
-
-That gives me three primes: 79, 179, and 379.\
+So the primes were 79, 179, and 379.\
 """,
-                                "signature": "Et8JCkYICxgCKkBJolNiXJlrl/yam9XKnuT4CSSOHPH+L51mM8VaHgaDMbfKChR1aqr90RSOqkGYtaxTEYpcRQTrwZkHT66jNKWSEgxng1sCJVZkl4kdx1saDL12G0WfMTF+5qRu3SIwMdWnrtG8Ow0lGhwvDkO0fKwTo7G+9C0KTUAc6KeFYUOXvTWtMaEKMaEGNOIDqpCYKsYIr21zp7zG0uXhMlfkZWoVF+6OH0X6P6ZfT8Rfi3RmJhjcSs9xzZe9SfTzRK/FBBS+T1mugT0QLVXk9v111SjQ8QTfHD63YFxkWbtyBovggVOk7my2dCb6YmjZXy+QOsSEffJ8Cy5T7P+yAdw7ZD+y2r98IN5opfTT5NAnsVQx9j4O27Hbk8GaklmKfV2c8f08j2my+Zu/REvCMVREHNCUX3Or15yzDho2d93xF0nE3MqYN25gD2hvCcJVm5vn1JJJ5xQWVTGMoLEdiHcLVAp3zfEpSEc2O+cveCRRCkW3Uh8SX38A0p38sMe1InLQkySAlSmByWrnk2MD3qV5RKzna8ZpmsGtrcBHfLV+T1Dwk9zqOQIfdQvKZj1zaWqxPyuUrt8i/xq62mzOZbe2bFtX46zbAzpxchXu0CGFP0DyzzJZnBWYw6W/siH3tJKz7BOvRn5EGaU8zUd6gBjBNc9YFXBEWp13M2ZUXYOPlO6FiuJJUw/OY7qKcVZ9riE5k7osGE+b81DxAwOMH5O3ZYEwkIz4uer2cpDL3887i++TYMciWnggi2R2qEJqKLgqf4s+6TvfQw8tPgNeQnLxRWZj381EUnq1DHn1fk2g0ZESrGovNldB6mDlv3BMvXF6JzDL3C4emRWxpM3bVEwJVEqh5yvWABb/H6McnXopBvUrmb2uR7aAs1Jgqnlfj8JCTpc1vfUxi228NdNXuIiYRgvk0Jii9/roAx2hs2nsyP3VRFkRqzNwRUXrHKmEUuJo/7zFEkvI7qo1dPKg1C71GsLPO4WBsm7fZKFsU2Krin8F5yyHjHvuW1uRqUbbtxG8SQe2TrkJkJwHCbkO9F+IuBOkPnYKjUzwnSqINXYvBsKl/9wHJuV27ijD1mMwQFns453fJxIS5uBwQSZ4uL5RGyzMp09tobyQpjGqAgy5mPUfa7pt8lccCPkSpHoA/i/8pl7PJnMa5eXpz7jMrz0h6kdZecFQAez53pitQd0W2TiK+3x1tkQS+4F/Ea30mPFi/+6947pm5tGlYmkLjKNrnA+1G/uYk+727vhwhyhWwdxSuCx2QXPkCP0lDU0/gM6Wu75FAJBTGlkacatDyCRxpW8aF7UwdlFiBtjbhRPz2+dQE6cqVy06jtlK176VtK7+StW3F7No5mk9omENJ9YbhW0y1nZZE4XDhuvls2BRN84xyN+xBjUuv0MfHiXkfEcWhUAGynyPcC21P2Zf/x50IqWxcJl5Ur+yKa3P9ef/rC0AVyyipfKoPg6bRDguczQqXbrBu8XJSOfMrk3GxTdFsqCs+d9hn8st/69MF3HMJYmjBV4Rahmhh3l7epuujnrdKQi+QalyTFUUXrJn6tcqPeg6TSwK2QiO2kvunVgJrjHEthmb7/Cx/iLWJN507qKmb2i1zbW0sa+eFPOtAy8muLUJM8HoAPMHS+xWZ9V5wxlsQV+Vp4vUPxMYAQ==",
+                                "signature": "EocDCkYICxgCKkBIWx+iJ3joRsE9k8/w9+ly1FAVn9xQOGgK4Vc/NWUXfZd9BNkvjZt12CdEUVSs89YudVpEgswF742zGYMGJCQdEgwgPNowuP5m6owI99kaDGFwdJ6m1bINUg8cAyIwQjFFx6xn3sO36DarsopqwcUcwzOkQfiZfl9nRFc6Jf9d+OBn5lm/jkwMYgtAlmeXKu4BQ/Bse686VoHfGJamMXt6eDyP816RwiHkrJLHjRMxmIIVyRZ20YI3g4UibqBO3sMklyMKGyfU7F1b1s2/aXEdj09lWawYzoqWf4H/FBoIMJTsZemg+Rwd/Id3ZOcVAMZwwhw+oKAV2rIk0s2nlwMLQHPn3n2qSz5OxVhLMWV937YY5dDbTWwo3wO64tgpjoY70v+S7FvaNvPnRo73lK1PmqlWvMZulqzOfOojV4eSPVY2aZC+TTHrMRMUrKbgwz7AS3MqpSb8zMABiOs+LtzrX6s00meSVNA859UNrC119bdYhVj8+LqZBIZDAtTHvhgB",
                             },
                             {
                                 "type": "text",
-                                "text": "The primes were: 79, 179, and 379.",
+                                "text": "The primes were 79, 179, and 379.",
                             },
                         ],
                     },
@@ -877,15 +892,15 @@ That gives me three primes: 79, 179, and 379.\
             "format": None,
             "tools": [],
             "usage": {
-                "input_tokens": 97,
-                "output_tokens": 547,
+                "input_tokens": 175,
+                "output_tokens": 99,
                 "cache_read_tokens": 0,
                 "cache_write_tokens": 0,
                 "reasoning_tokens": 0,
                 "raw": "None",
-                "total_tokens": 644,
+                "total_tokens": 274,
             },
-            "n_chunks": 122,
+            "n_chunks": 29,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_call_with_tools/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -439,15 +439,15 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         Text(
-                            text="I'll retrieve the secrets for both passwords you provided."
+                            text="I'll retrieve the secrets for both passwords using parallel function calls."
                         ),
                         ToolCall(
-                            id="toolu_0199cTXNM9CoZP2ivCetrRm3",
+                            id="toolu_012Hbq7BCqrkTwtEMQEzmrDs",
                             name="secret_retrieval_tool",
                             args='{"password": "mellon"}',
                         ),
                         ToolCall(
-                            id="toolu_011WQyAr9qBAfeS7Ce3mHF8A",
+                            id="toolu_01Gq18vb6oWSFwfmhzGi5f8H",
                             name="secret_retrieval_tool",
                             args='{"password": "radiance"}',
                         ),
@@ -460,17 +460,17 @@ async_stream_snapshot = snapshot(
                         "content": [
                             {
                                 "type": "text",
-                                "text": "I'll retrieve the secrets for both passwords you provided.",
+                                "text": "I'll retrieve the secrets for both passwords using parallel function calls.",
                             },
                             {
                                 "type": "tool_use",
-                                "id": "toolu_0199cTXNM9CoZP2ivCetrRm3",
+                                "id": "toolu_012Hbq7BCqrkTwtEMQEzmrDs",
                                 "name": "secret_retrieval_tool",
                                 "input": {"password": "mellon"},
                             },
                             {
                                 "type": "tool_use",
-                                "id": "toolu_011WQyAr9qBAfeS7Ce3mHF8A",
+                                "id": "toolu_01Gq18vb6oWSFwfmhzGi5f8H",
                                 "name": "secret_retrieval_tool",
                                 "input": {"password": "radiance"},
                             },
@@ -480,12 +480,12 @@ async_stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="toolu_0199cTXNM9CoZP2ivCetrRm3",
+                            id="toolu_012Hbq7BCqrkTwtEMQEzmrDs",
                             name="secret_retrieval_tool",
                             value="Welcome to Moria!",
                         ),
                         ToolOutput(
-                            id="toolu_011WQyAr9qBAfeS7Ce3mHF8A",
+                            id="toolu_01Gq18vb6oWSFwfmhzGi5f8H",
                             name="secret_retrieval_tool",
                             value="Life before Death",
                         ),
@@ -545,15 +545,15 @@ Here are the secrets retrieved for each password:
                 }
             ],
             "usage": {
-                "input_tokens": 602,
+                "input_tokens": 604,
                 "output_tokens": 39,
                 "cache_read_tokens": 0,
                 "cache_write_tokens": 0,
                 "reasoning_tokens": 0,
                 "raw": "None",
-                "total_tokens": 641,
+                "total_tokens": 643,
             },
-            "n_chunks": 14,
+            "n_chunks": 12,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_max_tokens/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -224,7 +224,7 @@ async_stream_snapshot = snapshot(
                     content=[
                         Text(
                             text="""\
-Here are all 50 U.S. states:
+Here are all 50 U.S. states in alphabetical order:
 
 1. Alabama
 2. Alaska
@@ -234,8 +234,7 @@ Here are all 50 U.S. states:
 6. Colorado
 7. Connecticut
 8. Delaware
-9. Florida
-10\
+9\
 """
                         )
                     ],
@@ -248,7 +247,7 @@ Here are all 50 U.S. states:
                             {
                                 "type": "text",
                                 "text": """\
-Here are all 50 U.S. states:
+Here are all 50 U.S. states in alphabetical order:
 
 1. Alabama
 2. Alaska
@@ -258,8 +257,7 @@ Here are all 50 U.S. states:
 6. Colorado
 7. Connecticut
 8. Delaware
-9. Florida
-10\
+9\
 """,
                             }
                         ],
@@ -277,7 +275,7 @@ Here are all 50 U.S. states:
                 "raw": "None",
                 "total_tokens": 65,
             },
-            "n_chunks": 10,
+            "n_chunks": 13,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -675,6 +675,7 @@ Respond only with valid JSON that matches this exact schema:
                     content=[
                         Text(
                             text="""\
+```json
 {
   "title": "THE NAME OF THE WIND",
   "author": {
@@ -682,7 +683,8 @@ Respond only with valid JSON that matches this exact schema:
     "last_name": "Rothfuss"
   },
   "rating": 7
-}\
+}
+```\
 """
                         )
                     ],
@@ -695,6 +697,7 @@ Respond only with valid JSON that matches this exact schema:
                             {
                                 "type": "text",
                                 "text": """\
+```json
 {
   "title": "THE NAME OF THE WIND",
   "author": {
@@ -702,7 +705,8 @@ Respond only with valid JSON that matches this exact schema:
     "last_name": "Rothfuss"
   },
   "rating": 7
-}\
+}
+```\
 """,
                             }
                         ],
@@ -792,14 +796,14 @@ Respond only with valid JSON that matches this exact schema:
             "tools": [],
             "usage": {
                 "input_tokens": 328,
-                "output_tokens": 58,
+                "output_tokens": 63,
                 "cache_read_tokens": 0,
                 "cache_write_tokens": 0,
                 "reasoning_tokens": 0,
                 "raw": "None",
-                "total_tokens": 386,
+                "total_tokens": 391,
             },
-            "n_chunks": 11,
+            "n_chunks": 12,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -329,7 +329,7 @@ async_stream_snapshot = snapshot(
                         "content": [
                             {
                                 "type": "tool_use",
-                                "id": "toolu_01T2B5FmsMG1xY31XmoCCRTb",
+                                "id": "toolu_01891B3yZSWpreEjFVKyBF9N",
                                 "name": "__mirascope_formatted_output_tool__",
                                 "input": {
                                     "title": "THE NAME OF THE WIND",
@@ -387,7 +387,7 @@ async_stream_snapshot = snapshot(
                 "raw": "None",
                 "total_tokens": 644,
             },
-            "n_chunks": 16,
+            "n_chunks": 20,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/json/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -689,7 +689,7 @@ Respond only with valid JSON that matches this exact schema:
                             text="I'll look up the book information for ISBN 0-7653-1178-X."
                         ),
                         ToolCall(
-                            id="toolu_01M967FW1bRxXjpDHxophJZg",
+                            id="toolu_01My26oDaaNkgBerQJcroNv4",
                             name="get_book_info",
                             args='{"isbn": "0-7653-1178-X"}',
                         ),
@@ -706,7 +706,7 @@ Respond only with valid JSON that matches this exact schema:
                             },
                             {
                                 "type": "tool_use",
-                                "id": "toolu_01M967FW1bRxXjpDHxophJZg",
+                                "id": "toolu_01My26oDaaNkgBerQJcroNv4",
                                 "name": "get_book_info",
                                 "input": {"isbn": "0-7653-1178-X"},
                             },
@@ -716,7 +716,7 @@ Respond only with valid JSON that matches this exact schema:
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="toolu_01M967FW1bRxXjpDHxophJZg",
+                            id="toolu_01My26oDaaNkgBerQJcroNv4",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/strict/anthropic_claude_sonnet_4_5_snapshots.py
@@ -404,7 +404,7 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="toolu_01MeT9kdBuYqFV4mFqfDXVso",
+                            id="toolu_01MHCLxpF4PVKhW69eNmBdEM",
                             name="get_book_info",
                             args='{"isbn": "0-7653-1178-X"}',
                         )
@@ -417,7 +417,7 @@ async_stream_snapshot = snapshot(
                         "content": [
                             {
                                 "type": "tool_use",
-                                "id": "toolu_01MeT9kdBuYqFV4mFqfDXVso",
+                                "id": "toolu_01MHCLxpF4PVKhW69eNmBdEM",
                                 "name": "get_book_info",
                                 "input": {"isbn": "0-7653-1178-X"},
                             }
@@ -427,7 +427,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="toolu_01MeT9kdBuYqFV4mFqfDXVso",
+                            id="toolu_01MHCLxpF4PVKhW69eNmBdEM",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -504,7 +504,7 @@ async_stream_snapshot = snapshot(
                 "raw": "None",
                 "total_tokens": 1000,
             },
-            "n_chunks": 8,
+            "n_chunks": 9,
         }
     }
 )

--- a/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
+++ b/python/tests/e2e/output/snapshots/test_structured_output_with_tools/tool/anthropic_beta_claude_sonnet_4_0_snapshots.py
@@ -434,7 +434,7 @@ async_stream_snapshot = snapshot(
                 AssistantMessage(
                     content=[
                         ToolCall(
-                            id="toolu_012x2VSJWaDWAf1NgQFzJ38i",
+                            id="toolu_01KnpHp1mZTYQTyMbHX1TxSR",
                             name="get_book_info",
                             args='{"isbn": "0-7653-1178-X"}',
                         )
@@ -447,7 +447,7 @@ async_stream_snapshot = snapshot(
                         "content": [
                             {
                                 "type": "tool_use",
-                                "id": "toolu_012x2VSJWaDWAf1NgQFzJ38i",
+                                "id": "toolu_01KnpHp1mZTYQTyMbHX1TxSR",
                                 "name": "get_book_info",
                                 "input": {"isbn": "0-7653-1178-X"},
                             }
@@ -457,7 +457,7 @@ async_stream_snapshot = snapshot(
                 UserMessage(
                     content=[
                         ToolOutput(
-                            id="toolu_012x2VSJWaDWAf1NgQFzJ38i",
+                            id="toolu_01KnpHp1mZTYQTyMbHX1TxSR",
                             name="get_book_info",
                             value="Title: Mistborn: The Final Empire, Author: Brandon Sanderson, Pages: 544, Published: 2006-07-25",
                         )
@@ -477,7 +477,7 @@ async_stream_snapshot = snapshot(
                         "content": [
                             {
                                 "type": "tool_use",
-                                "id": "toolu_01X8JRbMUHADWWJfpGW7kj8Y",
+                                "id": "toolu_01FGKBBHzTkBsrtHZmityqxV",
                                 "name": "__mirascope_formatted_output_tool__",
                                 "input": {
                                     "title": "Mistborn: The Final Empire",
@@ -541,7 +541,7 @@ async_stream_snapshot = snapshot(
                 "raw": "None",
                 "total_tokens": 804,
             },
-            "n_chunks": 19,
+            "n_chunks": 23,
         }
     }
 )

--- a/python/tests/ops/_internal/test_closure.py
+++ b/python/tests/ops/_internal/test_closure.py
@@ -485,7 +485,7 @@ def aliased_module_import_fn(query: str) -> str:
 """
     )
     assert closure.dependencies == snapshot(
-        {"openai": {"version": "2.14.0", "extras": None}}
+        {"openai": {"version": "2.15.0", "extras": None}}
     )
 
 
@@ -506,7 +506,7 @@ def aliased_import_fn(query: str) -> str:
 """
     )
     assert closure.dependencies == snapshot(
-        {"openai": {"version": "2.14.0", "extras": None}}
+        {"openai": {"version": "2.15.0", "extras": None}}
     )
 
 
@@ -640,7 +640,7 @@ def annotated_assignment_fn() -> str:
 """
     )
     assert closure.dependencies == snapshot(
-        {"openai": {"version": "2.14.0", "extras": None}}
+        {"openai": {"version": "2.15.0", "extras": None}}
     )
 
 
@@ -664,7 +664,7 @@ def internal_imports_fn() -> str:
 """
     )
     assert closure.dependencies == snapshot(
-        {"openai": {"version": "2.14.0", "extras": None}}
+        {"openai": {"version": "2.15.0", "extras": None}}
     )
 
 
@@ -759,7 +759,7 @@ def closure_inside_decorator_fn() -> str:
     assert closure.dependencies == snapshot(
         {
             "mirascope": {
-                "version": "2.0.0a6",
+                "version": "2.0.0b0",
                 "extras": ["all"],
             }
         }
@@ -793,7 +793,7 @@ def closure_inside_imported_decorator_fn() -> str:
     assert closure.dependencies == snapshot(
         {
             "mirascope": {
-                "version": "2.0.0a6",
+                "version": "2.0.0b0",
                 "extras": ["all"],
             }
         }

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -23,7 +23,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.75.0"
+version = "0.76.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -35,9 +35,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/1f/08e95f4b7e2d35205ae5dcbb4ae97e7d477fc521c275c02609e2931ece2d/anthropic-0.75.0.tar.gz", hash = "sha256:e8607422f4ab616db2ea5baacc215dd5f028da99ce2f022e33c7c535b29f3dfb", size = 439565, upload-time = "2025-11-24T20:41:45.28Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/be/d11abafaa15d6304826438170f7574d750218f49a106c54424a40cef4494/anthropic-0.76.0.tar.gz", hash = "sha256:e0cae6a368986d5cf6df743dfbb1b9519e6a9eee9c6c942ad8121c0b34416ffe", size = 495483, upload-time = "2026-01-13T18:41:14.908Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/1c/1cd02b7ae64302a6e06724bf80a96401d5313708651d277b1458504a1730/anthropic-0.75.0-py3-none-any.whl", hash = "sha256:ea8317271b6c15d80225a9f3c670152746e88805a7a61e14d4a374577164965b", size = 388164, upload-time = "2025-11-24T20:41:43.587Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/70/7b0fd9c1a738f59d3babe2b4212031c34ab7d0fda4ffef15b58a55c5bcea/anthropic-0.76.0-py3-none-any.whl", hash = "sha256:81efa3113901192af2f0fe977d3ec73fdadb1e691586306c4256cd6d5ccc331c", size = 390309, upload-time = "2026-01-13T18:41:13.483Z" },
 ]
 
 [[package]]
@@ -594,7 +594,7 @@ requests = [
 
 [[package]]
 name = "google-genai"
-version = "1.57.0"
+version = "1.58.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -608,9 +608,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/b4/8251c2d2576224a4b51a8ab6159820f9200b8da28ff555c78ee15607096e/google_genai-1.57.0.tar.gz", hash = "sha256:0ff9c36b8d68abfbdbd13b703ece926de5f3e67955666b36315ecf669b94a826", size = 485648, upload-time = "2026-01-07T20:38:20.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/49/0c2dd11c50db7ee2c299c63f1795256c96543be8b40e6f139c1a680f92e8/google_genai-1.58.0.tar.gz", hash = "sha256:bbec3abf253c17ad57b68e7f8d87d5cda34d5909c67b7ba726207a2bd10aa9fd", size = 486640, upload-time = "2026-01-15T00:38:48.404Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/02/858bdae08e2184b6afe0b18bc3113318522c9cf326a5a1698055edd31f88/google_genai-1.57.0-py3-none-any.whl", hash = "sha256:d63c7a89a1f549c4d14032f41a0cdb4b6fe3f565e2eee6b5e0907a0aeceabefd", size = 713323, upload-time = "2026-01-07T20:38:18.051Z" },
+    { url = "https://files.pythonhosted.org/packages/56/61/098a414cc41600036fe3eb24415221f5412f446e1be1ce9595bb32f2ae92/google_genai-1.58.0-py3-none-any.whl", hash = "sha256:2df3fceb92a519d51e266babde26f7c298fb12f84f469605c4ce80c2ec43f796", size = 718352, upload-time = "2026-01-15T00:38:46.658Z" },
 ]
 
 [[package]]
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "mirascope"
-version = "2.0.0a6"
+version = "2.0.0b0"
 source = { editable = "." }
 dependencies = [
     { name = "docstring-parser" },
@@ -1253,16 +1253,16 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.75.0,<1.0" },
+    { name = "anthropic", marker = "extra == 'anthropic'", specifier = ">=0.76.0,<1.0" },
     { name = "docstring-parser", specifier = ">=0.17.0" },
-    { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.57.0,<2" },
+    { name = "google-genai", marker = "extra == 'google'", specifier = ">=1.58.0,<2" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jiter", specifier = ">=0.7.0" },
     { name = "libcst", marker = "extra == 'ops'", specifier = ">=1.8.6" },
     { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1.25.0,<2" },
     { name = "mirascope", extras = ["anthropic", "api", "google", "openai", "mcp", "ops", "mlx"], marker = "extra == 'all'" },
     { name = "mlx-lm", marker = "extra == 'mlx'", specifier = ">=0.28.4,<1" },
-    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.14.0,<3" },
+    { name = "openai", marker = "extra == 'openai'", specifier = ">=2.15.0,<3" },
     { name = "opentelemetry-api", marker = "extra == 'ops'", specifier = ">=1.38.0,<2" },
     { name = "opentelemetry-exporter-otlp", marker = "extra == 'ops'", specifier = ">=1.38.0,<2" },
     { name = "opentelemetry-instrumentation", marker = "extra == 'ops'", specifier = ">=0.59b0,<1" },
@@ -1639,7 +1639,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.14.0"
+version = "2.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1651,9 +1651,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d8/b1/12fe1c196bea326261718eb037307c1c1fe1dedc2d2d4de777df822e6238/openai-2.14.0.tar.gz", hash = "sha256:419357bedde9402d23bf8f2ee372fca1985a73348debba94bddff06f19459952", size = 626938, upload-time = "2025-12-19T03:28:45.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/f4/4690ecb5d70023ce6bfcfeabfe717020f654bde59a775058ec6ac4692463/openai-2.15.0.tar.gz", hash = "sha256:42eb8cbb407d84770633f31bf727d4ffb4138711c670565a41663d9439174fba", size = 627383, upload-time = "2026-01-09T22:10:08.603Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/4b/7c1a00c2c3fbd004253937f7520f692a9650767aa73894d7a34f0d65d3f4/openai-2.14.0-py3-none-any.whl", hash = "sha256:7ea40aca4ffc4c4a776e77679021b47eec1160e341f42ae086ba949c9dcc9183", size = 1067558, upload-time = "2025-12-19T03:28:43.727Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/df/c306f7375d42bafb379934c2df4c2fa3964656c8c782bac75ee10c102818/openai-2.15.0-py3-none-any.whl", hash = "sha256:6ae23b932cd7230f7244e52954daa6602716d6b9bf235401a107af731baea6c3", size = 1067879, upload-time = "2026-01-09T22:10:06.446Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I bumped the major provider deps, I think it will be a nice habit to
keep these up-to-date when we release. I believe it is reasonable for
someone who upgrades to the latest version of Mirascope to also upgrade
to the latest version of the provider sdks, and regular bumps (along
with regularly reading the release notes) makes regressions or
unexpected changes less likely and easier to debug than if we only
rarely do giant upgrades.