### PR TITLE
feat(python-sdk): add `Response.text()` for convenience

### DIFF
--- a/docs/content/responses.mdx
+++ b/docs/content/responses.mdx
@@ -13,20 +13,30 @@ When you call an LLM, you get back an `llm.Response`. This object contains every
 
 The LLM's output is available through several properties:
 
-<CodeExample file="examples/responses/content_access.py" lines="3-" />
 
 ### Content Properties
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `content` | `Sequence[AssistantContentPart]` | All content parts in generation order |
-| `texts` | `Sequence[Text]` | Only the text portions of the response |
-| `tool_calls` | `Sequence[ToolCall]` | Tool calls the LLM wants executed  |
-| `thoughts` | `Sequence[Thought]` | Reasoning from the model's thinking process |
+| `content` | `Sequence[llm.AssistantContentPart]` | All content parts in generation order |
+| `texts` | `Sequence[llm.Text]` | Only the text portions of the response |
+| `tool_calls` | `Sequence[llm.ToolCall]` | Tool calls the LLM wants executed  |
+| `thoughts` | `Sequence[llm.Thought]` | Reasoning from the model's thinking process |
+| `messages` | `Sequence[llm.Message]` | All of the messages in the response's history (including the final assistant message) |
+| `usage` | `llm.Usage` | Token usage for this response |
 
-In many cases, the response contains a single `Text` part, accessible via `response.texts[0].text`. For robustness with zero or multiple text parts, use `"".join(part.text for part in response.texts)`. 
+It's often useful to combine a response's content into a single string. `response.text()` returns all text content joined together, ideal for displaying to users. 
 
-You can use `response.pretty()` to get a human-readable string representation of all content in the response, including thoughts or tool calls. This is particularly useful for development and debugging.
+`response.pretty()` includes stringified representations of all content types (text, thoughts, tool calls), which is helpful for debugging.
+
+<CodeExample file="examples/responses/content_access.py" lines="3-" />
+
+### Content Methods
+
+| Method | Returns | Description |
+| --- | --- | --- |
+| `text(sep="\n")` | `str` | All text content joined by separator |
+| `pretty()` | `str` | Human-readable representation of all content |
 
 <Note>
 `tool_calls` and `thoughts` are populated only when relevant. See [Tools](/docs/mirascope/v2/tools) and [Thinking](/docs/mirascope/v2/thinking) for details.
@@ -53,10 +63,12 @@ Every response includes metadata about how it was generated:
 
 | Property | Type | Description |
 | --- | --- | --- |
-| `provider_id` | `ProviderId` | The provider (e.g., `"openai"`, `"anthropic"`) |
-| `model_id` | `ModelId` | The full model identifier |
-| `params` | `Params` | Parameters used for generation |
-| `model` | `Model` | A `Model` instance matching this response |
+| `provider_id` | `llm.ProviderId` | The provider (e.g., `"openai"`, `"anthropic"`) |
+| `model_id` | `llm.ModelId` | The full model identifier |
+| `params` | `llm.Params` | Parameters used for generation |
+| `model` | `llm.Model` | A `Model` instance that can be used for continuing from this response. (Respects the model context manager.) |
+| `usage` | `llm.Usage` | Token usage of this response. |
+| `finish_reason` | `llm.FinishReason | None` | Information on why the response finished. |
 | `raw` | `Any` | The unprocessed provider response |
 
 The `raw` property gives you access to the original response object from the provider's SDK, in case you want to peek below Mirascope's abstraction layer to the provider's raw output.

--- a/python/examples/responses/basic.py
+++ b/python/examples/responses/basic.py
@@ -1,10 +1,6 @@
 from mirascope import llm
 
-model: llm.Model = llm.use_model("openai/gpt-4o")
+model = llm.model("openai/gpt-5-mini")
 response: llm.Response = model.call("What is the capital of France?")
 
-# Access response content
-print(response.pretty())  # Human-readable output
-print(response.texts)  # List of Text objects
-print(response.content)  # All content parts (Text, ToolCall, Thought)
-print(response.messages)  # All of the messages in the response.
+print(response.text())  # Prints the textual content of the response

--- a/python/examples/responses/content_access.py
+++ b/python/examples/responses/content_access.py
@@ -1,6 +1,6 @@
 from mirascope import llm
 
-model = llm.use_model("openai/gpt-4o")
+model = llm.model("openai/gpt-5")
 response = model.call("Tell me a joke.")
 
 # response.content contains all content parts: Text, ToolCall, Thought

--- a/python/examples/responses/finish_reason.py
+++ b/python/examples/responses/finish_reason.py
@@ -1,6 +1,6 @@
 from mirascope import llm
 
-model = llm.use_model("anthropic/claude-sonnet-4-5", max_tokens=40)
+model = llm.model("anthropic/claude-sonnet-4-5", max_tokens=40)
 response = model.call("Write a long story about a bear.")
 
 # finish_reason is None when the response completes normally

--- a/python/examples/responses/metadata.py
+++ b/python/examples/responses/metadata.py
@@ -1,6 +1,6 @@
 from mirascope import llm
 
-model = llm.use_model("openai/gpt-4o")
+model = llm.model("openai/gpt-5-mini")
 response = model.call("Hello!")
 
 # Response metadata

--- a/python/mirascope/llm/responses/root_response.py
+++ b/python/mirascope/llm/responses/root_response.py
@@ -171,6 +171,30 @@ class RootResponse(Generic[ToolkitT, FormattableT], ABC):
 
             return formattable.model_validate_json(json_text)
 
+    def text(self, sep: str = "\n") -> str:
+        """Return all text content from this response as a single string.
+
+        Joins the text from all `Text` parts in the response content using the
+        specified separator.
+
+        Args:
+            sep: The separator to use when joining multiple text parts.
+                Defaults to newline ("\\n").
+
+        Returns:
+            A string containing all text content joined by the separator.
+            Returns an empty string if the response contains no text parts.
+
+        Example:
+            >>> response.text()  # Join with newlines (default)
+            'Hello\\nWorld'
+            >>> response.text(sep=" ")  # Join with spaces
+            'Hello World'
+            >>> response.text(sep="")  # Concatenate directly
+            'HelloWorld'
+        """
+        return sep.join(text.text for text in self.texts)
+
     def pretty(self) -> str:
         """Return a string representation of all response content.
 

--- a/python/tests/llm/responses/test_response.py
+++ b/python/tests/llm/responses/test_response.py
@@ -142,6 +142,71 @@ def test_response_with_different_finish_reasons() -> None:
         assert response.finish_reason == finish_reason
 
 
+def test_text_empty() -> None:
+    """Test text() with no text parts."""
+    assistant_message = llm.messages.assistant(
+        content=[], model_id="openai/gpt-5-mini", provider_id="openai"
+    )
+    response = llm.Response(
+        raw=None,
+        usage=None,
+        provider_id="openai",
+        model_id="openai/gpt-5-mini",
+        provider_model_name="gpt-5-mini",
+        params={},
+        tools=[],
+        input_messages=[],
+        assistant_message=assistant_message,
+        finish_reason=None,
+    )
+    assert response.text() == ""
+
+
+def test_text_default_sep() -> None:
+    """Test text() with default newline separator."""
+    assistant_message = llm.messages.assistant(
+        content=[llm.Text(text="Hello"), llm.Text(text="World")],
+        model_id="openai/gpt-5-mini",
+        provider_id="openai",
+    )
+    response = llm.Response(
+        raw=None,
+        usage=None,
+        provider_id="openai",
+        model_id="openai/gpt-5-mini",
+        provider_model_name="gpt-5-mini",
+        params={},
+        tools=[],
+        input_messages=[],
+        assistant_message=assistant_message,
+        finish_reason=None,
+    )
+    assert response.text() == "Hello\nWorld"
+
+
+def test_text_custom_sep() -> None:
+    """Test text() with custom separator."""
+    assistant_message = llm.messages.assistant(
+        content=[llm.Text(text="Hello"), llm.Text(text="World")],
+        model_id="openai/gpt-5-mini",
+        provider_id="openai",
+    )
+    response = llm.Response(
+        raw=None,
+        usage=None,
+        provider_id="openai",
+        model_id="openai/gpt-5-mini",
+        provider_model_name="gpt-5-mini",
+        params={},
+        tools=[],
+        input_messages=[],
+        assistant_message=assistant_message,
+        finish_reason=None,
+    )
+    assert response.text(sep=" ") == "Hello World"
+    assert response.text(sep="") == "HelloWorld"
+
+
 def test_empty_response_pretty() -> None:
     """Test pretty representation of an empty response."""
     assistant_message = llm.messages.assistant(


### PR DESCRIPTION
Update docs. Note, I changed some examples to use `llm.model` instead of
`llm.use_model`. I'm thinking we'll discuss `use_model` specifically
when introducing the model context manager, but most examples don't need
the extra cognitive overhead.