### PR TITLE
docs(cloud): ClickHouse Analytics Flow

### DIFF
--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -296,7 +296,7 @@ cloud/
 OTLP ingest
   └── Cloudflare Queue (spans_ingest)
         ├── ClickHouse (analytics)
-        └── RecentSpansDO (realtime cache)
+        └── RealtimeSpansDurableObject (realtime cache)
 ```
 
 **ClickHouse Queue Processing (Detailed)**:
@@ -306,7 +306,7 @@ OTLP ingest
 2) spanIngestQueue consumes messages:
    - transform to ClickHouse row
    - bulk insert into ClickHouse
-   - upsert into RecentSpansDO
+   - upsert into RealtimeSpansDurableObject
 3) Failures trigger queue retry + DLQ
 ```
 


### PR DESCRIPTION
### TL;DR

Updated references to the realtime cache component in the system architecture documentation.

### What changed?

Renamed `RecentSpansDO` to `RealtimeSpansDurableObject` in the STRUCTURE.md file to accurately reflect the current naming convention used in the codebase. This change appears in both the OTLP ingest diagram and the ClickHouse Queue Processing details section.

### How to test?

Verify that the updated component name in STRUCTURE.md matches the actual implementation in the codebase.

### Why make this change?

This change ensures consistency between the documentation and the actual implementation, making it easier for developers to understand the system architecture and navigate the codebase.