### PR TITLE
fix(cloud): compute total_tokens and normalize ClickHouse timestamps

### DIFF
--- a/cloud/api/traces.handlers.ts
+++ b/cloud/api/traces.handlers.ts
@@ -21,6 +21,13 @@ export const DEFAULT_LIST_LIMIT = 100;
 /** Default offset for listByFunctionHash query. */
 export const DEFAULT_LIST_OFFSET = 0;
 
+/** Default time range in days for trace queries. */
+export const DEFAULT_TIME_RANGE_DAYS = 30;
+
+/** Default time range in milliseconds for trace queries. */
+export const DEFAULT_TIME_RANGE_MS =
+  DEFAULT_TIME_RANGE_DAYS * 24 * 60 * 60 * 1000;
+
 /**
  * Handler for creating traces from OTLP trace data.
  * Accepts OpenTelemetry trace data and stores it in the database.
@@ -85,7 +92,7 @@ export const listByFunctionHashHandler = (
 
     // Get current time range (last 30 days for search)
     const endTime = new Date();
-    const startTime = new Date(endTime.getTime() - 30 * 24 * 60 * 60 * 1000);
+    const startTime = new Date(endTime.getTime() - DEFAULT_TIME_RANGE_MS);
 
     // Search for spans with this function ID
     const searchResult = yield* clickHouseSearch.search({

--- a/cloud/db/clickhouse/traces.ts
+++ b/cloud/db/clickhouse/traces.ts
@@ -90,6 +90,9 @@ import { eq } from "drizzle-orm";
 import type { ProjectRole } from "@/db/schema";
 import type { ResourceSpans, KeyValue } from "@/api/traces.schemas";
 
+/** Default time range in milliseconds for trace queries (30 days). */
+const DEFAULT_TIME_RANGE_MS = 30 * 24 * 60 * 60 * 1000;
+
 /** Response type for trace creation. */
 export type CreateTraceResponse = {
   acceptedSpans: number;
@@ -538,7 +541,7 @@ export class Traces extends BaseAuthenticatedEffectService<
       });
 
       const endTime = new Date();
-      const startTime = new Date(endTime.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const startTime = new Date(endTime.getTime() - DEFAULT_TIME_RANGE_MS);
 
       const searchResult = yield* clickHouseSearch
         .search({

--- a/cloud/db/clickhouse/transform.test.ts
+++ b/cloud/db/clickhouse/transform.test.ts
@@ -76,4 +76,108 @@ describe("transformSpanForClickHouse", () => {
       );
     }),
   );
+
+  it.effect("calculates total_tokens from input_tokens and output_tokens", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture();
+      const row = transformSpanForClickHouse(input);
+
+      // Default fixture has input_tokens=12, output_tokens=34
+      expect(row.total_tokens).toBe(46);
+    }),
+  );
+
+  it.effect("uses explicit gen_ai.usage.total_tokens when available", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture({
+        span: {
+          attributes: {
+            "gen_ai.request.model": "gpt-4",
+            "gen_ai.system": "openai",
+            "gen_ai.usage.input_tokens": 10,
+            "gen_ai.usage.output_tokens": 20,
+            "gen_ai.usage.total_tokens": 100,
+            "gen_ai.usage.cost": 0.01,
+          },
+        },
+      });
+
+      const row = transformSpanForClickHouse(input);
+
+      // Explicit total_tokens should take precedence
+      expect(row.total_tokens).toBe(100);
+    }),
+  );
+
+  it.effect("returns null total_tokens when no token attributes exist", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture({
+        span: {
+          attributes: {
+            "gen_ai.request.model": "gpt-4",
+            "gen_ai.system": "openai",
+          },
+        },
+      });
+
+      const row = transformSpanForClickHouse(input);
+
+      expect(row.total_tokens).toBeNull();
+    }),
+  );
+
+  it.effect("calculates total_tokens with only input_tokens", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture({
+        span: {
+          attributes: {
+            "gen_ai.request.model": "gpt-4",
+            "gen_ai.system": "openai",
+            "gen_ai.usage.input_tokens": 50,
+          },
+        },
+      });
+
+      const row = transformSpanForClickHouse(input);
+
+      expect(row.total_tokens).toBe(50);
+    }),
+  );
+
+  it.effect("calculates total_tokens with only output_tokens", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture({
+        span: {
+          attributes: {
+            "gen_ai.request.model": "gpt-4",
+            "gen_ai.system": "openai",
+            "gen_ai.usage.output_tokens": 75,
+          },
+        },
+      });
+
+      const row = transformSpanForClickHouse(input);
+
+      expect(row.total_tokens).toBe(75);
+    }),
+  );
+
+  it.effect("handles string token values", () =>
+    Effect.gen(function* () {
+      const input = yield* TestTransformInputFixture({
+        span: {
+          attributes: {
+            "gen_ai.request.model": "gpt-4",
+            "gen_ai.system": "openai",
+            "gen_ai.usage.input_tokens": "20",
+            "gen_ai.usage.output_tokens": "30",
+          },
+        },
+      });
+
+      const row = transformSpanForClickHouse(input);
+
+      expect(row.total_tokens).toBe(50);
+    }),
+  );
 });


### PR DESCRIPTION
### TL;DR

Standardize timestamp formats and add default time range constants for trace queries.

### What changed?

- Added constants for default time range in days (`DEFAULT_TIME_RANGE_DAYS = 30`) and milliseconds (`DEFAULT_TIME_RANGE_MS`) for trace queries
- Implemented timestamp normalization to convert ClickHouse DateTime64 strings to ISO-8601 UTC format
- Added tests to verify timestamp normalization in search results
- Improved token calculation logic to properly handle total_tokens:
  - Uses explicit `gen_ai.usage.total_tokens` when available
  - Otherwise calculates by summing input and output tokens
  - Handles string token values by converting them to numbers
- Added tests for token calculation logic

### How to test?

1. Run the test suite to verify timestamp normalization and token calculation:
   ```
   npm test cloud/db/clickhouse/search.test.ts
   npm test cloud/db/clickhouse/transform.test.ts
   ```
2. Verify that trace queries return timestamps in ISO-8601 UTC format (ending with 'Z')
3. Check that token calculations correctly handle different input scenarios

### Why make this change?

- Standardizing timestamp formats to ISO-8601 UTC ensures consistent date handling across the application
- Extracting time range constants improves maintainability by centralizing these values
- Proper token calculation logic ensures accurate reporting of token usage metrics
- These changes improve data consistency and reliability in the tracing system