### PR TITLE
feat(cloud): enforce plan-based data retention via cron

### DIFF
--- a/cloud/payments/plans.test.ts
+++ b/cloud/payments/plans.test.ts
@@ -46,6 +46,7 @@ describe("Plans Module", () => {
           projects: 1,
           spansPerMonth: 1_000_000,
           apiRequestsPerMinute: 100,
+          dataRetentionDays: 30,
         });
       });
     });
@@ -57,6 +58,7 @@ describe("Plans Module", () => {
           projects: 5,
           spansPerMonth: Infinity,
           apiRequestsPerMinute: 1000,
+          dataRetentionDays: 90,
         });
       });
 
@@ -72,6 +74,7 @@ describe("Plans Module", () => {
           projects: Infinity,
           spansPerMonth: Infinity,
           apiRequestsPerMinute: 10000,
+          dataRetentionDays: 180,
         });
       });
 
@@ -132,6 +135,7 @@ describe("Plans Module", () => {
         projects: 1,
         spansPerMonth: 1_000_000,
         apiRequestsPerMinute: 100,
+        dataRetentionDays: 30,
       };
       expect(limits).toBeDefined();
     });

--- a/cloud/payments/plans.ts
+++ b/cloud/payments/plans.ts
@@ -9,9 +9,9 @@
  *
  * ## Pricing Tiers
  *
- * - **Free**: 1 seat, 1 project, 1M spans/month (hard limit enforced), 100 req/min
- * - **Pro**: 5 seats, 5 projects, unlimited spans (+$5/M over 1M included), 1000 req/min
- * - **Team**: Unlimited seats/projects, unlimited spans (+$5/M over 1M included), 10000 req/min
+ * - **Free**: 1 seat, 1 project, 1M spans/month (hard limit enforced), 100 req/min, 30 day retention
+ * - **Pro**: 5 seats, 5 projects, unlimited spans (+$5/M over 1M included), 1000 req/min, 90 day retention
+ * - **Team**: Unlimited seats/projects, unlimited spans (+$5/M over 1M included), 10000 req/min, 180 day retention
  *
  * ## Usage
  *
@@ -50,12 +50,14 @@ export const PLAN_TIER_ORDER: Record<PlanTier, number> = {
  * @property projects - Maximum number of projects (Infinity = unlimited)
  * @property spansPerMonth - Monthly span quota (Free: hard limit, Pro/Team: Infinity with graduated pricing)
  * @property apiRequestsPerMinute - API rate limit per organization
+ * @property dataRetentionDays - Number of days to retain trace data
  */
 export interface PlanLimits {
   seats: number;
   projects: number;
   spansPerMonth: number;
   apiRequestsPerMinute: number;
+  dataRetentionDays: number;
 }
 
 /**
@@ -70,6 +72,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     projects: 1,
     spansPerMonth: 1_000_000, // Hard limit enforced - no overage allowed
     apiRequestsPerMinute: 100,
+    dataRetentionDays: 30,
   },
   pro: {
     seats: 5,
@@ -80,6 +83,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     // Set to Infinity since we don't enforce a hard limit
     spansPerMonth: Infinity,
     apiRequestsPerMinute: 1000,
+    dataRetentionDays: 90,
   },
   team: {
     seats: Infinity, // Unlimited
@@ -90,6 +94,7 @@ export const PLAN_LIMITS: Record<PlanTier, PlanLimits> = {
     // Set to Infinity since we don't enforce a hard limit
     spansPerMonth: Infinity,
     apiRequestsPerMinute: 10000,
+    dataRetentionDays: 180,
   },
 } as const;
 

--- a/cloud/payments/subscriptions/service.test.ts
+++ b/cloud/payments/subscriptions/service.test.ts
@@ -1079,6 +1079,7 @@ describe("subscriptions", () => {
         expect(limits.projects).toBe(1);
         expect(limits.spansPerMonth).toBe(1_000_000);
         expect(limits.apiRequestsPerMinute).toBe(100);
+        expect(limits.dataRetentionDays).toBe(30);
       }),
     );
 
@@ -1091,6 +1092,7 @@ describe("subscriptions", () => {
         expect(limits.projects).toBe(5);
         expect(limits.spansPerMonth).toBe(Infinity);
         expect(limits.apiRequestsPerMinute).toBe(1000);
+        expect(limits.dataRetentionDays).toBe(90);
       }),
     );
 
@@ -1103,6 +1105,7 @@ describe("subscriptions", () => {
         expect(limits.projects).toBe(Infinity);
         expect(limits.spansPerMonth).toBe(Infinity);
         expect(limits.apiRequestsPerMinute).toBe(10000);
+        expect(limits.dataRetentionDays).toBe(180);
       }),
     );
   });

--- a/cloud/rate-limiting/service.test.ts
+++ b/cloud/rate-limiting/service.test.ts
@@ -30,6 +30,8 @@ describe("RateLimiter", () => {
               spansPerMonth: tier === "free" ? 1_000_000 : Infinity,
               apiRequestsPerMinute:
                 tier === "free" ? 100 : tier === "pro" ? 1000 : 10000,
+              dataRetentionDays:
+                tier === "free" ? 30 : tier === "pro" ? 90 : 180,
             }),
         },
       } as never,
@@ -444,6 +446,7 @@ describe("RateLimiter", () => {
                 projects: 1,
                 apiRequestsPerMinute: 0,
                 spansPerMonth: 0,
+                dataRetentionDays: 30,
               }),
           },
         } as never,
@@ -502,6 +505,8 @@ describe("RateLimiter", () => {
                 spansPerMonth: tier === "free" ? 1_000_000 : Infinity,
                 apiRequestsPerMinute:
                   tier === "free" ? 100 : tier === "pro" ? 1000 : 10000,
+                dataRetentionDays:
+                  tier === "free" ? 30 : tier === "pro" ? 90 : 180,
               }),
           },
         } as never,
@@ -553,6 +558,8 @@ describe("RateLimiter", () => {
                 spansPerMonth: tier === "free" ? 1_000_000 : Infinity,
                 apiRequestsPerMinute:
                   tier === "free" ? 100 : tier === "pro" ? 1000 : 10000,
+                dataRetentionDays:
+                  tier === "free" ? 30 : tier === "pro" ? 90 : 180,
               }),
           },
         } as never,

--- a/cloud/workers/dataRetentionCron.test.ts
+++ b/cloud/workers/dataRetentionCron.test.ts
@@ -1,0 +1,723 @@
+import { describe, it, expect, vi } from "vitest";
+import { Effect, Layer } from "effect";
+import { DrizzleORM } from "@/db/client";
+import { ClickHouse } from "@/db/clickhouse/client";
+import { Payments } from "@/payments";
+import { ClickHouseError, DatabaseError } from "@/errors";
+import dataRetentionCron, {
+  enforceDataRetentionLimits,
+} from "@/workers/dataRetentionCron";
+import type { CronTriggerEnv } from "@/workers/dataRetentionCron";
+import { createMockEnv } from "@/tests/settings";
+
+describe("dataRetentionCron", () => {
+  const mockEnvironment = createMockEnv() as unknown as CronTriggerEnv;
+
+  const mockEvent = {
+    scheduledTime: Date.now(),
+    cron: "0 10 * * *",
+  };
+
+  describe("enforceDataRetentionLimits", () => {
+    it("deletes expired data for each retention group", async () => {
+      const organizationFreeOne = "11111111-1111-1111-1111-111111111111";
+      const organizationFreeTwo = "22222222-2222-2222-2222-222222222222";
+      const organizationTeam = "33333333-3333-3333-3333-333333333333";
+
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi
+            .fn()
+            .mockReturnValue(
+              Effect.succeed([
+                { id: organizationFreeOne },
+                { id: organizationFreeTwo },
+                { id: organizationTeam },
+              ]),
+            ),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const getPlan = vi.fn((organizationId: string) =>
+        Effect.succeed(organizationId === organizationTeam ? "team" : "free"),
+      );
+
+      const getPlanLimits = vi.fn((planTier: "free" | "pro" | "team") =>
+        Effect.succeed({
+          seats: planTier === "free" ? 1 : 5,
+          projects: planTier === "free" ? 1 : 5,
+          spansPerMonth: planTier === "free" ? 1_000_000 : Infinity,
+          apiRequestsPerMinute: planTier === "free" ? 100 : 1000,
+          dataRetentionDays: planTier === "team" ? 180 : 30,
+        }),
+      );
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan,
+            getPlanLimits,
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const executedQueries: string[] = [];
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: (query: string) => {
+          executedQueries.push(query);
+          return Effect.succeed(undefined);
+        },
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      const spanQueries = executedQueries.filter((query) =>
+        query.includes("spans_analytics"),
+      );
+      const annotationQueries = executedQueries.filter((query) =>
+        query.includes("annotations_analytics"),
+      );
+
+      expect(spanQueries).toHaveLength(2);
+      expect(annotationQueries).toHaveLength(2);
+
+      expect(
+        spanQueries.some(
+          (query) =>
+            query.includes(`toUUID('${organizationFreeOne}')`) &&
+            query.includes(`toUUID('${organizationFreeTwo}')`),
+        ),
+      ).toBe(true);
+
+      expect(
+        spanQueries.some((query) =>
+          query.includes(`toUUID('${organizationTeam}')`),
+        ),
+      ).toBe(true);
+
+      expect(
+        annotationQueries.some(
+          (query) =>
+            query.includes(`toUUID('${organizationFreeOne}')`) &&
+            query.includes(`toUUID('${organizationFreeTwo}')`),
+        ),
+      ).toBe(true);
+
+      expect(
+        annotationQueries.some((query) =>
+          query.includes(`toUUID('${organizationTeam}')`),
+        ),
+      ).toBe(true);
+
+      expect(deleteSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("batches deletions when organizations exceed the batch size", async () => {
+      const organizationIds = Array.from(
+        { length: 101 },
+        (_value, index) =>
+          `00000000-0000-0000-0000-${String(index + 1).padStart(12, "0")}`,
+      );
+
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi
+            .fn()
+            .mockReturnValue(
+              Effect.succeed(organizationIds.map((id) => ({ id }))),
+            ),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: () => Effect.succeed("free"),
+            getPlanLimits: () =>
+              Effect.succeed({
+                seats: 1,
+                projects: 1,
+                spansPerMonth: 1_000_000,
+                apiRequestsPerMinute: 100,
+                dataRetentionDays: 30,
+              }),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const executedQueries: string[] = [];
+      const commandSpy = vi.fn((query: string) => {
+        executedQueries.push(query);
+        return Effect.succeed(undefined);
+      });
+
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: commandSpy,
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      expect(commandSpy).toHaveBeenCalledTimes(4);
+      expect(deleteSpy).toHaveBeenCalledTimes(2);
+      expect(
+        executedQueries.some((query) => query.includes("spans_analytics")),
+      ).toBe(true);
+      expect(
+        executedQueries.some((query) =>
+          query.includes("annotations_analytics"),
+        ),
+      ).toBe(true);
+    });
+
+    it("logs singular day retention when retention is one day", async () => {
+      const consoleLogSpy = vi
+        .spyOn(console, "log")
+        .mockImplementation(() => {});
+
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi
+            .fn()
+            .mockReturnValue(
+              Effect.succeed([{ id: "88888888-8888-8888-8888-888888888888" }]),
+            ),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: () => Effect.succeed("free"),
+            getPlanLimits: () =>
+              Effect.succeed({
+                seats: 1,
+                projects: 1,
+                spansPerMonth: 1_000_000,
+                apiRequestsPerMinute: 100,
+                dataRetentionDays: 1,
+              }),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: () => Effect.succeed(undefined),
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        expect.stringContaining("1 day"),
+      );
+
+      consoleLogSpy.mockRestore();
+    });
+
+    it("skips organizations with invalid retention days", async () => {
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi
+            .fn()
+            .mockReturnValue(
+              Effect.succeed([{ id: "44444444-4444-4444-4444-444444444444" }]),
+            ),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: () => Effect.succeed("team"),
+            getPlanLimits: () =>
+              Effect.succeed({
+                seats: Infinity,
+                projects: Infinity,
+                spansPerMonth: Infinity,
+                apiRequestsPerMinute: 10000,
+                dataRetentionDays: Infinity,
+              }),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const commandSpy = vi.fn(() => Effect.succeed(undefined));
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: commandSpy,
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      expect(commandSpy).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("invalid retention days"),
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("logs errors when plan lookup fails", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi
+            .fn()
+            .mockReturnValue(
+              Effect.succeed([{ id: "55555555-5555-5555-5555-555555555555" }]),
+            ),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: () => Effect.fail(new Error("Stripe unavailable")),
+            getPlanLimits: () =>
+              Effect.succeed({
+                seats: 1,
+                projects: 1,
+                spansPerMonth: 1_000_000,
+                apiRequestsPerMinute: 100,
+                dataRetentionDays: 30,
+              }),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const commandSpy = vi.fn(() => Effect.succeed(undefined));
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: commandSpy,
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      expect(commandSpy).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Failed to resolve plan for organization"),
+        expect.anything(),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Skipping retention for organization"),
+      );
+      expect(deleteSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("logs errors when ClickHouse deletion fails", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const consoleWarnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi
+            .fn()
+            .mockReturnValue(
+              Effect.succeed([{ id: "66666666-6666-6666-6666-666666666666" }]),
+            ),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: () => Effect.succeed("free"),
+            getPlanLimits: () =>
+              Effect.succeed({
+                seats: 1,
+                projects: 1,
+                spansPerMonth: 1_000_000,
+                apiRequestsPerMinute: 100,
+                dataRetentionDays: 30,
+              }),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: () =>
+          Effect.fail(
+            new ClickHouseError({
+              message: "ClickHouse down",
+              cause: new Error("ClickHouse down"),
+            }),
+          ),
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[dataRetentionCron] Failed to delete expired spans:",
+        expect.anything(),
+      );
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[dataRetentionCron] Failed to delete expired annotations:",
+        expect.anything(),
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        "[dataRetentionCron] Skipping PostgreSQL annotation deletion because ClickHouse deletion failed",
+      );
+      expect(deleteSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+    });
+
+    it("returns early when no organizations exist", async () => {
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue(Effect.succeed([])),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: () => Effect.succeed("free"),
+            getPlanLimits: () =>
+              Effect.succeed({
+                seats: 1,
+                projects: 1,
+                spansPerMonth: 1_000_000,
+                apiRequestsPerMinute: 100,
+                dataRetentionDays: 30,
+              }),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const commandSpy = vi.fn(() => Effect.succeed(undefined));
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: commandSpy,
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      expect(commandSpy).not.toHaveBeenCalled();
+      expect(deleteSpy).not.toHaveBeenCalled();
+    });
+
+    it("fails when organization query fails", async () => {
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi.fn().mockReturnValue(Effect.fail(new Error("DB down"))),
+        }),
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: vi.fn(),
+            getPlanLimits: vi.fn(),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: () => Effect.succeed(undefined),
+      } as never);
+
+      const error = await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+          Effect.flip,
+        ),
+      );
+
+      expect(error).toBeInstanceOf(DatabaseError);
+      expect(error.message).toContain(
+        "Failed to list organizations for retention",
+      );
+    });
+
+    it("logs errors when PostgreSQL annotation deletion fails", async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const deleteSpy = vi.fn().mockImplementation(() => ({
+        where: vi.fn().mockReturnValue({
+          returning: vi
+            .fn()
+            .mockReturnValue(Effect.fail(new Error("Delete failed"))),
+        }),
+      }));
+
+      const mockDrizzleLayer = Layer.succeed(DrizzleORM, {
+        select: vi.fn().mockReturnValue({
+          from: vi
+            .fn()
+            .mockReturnValue(
+              Effect.succeed([{ id: "77777777-7777-7777-7777-777777777777" }]),
+            ),
+        }),
+        delete: deleteSpy,
+      } as never);
+
+      const mockPaymentsLayer = Layer.succeed(Payments, {
+        customers: {
+          subscriptions: {
+            getPlan: () => Effect.succeed("free"),
+            getPlanLimits: () =>
+              Effect.succeed({
+                seats: 1,
+                projects: 1,
+                spansPerMonth: 1_000_000,
+                apiRequestsPerMinute: 100,
+                dataRetentionDays: 30,
+              }),
+          },
+        } as never,
+        products: {} as never,
+        paymentIntents: {} as never,
+      });
+
+      const mockClickHouseLayer = Layer.succeed(ClickHouse, {
+        unsafeQuery: () => Effect.succeed([]),
+        insert: () => Effect.succeed(undefined),
+        command: () => Effect.succeed(undefined),
+      } as never);
+
+      await Effect.runPromise(
+        enforceDataRetentionLimits.pipe(
+          Effect.provide(mockDrizzleLayer),
+          Effect.provide(mockPaymentsLayer),
+          Effect.provide(mockClickHouseLayer),
+        ),
+      );
+
+      expect(deleteSpy).toHaveBeenCalledTimes(1);
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "[dataRetentionCron] Failed to delete expired PostgreSQL annotations:",
+        expect.anything(),
+      );
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  it("logs error when no database connection is available", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const environmentWithoutDatabase: CronTriggerEnv = {
+      ...mockEnvironment,
+      DATABASE_URL: undefined,
+      HYPERDRIVE: undefined,
+    } as CronTriggerEnv;
+
+    await dataRetentionCron.scheduled(mockEvent, environmentWithoutDatabase);
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[dataRetentionCron] No database connection available (HYPERDRIVE or DATABASE_URL required)",
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("logs error when required environment variables are missing", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const environmentWithMissingVariables: CronTriggerEnv = {
+      DATABASE_URL: "postgres://test:test@localhost:5432/test",
+      ENVIRONMENT: "test",
+    } as CronTriggerEnv;
+
+    await dataRetentionCron.scheduled(
+      mockEvent,
+      environmentWithMissingVariables,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      "[dataRetentionCron] Cron trigger error:",
+      expect.objectContaining({
+        _tag: "SettingsValidationError",
+      }),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("uses HYPERDRIVE connection string when available", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const environmentWithHyperdrive: CronTriggerEnv = {
+      ...mockEnvironment,
+      DATABASE_URL: undefined,
+      HYPERDRIVE: {
+        connectionString: "postgres://hyperdrive:test@localhost:5432/test",
+      },
+    } as CronTriggerEnv;
+
+    await dataRetentionCron.scheduled(mockEvent, environmentWithHyperdrive);
+
+    expect(consoleErrorSpy).not.toHaveBeenCalledWith(
+      "[dataRetentionCron] No database connection available (HYPERDRIVE or DATABASE_URL required)",
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("exports a scheduled handler", () => {
+    expect(dataRetentionCron).toHaveProperty("scheduled");
+    expect(typeof dataRetentionCron.scheduled).toBe("function");
+  });
+
+  it("processes retention workflow", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    await dataRetentionCron.scheduled(mockEvent, mockEnvironment);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/cloud/workers/dataRetentionCron.ts
+++ b/cloud/workers/dataRetentionCron.ts
@@ -1,0 +1,301 @@
+/**
+ * @fileoverview Cloudflare Cron Trigger for enforcing trace data retention limits.
+ *
+ * Periodically deletes trace data in ClickHouse that exceeds the plan retention
+ * window for each organization.
+ *
+ * ## Responsibilities
+ *
+ * 1. Resolve organization plan tiers
+ * 2. Compute retention cutoffs per plan tier
+ * 3. Delete expired spans and annotations from ClickHouse
+ *
+ * ## Trigger Configuration
+ *
+ * Configure in wrangler.jsonc with a cron expression like `0 10 * * *` (daily).
+ */
+
+import { Effect, Layer } from "effect";
+import { DrizzleORM } from "@/db/client";
+import { annotations, organizations as organizationsTable } from "@/db/schema";
+import { and, inArray, lt } from "drizzle-orm";
+import { Settings } from "@/settings";
+import { Stripe } from "@/payments/client";
+import { Payments } from "@/payments/service";
+import { ClickHouse } from "@/db/clickhouse/client";
+import { DatabaseError } from "@/errors";
+import { formatDateTime64 } from "@/db/clickhouse/transform";
+import {
+  type ScheduledEvent,
+  type BillingCronTriggerEnv,
+} from "@/workers/config";
+
+export type { BillingCronTriggerEnv as CronTriggerEnv };
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Maximum number of organizations to include per ClickHouse delete command. */
+const ORGANIZATION_BATCH_SIZE = 100;
+
+/** Maximum number of concurrent plan lookups per retention run. */
+const PLAN_LOOKUP_CONCURRENCY = 10;
+
+/** Milliseconds in a day (used to compute retention cutoffs). */
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+const chunkArray = <T>(items: readonly T[], size: number): T[][] => {
+  if (items.length <= size) return [items.slice()];
+  const chunks: T[][] = [];
+  for (let index = 0; index < items.length; index += size) {
+    chunks.push(items.slice(index, index + size));
+  }
+  return chunks;
+};
+
+const buildOrganizationFilter = (organizationIds: readonly string[]): string =>
+  organizationIds.map((id) => `toUUID('${id}')`).join(", ");
+
+const buildSpansDeleteQuery = ({
+  organizationFilter,
+  cutoffTimestamp,
+}: {
+  organizationFilter: string;
+  cutoffTimestamp: string;
+}): string =>
+  `ALTER TABLE spans_analytics DELETE WHERE organization_id IN (${organizationFilter}) AND start_time < toDateTime64('${cutoffTimestamp}', 9, 'UTC')`;
+
+const buildAnnotationsDeleteQuery = ({
+  organizationFilter,
+  cutoffTimestamp,
+}: {
+  organizationFilter: string;
+  cutoffTimestamp: string;
+}): string =>
+  `ALTER TABLE annotations_analytics DELETE WHERE organization_id IN (${organizationFilter}) AND created_at < toDateTime64('${cutoffTimestamp}', 3, 'UTC')`;
+
+// =============================================================================
+// Retention Program
+// =============================================================================
+
+/**
+ * Enforces data retention limits for trace data in ClickHouse.
+ */
+export const enforceDataRetentionLimits = Effect.gen(function* () {
+  const client = yield* DrizzleORM;
+  const payments = yield* Payments;
+  const clickhouse = yield* ClickHouse;
+
+  const organizations = yield* client
+    .select({ id: organizationsTable.id })
+    .from(organizationsTable)
+    .pipe(
+      Effect.mapError(
+        (error) =>
+          new DatabaseError({
+            message: "Failed to list organizations for retention",
+            cause: error,
+          }),
+      ),
+    );
+
+  if (organizations.length === 0) {
+    return;
+  }
+
+  const retentionAssignments = yield* Effect.all(
+    organizations.map((organization) =>
+      payments.customers.subscriptions.getPlan(organization.id).pipe(
+        Effect.flatMap((planTier) =>
+          payments.customers.subscriptions.getPlanLimits(planTier),
+        ),
+        Effect.map((limits) => limits.dataRetentionDays),
+        Effect.catchAll((error) => {
+          console.error(
+            `[dataRetentionCron] Failed to resolve plan for organization ${organization.id}:`,
+            error,
+          );
+          console.warn(
+            `[dataRetentionCron] Skipping retention for organization ${organization.id} due to plan lookup failure`,
+          );
+          return Effect.succeed(null);
+        }),
+        Effect.map((retentionDays) => ({
+          organizationId: organization.id,
+          retentionDays,
+        })),
+      ),
+    ),
+    { concurrency: PLAN_LOOKUP_CONCURRENCY },
+  );
+
+  const retentionGroups = new Map<number, string[]>();
+
+  for (const assignment of retentionAssignments) {
+    const { organizationId, retentionDays } = assignment;
+
+    if (retentionDays === null) {
+      continue;
+    }
+
+    if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
+      console.warn(
+        `[dataRetentionCron] Skipping retention for organization ${organizationId} with invalid retention days: ${retentionDays}`,
+      );
+      continue;
+    }
+
+    const existingGroup = retentionGroups.get(retentionDays);
+    if (existingGroup) {
+      existingGroup.push(organizationId);
+    } else {
+      retentionGroups.set(retentionDays, [organizationId]);
+    }
+  }
+
+  for (const [retentionDays, organizationIds] of retentionGroups) {
+    const cutoffDate = new Date(
+      Date.now() - retentionDays * MILLISECONDS_PER_DAY,
+    );
+    const spanCutoffTimestamp = formatDateTime64(cutoffDate, 9);
+    const annotationCutoffTimestamp = formatDateTime64(cutoffDate, 3);
+
+    const organizationChunks = chunkArray(
+      organizationIds,
+      ORGANIZATION_BATCH_SIZE,
+    );
+
+    for (const organizationChunk of organizationChunks) {
+      const organizationFilter = buildOrganizationFilter(organizationChunk);
+
+      const spansQuery = buildSpansDeleteQuery({
+        organizationFilter,
+        cutoffTimestamp: spanCutoffTimestamp,
+      });
+      const annotationsQuery = buildAnnotationsDeleteQuery({
+        organizationFilter,
+        cutoffTimestamp: annotationCutoffTimestamp,
+      });
+
+      const spansDeleted = yield* clickhouse.command(spansQuery).pipe(
+        Effect.as(true),
+        Effect.catchAll((error) => {
+          console.error(
+            "[dataRetentionCron] Failed to delete expired spans:",
+            error,
+          );
+          return Effect.succeed(false);
+        }),
+      );
+
+      const annotationsDeleted = yield* clickhouse
+        .command(annotationsQuery)
+        .pipe(
+          Effect.as(true),
+          Effect.catchAll((error) => {
+            console.error(
+              "[dataRetentionCron] Failed to delete expired annotations:",
+              error,
+            );
+            return Effect.succeed(false);
+          }),
+        );
+
+      if (!spansDeleted || !annotationsDeleted) {
+        console.warn(
+          "[dataRetentionCron] Skipping PostgreSQL annotation deletion because ClickHouse deletion failed",
+        );
+        continue;
+      }
+
+      yield* client
+        .delete(annotations)
+        .where(
+          and(
+            inArray(annotations.organizationId, organizationChunk),
+            lt(annotations.createdAt, cutoffDate),
+          ),
+        )
+        .returning({ id: annotations.id })
+        .pipe(
+          Effect.mapError(
+            (error) =>
+              new DatabaseError({
+                message: "Failed to delete expired PostgreSQL annotations",
+                cause: error,
+              }),
+          ),
+          Effect.catchAll((error) => {
+            console.error(
+              "[dataRetentionCron] Failed to delete expired PostgreSQL annotations:",
+              error,
+            );
+            return Effect.succeed([]);
+          }),
+        );
+    }
+
+    console.log(
+      `[dataRetentionCron] Scheduled retention for ${organizationIds.length} organization${organizationIds.length === 1 ? "" : "s"} at ${retentionDays} day${retentionDays === 1 ? "" : "s"}`,
+    );
+  }
+});
+
+// =============================================================================
+// Cron Handler
+// =============================================================================
+
+export default {
+  /**
+   * Scheduled event handler for data retention enforcement.
+   *
+   * @param _event - Cloudflare scheduled event (unused, but required by interface)
+   * @param env - Cloudflare Workers environment bindings
+   */
+  async scheduled(
+    _event: ScheduledEvent,
+    env: BillingCronTriggerEnv,
+  ): Promise<void> {
+    // Database connection string from Hyperdrive or direct URL
+    const databaseUrl = env.HYPERDRIVE?.connectionString ?? env.DATABASE_URL;
+    if (!databaseUrl) {
+      console.error(
+        "[dataRetentionCron] No database connection available (HYPERDRIVE or DATABASE_URL required)",
+      );
+      return;
+    }
+
+    const program = Effect.gen(function* () {
+      const settings = yield* Settings;
+
+      const drizzleLayer = DrizzleORM.layer({ connectionString: databaseUrl });
+      const stripeLayer = Stripe.layer(settings.stripe);
+      const paymentsLayer = Payments.Default.pipe(
+        Layer.provide(stripeLayer),
+        Layer.provide(drizzleLayer),
+      );
+      const clickhouseLayer = ClickHouse.layer(settings.clickhouse);
+
+      yield* enforceDataRetentionLimits.pipe(
+        Effect.provide(drizzleLayer),
+        Effect.provide(paymentsLayer),
+        Effect.provide(clickhouseLayer),
+      );
+    });
+
+    await Effect.runPromise(
+      program.pipe(
+        Effect.provide(Settings.LiveFromEnvironment(env)),
+        Effect.catchAll((error) => {
+          console.error("[dataRetentionCron] Cron trigger error:", error);
+          return Effect.void;
+        }),
+      ),
+    );
+  },
+};

--- a/cloud/wrangler.jsonc
+++ b/cloud/wrangler.jsonc
@@ -8,7 +8,7 @@
     "enabled": true,
   },
   "triggers": {
-    "crons": ["*/5 * * * *"],
+    "crons": ["*/5 * * * *", "0 10 * * *"],
   },
   "queues": {
     "producers": [


### PR DESCRIPTION
### TL;DR

Added data retention limits to subscription plans with automatic enforcement via a daily cron job.

### What changed?

- Added `dataRetentionDays` property to the `PlanLimits` interface with different values per tier:
  - Free: 30 days
  - Pro: 90 days
  - Team: 180 days
- Created a new `dataRetentionCron` worker that runs daily at 10:00 UTC to enforce retention limits
- Implemented logic to delete expired spans and annotations from ClickHouse and PostgreSQL based on each organization's plan tier
- Updated documentation in the plans module to reflect the new retention periods
- Added a new cron trigger in wrangler.jsonc and server-entry.ts

### How to test?

1. Run the data retention cron job manually via the `/__scheduled/retention` endpoint
2. Verify that data older than the retention period for each organization is properly deleted
3. Check that spans and annotations are deleted from both ClickHouse and PostgreSQL
4. Confirm that organizations with different plan tiers have their data retained for the appropriate number of days

### Why make this change?

Data retention policies are important for:
1. Managing storage costs as the platform scales
2. Providing tiered value to customers based on their subscription level
3. Implementing proper data lifecycle management
4. Creating differentiation between subscription tiers with longer retention periods for higher-tier plans