### PR TITLE
feat(cloud): add traces analytics endpoints

### DIFF
--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -68,6 +68,8 @@ import {
   searchHandler,
   getTraceDetailHandler,
   getAnalyticsSummaryHandler,
+  getTimeSeriesMetricsHandler,
+  getFunctionAggregatesHandler,
 } from "@/api/traces-search.handlers";
 import { MirascopeCloudApi } from "@/api/api";
 
@@ -91,6 +93,12 @@ const TracesHandlersLive = HttpApiBuilder.group(
       )
       .handle("getAnalyticsSummary", ({ urlParams }) =>
         getAnalyticsSummaryHandler(urlParams),
+      )
+      .handle("getTimeSeriesMetrics", ({ urlParams }) =>
+        getTimeSeriesMetricsHandler(urlParams),
+      )
+      .handle("getFunctionAggregates", ({ urlParams }) =>
+        getFunctionAggregatesHandler(urlParams),
       )
       .handle("listByFunctionHash", ({ path, urlParams }) =>
         listByFunctionHashHandler(path.hash, urlParams),

--- a/cloud/api/traces-search.test.ts
+++ b/cloud/api/traces-search.test.ts
@@ -216,9 +216,11 @@ describe.sequential("Search API", (it) => {
           throw new Error("Missing API key context for search handler test");
         }
 
+        const apiKey = apiKeyInfo;
+
         const authenticationLayer = Layer.succeed(Authentication, {
           user: ownerFromContext,
-          apiKeyInfo,
+          apiKeyInfo: apiKey,
         });
 
         const clickHouseSearchLayer = ClickHouseSearch.Default.pipe(
@@ -288,6 +290,10 @@ describe.sequential("Search API", (it) => {
           Effect.succeed(createTraceDetailResponse({ traceId: "trace-1" })),
         getAnalyticsSummary: () =>
           Effect.succeed(createAnalyticsSummaryResponse()),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -425,6 +431,10 @@ describe.sequential("Search API", (it) => {
               topModels: [],
               topFunctions: [],
             }),
+          getTimeSeriesMetrics: () =>
+            Effect.succeed({ points: [], timeFrame: "day" }),
+          getFunctionAggregates: () =>
+            Effect.succeed({ functions: [], total: 0 }),
         });
 
         const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -536,6 +546,10 @@ describe.sequential("Search API", (it) => {
               topModels: [],
               topFunctions: [],
             }),
+          getTimeSeriesMetrics: () =>
+            Effect.succeed({ points: [], timeFrame: "day" }),
+          getFunctionAggregates: () =>
+            Effect.succeed({ functions: [], total: 0 }),
         });
 
         const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -642,6 +656,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -727,6 +745,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -813,6 +835,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -909,6 +935,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -1013,6 +1043,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -1116,6 +1150,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -1232,6 +1270,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -1334,6 +1376,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -1440,6 +1486,10 @@ describe.sequential("Search API", (it) => {
         getTraceDetail: () => Effect.succeed(clickHouseTraceDetail),
         getAnalyticsSummary: () =>
           Effect.succeed(createAnalyticsSummaryResponse()),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeTraceDetail = createTraceDetailResponse({
@@ -1518,6 +1568,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const result = await Effect.runPromise(
@@ -1571,6 +1625,10 @@ describe.sequential("Search API", (it) => {
         getTraceDetail: () => Effect.succeed(clickHouseTraceDetail),
         getAnalyticsSummary: () =>
           Effect.succeed(createAnalyticsSummaryResponse()),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -1633,6 +1691,10 @@ describe.sequential("Search API", (it) => {
         getTraceDetail: () => Effect.succeed(clickHouseTraceDetail),
         getAnalyticsSummary: () =>
           Effect.succeed(createAnalyticsSummaryResponse()),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeTraceDetail = createTraceDetailResponse({
@@ -1790,6 +1852,10 @@ describe.sequential("Search API", (it) => {
             topModels: [],
             topFunctions: [],
           }),
+        getTimeSeriesMetrics: () =>
+          Effect.succeed({ points: [], timeFrame: "day" }),
+        getFunctionAggregates: () =>
+          Effect.succeed({ functions: [], total: 0 }),
       });
 
       const realtimeLayer = Layer.succeed(RealtimeSpans, {
@@ -1836,6 +1902,7 @@ describe.sequential("Search API", (it) => {
       const result = yield* apiKeyClient.traces.getAnalyticsSummary({
         urlParams: {
           ...createSearchTimeWindow(),
+          rootOnly: true,
         },
       });
 
@@ -1859,6 +1926,37 @@ describe.sequential("Search API", (it) => {
 
       expect(typeof result.totalSpans).toBe("number");
     }),
+  );
+
+  it.effect("GET /traces/analytics/timeseries - returns time series metrics", () =>
+    Effect.gen(function* () {
+      const result = yield* apiKeyClient.traces.getTimeSeriesMetrics({
+        urlParams: {
+          ...createSearchTimeWindow(),
+          timeFrame: "day",
+          rootOnly: true,
+        },
+      });
+
+      expect(Array.isArray(result.points)).toBe(true);
+      expect(result.timeFrame).toBe("day");
+    }),
+  );
+
+  it.effect(
+    "GET /traces/analytics/functions - returns function aggregates",
+    () =>
+      Effect.gen(function* () {
+        const result = yield* apiKeyClient.traces.getFunctionAggregates({
+          urlParams: {
+            ...createSearchTimeWindow(),
+            rootOnly: true,
+          },
+        });
+
+        expect(Array.isArray(result.functions)).toBe(true);
+        expect(typeof result.total).toBe("number");
+      }),
   );
 
   it.effect("Dispose API key client", () =>
@@ -1887,6 +1985,7 @@ describe("Search schema definitions", () => {
         startTime: "2024-01-01T00:00:00Z",
         endTime: "2024-01-31T23:59:59Z",
         query: "llm call",
+        rootOnly: true,
         model: ["gpt-4", "gpt-3.5-turbo"],
         provider: ["openai"],
         hasError: false,
@@ -1897,6 +1996,7 @@ describe("Search schema definitions", () => {
       };
 
       expect(input.query).toBe("llm call");
+      expect(input.rootOnly).toBe(true);
       expect(input.model).toHaveLength(2);
       expect(input.provider).toHaveLength(1);
       expect(input.limit).toBe(100);
@@ -2136,6 +2236,54 @@ describe("Search schema definitions", () => {
       expect(response.topFunctions).toHaveLength(0);
     });
   });
+
+  describe("TimeSeriesResponse", () => {
+    it("validates time series response structure", () => {
+      const response = {
+        points: [
+          {
+            startTime: "2024-01-01T00:00:00Z",
+            endTime: "2024-01-02T00:00:00Z",
+            totalCostUsd: 1.23,
+            totalInputTokens: 100,
+            totalOutputTokens: 50,
+            totalTokens: 150,
+            averageDurationMs: 250,
+            spanCount: 2,
+          },
+        ],
+        timeFrame: "day" as const,
+      };
+
+      expect(response.points).toHaveLength(1);
+      expect(response.points[0].totalTokens).toBe(150);
+      expect(response.timeFrame).toBe("day");
+    });
+  });
+
+  describe("FunctionAggregatesResponse", () => {
+    it("validates function aggregates response structure", () => {
+      const response = {
+        functions: [
+          {
+            functionId: "00000000-0000-0000-0000-000000000001",
+            functionName: "my_function",
+            totalCostUsd: 1.0,
+            totalInputTokens: 120,
+            totalOutputTokens: 30,
+            totalTokens: 150,
+            averageDurationMs: 200,
+            spanCount: 3,
+          },
+        ],
+        total: 1,
+      };
+
+      expect(response.functions).toHaveLength(1);
+      expect(response.functions[0]?.functionName).toBe("my_function");
+      expect(response.total).toBe(1);
+    });
+  });
 });
 
 // =============================================================================
@@ -2200,6 +2348,10 @@ describe("Realtime span merge", () => {
           topModels: [],
           topFunctions: [],
         }),
+      getTimeSeriesMetrics: () =>
+        Effect.succeed({ points: [], timeFrame: "day" }),
+      getFunctionAggregates: () =>
+        Effect.succeed({ functions: [], total: 0 }),
     });
 
   const createRealtimeLayer = (

--- a/cloud/api/traces.schemas.ts
+++ b/cloud/api/traces.schemas.ts
@@ -13,8 +13,12 @@ import {
 import {
   AnalyticsSummaryRequestSchema,
   AnalyticsSummaryResponseSchema,
+  FunctionAggregatesRequestSchema,
+  FunctionAggregatesResponseSchema,
   SearchRequestSchema,
   SearchResponseSchema,
+  TimeSeriesRequestSchema,
+  TimeSeriesResponseSchema,
   TraceDetailResponseSchema,
 } from "@/api/traces-search.schemas";
 
@@ -192,6 +196,28 @@ export class TracesApi extends HttpApiGroup.make("traces")
     HttpApiEndpoint.get("getAnalyticsSummary", "/traces/analytics")
       .setUrlParams(AnalyticsSummaryRequestSchema)
       .addSuccess(AnalyticsSummaryResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(PermissionDeniedError, {
+        status: PermissionDeniedError.status,
+      })
+      .addError(ClickHouseError, { status: ClickHouseError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.get("getTimeSeriesMetrics", "/traces/analytics/timeseries")
+      .setUrlParams(TimeSeriesRequestSchema)
+      .addSuccess(TimeSeriesResponseSchema)
+      .addError(UnauthorizedError, { status: UnauthorizedError.status })
+      .addError(PermissionDeniedError, {
+        status: PermissionDeniedError.status,
+      })
+      .addError(ClickHouseError, { status: ClickHouseError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.get("getFunctionAggregates", "/traces/analytics/functions")
+      .setUrlParams(FunctionAggregatesRequestSchema)
+      .addSuccess(FunctionAggregatesResponseSchema)
       .addError(UnauthorizedError, { status: UnauthorizedError.status })
       .addError(PermissionDeniedError, {
         status: PermissionDeniedError.status,

--- a/cloud/api/traces.test.ts
+++ b/cloud/api/traces.test.ts
@@ -166,6 +166,10 @@ describe("listByFunctionHashHandler", () => {
           topModels: [],
           topFunctions: [],
         }),
+      getTimeSeriesMetrics: () =>
+        Effect.succeed({ points: [], timeFrame: "day" }),
+      getFunctionAggregates: () =>
+        Effect.succeed({ functions: [], total: 0 }),
     });
 
     const layers = Layer.mergeAll(

--- a/cloud/tests/db.ts
+++ b/cloud/tests/db.ts
@@ -94,6 +94,16 @@ const defaultClickHouseSearchService: ClickHouseSearchService = {
       topModels: [],
       topFunctions: [],
     }),
+  getTimeSeriesMetrics: () =>
+    Effect.succeed({
+      points: [],
+      timeFrame: "day",
+    }),
+  getFunctionAggregates: () =>
+    Effect.succeed({
+      functions: [],
+      total: 0,
+    }),
 };
 
 /**

--- a/cloud/tests/workers/realtimeSpans.ts
+++ b/cloud/tests/workers/realtimeSpans.ts
@@ -304,6 +304,7 @@ export const createSearchRequest = (input: {
   startTime?: string;
   endTime?: string;
   query?: string;
+  rootOnly?: boolean;
   sortBy?: "start_time" | "duration_ms" | "total_tokens";
   sortOrder?: "asc" | "desc";
 }) => {

--- a/cloud/workers/realtimeSpans/durableObject.test.ts
+++ b/cloud/workers/realtimeSpans/durableObject.test.ts
@@ -68,6 +68,28 @@ describe("RealtimeSpansDurableObject", () => {
     expect(searchBody.spans[0]?.spanId).toBe("span-1");
   });
 
+  it("filters root spans when rootOnly is true", async () => {
+    const state = createState();
+    const durableObject = new RealtimeSpansDurableObject(state);
+
+    await durableObject.fetch(createUpsertRequest(createSpanBatch()));
+
+    const searchResponse = await durableObject.fetch(
+      createSearchRequest({
+        rootOnly: true,
+        sortBy: "start_time",
+        sortOrder: "desc",
+      }),
+    );
+    const searchBody = await parseJson<{
+      spans: Array<{ spanId: string }>;
+      total: number;
+    }>(searchResponse);
+
+    expect(searchBody.total).toBe(1);
+    expect(searchBody.spans[0]?.spanId).toBe("span-1");
+  });
+
   it("filters out spans outside time range", async () => {
     const state = createState();
     const durableObject = new RealtimeSpansDurableObject(state);

--- a/cloud/workers/realtimeSpans/durableObject.ts
+++ b/cloud/workers/realtimeSpans/durableObject.ts
@@ -438,6 +438,7 @@ const matchesSearchFilters = (
 
   if (input.traceId && span.traceId !== input.traceId) return false;
   if (input.spanId && span.spanId !== input.spanId) return false;
+  if (input.rootOnly && span.parentSpanId) return false;
 
   if (input.query && !matchesQueryTokens(span.name, input.query)) {
     return false;

--- a/fern/openapi.json
+++ b/fern/openapi.json
@@ -836,6 +836,9 @@
                   "spanId": {
                     "type": "string"
                   },
+                  "rootOnly": {
+                    "type": "boolean"
+                  },
                   "model": {
                     "type": "array",
                     "items": {
@@ -1368,6 +1371,14 @@
               "type": "string"
             },
             "required": false
+          },
+          {
+            "name": "rootOnly",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/BooleanFromString"
+            },
+            "required": false
           }
         ],
         "security": [],
@@ -1480,6 +1491,382 @@
                         },
                         "additionalProperties": false
                       }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ClickHouseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ClickHouseError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DatabaseError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/traces/analytics/timeseries": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "operationId": "traces.getTimeSeriesMetrics",
+        "parameters": [
+          {
+            "name": "startTime",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "timeFrame",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "day",
+                "week",
+                "month",
+                "lifetime"
+              ]
+            },
+            "required": true
+          },
+          {
+            "name": "functionId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          },
+          {
+            "name": "rootOnly",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/BooleanFromString"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "points",
+                    "timeFrame"
+                  ],
+                  "properties": {
+                    "points": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "startTime",
+                          "endTime",
+                          "totalCostUsd",
+                          "totalInputTokens",
+                          "totalOutputTokens",
+                          "totalTokens",
+                          "averageDurationMs",
+                          "spanCount"
+                        ],
+                        "properties": {
+                          "startTime": {
+                            "type": "string"
+                          },
+                          "endTime": {
+                            "type": "string"
+                          },
+                          "totalCostUsd": {
+                            "type": "number"
+                          },
+                          "totalInputTokens": {
+                            "type": "number"
+                          },
+                          "totalOutputTokens": {
+                            "type": "number"
+                          },
+                          "totalTokens": {
+                            "type": "number"
+                          },
+                          "averageDurationMs": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "spanCount": {
+                            "type": "number"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "timeFrame": {
+                      "type": "string",
+                      "enum": [
+                        "day",
+                        "week",
+                        "month",
+                        "lifetime"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "UnauthorizedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "ClickHouseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/ClickHouseError"
+                    },
+                    {
+                      "$ref": "#/components/schemas/DatabaseError"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/traces/analytics/functions": {
+      "get": {
+        "tags": [
+          "traces"
+        ],
+        "operationId": "traces.getFunctionAggregates",
+        "parameters": [
+          {
+            "name": "startTime",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "endTime",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "rootOnly",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/BooleanFromString"
+            },
+            "required": false
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "functions",
+                    "total"
+                  ],
+                  "properties": {
+                    "functions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "functionId",
+                          "functionName",
+                          "totalCostUsd",
+                          "totalInputTokens",
+                          "totalOutputTokens",
+                          "totalTokens",
+                          "averageDurationMs",
+                          "spanCount"
+                        ],
+                        "properties": {
+                          "functionId": {
+                            "type": "string"
+                          },
+                          "functionName": {
+                            "type": "string"
+                          },
+                          "totalCostUsd": {
+                            "type": "number"
+                          },
+                          "totalInputTokens": {
+                            "type": "number"
+                          },
+                          "totalOutputTokens": {
+                            "type": "number"
+                          },
+                          "totalTokens": {
+                            "type": "number"
+                          },
+                          "averageDurationMs": {
+                            "anyOf": [
+                              {
+                                "type": "number"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "spanCount": {
+                            "type": "number"
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
                     }
                   },
                   "additionalProperties": false
@@ -9423,6 +9810,14 @@
           }
         },
         "additionalProperties": false
+      },
+      "BooleanFromString": {
+        "type": "string",
+        "enum": [
+          "true",
+          "false"
+        ],
+        "description": "a string to be decoded into a boolean"
       },
       "NumberFromString": {
         "type": "string",


### PR DESCRIPTION
### TL;DR

Added two new analytics API endpoints for time series metrics and function aggregates, plus support for filtering by root spans only.

### What changed?

- Added new API endpoint `/traces/analytics/timeseries` to get time-bucketed metrics over a specified time range
- Added new API endpoint `/traces/analytics/functions` to get per-function aggregate metrics
- Added `rootOnly` filter parameter to all analytics endpoints to restrict queries to root spans only
- Implemented time frame bucketing options (day, week, month, lifetime) for time series metrics
- Added appropriate schema definitions and validation for the new endpoints
- Updated tests to cover the new functionality

### How to test?

1. Use the API to fetch time series metrics:
   ```
   GET /traces/analytics/timeseries?startTime=2024-01-01T00:00:00Z&endTime=2024-01-31T23:59:59Z&timeFrame=day
   ```

2. Get per-function aggregates:
   ```
   GET /traces/analytics/functions?startTime=2024-01-01T00:00:00Z&endTime=2024-01-31T23:59:59Z
   ```

3. Filter any analytics endpoint to root spans only:
   ```
   GET /traces/analytics?startTime=2024-01-01T00:00:00Z&endTime=2024-01-31T23:59:59Z&rootOnly=true
   ```

### Why make this change?

These new endpoints provide more granular analytics capabilities for the traces API:

- Time series metrics allow for tracking usage patterns over time with flexible bucketing
- Function aggregates provide insights into which functions are consuming the most resources
- Root span filtering allows for more accurate analytics by focusing on top-level operations rather than including all child spans

These improvements will enable better visualization and analysis of trace data in dashboards and reports.