### PR TITLE
feat(cloud): add tags endpoints

### DIFF
--- a/cloud/api/annotations.handlers.ts
+++ b/cloud/api/annotations.handlers.ts
@@ -12,6 +12,7 @@ export * from "@/api/annotations.schemas";
 export const toAnnotation = (annotation: PublicAnnotation) => {
   return {
     ...annotation,
+    tags: annotation.tags ?? [],
     spanId: annotation.otelSpanId,
     traceId: annotation.otelTraceId,
     createdAt: annotation.createdAt?.toISOString() ?? null,
@@ -64,6 +65,9 @@ export const createAnnotationHandler = (payload: CreateAnnotationRequest) =>
     const db = yield* Database;
     const { user, apiKeyInfo } = yield* Authentication.ApiKey;
 
+    const tags =
+      payload.tags === null ? null : payload.tags ? [...payload.tags] : null;
+
     const result =
       yield* db.organizations.projects.environments.traces.annotations.create({
         userId: user.id,
@@ -76,6 +80,7 @@ export const createAnnotationHandler = (payload: CreateAnnotationRequest) =>
           label: payload.label ?? null,
           reasoning: payload.reasoning ?? null,
           metadata: payload.metadata ?? null,
+          tags,
         },
       });
 
@@ -117,6 +122,13 @@ export const updateAnnotationHandler = (
     const db = yield* Database;
     const { user, apiKeyInfo } = yield* Authentication.ApiKey;
 
+    const tags =
+      payload.tags === null
+        ? null
+        : payload.tags
+          ? [...payload.tags]
+          : undefined;
+
     const result =
       yield* db.organizations.projects.environments.traces.annotations.update({
         userId: user.id,
@@ -128,6 +140,7 @@ export const updateAnnotationHandler = (
           label: payload.label,
           reasoning: payload.reasoning,
           metadata: payload.metadata,
+          tags,
         },
       });
 

--- a/cloud/api/annotations.schemas.ts
+++ b/cloud/api/annotations.schemas.ts
@@ -7,6 +7,7 @@ import {
   PermissionDeniedError,
   UnauthorizedError,
 } from "@/errors";
+import { TagNameSchema } from "@/api/tags.schemas";
 
 const LabelSchema = Schema.Literal("pass", "fail");
 
@@ -18,6 +19,7 @@ const CreateAnnotationRequestSchema = Schema.Struct({
   metadata: Schema.optional(
     Schema.NullOr(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
   ),
+  tags: Schema.optional(Schema.NullOr(Schema.Array(TagNameSchema))),
 });
 
 export type CreateAnnotationRequest = typeof CreateAnnotationRequestSchema.Type;
@@ -28,6 +30,7 @@ const UpdateAnnotationRequestSchema = Schema.Struct({
   metadata: Schema.optional(
     Schema.NullOr(Schema.Record({ key: Schema.String, value: Schema.Unknown })),
   ),
+  tags: Schema.optional(Schema.NullOr(Schema.Array(TagNameSchema))),
 });
 
 export type UpdateAnnotationRequest = typeof UpdateAnnotationRequestSchema.Type;
@@ -43,6 +46,7 @@ const AnnotationResponseSchema = Schema.Struct({
   metadata: Schema.NullOr(
     Schema.Record({ key: Schema.String, value: Schema.Unknown }),
   ),
+  tags: Schema.Array(TagNameSchema),
   environmentId: Schema.String,
   projectId: Schema.String,
   organizationId: Schema.String,

--- a/cloud/api/api.ts
+++ b/cloud/api/api.ts
@@ -11,6 +11,7 @@ import { EnvironmentsApi } from "@/api/environments.schemas";
 import { ApiKeysApi } from "@/api/api-keys.schemas";
 import { FunctionsApi } from "@/api/functions.schemas";
 import { AnnotationsApi } from "@/api/annotations.schemas";
+import { TagsApi } from "@/api/tags.schemas";
 import { RateLimitError, ServiceUnavailableError } from "@/errors";
 
 export * from "@/errors";
@@ -26,6 +27,7 @@ export * from "@/api/environments.schemas";
 export * from "@/api/api-keys.schemas";
 export * from "@/api/functions.schemas";
 export * from "@/api/annotations.schemas";
+export * from "@/api/tags.schemas";
 export * from "@/api/traces-search.schemas";
 
 export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
@@ -41,6 +43,7 @@ export class MirascopeCloudApi extends HttpApi.make("MirascopeCloudApi")
   .add(ApiKeysApi)
   .add(FunctionsApi)
   .add(AnnotationsApi)
+  .add(TagsApi)
   .addError(RateLimitError, { status: RateLimitError.status })
   .addError(ServiceUnavailableError, {
     status: ServiceUnavailableError.status,

--- a/cloud/api/router.ts
+++ b/cloud/api/router.ts
@@ -75,6 +75,13 @@ import {
   deleteAnnotationHandler,
 } from "@/api/annotations.handlers";
 import {
+  listTagsHandler,
+  createTagHandler,
+  getTagHandler,
+  updateTagHandler,
+  deleteTagHandler,
+} from "@/api/tags.handlers";
+import {
   searchHandler,
   getTraceDetailHandler,
   getAnalyticsSummaryHandler,
@@ -336,6 +343,33 @@ const AnnotationsHandlersLive = HttpApiBuilder.group(
       .handle("delete", ({ path }) => deleteAnnotationHandler(path.id)),
 );
 
+const TagsHandlersLive = HttpApiBuilder.group(
+  MirascopeCloudApi,
+  "tags",
+  (handlers) =>
+    handlers
+      .handle("list", ({ path }) =>
+        listTagsHandler(path.organizationId, path.projectId),
+      )
+      .handle("create", ({ path, payload }) =>
+        createTagHandler(path.organizationId, path.projectId, payload),
+      )
+      .handle("get", ({ path }) =>
+        getTagHandler(path.organizationId, path.projectId, path.tagId),
+      )
+      .handle("update", ({ path, payload }) =>
+        updateTagHandler(
+          path.organizationId,
+          path.projectId,
+          path.tagId,
+          payload,
+        ),
+      )
+      .handle("delete", ({ path }) =>
+        deleteTagHandler(path.organizationId, path.projectId, path.tagId),
+      ),
+);
+
 export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(HealthHandlersLive),
   Layer.provide(TracesHandlersLive),
@@ -349,4 +383,5 @@ export const ApiLive = HttpApiBuilder.api(MirascopeCloudApi).pipe(
   Layer.provide(ApiKeysHandlersLive),
   Layer.provide(FunctionsHandlersLive),
   Layer.provide(AnnotationsHandlersLive),
+  Layer.provide(TagsHandlersLive),
 );

--- a/cloud/api/tags.handlers.ts
+++ b/cloud/api/tags.handlers.ts
@@ -1,0 +1,121 @@
+import { Effect } from "effect";
+import { Database } from "@/db";
+import { AuthenticatedUser } from "@/auth";
+import type { PublicTag } from "@/db/schema";
+import type { CreateTagRequest, UpdateTagRequest } from "@/api/tags.schemas";
+
+export * from "@/api/tags.schemas";
+
+export const toTag = (tag: PublicTag) => ({
+  ...tag,
+  createdAt: tag.createdAt?.toISOString() ?? null,
+  updatedAt: tag.updatedAt?.toISOString() ?? null,
+});
+
+/**
+ * Handler for listing tags in a project.
+ */
+export const listTagsHandler = (organizationId: string, projectId: string) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const user = yield* AuthenticatedUser;
+
+    const results = yield* db.organizations.projects.tags.findAll({
+      userId: user.id,
+      organizationId,
+      projectId,
+    });
+
+    return {
+      tags: results.map(toTag),
+      total: results.length,
+    };
+  });
+
+/**
+ * Handler for creating a tag in a project.
+ */
+export const createTagHandler = (
+  organizationId: string,
+  projectId: string,
+  payload: CreateTagRequest,
+) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const user = yield* AuthenticatedUser;
+
+    const result = yield* db.organizations.projects.tags.create({
+      userId: user.id,
+      organizationId,
+      projectId,
+      data: { name: payload.name },
+    });
+
+    return toTag(result);
+  });
+
+/**
+ * Handler for retrieving a tag by ID in a project.
+ */
+export const getTagHandler = (
+  organizationId: string,
+  projectId: string,
+  tagId: string,
+) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const user = yield* AuthenticatedUser;
+
+    const result = yield* db.organizations.projects.tags.findById({
+      userId: user.id,
+      organizationId,
+      projectId,
+      tagId,
+    });
+
+    return toTag(result);
+  });
+
+/**
+ * Handler for updating a tag in a project.
+ */
+export const updateTagHandler = (
+  organizationId: string,
+  projectId: string,
+  tagId: string,
+  payload: UpdateTagRequest,
+) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const user = yield* AuthenticatedUser;
+
+    const result = yield* db.organizations.projects.tags.update({
+      userId: user.id,
+      organizationId,
+      projectId,
+      tagId,
+      data: { name: payload.name },
+    });
+
+    return toTag(result);
+  });
+
+/**
+ * Handler for deleting a tag in a project.
+ */
+export const deleteTagHandler = (
+  organizationId: string,
+  projectId: string,
+  tagId: string,
+) =>
+  Effect.gen(function* () {
+    const db = yield* Database;
+    const user = yield* AuthenticatedUser;
+
+    yield* db.organizations.projects.tags.delete({
+      userId: user.id,
+      organizationId,
+      projectId,
+      tagId,
+    });
+  });

--- a/cloud/api/tags.schemas.ts
+++ b/cloud/api/tags.schemas.ts
@@ -1,0 +1,130 @@
+import { HttpApiEndpoint, HttpApiGroup } from "@effect/platform";
+import { Schema } from "effect";
+import {
+  NotFoundError,
+  PermissionDeniedError,
+  DatabaseError,
+  AlreadyExistsError,
+} from "@/errors";
+
+export const TagNameSchema = Schema.String.pipe(
+  Schema.minLength(1),
+  Schema.maxLength(100),
+);
+
+export const TagSchema = Schema.Struct({
+  id: Schema.String,
+  name: TagNameSchema,
+  projectId: Schema.String,
+  organizationId: Schema.String,
+  createdBy: Schema.NullOr(Schema.String),
+  createdAt: Schema.NullOr(Schema.String),
+  updatedAt: Schema.NullOr(Schema.String),
+});
+
+export const CreateTagRequestSchema = Schema.Struct({
+  name: TagNameSchema,
+});
+
+export const UpdateTagRequestSchema = Schema.Struct({
+  name: Schema.optional(TagNameSchema),
+});
+
+export const ListTagsResponseSchema = Schema.Struct({
+  tags: Schema.Array(TagSchema),
+  total: Schema.Number,
+});
+
+export type Tag = typeof TagSchema.Type;
+export type CreateTagRequest = typeof CreateTagRequestSchema.Type;
+export type UpdateTagRequest = typeof UpdateTagRequestSchema.Type;
+export type ListTagsResponse = typeof ListTagsResponseSchema.Type;
+
+export class TagsApi extends HttpApiGroup.make("tags")
+  .add(
+    HttpApiEndpoint.get(
+      "list",
+      "/organizations/:organizationId/projects/:projectId/tags",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+        }),
+      )
+      .addSuccess(ListTagsResponseSchema)
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.post(
+      "create",
+      "/organizations/:organizationId/projects/:projectId/tags",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+        }),
+      )
+      .setPayload(CreateTagRequestSchema)
+      .addSuccess(TagSchema)
+      .addError(AlreadyExistsError, { status: AlreadyExistsError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.get(
+      "get",
+      "/organizations/:organizationId/projects/:projectId/tags/:tagId",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+          tagId: Schema.String,
+        }),
+      )
+      .addSuccess(TagSchema)
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.put(
+      "update",
+      "/organizations/:organizationId/projects/:projectId/tags/:tagId",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+          tagId: Schema.String,
+        }),
+      )
+      .setPayload(UpdateTagRequestSchema)
+      .addSuccess(TagSchema)
+      .addError(AlreadyExistsError, { status: AlreadyExistsError.status })
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  )
+  .add(
+    HttpApiEndpoint.del(
+      "delete",
+      "/organizations/:organizationId/projects/:projectId/tags/:tagId",
+    )
+      .setPath(
+        Schema.Struct({
+          organizationId: Schema.String,
+          projectId: Schema.String,
+          tagId: Schema.String,
+        }),
+      )
+      .addSuccess(Schema.Void)
+      .addError(NotFoundError, { status: NotFoundError.status })
+      .addError(PermissionDeniedError, { status: PermissionDeniedError.status })
+      .addError(DatabaseError, { status: DatabaseError.status }),
+  ) {}

--- a/cloud/api/tags.test.ts
+++ b/cloud/api/tags.test.ts
@@ -1,0 +1,322 @@
+import { Effect } from "effect";
+import {
+  describe,
+  it,
+  expect,
+  TestApiContext,
+  createApiClient,
+} from "@/tests/api";
+import type { PublicProject, PublicEnvironment } from "@/db/schema";
+import { toTag } from "@/api/tags.handlers";
+import { TEST_DATABASE_URL } from "@/tests/db";
+
+describe("toTag", () => {
+  it("converts dates to ISO strings", () => {
+    const now = new Date();
+    const tag = {
+      id: "test-id",
+      name: "Bug",
+      projectId: "project-id",
+      organizationId: "org-id",
+      createdBy: "user-id",
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    const result = toTag(tag);
+
+    expect(result.createdAt).toBe(now.toISOString());
+    expect(result.updatedAt).toBe(now.toISOString());
+  });
+
+  it("handles null dates", () => {
+    const tag = {
+      id: "test-id",
+      name: "Bug",
+      projectId: "project-id",
+      organizationId: "org-id",
+      createdBy: null,
+      createdAt: null,
+      updatedAt: null,
+    };
+
+    const result = toTag(tag);
+
+    expect(result.createdAt).toBeNull();
+    expect(result.updatedAt).toBeNull();
+  });
+});
+
+describe.sequential("Tags API", (it) => {
+  let project: PublicProject;
+  let environment: PublicEnvironment;
+  let apiKeyClient: Awaited<ReturnType<typeof createApiClient>>["client"];
+  let disposeApiKeyClient: (() => Promise<void>) | null = null;
+  let createdTagId: string;
+
+  it.effect(
+    "POST /organizations/:orgId/projects - create project for tags",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        project = yield* client.projects.create({
+          path: { organizationId: org.id },
+          payload: {
+            name: "Tags Test Project",
+            slug: "tags-test-project",
+          },
+        });
+        expect(project.id).toBeDefined();
+      }),
+  );
+
+  it.effect(
+    "POST /organizations/:orgId/projects/:projId/environments - create environment for tags",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        environment = yield* client.environments.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: {
+            name: "Tags Test Environment",
+            slug: "tags-test-env",
+          },
+        });
+        expect(environment.id).toBeDefined();
+      }),
+  );
+
+  it.effect(
+    "POST /organizations/:orgId/projects/:projId/tags - creates tag",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.tags.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: { name: "Bug" },
+        });
+        expect(result.id).toBeDefined();
+        expect(result.name).toBe("Bug");
+        createdTagId = result.id;
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/tags - lists tags",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.tags.list({
+          path: { organizationId: org.id, projectId: project.id },
+        });
+        expect(result.total).toBeGreaterThanOrEqual(1);
+        expect(result.tags.length).toBeGreaterThanOrEqual(1);
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/tags/:tagId - gets tag",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.tags.get({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            tagId: createdTagId,
+          },
+        });
+        expect(result.id).toBe(createdTagId);
+        expect(result.name).toBe("Bug");
+      }),
+  );
+
+  it.effect(
+    "PUT /organizations/:orgId/projects/:projId/tags/:tagId - updates tag",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        const result = yield* client.tags.update({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            tagId: createdTagId,
+          },
+          payload: { name: "Bugfix" },
+        });
+        expect(result.id).toBe(createdTagId);
+        expect(result.name).toBe("Bugfix");
+      }),
+  );
+
+  it.effect("Create API key client for tags API key tests", () =>
+    Effect.gen(function* () {
+      const { org, owner } = yield* TestApiContext;
+      const apiKeyInfo = {
+        apiKeyId: "test-api-key-id",
+        organizationId: org.id,
+        projectId: project.id,
+        environmentId: environment.id,
+        ownerId: owner.id,
+        ownerEmail: owner.email,
+        ownerName: owner.name,
+        ownerDeletedAt: owner.deletedAt,
+      };
+
+      const result = yield* Effect.promise(() =>
+        createApiClient(
+          TEST_DATABASE_URL,
+          owner,
+          apiKeyInfo,
+          () => Effect.void,
+        ),
+      );
+      apiKeyClient = result.client;
+      disposeApiKeyClient = result.dispose;
+    }),
+  );
+
+  it.effect(
+    "POST /organizations/:orgId/projects/:projId/tags - creates tag via API key",
+    () =>
+      Effect.gen(function* () {
+        const { org } = yield* TestApiContext;
+        const result = yield* apiKeyClient.tags.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: { name: "ApiKeyTag" },
+        });
+        expect(result.id).toBeDefined();
+        expect(result.name).toBe("ApiKeyTag");
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/tags - lists tags via API key",
+    () =>
+      Effect.gen(function* () {
+        const { org } = yield* TestApiContext;
+        const result = yield* apiKeyClient.tags.list({
+          path: { organizationId: org.id, projectId: project.id },
+        });
+        expect(result.total).toBeGreaterThanOrEqual(1);
+        expect(result.tags.length).toBeGreaterThanOrEqual(1);
+      }),
+  );
+
+  it.effect(
+    "GET /organizations/:orgId/projects/:projId/tags/:tagId - gets tag via API key",
+    () =>
+      Effect.gen(function* () {
+        const { org } = yield* TestApiContext;
+        const created = yield* apiKeyClient.tags.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: { name: "ApiKeyGet" },
+        });
+
+        const result = yield* apiKeyClient.tags.get({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            tagId: created.id,
+          },
+        });
+
+        expect(result.id).toBe(created.id);
+        expect(result.name).toBe("ApiKeyGet");
+      }),
+  );
+
+  it.effect(
+    "PUT /organizations/:orgId/projects/:projId/tags/:tagId - updates tag via API key",
+    () =>
+      Effect.gen(function* () {
+        const { org } = yield* TestApiContext;
+        const created = yield* apiKeyClient.tags.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: { name: "ApiKeyUpdate" },
+        });
+
+        const result = yield* apiKeyClient.tags.update({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            tagId: created.id,
+          },
+          payload: { name: "ApiKeyUpdated" },
+        });
+
+        expect(result.id).toBe(created.id);
+        expect(result.name).toBe("ApiKeyUpdated");
+      }),
+  );
+
+  it.effect(
+    "DELETE /organizations/:orgId/projects/:projId/tags/:tagId - deletes tag via API key",
+    () =>
+      Effect.gen(function* () {
+        const { org } = yield* TestApiContext;
+        const created = yield* apiKeyClient.tags.create({
+          path: { organizationId: org.id, projectId: project.id },
+          payload: { name: "ApiKeyDelete" },
+        });
+
+        yield* apiKeyClient.tags.delete({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            tagId: created.id,
+          },
+        });
+
+        const result = yield* apiKeyClient.tags
+          .get({
+            path: {
+              organizationId: org.id,
+              projectId: project.id,
+              tagId: created.id,
+            },
+          })
+          .pipe(Effect.flip);
+
+        expect(result._tag).toBe("NotFoundError");
+      }),
+  );
+
+  it.effect(
+    "DELETE /organizations/:orgId/projects/:projId/tags/:tagId - deletes tag",
+    () =>
+      Effect.gen(function* () {
+        const { client, org } = yield* TestApiContext;
+        yield* client.tags.delete({
+          path: {
+            organizationId: org.id,
+            projectId: project.id,
+            tagId: createdTagId,
+          },
+        });
+
+        const result = yield* client.tags
+          .get({
+            path: {
+              organizationId: org.id,
+              projectId: project.id,
+              tagId: createdTagId,
+            },
+          })
+          .pipe(Effect.flip);
+
+        expect(result._tag).toBe("NotFoundError");
+      }),
+  );
+
+  it.effect("Dispose API key client", () =>
+    Effect.gen(function* () {
+      if (!disposeApiKeyClient) {
+        return;
+      }
+
+      const dispose = disposeApiKeyClient;
+      yield* Effect.promise(() => dispose());
+    }),
+  );
+});

--- a/cloud/db/annotations.ts
+++ b/cloud/db/annotations.ts
@@ -61,7 +61,7 @@ import {
 } from "@/db/base";
 import { DrizzleORM } from "@/db/client";
 import { ProjectMemberships } from "@/db/project-memberships";
-import { ProjectTags } from "@/db/project-tags";
+import { Tags } from "@/db/tags";
 import { ClickHouseSearch } from "@/db/clickhouse/search";
 import { RealtimeSpans } from "@/workers/realtimeSpans";
 import {
@@ -175,15 +175,12 @@ export class Annotations extends BaseAuthenticatedEffectService<
   ClickHouseSearch | RealtimeSpans
 > {
   private readonly projectMemberships: ProjectMemberships;
-  private readonly projectTags: ProjectTags;
+  private readonly tags: Tags;
 
-  constructor(
-    projectMemberships: ProjectMemberships,
-    projectTags: ProjectTags,
-  ) {
+  constructor(projectMemberships: ProjectMemberships, tags: Tags) {
     super();
     this.projectMemberships = projectMemberships;
-    this.projectTags = projectTags;
+    this.tags = tags;
   }
 
   // ---------------------------------------------------------------------------
@@ -303,7 +300,7 @@ export class Annotations extends BaseAuthenticatedEffectService<
       }
 
       if (data.tags) {
-        yield* this.projectTags.findByNames({
+        yield* this.tags.findByNames({
           userId,
           organizationId,
           projectId,
@@ -577,7 +574,7 @@ export class Annotations extends BaseAuthenticatedEffectService<
         updateData.metadata = data.metadata;
       }
       if (data.tags) {
-        yield* this.projectTags.findByNames({
+        yield* this.tags.findByNames({
           userId,
           organizationId,
           projectId,

--- a/cloud/db/database.ts
+++ b/cloud/db/database.ts
@@ -53,7 +53,7 @@ import { ApiKeys } from "@/db/api-keys";
 import { Traces } from "@/db/clickhouse/traces";
 import { Functions } from "@/db/functions";
 import { Annotations } from "@/db/annotations";
-import { ProjectTags } from "@/db/project-tags";
+import { Tags } from "@/db/tags";
 import { RouterRequests } from "@/db/router-requests";
 import { Payments } from "@/payments";
 
@@ -101,7 +101,7 @@ export interface EnvironmentsService extends Ready<Environments> {
  */
 export interface ProjectsService extends Ready<Projects> {
   readonly memberships: Ready<ProjectMemberships>;
-  readonly tags: Ready<ProjectTags>;
+  readonly tags: Ready<Tags>;
   readonly environments: EnvironmentsService;
 }
 
@@ -182,12 +182,12 @@ export class Database extends Context.Tag("Database")<
         organizationMemberships,
         projectMemberships,
       );
-      const projectTags = new ProjectTags(projectMemberships);
+      const tags = new Tags(projectMemberships);
       const environments = new Environments(projectMemberships);
       const apiKeys = new ApiKeys(projectMemberships);
       const traces = new Traces(projectMemberships);
       const functions = new Functions(projectMemberships);
-      const annotations = new Annotations(projectMemberships, projectTags);
+      const annotations = new Annotations(projectMemberships, tags);
       const routerRequests = new RouterRequests(projectMemberships);
 
       return {
@@ -200,7 +200,7 @@ export class Database extends Context.Tag("Database")<
           projects: {
             ...provideDependencies(projects),
             memberships: provideDependencies(projectMemberships),
-            tags: provideDependencies(projectTags),
+            tags: provideDependencies(tags),
             environments: {
               ...provideDependencies(environments),
               apiKeys: {

--- a/cloud/db/schema/index.ts
+++ b/cloud/db/schema/index.ts
@@ -8,7 +8,7 @@ export * from "@/db/schema/projects";
 export * from "@/db/schema/project-memberships";
 export * from "@/db/schema/project-membership-audit";
 export * from "@/db/schema/environments";
-export * from "@/db/schema/project-tags";
+export * from "@/db/schema/tags";
 export * from "@/db/schema/api-keys";
 export * from "@/db/schema/functions";
 export * from "@/db/schema/annotations";
@@ -41,7 +41,7 @@ export type {
   PublicEnvironment,
   NewEnvironment,
 } from "@/db/schema/environments";
-export type { PublicProjectTag } from "@/db/schema/project-tags";
+export type { PublicTag } from "@/db/schema/tags";
 export type {
   PublicApiKey,
   ApiKeyCreateResponse,
@@ -70,7 +70,7 @@ import { projects } from "@/db/schema/projects";
 import { projectMemberships } from "@/db/schema/project-memberships";
 import { projectMembershipAudit } from "@/db/schema/project-membership-audit";
 import { environments } from "@/db/schema/environments";
-import { projectTags } from "@/db/schema/project-tags";
+import { tags } from "@/db/schema/tags";
 import { apiKeys } from "@/db/schema/api-keys";
 import { functions } from "@/db/schema/functions";
 import { annotations } from "@/db/schema/annotations";
@@ -88,7 +88,7 @@ export type DatabaseTable =
   | typeof projectMemberships
   | typeof projectMembershipAudit
   | typeof environments
-  | typeof projectTags
+  | typeof tags
   | typeof apiKeys
   | typeof functions
   | typeof annotations

--- a/cloud/db/schema/tags.ts
+++ b/cloud/db/schema/tags.ts
@@ -4,7 +4,7 @@ import { projects } from "./projects";
 import { organizations } from "./organizations";
 import { users } from "./users";
 
-export const projectTags = pgTable(
+export const tags = pgTable(
   "project_tags",
   {
     id: uuid("id").primaryKey().defaultRandom(),
@@ -26,26 +26,26 @@ export const projectTags = pgTable(
   }),
 );
 
-export const projectTagsRelations = relations(projectTags, ({ one }) => ({
+export const tagsRelations = relations(tags, ({ one }) => ({
   project: one(projects, {
-    fields: [projectTags.projectId],
+    fields: [tags.projectId],
     references: [projects.id],
   }),
   organization: one(organizations, {
-    fields: [projectTags.organizationId],
+    fields: [tags.organizationId],
     references: [organizations.id],
   }),
   createdByUser: one(users, {
-    fields: [projectTags.createdBy],
+    fields: [tags.createdBy],
     references: [users.id],
   }),
 }));
 
-export type ProjectTag = typeof projectTags.$inferSelect;
-export type NewProjectTag = typeof projectTags.$inferInsert;
+export type Tag = typeof tags.$inferSelect;
+export type NewTag = typeof tags.$inferInsert;
 
-export type PublicProjectTag = Pick<
-  ProjectTag,
+export type PublicTag = Pick<
+  Tag,
   | "id"
   | "name"
   | "projectId"

--- a/cloud/db/tags.test.ts
+++ b/cloud/db/tags.test.ts
@@ -13,9 +13,9 @@ import {
   NotFoundError,
   PermissionDeniedError,
 } from "@/errors";
-import type { PublicProjectTag } from "@/db/schema";
+import type { PublicTag } from "@/db/schema";
 
-describe("ProjectTags", () => {
+describe("Tags", () => {
   // ==========================================================================
   // create
   // ==========================================================================
@@ -38,7 +38,7 @@ describe("ProjectTags", () => {
           projectId: project.id,
           organizationId: org.id,
           createdBy: owner.id,
-        } satisfies Partial<PublicProjectTag>);
+        } satisfies Partial<PublicTag>);
         expect(tag.id).toBeDefined();
       }),
     );

--- a/fern/openapi.json
+++ b/fern/openapi.json
@@ -8780,6 +8780,7 @@
                           "label",
                           "reasoning",
                           "metadata",
+                          "tags",
                           "environmentId",
                           "projectId",
                           "organizationId",
@@ -8842,6 +8843,16 @@
                                 "type": "null"
                               }
                             ]
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "description": "a string at most 100 character(s) long",
+                              "title": "maxLength(100)",
+                              "minLength": 1,
+                              "maxLength": 100
+                            }
                           },
                           "environmentId": {
                             "type": "string"
@@ -8990,6 +9001,7 @@
                     "label",
                     "reasoning",
                     "metadata",
+                    "tags",
                     "environmentId",
                     "projectId",
                     "organizationId",
@@ -9052,6 +9064,16 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "a string at most 100 character(s) long",
+                        "title": "maxLength(100)",
+                        "minLength": 1,
+                        "maxLength": 100
+                      }
                     },
                     "environmentId": {
                       "type": "string"
@@ -9234,6 +9256,23 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "description": "a string at most 100 character(s) long",
+                          "title": "maxLength(100)",
+                          "minLength": 1,
+                          "maxLength": 100
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -9277,6 +9316,7 @@
                     "label",
                     "reasoning",
                     "metadata",
+                    "tags",
                     "environmentId",
                     "projectId",
                     "organizationId",
@@ -9339,6 +9379,16 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "a string at most 100 character(s) long",
+                        "title": "maxLength(100)",
+                        "minLength": 1,
+                        "maxLength": 100
+                      }
                     },
                     "environmentId": {
                       "type": "string"
@@ -9489,6 +9539,7 @@
                     "label",
                     "reasoning",
                     "metadata",
+                    "tags",
                     "environmentId",
                     "projectId",
                     "organizationId",
@@ -9551,6 +9602,16 @@
                           "type": "null"
                         }
                       ]
+                    },
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string",
+                        "description": "a string at most 100 character(s) long",
+                        "title": "maxLength(100)",
+                        "minLength": 1,
+                        "maxLength": 100
+                      }
                     },
                     "environmentId": {
                       "type": "string"
@@ -9714,6 +9775,23 @@
                         "type": "null"
                       }
                     ]
+                  },
+                  "tags": {
+                    "anyOf": [
+                      {
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "description": "a string at most 100 character(s) long",
+                          "title": "maxLength(100)",
+                          "minLength": 1,
+                          "maxLength": 100
+                        }
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
                   }
                 },
                 "additionalProperties": false
@@ -9759,6 +9837,824 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/UnauthorizedError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/organizations/{organizationId}/projects/{projectId}/tags": {
+      "get": {
+        "tags": [
+          "tags"
+        ],
+        "operationId": "tags.list",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "tags",
+                    "total"
+                  ],
+                  "properties": {
+                    "tags": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "name",
+                          "projectId",
+                          "organizationId",
+                          "createdBy",
+                          "createdAt",
+                          "updatedAt"
+                        ],
+                        "properties": {
+                          "id": {
+                            "type": "string"
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "a string at most 100 character(s) long",
+                            "title": "maxLength(100)",
+                            "minLength": 1,
+                            "maxLength": 100
+                          },
+                          "projectId": {
+                            "type": "string"
+                          },
+                          "organizationId": {
+                            "type": "string"
+                          },
+                          "createdBy": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "createdAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          },
+                          "updatedAt": {
+                            "anyOf": [
+                              {
+                                "type": "string"
+                              },
+                              {
+                                "type": "null"
+                              }
+                            ]
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "total": {
+                      "type": "number"
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "tags"
+        ],
+        "operationId": "tags.create",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "name",
+                    "projectId",
+                    "organizationId",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "a string at most 100 character(s) long",
+                      "title": "maxLength(100)",
+                      "minLength": 1,
+                      "maxLength": 100
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "organizationId": {
+                      "type": "string"
+                    },
+                    "createdBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "AlreadyExistsError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlreadyExistsError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "name"
+                ],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "a string at most 100 character(s) long",
+                    "title": "maxLength(100)",
+                    "minLength": 1,
+                    "maxLength": 100
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
+      }
+    },
+    "/organizations/{organizationId}/projects/{projectId}/tags/{tagId}": {
+      "get": {
+        "tags": [
+          "tags"
+        ],
+        "operationId": "tags.get",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "tagId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "name",
+                    "projectId",
+                    "organizationId",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "a string at most 100 character(s) long",
+                      "title": "maxLength(100)",
+                      "minLength": 1,
+                      "maxLength": 100
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "organizationId": {
+                      "type": "string"
+                    },
+                    "createdBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "tags"
+        ],
+        "operationId": "tags.update",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "tagId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "id",
+                    "name",
+                    "projectId",
+                    "organizationId",
+                    "createdBy",
+                    "createdAt",
+                    "updatedAt"
+                  ],
+                  "properties": {
+                    "id": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "a string at most 100 character(s) long",
+                      "title": "maxLength(100)",
+                      "minLength": 1,
+                      "maxLength": 100
+                    },
+                    "projectId": {
+                      "type": "string"
+                    },
+                    "organizationId": {
+                      "type": "string"
+                    },
+                    "createdBy": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "createdAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    },
+                    "updatedAt": {
+                      "anyOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "null"
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "PermissionDeniedError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PermissionDeniedError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundError"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "AlreadyExistsError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlreadyExistsError"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "RateLimitError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RateLimitError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "DatabaseError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatabaseError"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "ServiceUnavailableError",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ServiceUnavailableError"
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "a string at most 100 character(s) long",
+                    "title": "maxLength(100)",
+                    "minLength": 1,
+                    "maxLength": 100
+                  }
+                },
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": true
+        }
+      },
+      "delete": {
+        "tags": [
+          "tags"
+        ],
+        "operationId": "tags.delete",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "projectId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "tagId",
+            "in": "path",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "security": [],
+        "responses": {
+          "204": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "The request did not match the expected schema",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpApiDecodeError"
                 }
               }
             }
@@ -10263,6 +11159,9 @@
     },
     {
       "name": "annotations"
+    },
+    {
+      "name": "tags"
     }
   ],
   "servers": [


### PR DESCRIPTION
### TL;DR

Added support for tags in annotations, allowing users to categorize and filter annotations more effectively.

### What changed?

- Added tags field to annotation schemas and handlers
- Created new API endpoints for managing tags at both project and API key levels
- Implemented proper tag handling in annotation creation and update operations
- Added comprehensive tests for tag functionality
- Ensured tags can be set to null, an array of strings, or omitted entirely

### How to test?

1. Create tags via the project tags API:
   ```
   POST /organizations/:orgId/projects/:projId/tags
   { "name": "Bug" }
   ```

2. Add tags to annotations:
   ```
   POST /annotations
   {
     "otelTraceId": "...",
     "otelSpanId": "...",
     "tags": ["Bug"]
   }
   ```

3. Update annotation tags:
   ```
   PUT /annotations/:id
   {
     "tags": ["Feature"]
   }
   ```

4. List tags in a project:
   ```
   GET /organizations/:orgId/projects/:projId/tags
   ```

5. Verify tags appear in annotation responses

### Why make this change?

Tags provide a flexible way to categorize annotations, making it easier for users to organize and filter their annotations based on different criteria. This enhances the annotation system's usability by allowing users to group related annotations together and quickly find relevant information.