### PR TITLE
fix(cloud): fix module resolve glob to move docs content out of cloud/

### DIFF
--- a/cloud/app/lib/content/virtual-module.ts
+++ b/cloud/app/lib/content/virtual-module.ts
@@ -62,9 +62,9 @@ function buildModuleMap(
 /* ========== MODULE-LEVEL GLOB IMPORTS =========== */
 // Evaluated once at module load for memory efficiency.
 
-const BLOG_PATH_REGEX = /^\/content\/blog\/(.*)\.mdx$/;
-const DOCS_PATH_REGEX = /^\/content\/docs\/(.*)\.mdx$/;
-const POLICY_PATH_REGEX = /^\/content\/policy\/(.*)\.mdx$/;
+const BLOG_PATH_REGEX = /^\/?\.{2}\/content\/blog\/(.*)\.mdx$/;
+const DOCS_PATH_REGEX = /^\/?\.{2}\/content\/docs\/(.*)\.mdx$/;
+const POLICY_PATH_REGEX = /^\/?\.{2}\/content\/policy\/(.*)\.mdx$/;
 
 const BLOG_MODULES = import.meta.glob<VirtualModuleExport>(
   "@/../content/blog/*.mdx",


### PR DESCRIPTION
Superseded by https://app.graphite.com/github/pr/Mirascope/mirascope/2089/refactor(docs)-move-docs-content-out-of-cloud%2F.