### PR TITLE
fix(ops): stabilize otel configuration typing

### DIFF
--- a/python/tests/ops/test_configuration.py
+++ b/python/tests/ops/test_configuration.py
@@ -7,9 +7,10 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+
 from mirascope import ops
 from mirascope.ops._internal import configuration
-from opentelemetry.sdk.trace import TracerProvider
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
 @pytest.fixture
 def mock_mirascope_client() -> Generator[MagicMock, None, None]:
     """Mock the Mirascope client to avoid actual API calls."""
-    with patch("mirascope.api.client.Mirascope") as mock:
+    with patch("mirascope.ops._internal.configuration.Mirascope") as mock:
         mock.return_value = MagicMock()
         yield mock
 
@@ -26,7 +27,7 @@ def mock_mirascope_client() -> Generator[MagicMock, None, None]:
 @pytest.fixture
 def mock_exporter() -> Generator[MagicMock, None, None]:
     """Mock the MirascopeOTLPExporter at the re-export location."""
-    with patch("mirascope.ops._internal.exporters.MirascopeOTLPExporter") as mock:
+    with patch("mirascope.ops._internal.configuration.MirascopeOTLPExporter") as mock:
         mock.return_value = MagicMock()
         yield mock
 
@@ -109,7 +110,9 @@ def test_create_mirascope_cloud_provider_success(
     mock_mirascope_client: MagicMock, mock_exporter: MagicMock
 ) -> None:
     """_create_mirascope_cloud_provider creates provider successfully."""
-    provider = configuration._create_mirascope_cloud_provider(api_key="test-key")
+    provider = configuration._create_mirascope_cloud_provider(  # pyright: ignore[reportPrivateUsage]
+        api_key="test-key"
+    )
 
     assert isinstance(provider, TracerProvider)
     mock_mirascope_client.assert_called_once_with(api_key="test-key")
@@ -121,7 +124,7 @@ def test_create_mirascope_cloud_provider_no_api_key() -> None:
     os.environ.pop("MIRASCOPE_API_KEY", None)
 
     with pytest.raises(RuntimeError, match="Failed to create Mirascope Cloud client"):
-        configuration._create_mirascope_cloud_provider()
+        configuration._create_mirascope_cloud_provider()  # pyright: ignore[reportPrivateUsage]
 
 
 def test_set_tracer() -> None:

--- a/python/tests/ops/test_model_call.py
+++ b/python/tests/ops/test_model_call.py
@@ -32,9 +32,9 @@ class Book(BaseModel):
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()
@@ -167,9 +167,11 @@ def test_model_call_with_parameters(span_exporter: InMemorySpanExporter) -> None
 
 
 @pytest.mark.vcr()
-def test_model_call_with_json_format(span_exporter: InMemorySpanExporter) -> None:
+def test_model_call_with_json_format(
+    span_exporter: InMemorySpanExporter, tracer_provider: TracerProvider
+) -> None:
     """Test OpenTelemetry instrumentation with structured output."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
 
     class Person(BaseModel):
         name: str

--- a/python/tests/ops/test_model_call_async.py
+++ b/python/tests/ops/test_model_call_async.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -16,9 +17,9 @@ from tests.ops.utils import span_snapshot
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()

--- a/python/tests/ops/test_model_context_call.py
+++ b/python/tests/ops/test_model_context_call.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -15,9 +16,9 @@ from tests.ops.utils import span_snapshot
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()

--- a/python/tests/ops/test_model_context_call_async.py
+++ b/python/tests/ops/test_model_context_call_async.py
@@ -6,6 +6,7 @@ from collections.abc import Generator
 
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -15,9 +16,9 @@ from tests.ops.utils import span_snapshot
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()

--- a/python/tests/ops/test_model_context_stream.py
+++ b/python/tests/ops/test_model_context_stream.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -18,9 +19,9 @@ from tests.ops.utils import span_snapshot
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()

--- a/python/tests/ops/test_model_context_stream_async.py
+++ b/python/tests/ops/test_model_context_stream_async.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -20,9 +21,9 @@ from tests.ops.utils import span_snapshot
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()

--- a/python/tests/ops/test_model_stream.py
+++ b/python/tests/ops/test_model_stream.py
@@ -10,6 +10,7 @@ import httpx
 import openai
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
     InMemorySpanExporter,
 )
@@ -21,9 +22,9 @@ from tests.ops.utils import span_snapshot
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()

--- a/python/tests/ops/test_tracing.py
+++ b/python/tests/ops/test_tracing.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from mirascope import llm, ops
@@ -19,9 +20,9 @@ T = TypeVar("T")
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()

--- a/python/tests/ops/test_versioning.py
+++ b/python/tests/ops/test_versioning.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from inline_snapshot import snapshot
+from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 from mirascope import llm, ops
@@ -20,9 +21,9 @@ from .utils import extract_span_data
 
 
 @pytest.fixture(autouse=True, scope="function")
-def initialize() -> Generator[None, None, None]:
+def initialize(tracer_provider: TracerProvider) -> Generator[None, None, None]:
     """Initialize ops configuration and LLM instrumentation for each test."""
-    ops.configure()
+    ops.configure(tracer_provider=tracer_provider)
     ops.instrument_llm()
     yield
     ops.uninstrument_llm()
@@ -767,7 +768,10 @@ def test_versioned_call_sync(span_exporter: InMemorySpanExporter) -> None:
 
 
 @pytest.mark.vcr()
-def test_versioned_call_wrapped_method(span_exporter: InMemorySpanExporter) -> None:
+def test_versioned_call_wrapped_method(
+    span_exporter: InMemorySpanExporter,
+    mirascope_api_key: None,
+) -> None:
     """Test VersionedCall.wrapped() returns VersionedResult."""
 
     @ops.version
@@ -811,7 +815,10 @@ def test_versioned_call_wrapped_method(span_exporter: InMemorySpanExporter) -> N
 
 
 @pytest.mark.vcr()
-def test_versioned_call_call_method(span_exporter: InMemorySpanExporter) -> None:
+def test_versioned_call_call_method(
+    span_exporter: InMemorySpanExporter,
+    mirascope_api_key: None,
+) -> None:
     """Test VersionedCall.call() returns Response directly and creates span."""
 
     @ops.version
@@ -868,7 +875,10 @@ def test_versioned_call_stream_method(span_exporter: InMemorySpanExporter) -> No
 
 
 @pytest.mark.vcr()
-def test_versioned_call_wrapped_stream(span_exporter: InMemorySpanExporter) -> None:
+def test_versioned_call_wrapped_stream(
+    span_exporter: InMemorySpanExporter,
+    mirascope_api_key: None,
+) -> None:
     """Test VersionedCall.wrapped_stream() returns VersionedResult[StreamResponse]."""
 
     @ops.version
@@ -961,6 +971,7 @@ async def test_versioned_async_call(span_exporter: InMemorySpanExporter) -> None
 @pytest.mark.asyncio
 async def test_versioned_async_call_call_method(
     span_exporter: InMemorySpanExporter,
+    mirascope_api_key: None,
 ) -> None:
     """Test VersionedAsyncCall.call() returns AsyncResponse directly."""
 
@@ -1182,7 +1193,10 @@ async def test_versioned_async_context_call_stream_method(
 
 
 @pytest.mark.vcr()
-def test_versioned_call_with_tags(span_exporter: InMemorySpanExporter) -> None:
+def test_versioned_call_with_tags(
+    span_exporter: InMemorySpanExporter,
+    mirascope_api_key: None,
+) -> None:
     """Test @ops.version(tags=[...]) passes tags to VersionedCall."""
 
     @ops.version(tags=["production", "recommendations"])


### PR DESCRIPTION
### TL;DR

Added proper error handling for missing OpenTelemetry dependencies and fixed import paths in tests.

### What changed?

- Added an explicit check for OpenTelemetry dependencies in `_create_mirascope_cloud_provider` that raises a helpful error message when dependencies are missing
- Fixed the import of `TracerProvider` from OpenTelemetry SDK
- Updated mock patch paths in tests to correctly target the modules where the classes are being used

### How to test?

1. Try to use `ops.configure()` without OpenTelemetry installed to verify the helpful error message
2. Run the existing tests to ensure they pass with the updated mock patch paths
3. Verify that tracing still works correctly when OpenTelemetry is properly installed

### Why make this change?

This change improves the developer experience by providing clearer error messages when required dependencies are missing. It also fixes the test mocks to properly patch the correct import paths, ensuring tests are accurately verifying the functionality. The explicit import of `TracerProvider` from OpenTelemetry SDK ensures the correct implementation is used.