### PR TITLE
fix(ops): align trace examples with wrapped results

### DIFF
--- a/python/examples/ops/basic_trace.py
+++ b/python/examples/ops/basic_trace.py
@@ -2,11 +2,11 @@ from mirascope import ops
 
 
 @ops.trace
-def process_data(data: dict) -> dict:
+def process_data(data: dict[str, str]) -> dict[str, dict[str, str]]:
     return {"processed": data}
 
 
-# Call returns Trace containing both result and span info
-trace = process_data({"key": "value"})
+# Use .wrapped() to get Trace containing both result and span info
+trace = process_data.wrapped({"key": "value"})
 print(trace.result)  # {"processed": {"key": "value"}}
 print(trace.span_id)  # Access the span ID

--- a/python/examples/ops/session_attributes.py
+++ b/python/examples/ops/session_attributes.py
@@ -14,5 +14,5 @@ with ops.session(
     print(f"Session ID: {session_ctx.id}")
     print(f"Attributes: {session_ctx.attributes}")
 
-    trace = handle_request("What's the weather?")
+    trace = handle_request.wrapped("What's the weather?")
     print(trace.result)

--- a/python/examples/ops/session_basic.py
+++ b/python/examples/ops/session_basic.py
@@ -9,8 +9,8 @@ def process_request(data: str) -> str:
 # Group related traces in a session
 with ops.session(id="user-123"):
     # All traces within this block share the session ID
-    trace1 = process_request("first request")
-    trace2 = process_request("second request")
+    trace1 = process_request.wrapped("first request")
+    trace2 = process_request.wrapped("second request")
 
 print(trace1.span_id)
 print(trace2.span_id)

--- a/python/examples/ops/span_events.py
+++ b/python/examples/ops/span_events.py
@@ -1,7 +1,7 @@
 from mirascope import ops
 
 
-def fetch_and_transform(url: str) -> dict:
+def fetch_and_transform(url: str) -> dict[str, int | str | bool]:
     with ops.span("fetch_and_transform", url=url) as s:
         # Log different event types
         s.info("Starting fetch operation")
@@ -11,8 +11,9 @@ def fetch_and_transform(url: str) -> dict:
         s.debug("Received response", response_size=len(str(data)))
 
         # Check for issues
-        if data.get("status") != "ok":
-            s.warning("Unexpected status", status=data.get("status"))
+        status = data.get("status")
+        if status is not None and status != "ok":
+            s.warning("Unexpected status", status=status)
 
         # Transform
         s.info("Transforming data")

--- a/python/examples/ops/trace_with_metadata.py
+++ b/python/examples/ops/trace_with_metadata.py
@@ -7,5 +7,5 @@ def analyze_sentiment(text: str) -> str:
     return "positive" if "good" in text.lower() else "neutral"
 
 
-trace = analyze_sentiment("This product is really good!")
+trace = analyze_sentiment.wrapped("This product is really good!")
 print(trace.result)  # "positive"

--- a/python/examples/ops/version_basic.py
+++ b/python/examples/ops/version_basic.py
@@ -8,9 +8,10 @@ def process_data(data: str) -> str:
 
 
 # Access version info
-print(f"Hash: {process_data.version_info.hash}")
-print(f"Version: {process_data.version_info.version}")
-print(f"Name: {process_data.version_info.name}")
+if (info := process_data.version_info) is not None:
+    print(f"Hash: {info.hash}")
+    print(f"Version: {info.version}")
+    print(f"Name: {info.name}")
 
 # Call the function
 result = process_data("example")

--- a/python/examples/ops/version_llm_call.py
+++ b/python/examples/ops/version_llm_call.py
@@ -9,8 +9,9 @@ def recommend_book(genre: str) -> str:
 
 
 # Access version info before calling
-print(f"Hash: {recommend_book.version_info.hash}")
-print(f"Version: {recommend_book.version_info.version}")
+if (info := recommend_book.version_info) is not None:
+    print(f"Hash: {info.hash}")
+    print(f"Version: {info.version}")
 
 # Call the function
 response = recommend_book("fantasy")

--- a/python/examples/ops/version_with_metadata.py
+++ b/python/examples/ops/version_with_metadata.py
@@ -12,11 +12,11 @@ def process_data(data: str) -> str:
 
 
 # Access version info
-info = process_data.version_info
-print(f"Name: {info.name}")
-print(f"Tags: {info.tags}")
-print(f"Metadata: {info.metadata}")
-print(f"Description: {info.description}")
+if (info := process_data.version_info) is not None:
+    print(f"Name: {info.name}")
+    print(f"Tags: {info.tags}")
+    print(f"Metadata: {info.metadata}")
+    print(f"Description: {info.description}")
 
 # Call the function
 result = process_data("example")


### PR DESCRIPTION
### TL;DR

Updated the ops examples to use `.wrapped()` method for tracing and improved type annotations.

### What changed?

- Changed direct function calls to use `.wrapped()` method when tracing is needed in all examples
- Added more specific type annotations using `dict[str, str]` instead of generic `dict`
- Added null checks for version info with the walrus operator (`if (info := process_data.version_info) is not None:`)
- Improved error handling in span_events.py by adding a null check before comparing status
- Enhanced code readability with better variable assignments

### How to test?

Run each example file to verify they work as expected:

```bash
python python/examples/ops/basic_trace.py
python python/examples/ops/session_attributes.py
python python/examples/ops/session_basic.py
python python/examples/ops/span_events.py
python python/examples/ops/trace_with_metadata.py
python python/examples/ops/version_basic.py
python python/examples/ops/version_llm_call.py
python python/examples/ops/version_with_metadata.py
```

### Why make this change?

These changes improve the examples by:
1. Making the tracing API more explicit with `.wrapped()` calls
2. Adding proper type annotations for better IDE support and type checking
3. Adding null safety checks to prevent potential runtime errors
4. Demonstrating better Python practices in the example code