### PR TITLE
fix(cloud): correct light/dark theme colors search bar entries

### DIFF
--- a/cloud/app/components/blocks/navigation/search-bar.tsx
+++ b/cloud/app/components/blocks/navigation/search-bar.tsx
@@ -42,7 +42,7 @@ function SearchResult({
     >
       <div className="min-w-0 flex-1">
         <div className="mb-2 flex items-center justify-between">
-          <h4 className="text-foreground truncate text-base font-medium">
+          <h4 className="text-accent-foreground truncate text-base font-medium">
             {result.title || "Untitled"}
           </h4>
           <div className="flex items-center gap-2">


### PR DESCRIPTION
Primarily fixes in both dark/light modes for home-page and other pages respectively

![image.png](https://app.graphite.com/user-attachments/assets/01393ee3-eb14-4e2d-a604-2dd4c5ab1c2c.png)

